### PR TITLE
docs: add role system blueprint

### DIFF
--- a/docs/security/auth-design.md
+++ b/docs/security/auth-design.md
@@ -1,0 +1,81 @@
+# Authentication & Authorization Blueprint
+
+## Goals
+- Support distinct login flows for platform, tenant, and customer actors with consistent token semantics.
+- Deliver fine-grained authorization that aligns with the role matrix and eliminates reliance on mutable client headers.
+- Preserve existing hot paths (`/central/login`, `/tenant/login`, middleware cookies) while introducing incremental improvements.
+
+## Current Snapshot
+- `JwtAuthenticationFilter` trusts claims but only gates issuer vs. path; authorities come straight from the token with no tenant scoping.
+- `TenantInterceptor` reads `X-Role` / `X-Tenant-ID` from headers or cookies to set thread-local context; missing validation against authenticated principal.
+- Spring Security allows every request (`.authorizeHttpRequests().anyRequest().permitAll()`), depending on method-level annotations that do not exist for most controllers.
+- Frontend middleware assigns `x-mw-role` based on host name but cannot differentiate staff vs. admin or customer personas.
+- Redis blacklisting only runs for central logout, leaving tenant JWTs unchecked.
+
+## Target Architecture
+### Entry Points
+| Actor | Entry path | Auth mechanism | Primary storage |
+| --- | --- | --- | --- |
+| Platform (central) | `/central/login` | Username/password → Spring AuthenticationManager | `central_users` + `central_roles` |
+| Tenant workforce | `/tenant/login` | Username/password scoped by tenant | `t_users` + `t_roles` |
+| Customer | `/customer/login` (new) | Email/password or social login | New customer tables per tenant |
+| Service-to-service | `/internal/*` (future) | mTLS + signed service tokens | Secrets manager |
+
+### Token Contract
+- JWT header: `kid` referencing active signing key (managed via `app.jwt.secret` rotation plan).
+- Claims for all actors:
+  - `sub`: principal identifier (username, email, or service ID).
+  - `aud`: `central`, `tenant`, or `customer`.
+  - `iss`: flow-specific issuer (`CentralAuth`, `TenantAuth`, `CustomerAuth`).
+  - `exp`, `iat`, `jti` for revocation bookkeeping.
+  - `tenant_id`: required for tenant staff & customers; `null` for central.
+  - `role_ids`: canonical role IDs (UUID/long) to re-hydrate authorities.
+  - `permissions`: optional flattened list for edge caches; must be revalidated server-side.
+  - `request_id`: optional but enables log stitching without relying on headers.
+- Tokens should be short-lived (15 min) with refresh tokens stored server-side (Redis or database) per audience.
+
+### Authentication Flow Changes
+1. **Central login**
+   - After `AuthenticationManager` success, fetch roles + permissions and sign JWT with above claims.
+   - Store refresh token with scope `central` in Redis (`refresh:central:{userId}:{jti}`).
+   - Response returns access token + refresh token expiry.
+2. **Tenant login**
+   - Augment repository queries to require `tenant_id` in addition to email; ensures `TenantAdmin` can not cross tenants.
+   - Generate JWT with `aud=tenant`, `tenant_id`, and resolved permission set derived from `t_roles` join tables.
+3. **Customer login**
+   - Introduce new authentication service backed by `tenant_customers` table.
+   - Support both password and passwordless (email magic link) in later iteration; initial design uses password.
+4. **Refresh & logout**
+   - New endpoints `/central/token/refresh`, `/tenant/token/refresh`, `/customer/token/refresh` verifying stored refresh tokens.
+   - Logout endpoints blacklist current `jti` and delete refresh entry.
+
+### Authorization Checks
+- Update `SecurityConfig` to require authentication by default, grouping matchers:
+  - Permit `POST /central/login`, `/tenant/login`, `/tenant/register`, `/customer/login`, health probes.
+  - Protect `/central/**` with `hasAuthority('CENTRAL:*')`, etc.
+  - Protect `/tenant/**` with `hasAuthority('TENANT:*')` plus tenant context check.
+  - Introduce `/customer/**` area guarded by `hasAuthority('CUSTOMER:*')`.
+- Replace raw `@RolesAllowed` with composed annotations mapping to permission constants that align with the matrix (e.g. `@RequiresPermission("central.tenants.read")`).
+- In service layer, validate tenant context matches authenticated principal (`TenantContext.getTenantId()` equals JWT `tenant_id`).
+- Extend `TenantInterceptor` to read tenant ID and role from `SecurityContext` instead of trusting cookies/headers; fallback to cookies only for unauthenticated SSR rendering.
+- Inject `X-Request-ID` and actor metadata into MDC to ensure logging shows `req`, `tenant`, and `actor`.
+
+### Frontend & Middleware Alignment
+- Middleware should derive actor persona from decoded JWT stored in `token` cookie instead of hostname-only heuristics.
+- Store structured session cookie (signed) containing `{ audience, tenant_id, roles }` for SSR guards.
+- Navigation guards read permission map from a `/me` endpoint for each audience:
+  - `/central/me`: returns admin profile + permissions.
+  - `/tenant/me`: returns staff profile + tenant scopes.
+  - `/customer/me`: returns membership state, entitlements.
+- Ensure `apiClient` attaches `X-Role` and `X-Tenant-ID` based on decoded token claims; reject stale cookies.
+
+### Auditing & Observability
+- Emit structured audit events on login/logout, permission changes, bulk actions, and admin overrides.
+- Include `jti`, `tenant_id`, `aud`, and top-level permission used.
+- Funnel audit events to dedicated Kafka topic or Redis stream for later ingestion.
+
+### Backward Compatibility & Migration Strategy
+- Phase 1: keep existing `/central` and `/tenant` login endpoints but augment responses with refresh token and new claims.
+- Phase 2: backend enforces authentication on protected routes; frontend updated in tandem to call `/me` to refresh context.
+- Phase 3: deprecate reliance on middleware-set `x-mw-role` for API authorization; keep cookie for SSR theming only.
+- Provide feature flags to toggle strict authorization per module to allow incremental rollout.

--- a/docs/security/data-model-plan.md
+++ b/docs/security/data-model-plan.md
@@ -1,0 +1,93 @@
+# Data Model & Migration Plan
+
+## Current Inventory
+- **Central**: `central_users`, `central_roles`, `central_permissions`, link tables `central_user_roles` and `central_role_permissions`.
+- **Tenant**: `t_users`, `t_roles`, `t_permissions`, `t_user_roles`, `t_role_permissions`; each row carries `tenant_id` but no uniqueness on permissions across tenants.
+- **Miscellaneous**: No dedicated customer tables; pages (`t_pages`) reference tenants via foreign key.
+
+Pain points:
+- Role names are free-form strings, making it difficult to enforce canonical personas defined in the role matrix.
+- Permissions are not classified by domain (content, analytics, billing), complicating policy evaluation.
+- No place to represent customer memberships, loyalty tiers, or policy overrides per tenant.
+- Liquibase changelog seeds inconsistent values (`AMIND` typo) and lacks initial tenant role seeding.
+
+## Target Entities
+### Shared Concepts
+- `permission` (global catalogue)
+  - Columns: `id` (bigint), `code` (`central.tenants.read`), `description`, `audience` (`CENTRAL|TENANT|CUSTOMER`).
+- `role` (global definitions)
+  - Columns: `id`, `code` (`central.admin`, `tenant.staff`, `customer.member`), `audience`, `display_name`, `description`, `mutable` (flag for custom roles).
+- `role_permission` (many-to-many between roles and permissions).
+
+### Platform (Central)
+- `central_user`
+  - Existing table extended with `email`, `display_name`, `last_login_at`.
+- `central_user_role`
+  - Moves to referencing global `role_id` with constraint `audience = 'CENTRAL'`.
+- `central_user_tenant_assignment`
+  - New table mapping sales/ops users to allowed tenant IDs for scoped analytics.
+
+### Tenant Workforce
+- `tenant_user`
+  - Add `username` (optional), `phone`, `last_login_at`, `status` (`ACTIVE|SUSPENDED`).
+- `tenant_user_role`
+  - Adds `role_id` referencing global roles; keep `tenant_id` for multi-tenancy.
+- `tenant_role_override`
+  - Allows tenants to define custom roles derived from base templates; fields: `id`, `tenant_id`, `base_role_id`, `code`, `display_name`, `description`.
+- `tenant_permission_override`
+  - Optional expansion for tenant-specific permission toggles (feature flags per tenant).
+
+### Customer Layer
+- `tenant_customer`
+  - `id` (UUID), `tenant_id`, `email`, `password_hash`, `status`, `verified_at`, `created_at`, `updated_at`.
+- `tenant_membership`
+  - `id`, `tenant_customer_id`, `tier_code`, `started_at`, `expires_at`, `status`.
+- `tenant_customer_role`
+  - Link to global roles for `CUSTOMER` audience (e.g. visitor vs. member) supporting entitlements.
+- `tenant_customer_profile`
+  - Optional JSONB column for preferences, addresses.
+
+### Audit & Policy Tables
+- `policy_assignment`
+  - Generic table to capture dynamic permissions (e.g., staff granted access to a content collection). Columns: `id`, `audience`, `actor_id`, `resource_type`, `resource_id`, `permission_code`, `scope` JSON, timestamps.
+- `permission_change_log`
+  - Append-only log to track who modified role-permission mappings.
+
+## ER Overview (textual)
+```
+role (id) ──< role_permission >── permission (id)
+  │                         │
+  │                         └── scoped by `audience`
+  ├──< central_user_role >── central_user (id)
+  ├──< tenant_user_role >── tenant_user (id, tenant_id)
+  └──< tenant_customer_role >── tenant_customer (id, tenant_id)
+
+tenant_user (tenant_id) ──< tenant_user_role >── role (TENANT)
+tenant_customer (tenant_id) ──< tenant_membership >── membership tiers
+policy_assignment ties {audience, actor_id} to fine-grained resource permissions.
+```
+
+## Migration Strategy
+1. **Introduce global catalog tables** (`permission`, `role`, `role_permission`). Backfill with existing central and tenant roles/permissions.
+2. **Migrate central data**
+   - Create temp mapping table `central_role_legacy_map` to map legacy IDs to new global ones.
+   - Update `central_user_roles` to reference new `role_id` and drop old `central_roles` table once data migrates.
+3. **Migrate tenant data**
+   - Seed base tenant roles (`tenant.admin`, `tenant.staff`) and map existing `t_roles` entries.
+   - Add `role_id` column to `t_user_roles`, populate via join, then drop legacy join table columns.
+4. **Bootstrap customers**
+   - Add `tenant_customer*` tables with foreign keys to `central_tenants`.
+   - No data migration required initially; provide seed script to create default `customer.visitor` and `customer.member` roles.
+5. **Cleanup & constraints**
+   - Enforce uniqueness: `UNIQUE (audience, code)` on `role`, `permission`.
+   - Add composite index `idx_tenant_user_role_tenant_role` on `(tenant_id, role_id)`.
+   - Remove typo `AMIND` record; replace with `central.tenants.manage`.
+6. **Versioning & rollout**
+   - Wrap destructive steps in Liquibase change sets with preconditions checking for existing columns / data state.
+   - Provide backward-compatible database views (`central_roles_v_legacy`, `t_roles_v_legacy`) during transition.
+
+## Data Governance Considerations
+- Use database triggers or application-level hooks to populate `permission_change_log` for auditability.
+- Maintain reference data in code (`.yml` or JSON) to seed permissions/roles during deployment.
+- Document tenant-specific customization boundaries to prevent escalations (e.g., staff cannot assign themselves admin role if tenant disables override).
+- Plan nightly job to detect orphaned assignments (role references with missing permission definitions) and alert ops.

--- a/docs/security/implementation-roadmap.md
+++ b/docs/security/implementation-roadmap.md
@@ -1,0 +1,78 @@
+# Role System Implementation Roadmap
+
+## Guiding Principles
+- Ship iteratively with isolated pull requests per subsystem to ease review.
+- Maintain backwards compatibility until both backend and frontend toggles are in place.
+- Capture test evidence (`make test service=backend`, `npm test -- --coverage`) and publish reports for every milestone.
+
+## Phase 0 – Foundations
+1. **Design sign-off**
+   - Review `docs/security/role-matrix.md`, `auth-design.md`, `data-model-plan.md` with backend, frontend, product stakeholders.
+   - Confirm naming conventions for roles and permissions.
+2. **Infrastructure prep**
+   - Add Liquibase placeholder changelog for new tables (empty change sets guarded by feature flag).
+   - Enable secret storage for new JWT signing keys if rotation is required.
+
+## Phase 1 – Platform & Tenant Hardening
+### Backend
+- Implement permission catalogue entities and repositories; seed central/tenant base roles (Liquibase change set `central-003-role-catalogue.yaml`).
+- Update `SecurityConfig` to require authentication and wire new `AuthorizationService` for permission checks.
+- Refactor `TenantInterceptor` + `JwtAuthenticationFilter` to source tenant context from authenticated principal.
+- Add `/central/me` and `/tenant/me` endpoints returning role + permission payloads.
+- Introduce refresh-token endpoints and Redis storage helpers.
+
+### Frontend
+- Decode JWT client-side to drive nav/route guards; update `AuthContext` to fetch `/me` on load.
+- Replace hostname-only middleware logic with token-driven persona detection; maintain SSR cookies for template selection.
+- Update central tenant management pages to handle permission-driven UI states (button disabling, etc.).
+
+### Data & Ops
+- Backfill seed data: central admin, sales, ops roles; tenant admin/staff roles.
+- Implement migration validation script verifying role/permission counts post-deploy.
+
+### Testing
+- Expand backend unit tests for `AuthorizationService`, token refresh, and updated interceptors.
+- Add integration test hitting `/central/tenants` with unauthorized token to assert 403.
+- Frontend: add Jest/RTL coverage for nav guards and `apiClient` header propagation.
+
+## Phase 2 – Customer Enablement
+### Backend
+- Create `tenant_customer*` tables and repositories.
+- Build `CustomerAuthService` with login/register/reset endpoints and JWT issuance.
+- Add customer-facing `/customer/me` and membership management APIs.
+- Extend audit logging for customer actions.
+
+### Frontend
+- Introduce customer login/registration pages; fetch membership state for gated content.
+- Update tenant templates to respect membership entitlements (SSR + CSR).
+
+### Data & Ops
+- Seed default customer roles (`customer.visitor`, `customer.member`).
+- Configure rate limiting for customer authentication endpoints.
+
+### Testing
+- Contract tests between Next.js middleware and backend tenant validation for customer context cookies.
+- Add E2E scenario (Playwright/Cypress) covering customer login, content access, logout.
+
+## Phase 3 – Advanced Controls & Tooling
+- Implement `policy_assignment` APIs for granular resource permissions.
+- Build admin UI for permission management and audit log browsing.
+- Integrate monitoring dashboards (request failure rate by audience, token refresh success, etc.).
+- Roll out feature flags to enforce strict permissions per module; remove legacy code paths once adoption hits 100%.
+
+## Follow-up Issues (suggested titles)
+1. `feat(security): introduce role & permission catalogue tables`
+2. `feat(auth): enforce jwt-based authorization for central endpoints`
+3. `feat(frontend): add role-aware navigation and guard hooks`
+4. `feat(auth): add refresh token flow for central and tenant audiences`
+5. `feat(data): scaffold customer authentication tables and services`
+6. `feat(frontend): deliver customer membership experience`
+7. `feat(observability): expand audit logging for permission changes`
+8. `feat(platform): ship granular policy assignment APIs`
+
+## Acceptance Checklist
+- ✅ All documents reviewed and version-controlled under `docs/security/`.
+- ✅ Liquibase migrations merged with idempotent preconditions.
+- ✅ Automated tests updated to cover new auth flows (>70% coverage remains satisfied).
+- ✅ Monitoring and alerting configured for authentication failures and permission change events.
+- ✅ Rollout plan approved with checkpoints for rollback.

--- a/docs/security/role-matrix.md
+++ b/docs/security/role-matrix.md
@@ -1,0 +1,62 @@
+# Role Permission Matrix
+
+## Purpose
+This matrix captures the target responsibilities for the platform (central), tenant, and customer actors so that authentication, authorization, and UX flows can be partitioned consistently.
+
+## Legend
+- `Y`: Allowed by default.
+- `R`: Allowed with restrictions (see notes).
+- `N`: Not permitted.
+
+## Platform (Central) Roles
+| Operation domain | Admin | Sales | Ops | Scope / notes |
+| --- | --- | --- | --- | --- |
+| View tenant directory & details | Y | Y | Y | Includes pagination, search, stats endpoints.
+| Create tenant & issue registration token | Y | Y | R | Ops only for emergency reissues with audit trail.
+| Update tenant profile (name, domain, email) | Y | R | N | Sales needs approval workflow for domain edits.
+| Suspend / reinstate tenant | Y | R | Y | Sales requests go through admin approval.
+| Delete tenant | Y | N | R | Ops handles teardown scripts; soft-delete first.
+| View tenant usage analytics | Y | Y | R | Ops can access infrastructure metrics only.
+| Manage central user accounts | Y | N | N | CRUD on `central_users`, password reset, enable/disable.
+| Manage central roles & permissions | Y | N | R | Ops can read-only verify for incident response.
+| Manage platform templates & global assets | Y | Y | R | Ops handles deployment packaging.
+| Configure billing & subscription plans | Y | Y | N | Sales edits quotes; admin finalizes pricing.
+| System configuration (feature flags, integrations) | Y | R | Y | Ops executes deploy-time overrides.
+| Access audit logs | Y | R | Y | Sales access limited to tenant they manage.
+| Manage observability stacks (logging, metrics, alerts) | R | N | Y | Admin covers policy; ops handles tooling.
+
+## Tenant Roles
+| Operation domain | Tenant Admin | Staff | Scope / notes |
+| --- | --- | --- | --- |
+| Manage tenant profile (branding, domains, metadata) | Y | R | Staff can update non-critical content only.
+| Manage tenant user accounts & roles | Y | N | Includes invitations, activation, role assignment.
+| Configure content structure (collections, templates, menus) | Y | Y | Admin approves breaking schema changes.
+| CRUD site content (pages, posts, media) | Y | Y | Subject to workflow policies configured per role.
+| Publish / unpublish content | Y | R | Staff requires approval unless delegated.
+| Manage customer segments & memberships | Y | R | Staff limited to read/update within assigned segment.
+| Access tenant analytics & reports | Y | R | Staff sees dashboards scoped to their departments.
+| Manage commerce settings (catalog, pricing, taxes) | Y | R | Staff can update inventory only.
+| Trigger bulk actions (imports, exports, automated jobs) | Y | N | Admin must sign off due to data risk.
+| Configure integrations (payment, messaging, apps) | Y | N | Admin handles secrets and callbacks.
+| Handle support tickets & customer communications | R | Y | Admin sees escalations; staff handles day-to-day.
+| View audit trail for tenant | Y | R | Staff access limited to actions they performed.
+
+## Customer Roles
+| Operation domain | Member | Visitor | Scope / notes |
+| --- | --- | --- | --- |
+| Browse public tenant content | Y | Y | Visitor sees public catalog/pages.
+| Access gated/member-only content | Y | N | Requires active membership and email verification.
+| Manage personal profile & preferences | Y | N | Includes password resets, notification settings.
+| Manage membership status (upgrade, cancel, renew) | Y | N | Subject to tenant-defined workflows.
+| Submit orders / bookings / inquiries | Y | R | Visitor can submit inquiry form; payments require membership.
+| View order history & receipts | Y | N | Depends on commerce enablement for the tenant.
+| Participate in loyalty programs / rewards | Y | N | Maintains point ledger tied to membership.
+| Access tenant support portal | Y | R | Visitor limited to anonymous ticket submission.
+
+## Cross-cutting Rules
+- Every request must propagate `X-Request-ID`; logging should emit `req=<id>` and `tenant=<scope>` so audit reconstruction stays aligned with this matrix.
+- JWTs and sessions must encode `role`, `scope` (`central` / `tenant` / `customer`), `tenant_id` where relevant, and fine-grained permission claims derived from the assignments above.
+- Multi-tenant writes require tenant context validation through `TenantInterceptor` plus a permission check; no request should rely solely on client headers.
+- Admin-only operations must be wrapped in method-level or domain service checks in addition to endpoint guards to protect background jobs, schedulers, and message listeners.
+- Frontend route guards and navigation menus should consume the same permission contracts to avoid divergent UX and back-end enforcement gaps.
+- Audit events must capture actor role, tenant scope, resource identifier, and the permission that authorized the action.


### PR DESCRIPTION
## Summary
- add role permission matrix for central, tenant, customer actors
- document auth and data model plans for the upcoming authorization revamp
- outline roadmap tasks to deliver the new role system

## Testing
- not run (docs only)

Fixes #41