### PR TITLE
docs: 补充单次终端执行策略与 MCP 使用指引

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,10 +37,10 @@ This repo is a split-architecture, multi-tenant CMS behind Traefik. Follow these
 - Recommended patterns
 	- One-shot commit/push (example):
 		- (Assumes the branch does not already exist and there are changes to commit. If not, commands may fail or behave unexpectedly.)
-		- `git checkout -b chore/update-copilot-instructions && git add .github/copilot-instructions.md && git commit -m "docs: update Copilot instructions (agent & MCP)" && git push -u origin chore/update-copilot-instructions`
+		- `git checkout -b <branch-name> && git add <file-path> && git commit -m "<commit-message>" && git push -u origin <branch-name>`
 		- For extra safety in scripts, use `set -e` or prefer a Makefile target.
 	- One-shot local CI run via Make:
-		- `make test && make lint || true` (adjust to your targets; prefer a single Make target like `make ci-local` that runs build/lint/test together)
+		- `make test && make lint` (do not use `|| true`, as it masks failures; prefer a single Make target like `make ci-local` that runs build/lint/test together)
 - Long-running tasks: start once in background (watch/dev servers) and interact via logs rather than restarting.
 - When an action would require multiple sequential terminal calls, either:
 	1) create or reuse a Make target (e.g., `make ci-local`, `make release`), or


### PR DESCRIPTION
本 PR 补充了 VS Code AI 代理在本仓库的单次终端执行策略与 MCP（Model Context Protocol）使用指引，以提升在本地开发与自动化场景下的稳定性与可复现性。

Refs #13

变更内容
- 更新 `.github/copilot-instructions.md`：
  - 单次终端执行策略：推荐使用 Makefile 目标，或在 zsh 中以 `set -eo pipefail` + `&&` 串联命令进行“一次性”执行，减少多次会话导致的不稳定。
  - 长任务建议：一次启动后台进程（watch/dev servers），通过日志交互而非频繁重启。
  - 当需要连续多步命令时，优先：
    1) 复用/新增 Make 目标（如 `make ci-local`, `make release`），或
    2) 单次 shell 执行中顺序串联命令。
  - MCP 使用指引：启用 GitHub / Web 内容 / 文件系统等 MCP 服务器，通过结构化能力完成多步骤任务；强调最小权限、安全与 fallback 策略。
  - PR/协作流程提醒：保持小而可审的 PR，按 GitHub Flow 执行，master 保持可用。

动机
- 降低代理在多次终端会话与复杂操作中的失败率，提高文档化与自动化操作一致性。

影响面
- 文档变更，无功能代码修改。

验证说明
- 已在文档中给出建议的命令风格与 Makefile 优先策略；后续在 CI/本地使用中持续迭代完善。