### PR TITLE
feat(user): ユーザー設定を実装 — パスワード変更（両側）+ ニックネーム編集

### DIFF
--- a/backend/src/main/java/com/kizuna/auth/api/central/CentralAuthController.java
+++ b/backend/src/main/java/com/kizuna/auth/api/central/CentralAuthController.java
@@ -2,22 +2,22 @@ package com.kizuna.auth.api.central;
 
 import com.kizuna.auth.api.dto.AdminDto;
 import com.kizuna.auth.api.dto.LoginRequest;
+import com.kizuna.auth.api.dto.PasswordChangeRequest;
 import com.kizuna.auth.api.dto.Token;
 import com.kizuna.auth.application.CentralAuthService;
-import com.kizuna.auth.infrastructure.JwtUtil;
+import com.kizuna.auth.infrastructure.TokenBlacklistService;
 import com.kizuna.user.domain.CentralUser;
 import com.kizuna.user.domain.CentralUserRepository;
 import jakarta.annotation.security.PermitAll;
 import jakarta.validation.Valid;
 import java.security.Principal;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,8 +35,7 @@ public class CentralAuthController {
 
   private final CentralAuthService authService;
   private final CentralUserRepository userRepository;
-  private final RedisTemplate<String, Object> redisTemplate;
-  private final JwtUtil jwtUtil;
+  private final TokenBlacklistService tokenBlacklistService;
 
   @PostMapping("/login")
   @PermitAll
@@ -55,26 +54,25 @@ public class CentralAuthController {
     return ResponseEntity.ok(new AdminDto(user.getId(), user.getUsername(), user.getUsername()));
   }
 
+  /** パスワード変更。成功時は現在のトークンを失効させるため、クライアントは再ログインが必要。 */
+  @PutMapping("/password")
+  @PreAuthorize("isAuthenticated()")
+  public ResponseEntity<Void> changePassword(
+      Principal principal,
+      @RequestHeader(name = "Authorization", required = false) String authHeader,
+      @Valid @RequestBody PasswordChangeRequest request) {
+    authService.changePassword(
+        principal.getName(), request.getCurrentPassword(), request.getNewPassword());
+    tokenBlacklistService.blacklist(authHeader);
+    SecurityContextHolder.clearContext();
+    return ResponseEntity.noContent().build();
+  }
+
   @PostMapping("/logout")
   @PermitAll
   public ResponseEntity<?> logout(
       @RequestHeader(name = "Authorization", required = false) String authHeader) {
-    if (authHeader != null && authHeader.startsWith("Bearer ")) {
-      String token = authHeader.substring(7);
-      try {
-        var claims = jwtUtil.getClaims(token);
-        long exp = claims.getExpiration().getTime();
-        long now = System.currentTimeMillis();
-        long ttl = Math.max(0, exp - now);
-        if (ttl > 0) {
-          redisTemplate
-              .opsForValue()
-              .set("blacklist:tokens:" + token, "1", ttl, TimeUnit.MILLISECONDS);
-        }
-      } catch (Exception e) {
-        // Token invalid or expired, ignore
-      }
-    }
+    tokenBlacklistService.blacklist(authHeader);
     SecurityContextHolder.clearContext();
     return ResponseEntity.noContent().build();
   }

--- a/backend/src/main/java/com/kizuna/auth/api/dto/PasswordChangeRequest.java
+++ b/backend/src/main/java/com/kizuna/auth/api/dto/PasswordChangeRequest.java
@@ -1,0 +1,15 @@
+package com.kizuna.auth.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class PasswordChangeRequest {
+
+  @NotBlank private String currentPassword;
+
+  @NotBlank
+  @Size(min = 8, max = 100)
+  private String newPassword;
+}

--- a/backend/src/main/java/com/kizuna/auth/api/store/AuthController.java
+++ b/backend/src/main/java/com/kizuna/auth/api/store/AuthController.java
@@ -1,17 +1,24 @@
 package com.kizuna.auth.api.store;
 
 import com.kizuna.auth.api.dto.LoginRequest;
+import com.kizuna.auth.api.dto.PasswordChangeRequest;
 import com.kizuna.auth.api.dto.TenantRegisterRequest;
 import com.kizuna.auth.api.dto.TenantRegisterResponse;
 import com.kizuna.auth.application.TenantAuthService;
+import com.kizuna.auth.infrastructure.TokenBlacklistService;
 import com.kizuna.tenant.domain.Tenant;
 import jakarta.annotation.security.PermitAll;
 import jakarta.validation.Valid;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
   private final TenantAuthService authService;
+  private final TokenBlacklistService tokenBlacklistService;
 
   @PostMapping("/login")
   @PermitAll
@@ -31,7 +39,24 @@ public class AuthController {
 
   @PostMapping("/logout")
   @PermitAll
-  public ResponseEntity<?> logout() {
+  public ResponseEntity<?> logout(
+      @RequestHeader(name = "Authorization", required = false) String authHeader) {
+    tokenBlacklistService.blacklist(authHeader);
+    SecurityContextHolder.clearContext();
+    return ResponseEntity.noContent().build();
+  }
+
+  /** パスワード変更。成功時は現在のトークンを失効させるため、クライアントは再ログインが必要。 */
+  @PutMapping("/password")
+  @PreAuthorize("isAuthenticated()")
+  public ResponseEntity<Void> changePassword(
+      Principal principal,
+      @RequestHeader(name = "Authorization", required = false) String authHeader,
+      @Valid @RequestBody PasswordChangeRequest request) {
+    authService.changePassword(
+        principal.getName(), request.getCurrentPassword(), request.getNewPassword());
+    tokenBlacklistService.blacklist(authHeader);
+    SecurityContextHolder.clearContext();
     return ResponseEntity.noContent().build();
   }
 

--- a/backend/src/main/java/com/kizuna/auth/application/CentralAuthService.java
+++ b/backend/src/main/java/com/kizuna/auth/application/CentralAuthService.java
@@ -13,4 +13,13 @@ public interface CentralAuthService {
    * @return the JWT token
    */
   Token login(String username, String password);
+
+  /**
+   * パスワードを変更する。現在のパスワードが一致しない場合は {@link com.kizuna.shared.exception.ServiceException}。
+   *
+   * @param username 対象ユーザー名
+   * @param currentPassword 現在のパスワード（平文）
+   * @param newPassword 新しいパスワード（平文）
+   */
+  void changePassword(String username, String currentPassword, String newPassword);
 }

--- a/backend/src/main/java/com/kizuna/auth/application/CentralAuthServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/auth/application/CentralAuthServiceImpl.java
@@ -2,13 +2,18 @@ package com.kizuna.auth.application;
 
 import com.kizuna.auth.api.dto.Token;
 import com.kizuna.auth.infrastructure.JwtUtil;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.user.domain.CentralUser;
+import com.kizuna.user.domain.CentralUserRepository;
 import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +21,8 @@ public class CentralAuthServiceImpl implements CentralAuthService {
 
   private final AuthenticationManager authenticationManager;
   private final JwtUtil jwtUtil;
+  private final CentralUserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
 
   @Override
   public Token login(String username, String password) {
@@ -27,5 +34,19 @@ public class CentralAuthServiceImpl implements CentralAuthService {
         Objects.requireNonNull(auth.getName()),
         JwtUtil.ISSUER_CENTRAL,
         Map.of("authorities", auth.getAuthorities().stream().map(a -> a.getAuthority()).toList()));
+  }
+
+  @Override
+  @Transactional
+  public void changePassword(String username, String currentPassword, String newPassword) {
+    CentralUser user =
+        userRepository
+            .findByUsername(username)
+            .orElseThrow(() -> new ServiceException("ユーザーが見つかりません"));
+    if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+      throw new ServiceException("現在のパスワードが正しくありません");
+    }
+    user.changePassword(passwordEncoder.encode(newPassword));
+    userRepository.save(user);
   }
 }

--- a/backend/src/main/java/com/kizuna/auth/application/TenantAuthService.java
+++ b/backend/src/main/java/com/kizuna/auth/application/TenantAuthService.java
@@ -27,4 +27,13 @@ public interface TenantAuthService {
    * @return 初期化されたテナントエンティティ
    */
   Tenant initializeAdminUser(TenantRegisterRequest tenant);
+
+  /**
+   * パスワードを変更する。現在のパスワードが一致しない場合は {@link com.kizuna.shared.exception.ServiceException}。
+   *
+   * @param email 対象ユーザーのメールアドレス
+   * @param currentPassword 現在のパスワード（平文）
+   * @param newPassword 新しいパスワード（平文）
+   */
+  void changePassword(String email, String currentPassword, String newPassword);
 }

--- a/backend/src/main/java/com/kizuna/auth/application/TenantAuthServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/auth/application/TenantAuthServiceImpl.java
@@ -4,6 +4,7 @@ import com.kizuna.auth.api.dto.TenantRegisterRequest;
 import com.kizuna.auth.api.dto.Token;
 import com.kizuna.auth.infrastructure.JwtUtil;
 import com.kizuna.shared.config.AppProperties;
+import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.tenancy.TenantContext;
 import com.kizuna.shared.tenancy.TenantScoped;
 import com.kizuna.tenant.domain.Tenant;
@@ -82,5 +83,18 @@ public class TenantAuthServiceImpl implements TenantAuthService {
     redisTemplate.delete(
         appProperties.getTenantCreatorCachePerfix() + tenantRegisterRequest.getToken());
     return tenant;
+  }
+
+  @Override
+  @Transactional
+  @TenantScoped
+  public void changePassword(String email, String currentPassword, String newPassword) {
+    StoreUser user =
+        userRepository.findByEmail(email).orElseThrow(() -> new ServiceException("ユーザーが見つかりません"));
+    if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+      throw new ServiceException("現在のパスワードが正しくありません");
+    }
+    user.changePassword(passwordEncoder.encode(newPassword));
+    userRepository.save(user);
   }
 }

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/JwtAuthenticationFilter.java
@@ -37,9 +37,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     String authHeader = request.getHeader("Authorization");
     if (StringUtils.hasText(authHeader) && authHeader.startsWith("Bearer ")) {
       String token = authHeader.substring(7);
-      Claims claims = jwtUtil.getClaims(token);
-      if (issuerMatchesDomain(claims.getIssuer(), request.getRequestURI())
-          && !redisTemplate.hasKey("blacklist:tokens:" + token)) {
+      Claims claims = parseClaims(token);
+      if (claims != null
+          && issuerMatchesDomain(claims.getIssuer(), request.getRequestURI())
+          && !redisTemplate.hasKey(TokenBlacklistService.KEY_PREFIX + token)) {
         if (new Date().before(claims.getExpiration())) {
           String username = claims.getSubject();
           List<?> authorities = claims.get("authorities", List.class);
@@ -59,6 +60,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       }
     }
     filterChain.doFilter(request, response);
+  }
+
+  /** 期限切れ・改ざん等で解析できないトークンは「未認証」として扱う（500 にしない）。 */
+  private Claims parseClaims(String token) {
+    try {
+      return jwtUtil.getClaims(token);
+    } catch (Exception e) {
+      log.debug("JWT の解析に失敗（未認証として続行）: {}", e.getMessage());
+      return null;
+    }
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/TokenBlacklistService.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/TokenBlacklistService.java
@@ -1,0 +1,45 @@
+package com.kizuna.auth.infrastructure;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * JWT を Redis のブラックリストに登録する（残存有効期間ぶんだけ保持）。 ログアウトとパスワード変更の両方から使う。判定は {@link JwtAuthenticationFilter}
+ * が行う。
+ */
+@Component
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+
+  /** Redis キーの接頭辞。判定側の {@link JwtAuthenticationFilter} と共有する。 */
+  static final String KEY_PREFIX = "blacklist:tokens:";
+
+  private final RedisTemplate<String, Object> redisTemplate;
+  private final JwtUtil jwtUtil;
+
+  /**
+   * Authorization ヘッダ値（"Bearer xxx"）または生トークンをブラックリストへ登録する。 無効・期限切れトークンは黙って無視する。
+   *
+   * @param authHeaderOrToken Authorization ヘッダ値または生トークン（null 可）
+   */
+  public void blacklist(String authHeaderOrToken) {
+    if (authHeaderOrToken == null) {
+      return;
+    }
+    String token =
+        authHeaderOrToken.startsWith("Bearer ")
+            ? authHeaderOrToken.substring(7)
+            : authHeaderOrToken;
+    try {
+      long exp = jwtUtil.getClaims(token).getExpiration().getTime();
+      long ttl = Math.max(0, exp - System.currentTimeMillis());
+      if (ttl > 0) {
+        redisTemplate.opsForValue().set(KEY_PREFIX + token, "1", ttl, TimeUnit.MILLISECONDS);
+      }
+    } catch (Exception e) {
+      // トークンが無効または期限切れ — ブラックリスト不要
+    }
+  }
+}

--- a/backend/src/main/java/com/kizuna/user/api/dto/StoreUserMeResponse.java
+++ b/backend/src/main/java/com/kizuna/user/api/dto/StoreUserMeResponse.java
@@ -1,0 +1,13 @@
+package com.kizuna.user.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StoreUserMeResponse {
+  private final String id;
+  private final String nickname;
+  private final String email;
+  private final String role;
+}

--- a/backend/src/main/java/com/kizuna/user/api/dto/StoreUserProfileUpdateRequest.java
+++ b/backend/src/main/java/com/kizuna/user/api/dto/StoreUserProfileUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.kizuna.user.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class StoreUserProfileUpdateRequest {
+
+  @NotBlank
+  @Size(max = 150)
+  private String nickname;
+}

--- a/backend/src/main/java/com/kizuna/user/api/store/StoreUserController.java
+++ b/backend/src/main/java/com/kizuna/user/api/store/StoreUserController.java
@@ -1,0 +1,38 @@
+package com.kizuna.user.api.store;
+
+import com.kizuna.user.api.dto.StoreUserMeResponse;
+import com.kizuna.user.api.dto.StoreUserProfileUpdateRequest;
+import com.kizuna.user.application.StoreUserService;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** ログイン中の店舗ユーザー自身のアカウント情報。 */
+@RestController
+@RequestMapping("/tenant/me")
+@RequiredArgsConstructor
+public class StoreUserController {
+
+  private final StoreUserService storeUserService;
+
+  @GetMapping
+  @PreAuthorize("isAuthenticated()")
+  public ResponseEntity<StoreUserMeResponse> me(Principal principal) {
+    return ResponseEntity.ok(storeUserService.me(principal.getName()));
+  }
+
+  @PutMapping
+  @PreAuthorize("isAuthenticated()")
+  public ResponseEntity<StoreUserMeResponse> updateProfile(
+      Principal principal, @Valid @RequestBody StoreUserProfileUpdateRequest request) {
+    return ResponseEntity.ok(
+        storeUserService.updateProfile(principal.getName(), request.getNickname()));
+  }
+}

--- a/backend/src/main/java/com/kizuna/user/application/StoreUserService.java
+++ b/backend/src/main/java/com/kizuna/user/application/StoreUserService.java
@@ -1,0 +1,22 @@
+package com.kizuna.user.application;
+
+import com.kizuna.user.api.dto.StoreUserMeResponse;
+
+/** 店舗ユーザー自身のアカウント操作サービス。 */
+public interface StoreUserService {
+
+  /**
+   * ログイン中ユーザーの情報を返す。
+   *
+   * @param email 対象ユーザーのメールアドレス（Principal 名）
+   */
+  StoreUserMeResponse me(String email);
+
+  /**
+   * ログイン中ユーザーのニックネームを変更する。
+   *
+   * @param email 対象ユーザーのメールアドレス（Principal 名）
+   * @param nickname 新しいニックネーム
+   */
+  StoreUserMeResponse updateProfile(String email, String nickname);
+}

--- a/backend/src/main/java/com/kizuna/user/application/StoreUserServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/user/application/StoreUserServiceImpl.java
@@ -1,0 +1,45 @@
+package com.kizuna.user.application;
+
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.tenancy.TenantScoped;
+import com.kizuna.user.api.dto.StoreUserMeResponse;
+import com.kizuna.user.domain.StoreUser;
+import com.kizuna.user.domain.StoreUserRepository;
+import com.kizuna.user.domain.TenantRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StoreUserServiceImpl implements StoreUserService {
+
+  private final StoreUserRepository userRepository;
+
+  @Override
+  @TenantScoped
+  @Transactional(readOnly = true)
+  public StoreUserMeResponse me(String email) {
+    return toResponse(findByEmail(email));
+  }
+
+  @Override
+  @TenantScoped
+  @Transactional
+  public StoreUserMeResponse updateProfile(String email, String nickname) {
+    StoreUser user = findByEmail(email);
+    user.rename(nickname);
+    return toResponse(userRepository.save(user));
+  }
+
+  private StoreUser findByEmail(String email) {
+    return userRepository
+        .findByEmail(email)
+        .orElseThrow(() -> new ServiceException("ユーザーが見つかりません"));
+  }
+
+  private static StoreUserMeResponse toResponse(StoreUser user) {
+    String role = user.getRoles().stream().findFirst().map(TenantRole::getName).orElse("");
+    return new StoreUserMeResponse(user.getId(), user.getNickname(), user.getEmail(), role);
+  }
+}

--- a/backend/src/main/java/com/kizuna/user/domain/CentralUser.java
+++ b/backend/src/main/java/com/kizuna/user/domain/CentralUser.java
@@ -38,4 +38,9 @@ public class CentralUser extends BaseEntity {
       joinColumns = @JoinColumn(name = "user_id"),
       inverseJoinColumns = @JoinColumn(name = "role_id"))
   private Set<CentralRole> roles = new HashSet<>();
+
+  /** パスワードを更新する。エンコード済みの値を渡すこと（検証は application 層の責務）。 */
+  public void changePassword(String encodedPassword) {
+    this.password = encodedPassword;
+  }
 }

--- a/backend/src/main/java/com/kizuna/user/domain/StoreUser.java
+++ b/backend/src/main/java/com/kizuna/user/domain/StoreUser.java
@@ -45,4 +45,14 @@ public class StoreUser extends TenantScopedEntity {
       joinColumns = @JoinColumn(name = "user_id"),
       inverseJoinColumns = @JoinColumn(name = "role_id"))
   private Set<TenantRole> roles = new HashSet<>();
+
+  /** パスワードを更新する。エンコード済みの値を渡すこと（検証は application 層の責務）。 */
+  public void changePassword(String encodedPassword) {
+    this.password = encodedPassword;
+  }
+
+  /** ニックネームを変更する。 */
+  public void rename(String nickname) {
+    this.nickname = nickname;
+  }
 }

--- a/backend/src/test/java/com/kizuna/auth/application/CentralAuthServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/auth/application/CentralAuthServiceImplTest.java
@@ -6,11 +6,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.kizuna.auth.api.dto.Token;
 import com.kizuna.auth.infrastructure.JwtUtil;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.user.domain.CentralUser;
+import com.kizuna.user.domain.CentralUserRepository;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,12 +24,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
 class CentralAuthServiceImplTest {
 
   @Mock private AuthenticationManager authenticationManager;
   @Mock private JwtUtil jwtUtil;
+  @Mock private CentralUserRepository userRepository;
+  @Mock private PasswordEncoder passwordEncoder;
 
   @InjectMocks private CentralAuthServiceImpl authService;
 
@@ -46,5 +55,44 @@ class CentralAuthServiceImplTest {
   void login_failure_throwsException() {
     when(authenticationManager.authenticate(any())).thenThrow(new RuntimeException("Bad"));
     assertThatThrownBy(() -> authService.login("bad", "pass")).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  void changePassword_success_savesEncodedPassword() {
+    CentralUser user = new CentralUser();
+    user.setUsername("admin");
+    user.setPassword("test-placeholder-stored-hash");
+
+    when(userRepository.findByUsername("admin")).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches("current", "test-placeholder-stored-hash")).thenReturn(true);
+    when(passwordEncoder.encode("newpass123")).thenReturn("test-placeholder-encoded-hash");
+
+    authService.changePassword("admin", "current", "newpass123");
+
+    assertThat(user.getPassword()).isEqualTo("test-placeholder-encoded-hash");
+    verify(userRepository).save(user);
+  }
+
+  @Test
+  void changePassword_wrongCurrentPassword_throws() {
+    CentralUser user = new CentralUser();
+    user.setPassword("test-placeholder-stored-hash");
+
+    when(userRepository.findByUsername("admin")).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches("wrong", "test-placeholder-stored-hash")).thenReturn(false);
+
+    assertThatThrownBy(() -> authService.changePassword("admin", "wrong", "newpass123"))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("現在のパスワードが正しくありません");
+    verify(userRepository, never()).save(any());
+  }
+
+  @Test
+  void changePassword_userNotFound_throws() {
+    when(userRepository.findByUsername("missing")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> authService.changePassword("missing", "current", "newpass123"))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("ユーザーが見つかりません");
   }
 }

--- a/backend/src/test/java/com/kizuna/auth/application/TenantAuthServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/auth/application/TenantAuthServiceImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,9 +14,11 @@ import com.kizuna.auth.api.dto.TenantRegisterRequest;
 import com.kizuna.auth.api.dto.Token;
 import com.kizuna.auth.infrastructure.JwtUtil;
 import com.kizuna.shared.config.AppProperties;
+import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.tenancy.TenantContext;
 import com.kizuna.tenant.domain.Tenant;
 import com.kizuna.tenant.domain.TenantRepository;
+import com.kizuna.user.domain.StoreUser;
 import com.kizuna.user.domain.StoreUserRepository;
 import java.util.List;
 import java.util.Map;
@@ -134,5 +137,45 @@ class TenantAuthServiceImplTest {
 
     assertThatThrownBy(() -> authService.initializeAdminUser(req))
         .isInstanceOf(NoSuchElementException.class);
+  }
+
+  @Test
+  void changePassword_success_savesEncodedPassword() {
+    StoreUser user = new StoreUser();
+    user.setEmail("staff@store1.kizuna.com");
+    user.setPassword("test-placeholder-stored-hash");
+
+    when(userRepository.findByEmail("staff@store1.kizuna.com")).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches("current", "test-placeholder-stored-hash")).thenReturn(true);
+    when(passwordEncoder.encode("newpass123")).thenReturn("test-placeholder-encoded-hash");
+
+    authService.changePassword("staff@store1.kizuna.com", "current", "newpass123");
+
+    assertThat(user.getPassword()).isEqualTo("test-placeholder-encoded-hash");
+    verify(userRepository).save(user);
+  }
+
+  @Test
+  void changePassword_wrongCurrentPassword_throws() {
+    StoreUser user = new StoreUser();
+    user.setPassword("test-placeholder-stored-hash");
+
+    when(userRepository.findByEmail("staff@store1.kizuna.com")).thenReturn(Optional.of(user));
+    when(passwordEncoder.matches("wrong", "test-placeholder-stored-hash")).thenReturn(false);
+
+    assertThatThrownBy(
+            () -> authService.changePassword("staff@store1.kizuna.com", "wrong", "newpass123"))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("現在のパスワードが正しくありません");
+    verify(userRepository, never()).save(any());
+  }
+
+  @Test
+  void changePassword_userNotFound_throws() {
+    when(userRepository.findByEmail("missing@x.com")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> authService.changePassword("missing@x.com", "current", "newpass123"))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("ユーザーが見つかりません");
   }
 }

--- a/backend/src/test/java/com/kizuna/user/application/StoreUserServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/StoreUserServiceImplTest.java
@@ -1,0 +1,70 @@
+package com.kizuna.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.user.api.dto.StoreUserMeResponse;
+import com.kizuna.user.domain.StoreUser;
+import com.kizuna.user.domain.StoreUserRepository;
+import com.kizuna.user.domain.TenantRole;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StoreUserServiceImplTest {
+
+  @Mock private StoreUserRepository userRepository;
+
+  @InjectMocks private StoreUserServiceImpl service;
+
+  private StoreUser user(String nickname) {
+    StoreUser user = new StoreUser();
+    user.setId("u1");
+    user.setNickname(nickname);
+    user.setEmail("staff@store1.kizuna.com");
+    TenantRole role = new TenantRole();
+    role.setName("ADMIN");
+    user.setRoles(Set.of(role));
+    return user;
+  }
+
+  @Test
+  void me_returnsCurrentUser() {
+    when(userRepository.findByEmail("staff@store1.kizuna.com"))
+        .thenReturn(Optional.of(user("スタッフA")));
+
+    StoreUserMeResponse res = service.me("staff@store1.kizuna.com");
+
+    assertThat(res.getNickname()).isEqualTo("スタッフA");
+    assertThat(res.getEmail()).isEqualTo("staff@store1.kizuna.com");
+    assertThat(res.getRole()).isEqualTo("ADMIN");
+  }
+
+  @Test
+  void me_userNotFound_throws() {
+    when(userRepository.findByEmail("missing@x.com")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.me("missing@x.com"))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("ユーザーが見つかりません");
+  }
+
+  @Test
+  void updateProfile_renamesAndSaves() {
+    StoreUser u = user("旧名");
+    when(userRepository.findByEmail("staff@store1.kizuna.com")).thenReturn(Optional.of(u));
+    when(userRepository.save(u)).thenReturn(u);
+
+    StoreUserMeResponse res = service.updateProfile("staff@store1.kizuna.com", "新名");
+
+    assertThat(u.getNickname()).isEqualTo("新名");
+    assertThat(res.getNickname()).isEqualTo("新名");
+  }
+}

--- a/frontend/src/_pages/central-settings/index.ts
+++ b/frontend/src/_pages/central-settings/index.ts
@@ -1,1 +1,2 @@
 export { default as SettingsPage } from './ui/SettingsPage';
+export { default as CentralAccountPage } from './ui/AccountPage';

--- a/frontend/src/_pages/central-settings/ui/AccountPage.tsx
+++ b/frontend/src/_pages/central-settings/ui/AccountPage.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { PasswordChangeForm } from '@/features/password-change';
+
+/** アカウント設定ページ（パスワード変更） */
+export default function AccountPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">アカウント設定</h1>
+        <p className="text-sm text-gray-500 mt-1">自分のパスワードを管理します。</p>
+      </div>
+      <PasswordChangeForm />
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-settings/index.ts
+++ b/frontend/src/_pages/store-settings/index.ts
@@ -1,1 +1,2 @@
 export { default as StoreProfilePage } from './ui/ProfilePage';
+export { default as StoreAccountPage } from './ui/AccountPage';

--- a/frontend/src/_pages/store-settings/ui/AccountPage.tsx
+++ b/frontend/src/_pages/store-settings/ui/AccountPage.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { storeAuthApi } from '@/entities/user';
+import { PasswordChangeForm } from '@/features/password-change';
+
+/** アカウント設定ページ（プロフィール + パスワード変更） */
+export default function AccountPage() {
+  const [nickname, setNickname] = useState('');
+  const [email, setEmail] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    const fetchMe = async () => {
+      try {
+        const me = await storeAuthApi.me();
+        setNickname(me.nickname);
+        setEmail(me.email);
+      } catch {
+        toast.error('アカウント情報の取得に失敗しました');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchMe();
+  }, []);
+
+  const handleProfileSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      const me = await storeAuthApi.updateMe({ nickname });
+      setNickname(me.nickname);
+      toast.success('プロフィールを更新しました');
+    } catch {
+      toast.error('プロフィールの更新に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoading) {
+    return <div className="p-8 text-center text-gray-500">読み込み中...</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">アカウント設定</h1>
+        <p className="text-sm text-gray-500 mt-1">自分のプロフィールとパスワードを管理します。</p>
+      </div>
+
+      {/* プロフィール */}
+      <form
+        onSubmit={handleProfileSubmit}
+        className="bg-white p-8 rounded-xl shadow-sm border border-gray-100 space-y-6"
+      >
+        <h3 className="text-lg font-semibold text-gray-900 border-l-4 border-indigo-500 pl-3">
+          プロフィール
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              メールアドレス（ログインID）
+            </label>
+            <input
+              type="email"
+              value={email}
+              disabled
+              className="w-full rounded-md border-gray-300 bg-gray-50 text-gray-500 shadow-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">ニックネーム *</label>
+            <input
+              type="text"
+              value={nickname}
+              onChange={e => setNickname(e.target.value)}
+              required
+              maxLength={150}
+              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+        </div>
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="px-10 py-2.5 rounded-md bg-indigo-600 text-white font-semibold shadow-lg shadow-indigo-200 hover:bg-indigo-700 disabled:opacity-50 transition-all"
+          >
+            {isSubmitting ? '保存中...' : '保存する'}
+          </button>
+        </div>
+      </form>
+
+      <PasswordChangeForm />
+    </div>
+  );
+}

--- a/frontend/src/app/central/settings/account/page.tsx
+++ b/frontend/src/app/central/settings/account/page.tsx
@@ -1,0 +1,1 @@
+export { CentralAccountPage as default } from '@/_pages/central-settings';

--- a/frontend/src/app/tenant/settings/account/page.tsx
+++ b/frontend/src/app/tenant/settings/account/page.tsx
@@ -1,0 +1,1 @@
+export { StoreAccountPage as default } from '@/_pages/store-settings';

--- a/frontend/src/entities/user/__tests__/central-auth-api.test.ts
+++ b/frontend/src/entities/user/__tests__/central-auth-api.test.ts
@@ -1,0 +1,25 @@
+import { centralAuthApi } from '@/entities/user';
+
+jest.mock('@/shared/api/client', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(async (url: string) => ({ data: { ok: true, url } })),
+    put: jest.fn(async () => ({ data: undefined })),
+    post: jest.fn(async (url: string) => ({ data: { ok: true, url } })),
+  },
+}));
+
+describe('central api', () => {
+  it('me calls /central/me', async () => {
+    const res = await centralAuthApi.me();
+    expect(res).toEqual({ ok: true, url: '/central/me' });
+  });
+  it('changePassword PUTs /central/password', async () => {
+    await expect(
+      centralAuthApi.changePassword({ current_password: 'a', new_password: 'b' })
+    ).resolves.toBeUndefined();
+  });
+  it('logout POSTs /central/logout', async () => {
+    await expect(centralAuthApi.logout()).resolves.toBeUndefined();
+  });
+});

--- a/frontend/src/entities/user/__tests__/store-auth-api.test.ts
+++ b/frontend/src/entities/user/__tests__/store-auth-api.test.ts
@@ -4,6 +4,7 @@ jest.mock('@/shared/api/client', () => ({
   __esModule: true,
   default: {
     get: jest.fn(async (url: string) => ({ data: { ok: true, url } })),
+    put: jest.fn(async (url: string) => ({ data: { ok: true, url } })),
     post: jest.fn(async (url: string, _data?: any) => ({
       data:
         url === '/tenant/init-admin-use'
@@ -35,5 +36,14 @@ describe('tenant api', () => {
   it('me calls /tenant/me', async () => {
     const res = await storeAuthApi.me();
     expect(res).toEqual({ ok: true, url: '/tenant/me' });
+  });
+  it('updateMe PUTs /tenant/me', async () => {
+    const res = await storeAuthApi.updateMe({ nickname: 'A' });
+    expect(res).toEqual({ ok: true, url: '/tenant/me' });
+  });
+  it('changePassword PUTs /tenant/password', async () => {
+    await expect(
+      storeAuthApi.changePassword({ current_password: 'a', new_password: 'b' })
+    ).resolves.toBeUndefined();
   });
 });

--- a/frontend/src/entities/user/api/central.ts
+++ b/frontend/src/entities/user/api/central.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '@/shared/api';
-import { Admin, LoginRequest, LoginResponse } from '../model/types';
+import { Admin, LoginRequest, LoginResponse, PasswordChangeRequest } from '../model/types';
 
 export const centralAuthApi = {
   login: async (credentials: LoginRequest): Promise<LoginResponse> => {
@@ -14,5 +14,9 @@ export const centralAuthApi = {
 
   logout: async (): Promise<void> => {
     await apiClient.post('/central/logout');
+  },
+
+  changePassword: async (data: PasswordChangeRequest): Promise<void> => {
+    await apiClient.put('/central/password', data);
   },
 };

--- a/frontend/src/entities/user/api/store.ts
+++ b/frontend/src/entities/user/api/store.ts
@@ -2,8 +2,10 @@ import { apiClient } from '@/shared/api';
 import {
   LoginRequest,
   LoginResponse,
+  PasswordChangeRequest,
   RegisterRequest,
   RegisterResponse,
+  StoreUserProfileUpdateRequest,
   StoreUserResponse,
 } from '../model/types';
 
@@ -22,5 +24,12 @@ export const storeAuthApi = {
   me: async (): Promise<StoreUserResponse> => {
     const response = await apiClient.get('/tenant/me');
     return response.data;
+  },
+  updateMe: async (data: StoreUserProfileUpdateRequest): Promise<StoreUserResponse> => {
+    const response = await apiClient.put('/tenant/me', data);
+    return response.data;
+  },
+  changePassword: async (data: PasswordChangeRequest): Promise<void> => {
+    await apiClient.put('/tenant/password', data);
   },
 };

--- a/frontend/src/entities/user/model/types.ts
+++ b/frontend/src/entities/user/model/types.ts
@@ -13,6 +13,17 @@ export interface StoreUserResponse {
   role: string;
 }
 
+// パスワード変更リクエスト
+export interface PasswordChangeRequest {
+  current_password: string;
+  new_password: string;
+}
+
+// 店舗ユーザーのプロフィール更新リクエスト
+export interface StoreUserProfileUpdateRequest {
+  nickname: string;
+}
+
 // ログインリクエスト
 export interface LoginRequest {
   username: string;

--- a/frontend/src/features/password-change/index.ts
+++ b/frontend/src/features/password-change/index.ts
@@ -1,0 +1,1 @@
+export { PasswordChangeForm } from './ui/PasswordChangeForm';

--- a/frontend/src/features/password-change/ui/PasswordChangeForm.tsx
+++ b/frontend/src/features/password-change/ui/PasswordChangeForm.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { centralAuthApi, storeAuthApi, useAuth } from '@/entities/user';
+import { isTenantDomain } from '@/shared/lib';
+
+// axios エラーからサーバーのバリデーションメッセージを取り出す
+function errorMessage(error: unknown): string {
+  if (error && typeof error === 'object' && 'response' in error) {
+    const data = (error as { response?: { data?: { error?: string } } }).response?.data;
+    if (data?.error) return data.error;
+  }
+  return 'パスワードの変更に失敗しました';
+}
+
+/** パスワード変更フォーム。成功するとトークンが失効するため、ログアウトして再ログインを促す。 */
+export function PasswordChangeForm() {
+  const { logout } = useAuth();
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (newPassword !== confirmPassword) {
+      toast.error('新しいパスワードが一致しません');
+      return;
+    }
+    if (newPassword.length < 8) {
+      toast.error('新しいパスワードは8文字以上で入力してください');
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const api = isTenantDomain() ? storeAuthApi : centralAuthApi;
+      await api.changePassword({
+        current_password: currentPassword,
+        new_password: newPassword,
+      });
+      toast.success('パスワードを変更しました。再度ログインしてください');
+      logout();
+    } catch (error) {
+      toast.error(errorMessage(error));
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-white p-8 rounded-xl shadow-sm border border-gray-100 space-y-6"
+    >
+      <h3 className="text-lg font-semibold text-gray-900 border-l-4 border-indigo-500 pl-3">
+        パスワード変更
+      </h3>
+      <p className="text-sm text-gray-500">
+        変更後は自動的にログアウトされ、新しいパスワードでの再ログインが必要です。
+      </p>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">現在のパスワード *</label>
+          <input
+            type="password"
+            value={currentPassword}
+            onChange={e => setCurrentPassword(e.target.value)}
+            required
+            autoComplete="current-password"
+            className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            新しいパスワード（8文字以上）*
+          </label>
+          <input
+            type="password"
+            value={newPassword}
+            onChange={e => setNewPassword(e.target.value)}
+            required
+            minLength={8}
+            autoComplete="new-password"
+            className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            新しいパスワード（確認）*
+          </label>
+          <input
+            type="password"
+            value={confirmPassword}
+            onChange={e => setConfirmPassword(e.target.value)}
+            required
+            minLength={8}
+            autoComplete="new-password"
+            className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+          />
+        </div>
+      </div>
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="px-10 py-2.5 rounded-md bg-indigo-600 text-white font-semibold shadow-lg shadow-indigo-200 hover:bg-indigo-700 disabled:opacity-50 transition-all"
+        >
+          {isSubmitting ? '変更中...' : 'パスワードを変更する'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/widgets/header/ui/Header.tsx
+++ b/frontend/src/widgets/header/ui/Header.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import Link from 'next/link';
 import { useAuth } from '@/entities/user';
+import { isTenantDomain } from '@/shared/lib';
 import { BellIcon, UserCircleIcon } from '@heroicons/react/24/outline';
 
 export function Header() {
   const { logout } = useAuth();
+  const accountHref = isTenantDomain() ? '/tenant/settings/account' : '/central/settings/account';
 
   return (
     <header className="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-8 sticky top-0 z-20">
@@ -30,6 +33,12 @@ export function Header() {
               <UserCircleIcon className="h-8 w-8 text-gray-400 group-hover:text-indigo-500 transition-colors" />
             </button>
             <div className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 border border-gray-100 hidden group-hover:block transition-all duration-200 opacity-0 group-hover:opacity-100 scale-95 group-hover:scale-100 origin-top-right">
+              <Link
+                href={accountHref}
+                className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+              >
+                アカウント設定
+              </Link>
               <button
                 onClick={logout}
                 className="block w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-red-50"


### PR DESCRIPTION
## Summary

Issue #170 の **User Settings スライス**（合意済みスコープ: 両側パスワード変更 + Store ニックネーム編集。CentralUser のプロフィール編集は username=ログインID のため対象外、email 変更は検証フローが必要なため別課題）。

Refs #170

### Backend

- **パスワード変更** `PUT /central/password` / `PUT /tenant/password` — 現在のパスワード検証（不一致は 400 + メッセージ）→ エンコード保存 → **現在の JWT をブラックリスト登録**（クライアントは再ログイン）
- **TokenBlacklistService** を抽出（central logout のインライン実装を集約、KEY_PREFIX は filter と共有）
- **store logout の no-op を修復** — 従来はトークンを失効させず 204 を返すだけだった（既存の安全ギャップ）
- **user モジュールに初の api 層**: `GET/PUT /tenant/me`。フロントの `storeAuthApi.me()` が呼んでいた**未実装エンドポイントの断裂を解消**。ニックネーム変更は `StoreUser.rename()` 行動メソッド
- **期限切れ JWT で全リクエスト 500 になる既存バグを修復** — `JwtAuthenticationFilter` が解析例外を捕捉せず ExpiredJwtException がそのまま 500 化していた（一晩放置したタブが全滅する挙動）。解析失敗 = 未認証として続行に変更

### Frontend（FSD）

- `features/password-change` — 両作用域共用フォーム（`isTenantDomain()` で API 分岐、確認入力・8文字チェック、成功時は logout → 再ログイン誘導）
- Store アカウント設定ページ（プロフィール + パスワード変更）/ Central アカウント設定ページ + 薄殻ルート
- Header ドロップダウンに「アカウント設定」（DB メニューシード変更不要）

### 既知の注意点

- 新パスワードは `@Size(min=8)`。**シードの `pass`（4文字）は新ポリシー未満**のため、一度変更すると API 経由で戻せない。シードパスワードの更新（+README 同期）は別課題として起票推奨

## Test plan

- ✅ 単体: changePassword 成功/現在PW不一致/ユーザー不在（両側）、me/rename、既存 auth テスト全緑
- ✅ `task lint` / `task test`（Docker = CI）
- ✅ API E2E（curl・実スタック）10 手順: ログイン → me → ニックネーム変更 → 誤PW 400 → 変更 204 → **旧トークン即 403** → 旧PWログイン失敗 → 新PWログイン成功 → logout 後トークン失効 → シード状態復元
- ✅ ブラウザ E2E: ログイン → ドロップダウン → アカウント設定 → 回填確認 → ニックネーム変更成功トースト → 誤PW でサーバメッセージのトースト表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)