### PR TITLE
JWT の issuer とリクエストドメインの照合を追加

### DIFF
--- a/backend/src/main/java/com/kizuna/config/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/kizuna/config/filter/JwtAuthenticationFilter.java
@@ -39,7 +39,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     if (StringUtils.hasText(authHeader) && authHeader.startsWith("Bearer ")) {
       String token = authHeader.substring(7);
       Claims claims = jwtUtil.getClaims(token);
-      if (!redisTemplate.hasKey("blacklist:tokens:" + token)) {
+      if (issuerMatchesDomain(claims.getIssuer(), request.getRequestURI())
+          && !redisTemplate.hasKey("blacklist:tokens:" + token)) {
         if (new Date().before(claims.getExpiration())) {
           String username = claims.getSubject();
           List<?> authorities = claims.get("authorities", List.class);
@@ -59,5 +60,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       }
     }
     filterChain.doFilter(request, response);
+  }
+
+  /**
+   * リクエストパスの属するドメインとトークンの issuer が一致するか検証する。 Central / Tenant は署名キーを共有しているため、issuer
+   * の照合でドメイン間のトークン流用を防ぐ。ドメイン外のパス（/files 等）は制限しない。
+   */
+  private boolean issuerMatchesDomain(String issuer, String path) {
+    if (path.equals("/central") || path.startsWith("/central/")) {
+      return JwtUtil.ISSUER_CENTRAL.equals(issuer);
+    }
+    if (path.equals("/tenant") || path.startsWith("/tenant/")) {
+      return JwtUtil.ISSUER_TENANT.equals(issuer);
+    }
+    return true;
   }
 }

--- a/backend/src/main/java/com/kizuna/service/central/auth/CentralAuthServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/service/central/auth/CentralAuthServiceImpl.java
@@ -25,7 +25,7 @@ public class CentralAuthServiceImpl implements CentralAuthService {
 
     return jwtUtil.generateToken(
         Objects.requireNonNull(auth.getName()),
-        "CentralAuth",
+        JwtUtil.ISSUER_CENTRAL,
         Map.of("authorities", auth.getAuthorities().stream().map(a -> a.getAuthority()).toList()));
   }
 }

--- a/backend/src/main/java/com/kizuna/service/tenant/auth/TenantAuthServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/service/tenant/auth/TenantAuthServiceImpl.java
@@ -55,7 +55,8 @@ public class TenantAuthServiceImpl implements TenantAuthService {
     if (tenantId != null) {
       claims.put("tenantId", tenantId);
     }
-    return jwtUtil.generateToken(Objects.requireNonNull(auth.getName()), "TenantAuth", claims);
+    return jwtUtil.generateToken(
+        Objects.requireNonNull(auth.getName()), JwtUtil.ISSUER_TENANT, claims);
   }
 
   @Override

--- a/backend/src/main/java/com/kizuna/utils/JwtUtil.java
+++ b/backend/src/main/java/com/kizuna/utils/JwtUtil.java
@@ -17,6 +17,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class JwtUtil {
 
+  /** セントラルドメインのトークン発行者 */
+  public static final String ISSUER_CENTRAL = "CentralAuth";
+
+  /** テナントドメインのトークン発行者 */
+  public static final String ISSUER_TENANT = "TenantAuth";
+
   private final AppProperties appProperties;
 
   public Token generateToken(

--- a/backend/src/test/java/com/kizuna/config/filter/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/kizuna/config/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,89 @@
+package com.kizuna.config.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.kizuna.utils.JwtUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+  @Mock private JwtUtil jwtUtil;
+
+  @Mock private RedisTemplate<String, Object> redisTemplate;
+
+  @InjectMocks private JwtAuthenticationFilter filter;
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  /** 指定した issuer を持つ有効な Claims を生成する */
+  private Claims buildClaims(String issuer) {
+    return Jwts.claims()
+        .issuer(issuer)
+        .subject("user")
+        .expiration(new Date(System.currentTimeMillis() + 60_000))
+        .add("authorities", List.of("SYSTEM_CONFIG"))
+        .build();
+  }
+
+  /** 指定パスに Bearer トークン付きリクエストを流し、認証結果を返す */
+  private boolean authenticated(String path, String issuer) throws Exception {
+    when(jwtUtil.getClaims("token")).thenReturn(buildClaims(issuer));
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+    request.addHeader("Authorization", "Bearer token");
+    filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+    return SecurityContextHolder.getContext().getAuthentication() != null;
+  }
+
+  @Test
+  @DisplayName("CentralAuth 発行のトークンは /central 配下で認証されること")
+  void centralTokenOnCentralPath() throws Exception {
+    when(redisTemplate.hasKey("blacklist:tokens:token")).thenReturn(false);
+    assertThat(authenticated("/central/configs", "CentralAuth")).isTrue();
+  }
+
+  @Test
+  @DisplayName("TenantAuth 発行のトークンは /central 配下で認証されないこと")
+  void tenantTokenOnCentralPath() throws Exception {
+    assertThat(authenticated("/central/configs", "TenantAuth")).isFalse();
+  }
+
+  @Test
+  @DisplayName("CentralAuth 発行のトークンは /tenant 配下で認証されないこと")
+  void centralTokenOnTenantPath() throws Exception {
+    assertThat(authenticated("/tenant/orders", "CentralAuth")).isFalse();
+  }
+
+  @Test
+  @DisplayName("ドメイン外のパスでは issuer を制限しないこと")
+  void anyIssuerOnDomainFreePath() throws Exception {
+    when(redisTemplate.hasKey("blacklist:tokens:token")).thenReturn(false);
+    assertThat(authenticated("/files/upload", "TenantAuth")).isTrue();
+  }
+
+  @Test
+  @DisplayName("ブラックリスト登録済みのトークンは認証されないこと")
+  void blacklistedToken() throws Exception {
+    when(redisTemplate.hasKey("blacklist:tokens:token")).thenReturn(true);
+    assertThat(authenticated("/central/configs", "CentralAuth")).isFalse();
+  }
+}


### PR DESCRIPTION
## 概要

PR #184 のフォローアップ。Central / Tenant が JWT 署名キーを共有しているため、これまで一方のドメインで発行されたトークンがもう一方のドメインの `isAuthenticated()` エンドポイント（`/central/auth/me`、`/central/menus/me`、`/tenant/menus/me` 等）でも受け入れられていた問題を修正する。

## 変更内容

- `JwtAuthenticationFilter`: リクエストパスとトークンの issuer を照合
  - `/central/*` → issuer `CentralAuth` のみ許可
  - `/tenant/*` → issuer `TenantAuth` のみ許可
  - ドメイン外のパス（`/files/upload` 等）は従来通り制限なし
- issuer 文字列を `JwtUtil.ISSUER_CENTRAL` / `ISSUER_TENANT` 定数に一元化し、発行側（両 AuthServiceImpl）と検証側で共有
- `JwtAuthenticationFilterTest` を新規追加（TDD: 越境 2 ケースの失敗を確認してから実装）

## テスト

- [x] 新規フィルタ単体テスト 5 件（越境拒否 ×2、正常認証、ドメイン外パス、ブラックリスト）
- [x] `task lint service=backend && task test service=backend` 通過（カバレッジ検証含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)