### PR TITLE
feat(customer): 顧客管理 UI を実装 — 横断検索・絞り込み・注文履歴

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,3 +55,4 @@ _Avoid_: TenantMenu（旧名）
 ## Open questions
 
 - **Order.storeName**：订单上的自由文本"店名"字段。Tenant 与门店已确认 1:1，此字段的真实含义（屋号/品牌/渠道名？）待澄清后改名或移除。
+- **Customer.rank / classification**：均为自由文本，等级/区分的正式取值体系未定义（DB 默认 rank='SILVER'）。UI 以文本输入暂顶，待业务确定取值集后收敛为 enum + 下拉。

--- a/backend/src/main/java/com/kizuna/customer/api/dto/CustomerCreateRequest.java
+++ b/backend/src/main/java/com/kizuna/customer/api/dto/CustomerCreateRequest.java
@@ -12,6 +12,9 @@ public class CustomerCreateRequest {
   private String buildingName;
   private String classification;
   private Boolean hasPet;
+  private String rank;
+  private String lineId;
+  private String usageAreas;
   private String ngType;
   private String ngContent;
 }

--- a/backend/src/main/java/com/kizuna/customer/api/dto/CustomerMapper.java
+++ b/backend/src/main/java/com/kizuna/customer/api/dto/CustomerMapper.java
@@ -12,6 +12,8 @@ public interface CustomerMapper {
 
   @Mapping(target = "points", constant = "0")
   @Mapping(target = "landmark", ignore = true)
+  // rank は DB デフォルト（'SILVER'）と同義。エンティティに列をマッピングしたため明示的に補完する
+  @Mapping(target = "rank", source = "rank", defaultValue = "SILVER")
   Customer toEntity(CustomerCreateRequest request);
 
   /** 更新リクエストをドメインの部分更新コマンドに変換します。null フィールドは「変更しない」。 */

--- a/backend/src/main/java/com/kizuna/customer/api/dto/CustomerResponse.java
+++ b/backend/src/main/java/com/kizuna/customer/api/dto/CustomerResponse.java
@@ -19,6 +19,9 @@ public class CustomerResponse {
   private String classification;
   private Boolean hasPet;
   private Integer points;
+  private String rank;
+  private String lineId;
+  private String usageAreas;
   private String ngType;
   private String ngContent;
 }

--- a/backend/src/main/java/com/kizuna/customer/api/dto/CustomerUpdateRequest.java
+++ b/backend/src/main/java/com/kizuna/customer/api/dto/CustomerUpdateRequest.java
@@ -11,6 +11,9 @@ public class CustomerUpdateRequest {
   private String buildingName;
   private String classification;
   private Boolean hasPet;
+  private String rank;
+  private String lineId;
+  private String usageAreas;
   private String ngType;
   private String ngContent;
 }

--- a/backend/src/main/java/com/kizuna/customer/api/store/CustomerController.java
+++ b/backend/src/main/java/com/kizuna/customer/api/store/CustomerController.java
@@ -32,8 +32,10 @@ public class CustomerController {
   @PreAuthorize("hasAuthority('CUSTOMER_MANAGE')")
   public ResponseEntity<Page<CustomerResponse>> list(
       @RequestParam(required = false) String search,
+      @RequestParam(required = false) String rank,
+      @RequestParam(required = false) String classification,
       @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
-    return ResponseEntity.ok(customerService.list(search, pageable));
+    return ResponseEntity.ok(customerService.list(search, rank, classification, pageable));
   }
 
   @GetMapping("/{id}")

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomerService {
-  Page<CustomerResponse> list(String search, Pageable pageable);
+  Page<CustomerResponse> list(String search, String rank, String classification, Pageable pageable);
 
   CustomerResponse get(String id);
 

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerServiceImpl.java
@@ -10,9 +10,13 @@ import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.tenancy.TenantContext;
 import com.kizuna.shared.tenancy.TenantScoped;
 import com.kizuna.tenant.domain.TenantRepository;
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,13 +32,41 @@ public class CustomerServiceImpl implements CustomerService {
   @Override
   @TenantScoped
   @Transactional(readOnly = true)
-  public Page<CustomerResponse> list(String search, Pageable pageable) {
-    if (search != null && !search.isEmpty()) {
-      return customerRepository
-          .findByNameContainingIgnoreCase(search, pageable)
-          .map(customerMapper::toResponse);
-    }
-    return customerRepository.findAll(pageable).map(customerMapper::toResponse);
+  public Page<CustomerResponse> list(
+      String search, String rank, String classification, Pageable pageable) {
+    Specification<Customer> spec =
+        searchSpec(blankToNull(search), blankToNull(rank), blankToNull(classification));
+    return customerRepository.findAll(spec, pageable).map(customerMapper::toResponse);
+  }
+
+  /**
+   * 検索語は 名前・電話番号・LINE ID を横断し、rank / classification は完全一致の絞り込み。 null の条件は述語を生成しない（JPQL の ":param is
+   * null or ..." パターンは PostgreSQL の null パラメータ型推論で 500 になるため Specification で組み立てる）。
+   */
+  private static Specification<Customer> searchSpec(
+      String search, String rank, String classification) {
+    return (root, query, cb) -> {
+      List<Predicate> predicates = new ArrayList<>();
+      if (search != null) {
+        String pattern = "%" + search.toLowerCase() + "%";
+        predicates.add(
+            cb.or(
+                cb.like(cb.lower(root.get("name")), pattern),
+                cb.like(root.get("phoneNumber"), "%" + search + "%"),
+                cb.like(root.get("lineId"), "%" + search + "%")));
+      }
+      if (rank != null) {
+        predicates.add(cb.equal(root.get("rank"), rank));
+      }
+      if (classification != null) {
+        predicates.add(cb.equal(root.get("classification"), classification));
+      }
+      return cb.and(predicates.toArray(new Predicate[0]));
+    };
+  }
+
+  private static String blankToNull(String value) {
+    return (value == null || value.isBlank()) ? null : value;
   }
 
   @Override

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerServiceImpl.java
@@ -53,7 +53,7 @@ public class CustomerServiceImpl implements CustomerService {
             cb.or(
                 cb.like(cb.lower(root.get("name")), pattern),
                 cb.like(root.get("phoneNumber"), "%" + search + "%"),
-                cb.like(root.get("lineId"), "%" + search + "%")));
+                cb.like(cb.lower(root.get("lineId")), pattern)));
       }
       if (rank != null) {
         predicates.add(cb.equal(root.get("rank"), rank));

--- a/backend/src/main/java/com/kizuna/customer/domain/Customer.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/Customer.java
@@ -46,6 +46,15 @@ public class Customer extends TenantScopedEntity {
   @Column(name = "points")
   private Integer points;
 
+  @Column(name = "rank")
+  private String rank;
+
+  @Column(name = "line_id")
+  private String lineId;
+
+  @Column(name = "usage_areas")
+  private String usageAreas;
+
   @Column(name = "ng_type")
   private String ngType;
 
@@ -71,6 +80,15 @@ public class Customer extends TenantScopedEntity {
     }
     if (patch.classification() != null) {
       this.classification = patch.classification();
+    }
+    if (patch.rank() != null) {
+      this.rank = patch.rank();
+    }
+    if (patch.lineId() != null) {
+      this.lineId = patch.lineId();
+    }
+    if (patch.usageAreas() != null) {
+      this.usageAreas = patch.usageAreas();
     }
     if (patch.hasPet() != null) {
       this.hasPet = patch.hasPet();

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerPatch.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerPatch.java
@@ -9,5 +9,8 @@ public record CustomerPatch(
     String buildingName,
     String classification,
     Boolean hasPet,
+    String rank,
+    String lineId,
+    String usageAreas,
     String ngType,
     String ngContent) {}

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
@@ -1,8 +1,6 @@
 package com.kizuna.customer.domain;
 
 import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
@@ -10,7 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CustomerRepository
     extends JpaRepository<Customer, String>, JpaSpecificationExecutor<Customer> {
-  Page<Customer> findByNameContainingIgnoreCase(String name, Pageable pageable);
 
   Optional<Customer> findByPhoneNumber(String phoneNumber);
 

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderMapper.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderMapper.java
@@ -45,5 +45,9 @@ public interface OrderMapper {
 
   @Mapping(target = "points", constant = "0")
   @Mapping(target = "name", source = "customerName")
+  // rank は DB デフォルト（'SILVER'）と同義。注文経由の顧客作成でも通常作成と揃える
+  @Mapping(target = "rank", constant = "SILVER")
+  @Mapping(target = "lineId", ignore = true)
+  @Mapping(target = "usageAreas", ignore = true)
   Customer toCustomer(OrderCreateRequest request);
 }

--- a/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
+++ b/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -30,8 +31,9 @@ public class OrderController {
   @GetMapping
   @PreAuthorize("hasAuthority('ORDER_MANAGE')")
   public ResponseEntity<Page<OrderResponse>> list(
+      @RequestParam(name = "customer_id", required = false) String customerId,
       @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
-    return ResponseEntity.ok(orderService.list(pageable));
+    return ResponseEntity.ok(orderService.list(customerId, pageable));
   }
 
   @GetMapping("/{id}")

--- a/backend/src/main/java/com/kizuna/order/application/OrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderService.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface OrderService {
-  Page<OrderResponse> list(Pageable pageable);
+  Page<OrderResponse> list(String customerId, Pageable pageable);
 
   OrderResponse get(String id);
 

--- a/backend/src/main/java/com/kizuna/order/application/OrderServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderServiceImpl.java
@@ -36,9 +36,10 @@ public class OrderServiceImpl implements OrderService {
   @Override
   @TenantScoped
   @Transactional(readOnly = true)
-  public Page<OrderResponse> list(Pageable pageable) {
-    // 一覧は集約を経由せず JPQL join projection で取得（D3）
-    return orderRepository.findAllViews(pageable).map(orderMapper::toResponse);
+  public Page<OrderResponse> list(String customerId, Pageable pageable) {
+    // 一覧は集約を経由せず JPQL join projection で取得（D3）。customerId は顧客詳細の注文履歴用
+    String filter = (customerId == null || customerId.isBlank()) ? null : customerId;
+    return orderRepository.findAllViews(filter, pageable).map(orderMapper::toResponse);
   }
 
   @Override

--- a/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
@@ -37,8 +37,14 @@ public interface OrderRepository
         left join com.kizuna.user.domain.StoreUser u on u.id = o.receptionistId
       """;
 
-  @Query(value = VIEW_SELECT, countQuery = "select count(o) from com.kizuna.order.domain.Order o")
-  Page<OrderView> findAllViews(Pageable pageable);
+  @Query(
+      value = VIEW_SELECT + " where (:customerId is null or o.customerId = :customerId)",
+      countQuery =
+          """
+          select count(o) from com.kizuna.order.domain.Order o
+          where (:customerId is null or o.customerId = :customerId)
+          """)
+  Page<OrderView> findAllViews(@Param("customerId") String customerId, Pageable pageable);
 
   @Query(VIEW_SELECT + " where o.id = :id")
   Optional<OrderView> findViewById(@Param("id") String id);

--- a/backend/src/test/java/com/kizuna/customer/application/CustomerServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/customer/application/CustomerServiceImplTest.java
@@ -3,7 +3,6 @@ package com.kizuna.customer.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,12 +21,14 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 
 @ExtendWith(MockitoExtension.class)
 class CustomerServiceImplTest {
@@ -47,27 +48,31 @@ class CustomerServiceImplTest {
     CustomerResponse resp = new CustomerResponse();
     resp.setName("Test");
 
-    when(customerRepository.findByNameContainingIgnoreCase(eq("test"), any(PageRequest.class)))
+    when(customerRepository.findAll(
+            ArgumentMatchers.<Specification<Customer>>any(), any(PageRequest.class)))
         .thenReturn(page);
     when(customerMapper.toResponse(c)).thenReturn(resp);
 
-    Page<CustomerResponse> result = customerService.list("test", PageRequest.of(0, 10));
+    Page<CustomerResponse> result =
+        customerService.list("test", "GOLD", "VIP", PageRequest.of(0, 10));
     assertThat(result.getContent()).hasSize(1);
     assertThat(result.getContent().get(0).getName()).isEqualTo("Test");
   }
 
   @Test
-  void list_withoutSearch_returnsAll() {
+  void list_withoutFilters_returnsAll() {
     Customer c = Customer.builder().name("All").build();
     Page<Customer> page = new PageImpl<>(List.of(c));
 
     CustomerResponse resp = new CustomerResponse();
     resp.setName("All");
 
-    when(customerRepository.findAll(any(PageRequest.class))).thenReturn(page);
+    when(customerRepository.findAll(
+            ArgumentMatchers.<Specification<Customer>>any(), any(PageRequest.class)))
+        .thenReturn(page);
     when(customerMapper.toResponse(c)).thenReturn(resp);
 
-    Page<CustomerResponse> result = customerService.list(null, PageRequest.of(0, 10));
+    Page<CustomerResponse> result = customerService.list("", " ", null, PageRequest.of(0, 10));
     assertThat(result.getContent()).hasSize(1);
     assertThat(result.getContent().get(0).getName()).isEqualTo("All");
   }
@@ -153,7 +158,9 @@ class CustomerServiceImplTest {
     req.setName("Updated");
 
     when(customerMapper.toPatch(req))
-        .thenReturn(new CustomerPatch("Updated", null, null, null, null, null, null, null, null));
+        .thenReturn(
+            new CustomerPatch(
+                "Updated", null, null, null, null, null, null, null, null, null, null, null));
 
     CustomerResponse resp = new CustomerResponse();
     resp.setName("Updated");

--- a/backend/src/test/java/com/kizuna/customer/domain/CustomerTest.java
+++ b/backend/src/test/java/com/kizuna/customer/domain/CustomerTest.java
@@ -1,0 +1,69 @@
+package com.kizuna.customer.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class CustomerTest {
+
+  @Test
+  void apply_updatesAllFields() {
+    Customer customer =
+        Customer.builder()
+            .name("旧名")
+            .phoneNumber("090-0000-0000")
+            .phoneNumber2("080-0000-0000")
+            .address("旧住所")
+            .buildingName("旧ビル")
+            .classification("旧区分")
+            .hasPet(false)
+            .rank("SILVER")
+            .lineId("old_line")
+            .usageAreas("旧エリア")
+            .ngType("注意")
+            .ngContent("旧NG")
+            .build();
+
+    customer.apply(
+        new CustomerPatch(
+            "新名",
+            "090-1111-1111",
+            "080-1111-1111",
+            "新住所",
+            "新ビル",
+            "新区分",
+            true,
+            "GOLD",
+            "new_line",
+            "新エリア",
+            "禁止",
+            "新NG"));
+
+    assertThat(customer.getName()).isEqualTo("新名");
+    assertThat(customer.getPhoneNumber()).isEqualTo("090-1111-1111");
+    assertThat(customer.getPhoneNumber2()).isEqualTo("080-1111-1111");
+    assertThat(customer.getAddress()).isEqualTo("新住所");
+    assertThat(customer.getBuildingName()).isEqualTo("新ビル");
+    assertThat(customer.getClassification()).isEqualTo("新区分");
+    assertThat(customer.getHasPet()).isTrue();
+    assertThat(customer.getRank()).isEqualTo("GOLD");
+    assertThat(customer.getLineId()).isEqualTo("new_line");
+    assertThat(customer.getUsageAreas()).isEqualTo("新エリア");
+    assertThat(customer.getNgType()).isEqualTo("禁止");
+    assertThat(customer.getNgContent()).isEqualTo("新NG");
+  }
+
+  @Test
+  void apply_nullFieldsKeepCurrentValues() {
+    Customer customer =
+        Customer.builder().name("名前").rank("GOLD").lineId("line").hasPet(true).build();
+
+    customer.apply(
+        new CustomerPatch(null, null, null, null, null, null, null, null, null, null, null, null));
+
+    assertThat(customer.getName()).isEqualTo("名前");
+    assertThat(customer.getRank()).isEqualTo("GOLD");
+    assertThat(customer.getLineId()).isEqualTo("line");
+    assertThat(customer.getHasPet()).isTrue();
+  }
+}

--- a/backend/src/test/java/com/kizuna/order/application/OrderServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderServiceImplTest.java
@@ -3,6 +3,7 @@ package com.kizuna.order.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -65,10 +66,24 @@ class OrderServiceImplTest {
     OrderResponse res = OrderResponse.builder().id("o1").build();
     Page<OrderView> page = new PageImpl<>(List.of(view), PageRequest.of(0, 10), 1);
 
-    when(orderRepository.findAllViews(any(Pageable.class))).thenReturn(page);
+    when(orderRepository.findAllViews(eq(null), any(Pageable.class))).thenReturn(page);
     when(orderMapper.toResponse(view)).thenReturn(res);
 
-    Page<OrderResponse> result = service.list(PageRequest.of(0, 10));
+    Page<OrderResponse> result = service.list(null, PageRequest.of(0, 10));
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().get(0).getId()).isEqualTo("o1");
+  }
+
+  @Test
+  void listFiltersByCustomerId() {
+    OrderView view = mock(OrderView.class);
+    OrderResponse res = OrderResponse.builder().id("o1").build();
+    Page<OrderView> page = new PageImpl<>(List.of(view), PageRequest.of(0, 10), 1);
+
+    when(orderRepository.findAllViews(eq("c1"), any(Pageable.class))).thenReturn(page);
+    when(orderMapper.toResponse(view)).thenReturn(res);
+
+    Page<OrderResponse> result = service.list("c1", PageRequest.of(0, 10));
     assertThat(result.getContent()).hasSize(1);
     assertThat(result.getContent().get(0).getId()).isEqualTo("o1");
   }

--- a/frontend/src/_pages/store-customers/index.ts
+++ b/frontend/src/_pages/store-customers/index.ts
@@ -1,0 +1,3 @@
+export { default as CustomersPage } from './ui/CustomersPage';
+export { default as CustomerCreatePage } from './ui/CustomerCreatePage';
+export { default as CustomerEditPage } from './ui/CustomerEditPage';

--- a/frontend/src/_pages/store-customers/ui/CustomerCreatePage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerCreatePage.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { CustomerForm, CustomerFormData } from './CustomerForm';
+import { CustomerCreateRequest, customerApi } from '@/entities/customer';
+import { toast } from 'react-hot-toast';
+
+/** 新規顧客登録ページ */
+export default function CustomerCreatePage() {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (data: CustomerFormData) => {
+    try {
+      setIsSubmitting(true);
+      const requestData: CustomerCreateRequest = {
+        name: data.name,
+        phone_number: data.phone_number || undefined,
+        phone_number2: data.phone_number2 || undefined,
+        address: data.address || undefined,
+        building_name: data.building_name || undefined,
+        classification: data.classification || undefined,
+        has_pet: data.has_pet,
+        rank: data.rank || undefined,
+        line_id: data.line_id || undefined,
+        usage_areas: data.usage_areas || undefined,
+        ng_type: data.ng_type || undefined,
+        ng_content: data.ng_content || undefined,
+      };
+      await customerApi.create(requestData);
+      toast.success('顧客を登録しました');
+      router.push('/tenant/customers');
+    } catch {
+      toast.error('顧客の登録に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">新規顧客登録</h1>
+        <p className="text-sm text-gray-500 mt-1">新しい顧客情報を入力してください。</p>
+      </div>
+      <CustomerForm onSubmit={handleSubmit} isSubmitting={isSubmitting} />
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-customers/ui/CustomerCreatePage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerCreatePage.tsx
@@ -2,8 +2,8 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { CustomerForm, CustomerFormData } from './CustomerForm';
-import { CustomerCreateRequest, customerApi } from '@/entities/customer';
+import { CustomerForm, CustomerFormData, toCustomerRequest } from './CustomerForm';
+import { customerApi } from '@/entities/customer';
 import { toast } from 'react-hot-toast';
 
 /** 新規顧客登録ページ */
@@ -14,21 +14,7 @@ export default function CustomerCreatePage() {
   const handleSubmit = async (data: CustomerFormData) => {
     try {
       setIsSubmitting(true);
-      const requestData: CustomerCreateRequest = {
-        name: data.name,
-        phone_number: data.phone_number || undefined,
-        phone_number2: data.phone_number2 || undefined,
-        address: data.address || undefined,
-        building_name: data.building_name || undefined,
-        classification: data.classification || undefined,
-        has_pet: data.has_pet,
-        rank: data.rank || undefined,
-        line_id: data.line_id || undefined,
-        usage_areas: data.usage_areas || undefined,
-        ng_type: data.ng_type || undefined,
-        ng_content: data.ng_content || undefined,
-      };
-      await customerApi.create(requestData);
+      await customerApi.create(toCustomerRequest(data));
       toast.success('顧客を登録しました');
       router.push('/tenant/customers');
     } catch {

--- a/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { CustomerForm, CustomerFormData } from './CustomerForm';
+import { CustomerResponse, CustomerUpdateRequest, customerApi } from '@/entities/customer';
+import { Order, orderApi } from '@/entities/order';
+import { toast } from 'react-hot-toast';
+
+/** 顧客編集ページ（プロフィール編集 + 注文履歴） */
+export default function CustomerEditPage() {
+  const params = useParams();
+  const id = params.id as string;
+  const router = useRouter();
+  const [customer, setCustomer] = useState<CustomerResponse | null>(null);
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await customerApi.get(id);
+        setCustomer(data);
+      } catch {
+        toast.error('顧客情報の取得に失敗しました');
+        router.push('/tenant/customers');
+        return;
+      } finally {
+        setIsLoading(false);
+      }
+      try {
+        const page = await orderApi.list({ customer_id: id, size: 20, sort: 'businessDate,desc' });
+        setOrders(page.content);
+      } catch {
+        // 注文履歴が取れなくてもプロフィール編集は可能にする
+        toast.error('注文履歴の取得に失敗しました');
+      }
+    };
+    fetchData();
+  }, [id, router]);
+
+  const handleSubmit = async (data: CustomerFormData) => {
+    try {
+      setIsSubmitting(true);
+      const requestData: CustomerUpdateRequest = {
+        name: data.name,
+        phone_number: data.phone_number || undefined,
+        phone_number2: data.phone_number2 || undefined,
+        address: data.address || undefined,
+        building_name: data.building_name || undefined,
+        classification: data.classification || undefined,
+        has_pet: data.has_pet,
+        rank: data.rank || undefined,
+        line_id: data.line_id || undefined,
+        usage_areas: data.usage_areas || undefined,
+        ng_type: data.ng_type || undefined,
+        ng_content: data.ng_content || undefined,
+      };
+      await customerApi.update(id, requestData);
+      toast.success('顧客情報を更新しました');
+      router.push('/tenant/customers');
+    } catch {
+      toast.error('顧客情報の更新に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoading) {
+    return <div className="p-8 text-center text-gray-500">読み込み中...</div>;
+  }
+
+  if (!customer) return null;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">顧客編集</h1>
+          <p className="text-sm text-gray-500 mt-1">「{customer.name}」の情報を編集します。</p>
+        </div>
+        <div className="text-sm text-gray-600 bg-white px-4 py-2 rounded-md border border-gray-200">
+          保有ポイント: <span className="font-semibold">{customer.points ?? 0}</span>
+        </div>
+      </div>
+
+      <CustomerForm
+        initialData={{
+          name: customer.name,
+          phone_number: customer.phone_number || '',
+          phone_number2: customer.phone_number2 || '',
+          address: customer.address || '',
+          building_name: customer.building_name || '',
+          classification: customer.classification || '',
+          has_pet: customer.has_pet ?? false,
+          rank: customer.rank || '',
+          line_id: customer.line_id || '',
+          usage_areas: customer.usage_areas || '',
+          ng_type: customer.ng_type || '',
+          ng_content: customer.ng_content || '',
+        }}
+        onSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+      />
+
+      {/* 注文履歴 */}
+      <div className="bg-white shadow-sm border border-gray-200 rounded-lg overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-200 bg-gray-50">
+          <h3 className="text-lg font-medium text-gray-900">注文履歴</h3>
+        </div>
+        {orders.length === 0 ? (
+          <div className="p-8 text-center text-gray-500">注文履歴がありません</div>
+        ) : (
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  営業日
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  キャスト
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  コース
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  使用ポイント
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  ステータス
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {orders.map(order => (
+                <tr key={order.id} className="hover:bg-gray-50 transition-colors">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {order.business_date}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {order.cast_name || '-'}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {order.course_minutes}分
+                    {order.extension_minutes > 0 && ` (+延長${order.extension_minutes}分)`}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {order.used_points}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {order.status}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter, useParams } from 'next/navigation';
-import { CustomerForm, CustomerFormData } from './CustomerForm';
-import { CustomerResponse, CustomerUpdateRequest, customerApi } from '@/entities/customer';
+import { CustomerForm, CustomerFormData, toCustomerRequest } from './CustomerForm';
+import { CustomerResponse, customerApi } from '@/entities/customer';
 import { Order, orderApi } from '@/entities/order';
 import { toast } from 'react-hot-toast';
 
@@ -43,21 +43,7 @@ export default function CustomerEditPage() {
   const handleSubmit = async (data: CustomerFormData) => {
     try {
       setIsSubmitting(true);
-      const requestData: CustomerUpdateRequest = {
-        name: data.name,
-        phone_number: data.phone_number || undefined,
-        phone_number2: data.phone_number2 || undefined,
-        address: data.address || undefined,
-        building_name: data.building_name || undefined,
-        classification: data.classification || undefined,
-        has_pet: data.has_pet,
-        rank: data.rank || undefined,
-        line_id: data.line_id || undefined,
-        usage_areas: data.usage_areas || undefined,
-        ng_type: data.ng_type || undefined,
-        ng_content: data.ng_content || undefined,
-      };
-      await customerApi.update(id, requestData);
+      await customerApi.update(id, toCustomerRequest(data));
       toast.success('顧客情報を更新しました');
       router.push('/tenant/customers');
     } catch {

--- a/frontend/src/_pages/store-customers/ui/CustomerForm.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerForm.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
+
+/** 顧客フォームのデータ型 */
+export interface CustomerFormData {
+  name: string;
+  phone_number: string;
+  phone_number2: string;
+  address: string;
+  building_name: string;
+  classification: string;
+  has_pet: boolean;
+  rank: string;
+  line_id: string;
+  usage_areas: string;
+  ng_type: string;
+  ng_content: string;
+}
+
+interface CustomerFormProps {
+  /** 編集時の初期データ */
+  initialData?: Partial<CustomerFormData>;
+  /** フォーム送信時のコールバック */
+  onSubmit: (data: CustomerFormData) => void;
+  /** 送信中フラグ */
+  isSubmitting?: boolean;
+}
+
+/** 顧客登録・編集フォームコンポーネント */
+export function CustomerForm({ initialData, onSubmit, isSubmitting }: CustomerFormProps) {
+  const router = useRouter();
+  const { register, handleSubmit } = useForm<CustomerFormData>({
+    defaultValues: {
+      name: '',
+      phone_number: '',
+      phone_number2: '',
+      address: '',
+      building_name: '',
+      classification: '',
+      has_pet: false,
+      rank: 'SILVER',
+      line_id: '',
+      usage_areas: '',
+      ng_type: '',
+      ng_content: '',
+      ...initialData,
+    },
+  });
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="space-y-8 bg-white p-8 rounded-xl shadow-sm border border-gray-100"
+    >
+      {/* 基本情報 */}
+      <section>
+        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
+          基本情報
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">名前 *</label>
+            <input
+              type="text"
+              {...register('name', { required: true })}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">区分</label>
+            <input
+              type="text"
+              {...register('classification')}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">電話番号</label>
+            <input
+              type="tel"
+              {...register('phone_number')}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">電話番号2</label>
+            <input
+              type="tel"
+              {...register('phone_number2')}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">LINE ID</label>
+            <input
+              type="text"
+              {...register('line_id')}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">ランク</label>
+            <input
+              type="text"
+              {...register('rank')}
+              placeholder="SILVER"
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* 住所 */}
+      <section>
+        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
+          住所
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">住所</label>
+            <input
+              type="text"
+              {...register('address')}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">建物名</label>
+            <input
+              type="text"
+              {...register('building_name')}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">利用エリア</label>
+            <input
+              type="text"
+              {...register('usage_areas')}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+          <div className="flex items-end pb-2">
+            <label className="inline-flex items-center text-sm font-medium text-gray-700">
+              <input
+                type="checkbox"
+                {...register('has_pet')}
+                className="mr-2 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              ペットあり
+            </label>
+          </div>
+        </div>
+      </section>
+
+      {/* NG 情報 */}
+      <section>
+        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
+          NG 情報
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">NG タイプ</label>
+            <input
+              type="text"
+              {...register('ng_type')}
+              placeholder="注意・禁止など"
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+        </div>
+        <div className="mt-4">
+          <label className="block text-sm font-medium text-gray-700 mb-1">NG 内容</label>
+          <textarea
+            {...register('ng_content')}
+            rows={3}
+            className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          />
+        </div>
+      </section>
+
+      {/* ボタン */}
+      <div className="flex justify-end space-x-4 pt-6 border-t border-gray-100">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="px-6 py-2.5 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors"
+        >
+          キャンセル
+        </button>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="px-10 py-2.5 rounded-md bg-indigo-600 text-white font-semibold shadow-lg shadow-indigo-200 hover:bg-indigo-700 disabled:opacity-50 transition-all"
+        >
+          {isSubmitting ? '保存中...' : '保存する'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/_pages/store-customers/ui/CustomerForm.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerForm.tsx
@@ -2,6 +2,7 @@
 
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
+import { CustomerCreateRequest } from '@/entities/customer';
 
 /** 顧客フォームのデータ型 */
 export interface CustomerFormData {
@@ -17,6 +18,24 @@ export interface CustomerFormData {
   usage_areas: string;
   ng_type: string;
   ng_content: string;
+}
+
+/** フォーム値を API リクエスト形式へ変換する（空文字のフィールドは undefined に落とす） */
+export function toCustomerRequest(data: CustomerFormData): CustomerCreateRequest {
+  return {
+    name: data.name,
+    phone_number: data.phone_number || undefined,
+    phone_number2: data.phone_number2 || undefined,
+    address: data.address || undefined,
+    building_name: data.building_name || undefined,
+    classification: data.classification || undefined,
+    has_pet: data.has_pet,
+    rank: data.rank || undefined,
+    line_id: data.line_id || undefined,
+    usage_areas: data.usage_areas || undefined,
+    ng_type: data.ng_type || undefined,
+    ng_content: data.ng_content || undefined,
+  };
 }
 
 interface CustomerFormProps {

--- a/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  PlusIcon,
+  MagnifyingGlassIcon,
+  PencilSquareIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
+import { useCallback, useEffect, useState } from 'react';
+import { CustomerResponse, customerApi } from '@/entities/customer';
+import { toast } from 'react-hot-toast';
+
+/** 顧客一覧ページ */
+export default function CustomersPage() {
+  const [customers, setCustomers] = useState<CustomerResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [rank, setRank] = useState('');
+  const [classification, setClassification] = useState('');
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+
+  const fetchCustomers = useCallback(
+    async (pageNumber: number) => {
+      try {
+        setIsLoading(true);
+        const response = await customerApi.list({
+          page: pageNumber,
+          size: 20,
+          search: search || undefined,
+          rank: rank || undefined,
+          classification: classification || undefined,
+        });
+        setCustomers(response.content);
+        setTotalPages(response.total_pages);
+        setPage(response.number);
+      } catch {
+        toast.error('顧客一覧の取得に失敗しました');
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [search, rank, classification]
+  );
+
+  useEffect(() => {
+    fetchCustomers(0);
+    // 初回のみ取得。検索・絞り込みはボタン/Enter で明示的に実行する
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSearch = () => {
+    fetchCustomers(0);
+  };
+
+  const handleDelete = async (id: string, name: string) => {
+    if (!confirm(`「${name}」を削除しますか？`)) return;
+    try {
+      await customerApi.delete(id);
+      toast.success('顧客を削除しました');
+      fetchCustomers(page);
+    } catch {
+      toast.error('顧客の削除に失敗しました');
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">顧客管理</h1>
+          <p className="text-sm text-gray-500 mt-1">顧客情報の登録・編集ができます。</p>
+        </div>
+        <Link
+          href="/tenant/customers/create"
+          className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
+        >
+          <PlusIcon className="-ml-1 mr-2 h-5 w-5" />
+          新規顧客登録
+        </Link>
+      </div>
+
+      {/* 検索・絞り込みバー */}
+      <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200 flex flex-col md:flex-row md:items-center gap-4">
+        <div className="flex-1 relative">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />
+          </div>
+          <input
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && handleSearch()}
+            className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md leading-5 bg-white placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+            placeholder="名前・電話番号・LINE ID で検索..."
+          />
+        </div>
+        <input
+          type="text"
+          value={rank}
+          onChange={e => setRank(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && handleSearch()}
+          className="w-full md:w-32 px-3 py-2 border border-gray-300 rounded-md leading-5 bg-white placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+          placeholder="ランク"
+        />
+        <input
+          type="text"
+          value={classification}
+          onChange={e => setClassification(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && handleSearch()}
+          className="w-full md:w-32 px-3 py-2 border border-gray-300 rounded-md leading-5 bg-white placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+          placeholder="区分"
+        />
+        <button
+          onClick={handleSearch}
+          className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+        >
+          検索
+        </button>
+      </div>
+
+      {/* テーブル */}
+      <div className="bg-white shadow-sm border border-gray-200 rounded-lg overflow-hidden">
+        {isLoading ? (
+          <div className="p-8 text-center text-gray-500">読み込み中...</div>
+        ) : customers.length === 0 ? (
+          <div className="p-8 text-center text-gray-500">顧客が登録されていません</div>
+        ) : (
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  名前
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  電話番号
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  LINE ID
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  ランク
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  区分
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  ポイント
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  NG
+                </th>
+                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  アクション
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {customers.map(customer => (
+                <tr key={customer.id} className="hover:bg-gray-50 transition-colors">
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <div className="text-sm font-medium text-gray-900">{customer.name}</div>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {customer.phone_number || '-'}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {customer.line_id || '-'}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {customer.rank || '-'}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {customer.classification || '-'}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {customer.points ?? 0}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    {customer.ng_type ? (
+                      <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">
+                        {customer.ng_type}
+                      </span>
+                    ) : (
+                      <span className="text-sm text-gray-400">-</span>
+                    )}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-3">
+                    <Link
+                      href={`/tenant/customers/${customer.id}/edit`}
+                      className="text-gray-400 hover:text-amber-600 inline-block"
+                    >
+                      <PencilSquareIcon className="h-5 w-5" />
+                    </Link>
+                    <button
+                      onClick={() => handleDelete(customer.id, customer.name)}
+                      className="text-gray-400 hover:text-red-600"
+                    >
+                      <TrashIcon className="h-5 w-5" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* ページネーション */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center space-x-4">
+          <button
+            onClick={() => fetchCustomers(page - 1)}
+            disabled={page <= 0 || isLoading}
+            className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
+          >
+            前へ
+          </button>
+          <span className="text-sm text-gray-600">
+            {page + 1} / {totalPages} ページ
+          </span>
+          <button
+            onClick={() => fetchCustomers(page + 1)}
+            disabled={page >= totalPages - 1 || isLoading}
+            className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
+          >
+            次へ
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
@@ -28,6 +28,7 @@ export default function CustomersPage() {
         const response = await customerApi.list({
           page: pageNumber,
           size: 20,
+          sort: 'createdAt,desc',
           search: search || undefined,
           rank: rank || undefined,
           classification: classification || undefined,

--- a/frontend/src/app/tenant/customers/[id]/edit/page.tsx
+++ b/frontend/src/app/tenant/customers/[id]/edit/page.tsx
@@ -1,0 +1,1 @@
+export { CustomerEditPage as default } from '@/_pages/store-customers';

--- a/frontend/src/app/tenant/customers/create/page.tsx
+++ b/frontend/src/app/tenant/customers/create/page.tsx
@@ -1,0 +1,1 @@
+export { CustomerCreatePage as default } from '@/_pages/store-customers';

--- a/frontend/src/app/tenant/customers/page.tsx
+++ b/frontend/src/app/tenant/customers/page.tsx
@@ -1,0 +1,1 @@
+export { CustomersPage as default } from '@/_pages/store-customers';

--- a/frontend/src/entities/customer/__tests__/customer-api.test.ts
+++ b/frontend/src/entities/customer/__tests__/customer-api.test.ts
@@ -1,0 +1,32 @@
+import { customerApi } from '@/entities/customer';
+
+jest.mock('@/shared/api/client', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(async (url: string) => ({ data: { ok: true, url } })),
+    post: jest.fn(async (url: string) => ({ data: { ok: true, url } })),
+    put: jest.fn(async (url: string) => ({ data: { ok: true, url } })),
+    delete: jest.fn(async () => ({ data: undefined })),
+  },
+}));
+
+describe('customerApi', () => {
+  it('list は /tenant/customers を GET する', async () => {
+    expect(await customerApi.list()).toEqual({ ok: true, url: '/tenant/customers' });
+  });
+  it('get は /tenant/customers/:id を GET する', async () => {
+    expect(await customerApi.get('c1')).toEqual({ ok: true, url: '/tenant/customers/c1' });
+  });
+  it('create は /tenant/customers を POST する', async () => {
+    expect(await customerApi.create({ name: 'A' })).toEqual({
+      ok: true,
+      url: '/tenant/customers',
+    });
+  });
+  it('update は /tenant/customers/:id を PUT する', async () => {
+    expect(await customerApi.update('c1', {})).toEqual({ ok: true, url: '/tenant/customers/c1' });
+  });
+  it('delete は /tenant/customers/:id を DELETE する', async () => {
+    await expect(customerApi.delete('c1')).resolves.toBeUndefined();
+  });
+});

--- a/frontend/src/entities/customer/api/customer.ts
+++ b/frontend/src/entities/customer/api/customer.ts
@@ -1,0 +1,35 @@
+import { Page, PaginationParams, apiClient } from '@/shared/api';
+import { CustomerCreateRequest, CustomerResponse, CustomerUpdateRequest } from '../model/types';
+
+// 一覧のクエリ: 共通ページネーション + rank / classification の絞り込み
+export type CustomerListParams = PaginationParams & {
+  rank?: string;
+  classification?: string;
+};
+
+export const customerApi = {
+  /** 顧客一覧を取得する */
+  list: async (params?: CustomerListParams): Promise<Page<CustomerResponse>> => {
+    const response = await apiClient.get('/tenant/customers', { params });
+    return response.data;
+  },
+  /** 顧客詳細を取得する */
+  get: async (id: string): Promise<CustomerResponse> => {
+    const response = await apiClient.get(`/tenant/customers/${id}`);
+    return response.data;
+  },
+  /** 顧客を新規作成する */
+  create: async (data: CustomerCreateRequest): Promise<CustomerResponse> => {
+    const response = await apiClient.post('/tenant/customers', data);
+    return response.data;
+  },
+  /** 顧客情報を更新する */
+  update: async (id: string, data: CustomerUpdateRequest): Promise<CustomerResponse> => {
+    const response = await apiClient.put(`/tenant/customers/${id}`, data);
+    return response.data;
+  },
+  /** 顧客を削除する */
+  delete: async (id: string): Promise<void> => {
+    await apiClient.delete(`/tenant/customers/${id}`);
+  },
+};

--- a/frontend/src/entities/customer/index.ts
+++ b/frontend/src/entities/customer/index.ts
@@ -1,0 +1,3 @@
+export * from './model/types';
+export { customerApi } from './api/customer';
+export type { CustomerListParams } from './api/customer';

--- a/frontend/src/entities/customer/model/types.ts
+++ b/frontend/src/entities/customer/model/types.ts
@@ -1,0 +1,49 @@
+// 顧客（Customer）レスポンス
+export interface CustomerResponse {
+  id: string;
+  name: string;
+  phone_number?: string;
+  phone_number2?: string;
+  address?: string;
+  building_name?: string;
+  classification?: string;
+  has_pet?: boolean;
+  points?: number;
+  rank?: string;
+  line_id?: string;
+  usage_areas?: string;
+  ng_type?: string;
+  ng_content?: string;
+}
+
+// 顧客作成リクエスト
+export interface CustomerCreateRequest {
+  name: string;
+  phone_number?: string;
+  phone_number2?: string;
+  address?: string;
+  building_name?: string;
+  classification?: string;
+  has_pet?: boolean;
+  rank?: string;
+  line_id?: string;
+  usage_areas?: string;
+  ng_type?: string;
+  ng_content?: string;
+}
+
+// 顧客更新リクエスト
+export interface CustomerUpdateRequest {
+  name?: string;
+  phone_number?: string;
+  phone_number2?: string;
+  address?: string;
+  building_name?: string;
+  classification?: string;
+  has_pet?: boolean;
+  rank?: string;
+  line_id?: string;
+  usage_areas?: string;
+  ng_type?: string;
+  ng_content?: string;
+}

--- a/frontend/src/entities/order/api/order.ts
+++ b/frontend/src/entities/order/api/order.ts
@@ -2,7 +2,7 @@ import { Page, PaginationParams, apiClient } from '@/shared/api';
 import { Order, OrderCreateRequest } from '../model/types';
 
 export const orderApi = {
-  list: async (params?: PaginationParams): Promise<Page<Order>> => {
+  list: async (params?: PaginationParams & { customer_id?: string }): Promise<Page<Order>> => {
     const response = await apiClient.get('/tenant/orders', { params });
     return response.data;
   },


### PR DESCRIPTION
## Summary

Issue #167 のコア範囲を実装。方針:「既存データをすべて見える化する。新しいドメイン概念は発明しない」。

Refs #167

### Backend

- `Customer` エンティティに **rank / line_id / usage_areas** をマッピング（DB 列は既存・エンティティ未マッピングだった 3 列。rank の DB デフォルト `'SILVER'` は MapStruct `defaultValue` で両方の作成経路〈通常作成・注文経由のスマートリンク作成〉と整合）
- 検索を **名前・電話番号・LINE ID の横断**に拡張し、**rank / classification の完全一致絞り込み**を追加
  - 実装は `JpaSpecificationExecutor`。当初の JPQL `(:p is null or lower(concat('%',:p,'%')) ...)` は **PostgreSQL の null パラメータ型推論で `lower(bytea)` 500** になる（フィルタ無しのデフォルト一覧が即死する）ことを E2E で検出し、Specification に置換
- 注文一覧 `GET /tenant/orders` に `customer_id` フィルタを追加（顧客詳細の注文履歴用。既存の `findAllViews` に統合、モジュール境界は維持）

### Frontend（FSD）

- `entities/customer` slice（snake_case 型 / API / テスト）
- `_pages/store-customers`: 一覧（検索・絞り込み・前後ページネーション）/ 新規登録 / 編集（プロフィール + 保有ポイント + 注文履歴）
- `app/tenant/customers/*` 薄殻ルート。サイドバーはメニューシードが既に `/tenant/customers` を指しているため**変更不要**

### スコープ外（意図的に除外。rank / classification の件のみ CONTEXT.md open questions に記録、他は本 PR 本文が正）

- ポイント取引履歴・コミュニケーションログ・誕生日リマインダー（データモデル自体が存在しない — UI 作業ではなく新規ドメイン設計）
- 顧客セグメント・マージ・一括操作
- rank / classification の取値体系は未定義のため自由入力で暫定（正式決定後に enum + セレクトへ収斂）

- 一覧の並び順コントロール（ポイント残高ソート等）と `landmark` 列のフォーム見光は未実装 — フォローアップ issue 起票を推奨

## レビュー指摘の反映（2nd commit）

- LINE ID 検索を大文字小文字を区別しない比較に修正（`lower()`）
- 一覧デフォルトソートを `createdAt,desc` に変更（新規顧客が先頭ページに）
- Create / Edit ページの重複したリクエスト組立を `toCustomerRequest()` に抽出
- `.claude/rules/frontend.md` の entities 列挙に `customer` を追記

## Test plan

- ✅ `task lint` / `task test`（Docker = CI）
- ✅ backend: JUnit + Jacoco 全緑（`CustomerTest` で充血 `apply()` をカバー）
- ✅ frontend: Jest 22 suites / 73 tests
- ✅ API E2E（curl・実 Postgres）: 認証 → 作成（rank デフォルト）→ 横断検索（電話 / LINE ID）→ 絞り込み全組み合わせ（null 含む）→ customer_id 注文フィルタ → 削除
- ✅ ブラウザ E2E（Chrome）: ログイン → サイドバー → 一覧 → 新規登録 → LINE ID 検索 → rank 絞り込み → 編集（回填・注文履歴空状態）→ 更新反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)
