### PR TITLE
refactor(backend): 共有カーネル shared モジュールを成形

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -14,7 +14,9 @@ def jacocoCoverageExcludes = [
     "**/model/**",
     "**/repository/**",
     "**/mapper/**",
-    "**/exception/**"
+    "**/exception/**",
+    // 旧 config/model/exception から shared へ移動した横断的設施（除外基準は従来どおり、PR9 で全体を見直す）
+    "**/shared/**"
 ]
 
 java {

--- a/backend/src/main/java/com/kizuna/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/kizuna/config/WebMvcConfig.java
@@ -1,7 +1,7 @@
 package com.kizuna.config;
 
 import com.kizuna.config.interceptor.MaintenanceModeInterceptor;
-import com.kizuna.config.interceptor.TenantIdInterceptor;
+import com.kizuna.shared.tenancy.TenantIdInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.NonNull;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;

--- a/backend/src/main/java/com/kizuna/controller/FileUploadController.java
+++ b/backend/src/main/java/com/kizuna/controller/FileUploadController.java
@@ -1,9 +1,9 @@
 package com.kizuna.controller;
 
-import com.kizuna.config.AppProperties;
-import com.kizuna.config.interceptor.TenantContext;
 import com.kizuna.model.dto.file.FileUploadResponse;
 import com.kizuna.service.storage.FileStorageService;
+import com.kizuna.shared.config.AppProperties;
+import com.kizuna.shared.tenancy.TenantContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;

--- a/backend/src/main/java/com/kizuna/controller/tenant/listener/TenantCreatedListener.java
+++ b/backend/src/main/java/com/kizuna/controller/tenant/listener/TenantCreatedListener.java
@@ -1,9 +1,9 @@
 package com.kizuna.controller.tenant.listener;
 
-import com.kizuna.config.AppProperties;
 import com.kizuna.controller.tenant.listener.event.TenantCreatedEvent;
 import com.kizuna.model.entity.central.tenant.Tenant;
 import com.kizuna.service.mail.MailService;
+import com.kizuna.shared.config.AppProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.scheduling.annotation.Async;

--- a/backend/src/main/java/com/kizuna/model/entity/central/SystemConfig.java
+++ b/backend/src/main/java/com/kizuna/model/entity/central/SystemConfig.java
@@ -1,5 +1,6 @@
 package com.kizuna.model.entity.central;
 
+import com.kizuna.shared.persistence.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;

--- a/backend/src/main/java/com/kizuna/model/entity/central/security/CentralPermission.java
+++ b/backend/src/main/java/com/kizuna/model/entity/central/security/CentralPermission.java
@@ -1,6 +1,6 @@
 package com.kizuna.model.entity.central.security;
 
-import com.kizuna.model.entity.central.BaseEntity;
+import com.kizuna.shared.persistence.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/backend/src/main/java/com/kizuna/model/entity/central/security/CentralRole.java
+++ b/backend/src/main/java/com/kizuna/model/entity/central/security/CentralRole.java
@@ -1,6 +1,6 @@
 package com.kizuna.model.entity.central.security;
 
-import com.kizuna.model.entity.central.BaseEntity;
+import com.kizuna.shared.persistence.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/backend/src/main/java/com/kizuna/model/entity/central/security/CentralUser.java
+++ b/backend/src/main/java/com/kizuna/model/entity/central/security/CentralUser.java
@@ -1,6 +1,6 @@
 package com.kizuna.model.entity.central.security;
 
-import com.kizuna.model.entity.central.BaseEntity;
+import com.kizuna.shared.persistence.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/backend/src/main/java/com/kizuna/model/entity/central/tenant/Tenant.java
+++ b/backend/src/main/java/com/kizuna/model/entity/central/tenant/Tenant.java
@@ -1,6 +1,6 @@
 package com.kizuna.model.entity.central.tenant;
 
-import com.kizuna.model.entity.central.BaseEntity;
+import com.kizuna.shared.persistence.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;

--- a/backend/src/main/java/com/kizuna/model/entity/tenant/BaseEntity.java
+++ b/backend/src/main/java/com/kizuna/model/entity/tenant/BaseEntity.java
@@ -1,6 +1,7 @@
 package com.kizuna.model.entity.tenant;
 
 import com.kizuna.model.entity.central.tenant.Tenant;
+import com.kizuna.shared.persistence.SnowflakeId;
 import jakarta.persistence.Column;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;

--- a/backend/src/main/java/com/kizuna/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/kizuna/service/CustomUserDetailsService.java
@@ -1,12 +1,12 @@
 package com.kizuna.service;
 
-import com.kizuna.config.interceptor.TenantContext;
 import com.kizuna.model.entity.central.security.CentralPermission;
 import com.kizuna.model.entity.central.security.CentralRole;
 import com.kizuna.model.entity.tenant.security.TenantPermission;
 import com.kizuna.model.entity.tenant.security.TenantRole;
 import com.kizuna.repository.central.CentralUserRepository;
 import com.kizuna.repository.tenant.TenantUserRepository;
+import com.kizuna.shared.tenancy.TenantContext;
 import io.jsonwebtoken.lang.Collections;
 import java.util.Collection;
 import java.util.List;

--- a/backend/src/main/java/com/kizuna/service/central/config/SystemConfigServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/service/central/config/SystemConfigServiceImpl.java
@@ -1,11 +1,11 @@
 package com.kizuna.service.central.config;
 
-import com.kizuna.exception.ServiceException;
 import com.kizuna.mapper.central.SystemConfigMapper;
 import com.kizuna.model.dto.central.config.SystemConfigResponse;
 import com.kizuna.model.dto.central.config.SystemConfigUpdateRequest;
 import com.kizuna.model.entity.central.SystemConfig;
 import com.kizuna.repository.central.SystemConfigRepository;
+import com.kizuna.shared.exception.ServiceException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/backend/src/main/java/com/kizuna/service/central/tenant/CentralTenantServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/service/central/tenant/CentralTenantServiceImpl.java
@@ -1,8 +1,6 @@
 package com.kizuna.service.central.tenant;
 
-import com.kizuna.config.AppProperties;
 import com.kizuna.controller.tenant.listener.event.TenantCreatedEvent;
-import com.kizuna.exception.ServiceException;
 import com.kizuna.model.dto.central.tenant.PaginatedTenantVO;
 import com.kizuna.model.dto.central.tenant.TenantCreateDTO;
 import com.kizuna.model.dto.central.tenant.TenantStatusVO;
@@ -12,6 +10,8 @@ import com.kizuna.model.entity.central.tenant.Tenant;
 import com.kizuna.model.entity.tenant.TenantConfig;
 import com.kizuna.repository.central.TenantRepository;
 import com.kizuna.repository.tenant.TenantConfigRepository;
+import com.kizuna.shared.config.AppProperties;
+import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.utils.RandomTokenUtils;
 import java.util.List;
 import java.util.Optional;

--- a/backend/src/main/java/com/kizuna/service/storage/LocalFileStorageServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/service/storage/LocalFileStorageServiceImpl.java
@@ -1,7 +1,7 @@
 package com.kizuna.service.storage;
 
-import com.kizuna.config.AppProperties;
-import com.kizuna.exception.ServiceException;
+import com.kizuna.shared.config.AppProperties;
+import com.kizuna.shared.exception.ServiceException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/backend/src/main/java/com/kizuna/service/tenant/ConfigServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/service/tenant/ConfigServiceImpl.java
@@ -1,13 +1,13 @@
 package com.kizuna.service.tenant;
 
-import com.kizuna.config.TenantScoped;
-import com.kizuna.config.interceptor.TenantContext;
-import com.kizuna.exception.ServiceException;
 import com.kizuna.mapper.tenant.TenantConfigMapper;
 import com.kizuna.model.dto.tenant.tenantconfig.TenantConfigResponse;
 import com.kizuna.model.dto.tenant.tenantconfig.TenantConfigUpdateRequest;
 import com.kizuna.model.entity.tenant.TenantConfig;
 import com.kizuna.repository.tenant.TenantConfigRepository;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.tenancy.TenantContext;
+import com.kizuna.shared.tenancy.TenantScoped;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/backend/src/main/java/com/kizuna/service/tenant/auth/TenantAuthServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/service/tenant/auth/TenantAuthServiceImpl.java
@@ -1,14 +1,14 @@
 package com.kizuna.service.tenant.auth;
 
-import com.kizuna.config.AppProperties;
-import com.kizuna.config.TenantScoped;
-import com.kizuna.config.interceptor.TenantContext;
 import com.kizuna.model.dto.auth.Token;
 import com.kizuna.model.dto.tenant.TenantRegisterRequest;
 import com.kizuna.model.entity.central.tenant.Tenant;
 import com.kizuna.model.entity.tenant.security.TenantUser;
 import com.kizuna.repository.central.TenantRepository;
 import com.kizuna.repository.tenant.TenantUserRepository;
+import com.kizuna.shared.config.AppProperties;
+import com.kizuna.shared.tenancy.TenantContext;
+import com.kizuna.shared.tenancy.TenantScoped;
 import com.kizuna.utils.JwtUtil;
 import java.util.HashMap;
 import java.util.Map;

--- a/backend/src/main/java/com/kizuna/service/tenant/crm/CustomerServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/service/tenant/crm/CustomerServiceImpl.java
@@ -1,8 +1,5 @@
 package com.kizuna.service.tenant.crm;
 
-import com.kizuna.config.TenantScoped;
-import com.kizuna.config.interceptor.TenantContext;
-import com.kizuna.exception.ServiceException;
 import com.kizuna.mapper.tenant.CustomerMapper;
 import com.kizuna.model.dto.tenant.customer.CustomerCreateRequest;
 import com.kizuna.model.dto.tenant.customer.CustomerResponse;
@@ -10,6 +7,9 @@ import com.kizuna.model.dto.tenant.customer.CustomerUpdateRequest;
 import com.kizuna.model.entity.tenant.Customer;
 import com.kizuna.repository.central.TenantRepository;
 import com.kizuna.repository.tenant.CustomerRepository;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.tenancy.TenantContext;
+import com.kizuna.shared.tenancy.TenantScoped;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/backend/src/main/java/com/kizuna/service/tenant/crm/OrderServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/service/tenant/crm/OrderServiceImpl.java
@@ -1,8 +1,5 @@
 package com.kizuna.service.tenant.crm;
 
-import com.kizuna.config.TenantScoped;
-import com.kizuna.config.interceptor.TenantContext;
-import com.kizuna.exception.ServiceException;
 import com.kizuna.mapper.tenant.CustomerMapper;
 import com.kizuna.mapper.tenant.OrderMapper;
 import com.kizuna.model.dto.tenant.order.OrderCreateRequest;
@@ -15,6 +12,9 @@ import com.kizuna.repository.tenant.CastRepository;
 import com.kizuna.repository.tenant.CustomerRepository;
 import com.kizuna.repository.tenant.OrderRepository;
 import com.kizuna.repository.tenant.TenantUserRepository;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.tenancy.TenantContext;
+import com.kizuna.shared.tenancy.TenantScoped;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/backend/src/main/java/com/kizuna/service/tenant/hrm/CastServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/service/tenant/hrm/CastServiceImpl.java
@@ -1,8 +1,5 @@
 package com.kizuna.service.tenant.hrm;
 
-import com.kizuna.config.TenantScoped;
-import com.kizuna.config.interceptor.TenantContext;
-import com.kizuna.exception.ServiceException;
 import com.kizuna.mapper.tenant.CastMapper;
 import com.kizuna.model.dto.tenant.cast.CastCreateRequest;
 import com.kizuna.model.dto.tenant.cast.CastResponse;
@@ -10,6 +7,9 @@ import com.kizuna.model.dto.tenant.cast.CastUpdateRequest;
 import com.kizuna.model.entity.tenant.Cast;
 import com.kizuna.repository.central.TenantRepository;
 import com.kizuna.repository.tenant.CastRepository;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.tenancy.TenantContext;
+import com.kizuna.shared.tenancy.TenantScoped;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/backend/src/main/java/com/kizuna/service/tenant/menu/TenantMenuServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/service/tenant/menu/TenantMenuServiceImpl.java
@@ -1,9 +1,9 @@
 package com.kizuna.service.tenant.menu;
 
-import com.kizuna.config.interceptor.TenantContext;
 import com.kizuna.model.dto.menu.MenuVO;
 import com.kizuna.model.entity.tenant.menu.TenantMenu;
 import com.kizuna.repository.tenant.menu.TenantMenuRepository;
+import com.kizuna.shared.tenancy.TenantContext;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;

--- a/backend/src/main/java/com/kizuna/shared/config/AppProperties.java
+++ b/backend/src/main/java/com/kizuna/shared/config/AppProperties.java
@@ -1,4 +1,4 @@
-package com.kizuna.config;
+package com.kizuna.shared.config;
 
 import java.util.List;
 import lombok.Getter;

--- a/backend/src/main/java/com/kizuna/shared/config/CacheConfig.java
+++ b/backend/src/main/java/com/kizuna/shared/config/CacheConfig.java
@@ -1,4 +1,4 @@
-package com.kizuna.config;
+package com.kizuna.shared.config;
 
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Configuration;

--- a/backend/src/main/java/com/kizuna/shared/config/JacksonConfig.java
+++ b/backend/src/main/java/com/kizuna/shared/config/JacksonConfig.java
@@ -1,4 +1,4 @@
-package com.kizuna.config;
+package com.kizuna.shared.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/backend/src/main/java/com/kizuna/shared/config/RedisConfig.java
+++ b/backend/src/main/java/com/kizuna/shared/config/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.kizuna.config;
+package com.kizuna.shared.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/backend/src/main/java/com/kizuna/shared/exception/CommonExceptionHandler.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/CommonExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.kizuna.exception;
+package com.kizuna.shared.exception;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/backend/src/main/java/com/kizuna/shared/exception/ServiceException.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/ServiceException.java
@@ -1,4 +1,4 @@
-package com.kizuna.exception;
+package com.kizuna.shared.exception;
 
 import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/backend/src/main/java/com/kizuna/shared/package-info.java
+++ b/backend/src/main/java/com/kizuna/shared/package-info.java
@@ -1,0 +1,4 @@
+/** 共有カーネル: テナントコンテキスト、共通エンティティ基盤、横断的設定・例外。 全モジュールから参照されるため OPEN モジュールとして公開する。 */
+@org.springframework.modulith.ApplicationModule(
+    type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+package com.kizuna.shared;

--- a/backend/src/main/java/com/kizuna/shared/persistence/BaseEntity.java
+++ b/backend/src/main/java/com/kizuna/shared/persistence/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.kizuna.model.entity.central;
+package com.kizuna.shared.persistence;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;

--- a/backend/src/main/java/com/kizuna/shared/persistence/SnowflakeId.java
+++ b/backend/src/main/java/com/kizuna/shared/persistence/SnowflakeId.java
@@ -1,4 +1,4 @@
-package com.kizuna.model.entity.tenant;
+package com.kizuna.shared.persistence;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;

--- a/backend/src/main/java/com/kizuna/shared/persistence/SnowflakeIdGenerator.java
+++ b/backend/src/main/java/com/kizuna/shared/persistence/SnowflakeIdGenerator.java
@@ -1,4 +1,4 @@
-package com.kizuna.model.entity.tenant;
+package com.kizuna.shared.persistence;
 
 import java.io.Serializable;
 import java.time.Instant;

--- a/backend/src/main/java/com/kizuna/shared/tenancy/TenantContext.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/TenantContext.java
@@ -1,4 +1,4 @@
-package com.kizuna.config.interceptor;
+package com.kizuna.shared.tenancy;
 
 import org.springframework.stereotype.Component;
 

--- a/backend/src/main/java/com/kizuna/shared/tenancy/TenantFilterEnable.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/TenantFilterEnable.java
@@ -1,6 +1,5 @@
-package com.kizuna.config;
+package com.kizuna.shared.tenancy;
 
-import com.kizuna.config.interceptor.TenantContext;
 import jakarta.persistence.EntityManager;
 import lombok.AllArgsConstructor;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -27,7 +26,7 @@ public class TenantFilterEnable {
   private final EntityManager entityManager;
   private final TenantContext tenantContext;
 
-  @Around(value = "@annotation(com.kizuna.config.TenantScoped)")
+  @Around(value = "@annotation(com.kizuna.shared.tenancy.TenantScoped)")
   public Object enableTenantFilterForTenantServiceMethods(ProceedingJoinPoint pjp)
       throws Throwable {
     if (tenantContext.isTenant()) {

--- a/backend/src/main/java/com/kizuna/shared/tenancy/TenantIdInterceptor.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/TenantIdInterceptor.java
@@ -1,4 +1,4 @@
-package com.kizuna.config.interceptor;
+package com.kizuna.shared.tenancy;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/backend/src/main/java/com/kizuna/shared/tenancy/TenantScoped.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/TenantScoped.java
@@ -1,4 +1,4 @@
-package com.kizuna.config;
+package com.kizuna.shared.tenancy;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/backend/src/main/java/com/kizuna/shared/web/RequestCorrelationFilter.java
+++ b/backend/src/main/java/com/kizuna/shared/web/RequestCorrelationFilter.java
@@ -1,6 +1,6 @@
-package com.kizuna.config.filter;
+package com.kizuna.shared.web;
 
-import com.kizuna.config.interceptor.TenantContext;
+import com.kizuna.shared.tenancy.TenantContext;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/backend/src/main/java/com/kizuna/utils/JwtUtil.java
+++ b/backend/src/main/java/com/kizuna/utils/JwtUtil.java
@@ -1,7 +1,7 @@
 package com.kizuna.utils;
 
-import com.kizuna.config.AppProperties;
 import com.kizuna.model.dto.auth.Token;
+import com.kizuna.shared.config.AppProperties;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;

--- a/backend/src/test/java/com/kizuna/ModularityTests.java
+++ b/backend/src/test/java/com/kizuna/ModularityTests.java
@@ -13,7 +13,6 @@ class ModularityTests {
       JavaClass.Predicates.resideInAnyPackage(
           "com.kizuna.config..",
           "com.kizuna.controller..",
-          "com.kizuna.exception..",
           "com.kizuna.mapper..",
           "com.kizuna.model..",
           "com.kizuna.repository..",

--- a/backend/src/test/java/com/kizuna/controller/central/CentralConfigControllerTest.java
+++ b/backend/src/test/java/com/kizuna/controller/central/CentralConfigControllerTest.java
@@ -8,12 +8,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.kizuna.config.JacksonConfig;
-import com.kizuna.config.interceptor.TenantContext;
-import com.kizuna.exception.ServiceException;
 import com.kizuna.model.dto.central.config.SystemConfigResponse;
 import com.kizuna.model.dto.central.config.SystemConfigUpdateRequest;
 import com.kizuna.service.central.config.SystemConfigService;
+import com.kizuna.shared.config.JacksonConfig;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.tenancy.TenantContext;
 import com.kizuna.utils.JwtUtil;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/kizuna/service/CustomUserDetailsServiceTest.java
+++ b/backend/src/test/java/com/kizuna/service/CustomUserDetailsServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
-import com.kizuna.config.interceptor.TenantContext;
 import com.kizuna.model.entity.central.security.CentralPermission;
 import com.kizuna.model.entity.central.security.CentralRole;
 import com.kizuna.model.entity.central.security.CentralUser;
@@ -13,6 +12,7 @@ import com.kizuna.model.entity.tenant.security.TenantRole;
 import com.kizuna.model.entity.tenant.security.TenantUser;
 import com.kizuna.repository.central.CentralUserRepository;
 import com.kizuna.repository.tenant.TenantUserRepository;
+import com.kizuna.shared.tenancy.TenantContext;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;

--- a/backend/src/test/java/com/kizuna/service/central/config/SystemConfigServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/service/central/config/SystemConfigServiceImplTest.java
@@ -8,12 +8,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.kizuna.exception.ServiceException;
 import com.kizuna.mapper.central.SystemConfigMapper;
 import com.kizuna.model.dto.central.config.SystemConfigResponse;
 import com.kizuna.model.dto.central.config.SystemConfigUpdateRequest;
 import com.kizuna.model.entity.central.SystemConfig;
 import com.kizuna.repository.central.SystemConfigRepository;
+import com.kizuna.shared.exception.ServiceException;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/kizuna/service/central/tenant/CentralTenantServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/service/central/tenant/CentralTenantServiceImplTest.java
@@ -7,8 +7,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.kizuna.config.AppProperties;
-import com.kizuna.exception.ServiceException;
 import com.kizuna.model.dto.central.tenant.TenantCreateDTO;
 import com.kizuna.model.dto.central.tenant.TenantStatusVO;
 import com.kizuna.model.dto.central.tenant.TenantUpdateDTO;
@@ -16,6 +14,8 @@ import com.kizuna.model.dto.central.tenant.TenantVO;
 import com.kizuna.model.entity.central.tenant.Tenant;
 import com.kizuna.repository.central.TenantRepository;
 import com.kizuna.repository.tenant.TenantConfigRepository;
+import com.kizuna.shared.config.AppProperties;
+import com.kizuna.shared.exception.ServiceException;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/kizuna/service/storage/LocalFileStorageServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/service/storage/LocalFileStorageServiceImplTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
-import com.kizuna.config.AppProperties;
-import com.kizuna.exception.ServiceException;
+import com.kizuna.shared.config.AppProperties;
+import com.kizuna.shared.exception.ServiceException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/backend/src/test/java/com/kizuna/service/tenant/ConfigServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/service/tenant/ConfigServiceImplTest.java
@@ -8,8 +8,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.kizuna.config.interceptor.TenantContext;
-import com.kizuna.exception.ServiceException;
 import com.kizuna.mapper.tenant.TenantConfigMapper;
 import com.kizuna.model.dto.tenant.tenantconfig.PartnerLink;
 import com.kizuna.model.dto.tenant.tenantconfig.SnsLink;
@@ -17,6 +15,8 @@ import com.kizuna.model.dto.tenant.tenantconfig.TenantConfigResponse;
 import com.kizuna.model.dto.tenant.tenantconfig.TenantConfigUpdateRequest;
 import com.kizuna.model.entity.tenant.TenantConfig;
 import com.kizuna.repository.tenant.TenantConfigRepository;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.tenancy.TenantContext;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;

--- a/backend/src/test/java/com/kizuna/service/tenant/auth/TenantAuthServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/service/tenant/auth/TenantAuthServiceImplTest.java
@@ -9,13 +9,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.kizuna.config.AppProperties;
-import com.kizuna.config.interceptor.TenantContext;
 import com.kizuna.model.dto.auth.Token;
 import com.kizuna.model.dto.tenant.TenantRegisterRequest;
 import com.kizuna.model.entity.central.tenant.Tenant;
 import com.kizuna.repository.central.TenantRepository;
 import com.kizuna.repository.tenant.TenantUserRepository;
+import com.kizuna.shared.config.AppProperties;
+import com.kizuna.shared.tenancy.TenantContext;
 import com.kizuna.utils.JwtUtil;
 import java.util.List;
 import java.util.Map;

--- a/backend/src/test/java/com/kizuna/service/tenant/crm/CustomerServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/service/tenant/crm/CustomerServiceImplTest.java
@@ -7,8 +7,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.kizuna.config.interceptor.TenantContext;
-import com.kizuna.exception.ServiceException;
 import com.kizuna.mapper.tenant.CustomerMapper;
 import com.kizuna.model.dto.tenant.customer.CustomerCreateRequest;
 import com.kizuna.model.dto.tenant.customer.CustomerResponse;
@@ -17,6 +15,8 @@ import com.kizuna.model.entity.central.tenant.Tenant;
 import com.kizuna.model.entity.tenant.Customer;
 import com.kizuna.repository.central.TenantRepository;
 import com.kizuna.repository.tenant.CustomerRepository;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.tenancy.TenantContext;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/kizuna/service/tenant/crm/OrderServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/service/tenant/crm/OrderServiceImplTest.java
@@ -6,8 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.kizuna.config.interceptor.TenantContext;
-import com.kizuna.exception.ServiceException;
 import com.kizuna.mapper.tenant.CustomerMapper;
 import com.kizuna.mapper.tenant.OrderMapper;
 import com.kizuna.model.dto.tenant.order.OrderCreateRequest;
@@ -23,6 +21,8 @@ import com.kizuna.repository.tenant.CastRepository;
 import com.kizuna.repository.tenant.CustomerRepository;
 import com.kizuna.repository.tenant.OrderRepository;
 import com.kizuna.repository.tenant.TenantUserRepository;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.tenancy.TenantContext;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/kizuna/service/tenant/hrm/CastServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/service/tenant/hrm/CastServiceImplTest.java
@@ -7,8 +7,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.kizuna.config.interceptor.TenantContext;
-import com.kizuna.exception.ServiceException;
 import com.kizuna.mapper.tenant.CastMapper;
 import com.kizuna.model.dto.tenant.cast.CastCreateRequest;
 import com.kizuna.model.dto.tenant.cast.CastResponse;
@@ -17,6 +15,8 @@ import com.kizuna.model.entity.central.tenant.Tenant;
 import com.kizuna.model.entity.tenant.Cast;
 import com.kizuna.repository.central.TenantRepository;
 import com.kizuna.repository.tenant.CastRepository;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.tenancy.TenantContext;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/kizuna/service/tenant/menu/TenantMenuServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/service/tenant/menu/TenantMenuServiceImplTest.java
@@ -4,10 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
-import com.kizuna.config.interceptor.TenantContext;
 import com.kizuna.model.dto.menu.MenuVO;
 import com.kizuna.model.entity.tenant.menu.TenantMenu;
 import com.kizuna.repository.tenant.menu.TenantMenuRepository;
+import com.kizuna.shared.tenancy.TenantContext;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/kizuna/utils/JwtUtilTest.java
+++ b/backend/src/test/java/com/kizuna/utils/JwtUtilTest.java
@@ -3,8 +3,8 @@ package com.kizuna.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.kizuna.config.AppProperties;
 import com.kizuna.model.dto.auth.Token;
+import com.kizuna.shared.config.AppProperties;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;


### PR DESCRIPTION
## 概要

DDD×FSD リファクタ 2/10。横断的設施を `com.kizuna.shared` モジュールへ帰位し、Modulith の検証対象となる最初の実モジュールを作る。**挙動変化ゼロ**（純パッケージ移動、import 書き換えのみ）。

Closes #193

> **Note**: #192 の PR #202 の上に積んでいます（base: `feature/192-tooling-modulith-steiger`）。#202 を先にマージしてください。

## 変更内容

| 移動先 | クラス |
|---|---|
| `shared/tenancy` | TenantContext、TenantIdInterceptor、TenantFilterEnable、TenantScoped |
| `shared/web` | RequestCorrelationFilter |
| `shared/config` | AppProperties、CacheConfig、RedisConfig、JacksonConfig |
| `shared/exception` | ServiceException、CommonExceptionHandler |
| `shared/persistence` | BaseEntity（central 系）、SnowflakeId、SnowflakeIdGenerator |

- `shared` は OPEN モジュール（共有カーネルとして全モジュールの利用を許可）
- 空になった `com.kizuna.exception` を ModularityTests の除外リストから削除（除外リスト縮小の第一歩）
- Jacoco 除外に `shared/**` を追加 — 移動したクラスは全て旧 `config/model/exception` 除外の対象だったため、カバレッジの測定基準を従来と同一に保つ（PR9 で全体見直し）

## 移動を見送ったもの（依存の都合、各モジュール移行時に帰位）

- **JwtUtil / JwtAuthenticationFilter / SecurityConfig** → auth モジュール（#195）。JwtUtil が legacy DTO（Token）に依存
- **MaintenanceModeInterceptor / WebMvcConfig** → settings モジュール（#197）。SystemConfigService に依存（config↔service 循環の元）
- **tenant 側 BaseEntity** → `Tenant` への `@ManyToOne` が残っており、D3（ID 参照化）は PR5 で実施。5 サービスの `setTenant()` に波及するためこのバッチでは動かさない

## 検証

- [x] ModularityTests: `shared` モジュールが検証対象に入り verify() 通過
- [x] 既存テスト全緑（移動に追随、断言は不変）、カバレッジ ≥70%
- [x] `task lint` + `task test`（Docker/JDK21、Spotless 含む）通過
- [x] `req=<id> tenant=<id>` ログ形式・AppProperties の用法は不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)