### PR TITLE
fix(tenant): 未登録ドメイン検索が 500 になるキャッシュ null 書き込みを修復

### DIFF
--- a/backend/src/main/java/com/kizuna/tenant/application/CentralTenantServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/tenant/application/CentralTenantServiceImpl.java
@@ -69,7 +69,9 @@ public class CentralTenantServiceImpl implements CentralTenantService {
 
   @Override
   @Transactional(readOnly = true)
-  @Cacheable(value = "tenantByDomain", key = "#domain")
+  // Optional は unwrap されるため未登録ドメインは null。cache-null-values=false の Redis に
+  // null を書くと IllegalArgumentException → 500 になるのでキャッシュ対象外にする（#207）
+  @Cacheable(value = "tenantByDomain", key = "#domain", unless = "#result == null")
   public Optional<TenantVO> getByDomain(String domain) {
     log.debug("テナントをデータベースから検索 domain: {}", domain);
     return tenantRepository.findByDomain(domain).map(this::toDto);

--- a/backend/src/test/java/com/kizuna/tenant/application/CentralTenantServiceCacheTest.java
+++ b/backend/src/test/java/com/kizuna/tenant/application/CentralTenantServiceCacheTest.java
@@ -1,0 +1,86 @@
+package com.kizuna.tenant.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.kizuna.shared.config.AppProperties;
+import com.kizuna.storeprofile.domain.StoreProfileRepository;
+import com.kizuna.tenant.domain.Tenant;
+import com.kizuna.tenant.domain.TenantRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * getByDomain のキャッシュ挙動（#207）。本番は Redis で cache-null-values=false のため、null（未登録ドメイン）を キャッシュに書こうとすると
+ * IllegalArgumentException → 500 になる。同じ null 拒否設定の ConcurrentMapCacheManager でプロキシ経由の挙動を再現する。
+ */
+@SpringJUnitConfig(CentralTenantServiceCacheTest.Config.class)
+class CentralTenantServiceCacheTest {
+
+  @Configuration
+  @EnableCaching
+  static class Config {
+
+    @Bean
+    CacheManager cacheManager() {
+      ConcurrentMapCacheManager manager = new ConcurrentMapCacheManager();
+      // 本番設定（REDIS_CACHE_NULL_VALUES:false）と同じ null 拒否契約
+      manager.setAllowNullValues(false);
+      return manager;
+    }
+
+    @Bean
+    TenantRepository tenantRepository() {
+      return mock(TenantRepository.class);
+    }
+
+    @Bean
+    CentralTenantService centralTenantService(TenantRepository tenantRepository) {
+      return new CentralTenantServiceImpl(
+          tenantRepository,
+          mock(StoreProfileRepository.class),
+          mock(ApplicationEventPublisher.class),
+          mock(AppProperties.class));
+    }
+  }
+
+  @Autowired private CentralTenantService service;
+  @Autowired private TenantRepository tenantRepository;
+
+  @Test
+  @DisplayName("未登録ドメインの検索は例外にならず empty を返すこと（null をキャッシュに書かない）")
+  void unknownDomainReturnsEmptyWithoutCachingNull() {
+    when(tenantRepository.findByDomain(anyString())).thenReturn(Optional.empty());
+
+    assertThat(service.getByDomain("unknown.example.com")).isEmpty();
+  }
+
+  @Test
+  @DisplayName("登録済みドメインの検索結果はキャッシュされ 2 回目は DB を叩かないこと")
+  void knownDomainResultIsCached() {
+    Tenant tenant = new Tenant();
+    tenant.setId(1L);
+    tenant.setName("店舗A");
+    tenant.setDomain("a.example.com");
+    tenant.setEmail("a@example.com");
+    when(tenantRepository.findByDomain("a.example.com")).thenReturn(Optional.of(tenant));
+
+    assertThat(service.getByDomain("a.example.com")).isPresent();
+    assertThat(service.getByDomain("a.example.com")).isPresent();
+
+    verify(tenantRepository, times(1)).findByDomain("a.example.com");
+  }
+}


### PR DESCRIPTION
## 概要

#207 の修復。`GET /central/tenant?domain=<未登録>` が 404 ではなく 500 を返していた。原因は `@Cacheable("tenantByDomain")` が `Optional.empty`（キャッシュ層では null）を `cache-null-values=false` の Redis に書き込もうとして `IllegalArgumentException` になること。

## 変更

- `unless = "#result == null"` を付与（Optional は Spring Cache が unwrap するため、未登録ドメイン = null はキャッシュ対象外になる）
- 再現テスト `CentralTenantServiceCacheTest`: 本番と同じ null 拒否契約（`ConcurrentMapCacheManager#setAllowNullValues(false)`）+ `@EnableCaching` プロキシ経由で red-first 再現 → 修正で green
- ガードテスト: 登録済みドメインは引き続きキャッシュされる（2 回呼んでも DB 1 回）

## 検証

- 実機: 新イメージで `GET /api/central/tenant?domain=unknown.example.com` → **404**（修正前 500）、エラーログ 0 件
- `task lint` / `task test` 全緑

## トレードオフ

未登録ドメインはキャッシュされないため毎回 DB を叩く（負のキャッシュ無し）。未登録ドメインへのアクセスは稀で、404 の正しさを優先。

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)