### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/backend/src/main/java/com/cms/config/SecurityConfig.java
+++ b/backend/src/main/java/com/cms/config/SecurityConfig.java
@@ -18,7 +18,7 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.csrf(csrf -> csrf.disable())
+    http
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
     return http.build();


### PR DESCRIPTION
Potential fix for [https://github.com/kanghouchao/MYCMS/security/code-scanning/1](https://github.com/kanghouchao/MYCMS/security/code-scanning/1)

To fix the problem, we should remove the disabling of CSRF protection on line 21, thereby enabling the default protection provided by Spring Security. This involves removing `.csrf(csrf -> csrf.disable())` from the security filter chain configuration. The default CSRF behavior will then be applied. If some endpoints are intended to be called by non-browser clients and truly need CSRF to be disabled for them, we can selectively disable it for those endpoints, but that requires careful consideration and is not shown in the original code.

This change only affects lines 21 of file `backend/src/main/java/com/cms/config/SecurityConfig.java`. No additional imports or definitions are needed as CSRF protection is already part of the Spring Security core. Functionality is preserved except that CSRF tokens will now be expected on state-changing requests from browsers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
