### PR TITLE
refactor(frontend): 一覧ページの取得ライフサイクルとエラー抽出を shared/lib へ集約（PR-C）

### DIFF
--- a/frontend/src/_pages/central-settings/ui/SettingsPage.tsx
+++ b/frontend/src/_pages/central-settings/ui/SettingsPage.tsx
@@ -7,19 +7,11 @@ import {
   SystemConfigUpdateRequest,
   systemConfigService,
 } from '@/entities/system-config';
+import { getApiErrorMessage } from '@/shared/lib';
 
 type ConfigGroup = {
   [category: string]: SystemConfigResponse[];
 };
-
-// axios エラーからサーバーのバリデーションメッセージを取り出す
-function errorMessage(error: unknown): string {
-  if (error && typeof error === 'object' && 'response' in error) {
-    const data = (error as { response?: { data?: { error?: string } } }).response?.data;
-    if (data?.error) return data.error;
-  }
-  return '設定の更新に失敗しました';
-}
 
 export default function SystemSettingsPage() {
   const [configs, setConfigs] = useState<SystemConfigResponse[]>([]);
@@ -62,7 +54,7 @@ export default function SystemSettingsPage() {
       await saveConfig(config.config_key, config.config_value === 'true' ? 'false' : 'true');
     } catch (error) {
       console.error('設定の更新に失敗しました', error);
-      toast.error(errorMessage(error));
+      toast.error(getApiErrorMessage(error, '設定の更新に失敗しました'));
     } finally {
       setSaving(false);
     }
@@ -87,7 +79,7 @@ export default function SystemSettingsPage() {
       setEditingKey(null);
     } catch (error) {
       console.error('設定の更新に失敗しました', error);
-      toast.error(errorMessage(error));
+      toast.error(getApiErrorMessage(error, '設定の更新に失敗しました'));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/_pages/store-casts/ui/CastsPage.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastsPage.tsx
@@ -8,40 +8,29 @@ import {
   PencilSquareIcon,
   TrashIcon,
 } from '@heroicons/react/24/outline';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { CastResponse, castApi } from '@/entities/cast';
+import { useManagedList } from '@/shared/lib';
 import { toast } from 'react-hot-toast';
 
 /** キャスト一覧ページ */
 export default function CastListPage() {
-  const [casts, setCasts] = useState<CastResponse[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [search, setSearch] = useState('');
-
-  useEffect(() => {
-    fetchCasts();
-  }, []);
-
-  /** キャスト一覧を取得する */
-  const fetchCasts = async (searchQuery?: string) => {
-    try {
-      setIsLoading(true);
-      const response = await castApi.list({
-        size: 100,
-        sort: 'displayOrder,asc',
-        search: searchQuery || undefined,
-      });
-      setCasts(response.content);
-    } catch {
-      toast.error('キャスト一覧の取得に失敗しました');
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const {
+    items: casts,
+    isLoading,
+    refetch,
+  } = useManagedList<CastResponse>(
+    () =>
+      castApi
+        .list({ size: 100, sort: 'displayOrder,asc', search: search || undefined })
+        .then(page => page.content),
+    'キャスト一覧の取得に失敗しました'
+  );
 
   /** 検索を実行する */
   const handleSearch = () => {
-    fetchCasts(search);
+    void refetch();
   };
 
   /** キャストを削除する */
@@ -50,7 +39,7 @@ export default function CastListPage() {
     try {
       await castApi.delete(id);
       toast.success('キャストを削除しました');
-      fetchCasts(search);
+      void refetch();
     } catch {
       toast.error('キャストの削除に失敗しました');
     }

--- a/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
@@ -1,37 +1,15 @@
 'use client';
 
 import Link from 'next/link';
-import {
-  PlusIcon,
-  MagnifyingGlassIcon,
-  PencilSquareIcon,
-  TrashIcon,
-  EyeIcon,
-} from '@heroicons/react/24/outline';
-import { useEffect, useState } from 'react';
+import { PlusIcon, PencilSquareIcon } from '@heroicons/react/24/outline';
 import { Order, orderApi } from '@/entities/order';
-import { toast } from 'react-hot-toast';
+import { useManagedList } from '@/shared/lib';
 
 export default function OrderListPage() {
-  const [orders, setOrders] = useState<Order[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    fetchOrders();
-  }, []);
-
-  const fetchOrders = async () => {
-    try {
-      setIsLoading(true);
-      const response = await orderApi.list({ size: 100, sort: 'createdAt,desc' });
-      setOrders(response.content);
-    } catch (error) {
-      console.error(error);
-      toast.error('オーダーの取得に失敗しました');
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const { items: orders, isLoading } = useManagedList<Order>(
+    () => orderApi.list({ size: 100, sort: 'createdAt,desc' }).then(page => page.content),
+    'オーダーの取得に失敗しました'
+  );
 
   return (
     <div className="space-y-6">
@@ -47,23 +25,6 @@ export default function OrderListPage() {
           <PlusIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
           新規オーダー登録
         </Link>
-      </div>
-
-      {/* Search Bar */}
-      <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200 flex items-center space-x-4">
-        <div className="flex-1 relative">
-          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />
-          </div>
-          <input
-            type="text"
-            className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md leading-5 bg-white placeholder-gray-500 focus:outline-none focus:placeholder-gray-400 focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-            placeholder="電話番号、お客様名で検索..."
-          />
-        </div>
-        <button className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
-          検索
-        </button>
       </div>
 
       {/* Orders Table */}
@@ -126,18 +87,12 @@ export default function OrderListPage() {
                     </span>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-3">
-                    <button className="text-gray-400 hover:text-indigo-600">
-                      <EyeIcon className="h-5 w-5" />
-                    </button>
                     <Link
                       href={`/tenant/orders/${order.id}/edit`}
                       className="text-gray-400 hover:text-amber-600 inline-block"
                     >
                       <PencilSquareIcon className="h-5 w-5" />
                     </Link>
-                    <button className="text-gray-400 hover:text-red-600">
-                      <TrashIcon className="h-5 w-5" />
-                    </button>
                   </td>
                 </tr>
               ))}

--- a/frontend/src/features/password-change/ui/PasswordChangeForm.tsx
+++ b/frontend/src/features/password-change/ui/PasswordChangeForm.tsx
@@ -3,16 +3,7 @@
 import { useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { centralAuthApi, storeAuthApi, useAuth } from '@/entities/user';
-import { isTenantDomain } from '@/shared/lib';
-
-// axios エラーからサーバーのバリデーションメッセージを取り出す
-function errorMessage(error: unknown): string {
-  if (error && typeof error === 'object' && 'response' in error) {
-    const data = (error as { response?: { data?: { error?: string } } }).response?.data;
-    if (data?.error) return data.error;
-  }
-  return 'パスワードの変更に失敗しました';
-}
+import { getApiErrorMessage, isTenantDomain } from '@/shared/lib';
 
 /** パスワード変更フォーム。成功するとトークンが失効するため、ログアウトして再ログインを促す。 */
 export function PasswordChangeForm() {
@@ -42,7 +33,7 @@ export function PasswordChangeForm() {
       toast.success('パスワードを変更しました。再度ログインしてください');
       logout();
     } catch (error) {
-      toast.error(errorMessage(error));
+      toast.error(getApiErrorMessage(error, 'パスワードの変更に失敗しました'));
       setIsSubmitting(false);
     }
   };

--- a/frontend/src/features/tenant-register/ui/RegisterForm.tsx
+++ b/frontend/src/features/tenant-register/ui/RegisterForm.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { storeAuthApi } from '@/entities/user';
-import { isTenantDomain } from '@/shared/lib';
+import { getApiErrorMessage, isTenantDomain } from '@/shared/lib';
 import { AuthLayout } from '@/shared/ui';
 
 /** テナント初期管理者の登録動作。 */
@@ -82,10 +82,12 @@ export default function RegisterForm() {
       setTimeout(navigate, 1500);
     } catch (err) {
       console.error('テナント登録に失敗', err);
-      const message =
-        (err as any)?.response?.data?.message ||
-        '登録に失敗しました。リンクの有効期限や入力内容をご確認のうえ、必要に応じてサポートへご連絡ください。';
-      setError(message);
+      setError(
+        getApiErrorMessage(
+          err,
+          '登録に失敗しました。リンクの有効期限や入力内容をご確認のうえ、必要に応じてサポートへご連絡ください。'
+        )
+      );
     }
   };
 

--- a/frontend/src/shared/lib/__tests__/apiError.test.ts
+++ b/frontend/src/shared/lib/__tests__/apiError.test.ts
@@ -16,4 +16,9 @@ describe('getApiErrorMessage', () => {
     expect(getApiErrorMessage(null, '代替')).toBe('代替');
     expect(getApiErrorMessage({ response: { data: {} } }, '代替')).toBe('代替');
   });
+
+  it('error / message が文字列でなければ無視して fallback を返す', () => {
+    expect(getApiErrorMessage({ response: { data: { error: { code: 1 } } } }, '代替')).toBe('代替');
+    expect(getApiErrorMessage({ response: { data: { message: 42 } } }, '代替')).toBe('代替');
+  });
 });

--- a/frontend/src/shared/lib/__tests__/apiError.test.ts
+++ b/frontend/src/shared/lib/__tests__/apiError.test.ts
@@ -1,0 +1,19 @@
+import { getApiErrorMessage } from '@/shared/lib';
+
+describe('getApiErrorMessage', () => {
+  it('error フィールドを優先して返す', () => {
+    const err = { response: { data: { error: 'サーバー側メッセージ' } } };
+    expect(getApiErrorMessage(err, '代替')).toBe('サーバー側メッセージ');
+  });
+
+  it('error がなければ message を返す', () => {
+    const err = { response: { data: { message: '登録エラー' } } };
+    expect(getApiErrorMessage(err, '代替')).toBe('登録エラー');
+  });
+
+  it('レスポンス形状でなければ fallback を返す', () => {
+    expect(getApiErrorMessage(new Error('boom'), '代替')).toBe('代替');
+    expect(getApiErrorMessage(null, '代替')).toBe('代替');
+    expect(getApiErrorMessage({ response: { data: {} } }, '代替')).toBe('代替');
+  });
+});

--- a/frontend/src/shared/lib/__tests__/useManagedList.test.tsx
+++ b/frontend/src/shared/lib/__tests__/useManagedList.test.tsx
@@ -17,16 +17,40 @@ describe('useManagedList', () => {
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
-  it('refetch は最新のクロージャで再取得する', async () => {
-    let value = ['first'];
-    const { result } = renderHook(() => useManagedList(async () => value, '取得失敗'));
+  it('refetch は再レンダー後の最新の fetcher を使う', async () => {
+    const first = jest.fn(async () => ['first']);
+    const second = jest.fn(async () => ['second']);
+    const { result, rerender } = renderHook(({ fetcher }) => useManagedList(fetcher, '取得失敗'), {
+      initialProps: { fetcher: first as () => Promise<string[]> },
+    });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    value = ['second'];
+    rerender({ fetcher: second });
     await act(async () => {
       await result.current.refetch();
     });
+    expect(second).toHaveBeenCalledTimes(1);
     expect(result.current.items).toEqual(['second']);
+  });
+
+  it('古いリクエストの遅延応答は新しい結果を上書きしない', async () => {
+    const resolvers: Array<(value: string[]) => void> = [];
+    const fetcher = jest.fn(() => new Promise<string[]>(resolve => resolvers.push(resolve)));
+    const { result } = renderHook(() => useManagedList(fetcher, '取得失敗'));
+
+    // マウント時の取得（1件目）が在途のまま 2 件目を発火し、2件目 → 1件目の順に解決する
+    act(() => {
+      void result.current.refetch();
+    });
+    await act(async () => {
+      resolvers[1](['newer']);
+    });
+    await act(async () => {
+      resolvers[0](['stale']);
+    });
+
+    expect(result.current.items).toEqual(['newer']);
+    expect(result.current.isLoading).toBe(false);
   });
 
   it('失敗時はトーストを出し loading を解除する', async () => {

--- a/frontend/src/shared/lib/__tests__/useManagedList.test.tsx
+++ b/frontend/src/shared/lib/__tests__/useManagedList.test.tsx
@@ -53,6 +53,22 @@ describe('useManagedList', () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  it('アンマウント後に失敗したリクエストはトーストを出さない', async () => {
+    let rejectRequest!: (reason?: unknown) => void;
+    const fetcher = () =>
+      new Promise<string[]>((_, reject) => {
+        rejectRequest = reject;
+      });
+    const { unmount } = renderHook(() => useManagedList(fetcher, '取得失敗'));
+
+    unmount();
+    await act(async () => {
+      rejectRequest(new Error('boom'));
+    });
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
   it('失敗時はトーストを出し loading を解除する', async () => {
     const { result } = renderHook(() =>
       useManagedList(async () => {

--- a/frontend/src/shared/lib/__tests__/useManagedList.test.tsx
+++ b/frontend/src/shared/lib/__tests__/useManagedList.test.tsx
@@ -1,0 +1,43 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
+import { useManagedList } from '@/shared/lib';
+
+jest.mock('react-hot-toast', () => ({
+  toast: { error: jest.fn() },
+}));
+
+describe('useManagedList', () => {
+  it('マウント時に取得し items と isLoading を管理する', async () => {
+    const fetcher = jest.fn(async () => ['a', 'b']);
+    const { result } = renderHook(() => useManagedList(fetcher, '取得失敗'));
+
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.items).toEqual(['a', 'b']);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetch は最新のクロージャで再取得する', async () => {
+    let value = ['first'];
+    const { result } = renderHook(() => useManagedList(async () => value, '取得失敗'));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    value = ['second'];
+    await act(async () => {
+      await result.current.refetch();
+    });
+    expect(result.current.items).toEqual(['second']);
+  });
+
+  it('失敗時はトーストを出し loading を解除する', async () => {
+    const { result } = renderHook(() =>
+      useManagedList(async () => {
+        throw new Error('boom');
+      }, '取得失敗')
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(toast.error).toHaveBeenCalledWith('取得失敗');
+    expect(result.current.items).toEqual([]);
+  });
+});

--- a/frontend/src/shared/lib/apiError.ts
+++ b/frontend/src/shared/lib/apiError.ts
@@ -1,0 +1,11 @@
+// バックエンドのエラーレスポンス（{ error } または { message }）から表示用メッセージを取り出す。
+// 各ページ・フォームで同型の抽出ロジックを複製しないこと（漂流の実績あり）。
+export function getApiErrorMessage(error: unknown, fallback: string): string {
+  if (error && typeof error === 'object' && 'response' in error) {
+    const data = (error as { response?: { data?: { error?: string; message?: string } } }).response
+      ?.data;
+    if (data?.error) return data.error;
+    if (data?.message) return data.message;
+  }
+  return fallback;
+}

--- a/frontend/src/shared/lib/apiError.ts
+++ b/frontend/src/shared/lib/apiError.ts
@@ -4,8 +4,8 @@ export function getApiErrorMessage(error: unknown, fallback: string): string {
   if (error && typeof error === 'object' && 'response' in error) {
     const data = (error as { response?: { data?: { error?: string; message?: string } } }).response
       ?.data;
-    if (data?.error) return data.error;
-    if (data?.message) return data.message;
+    if (typeof data?.error === 'string') return data.error;
+    if (typeof data?.message === 'string') return data.message;
   }
   return fallback;
 }

--- a/frontend/src/shared/lib/index.ts
+++ b/frontend/src/shared/lib/index.ts
@@ -1,2 +1,4 @@
 export * from './config';
 export { default as redirectToLogin } from './navigation';
+export { getApiErrorMessage } from './apiError';
+export { useManagedList } from './useManagedList';

--- a/frontend/src/shared/lib/useManagedList.ts
+++ b/frontend/src/shared/lib/useManagedList.ts
@@ -11,17 +11,21 @@ import { toast } from 'react-hot-toast';
 export function useManagedList<T>(fetcher: () => Promise<T[]>, errorMessage: string) {
   const fetcherRef = useRef(fetcher);
   fetcherRef.current = fetcher;
+  // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する
+  const requestIdRef = useRef(0);
   const [items, setItems] = useState<T[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   const refetch = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    setIsLoading(true);
     try {
-      setIsLoading(true);
-      setItems(await fetcherRef.current());
+      const result = await fetcherRef.current();
+      if (requestId === requestIdRef.current) setItems(result);
     } catch {
-      toast.error(errorMessage);
+      if (requestId === requestIdRef.current) toast.error(errorMessage);
     } finally {
-      setIsLoading(false);
+      if (requestId === requestIdRef.current) setIsLoading(false);
     }
   }, [errorMessage]);
 

--- a/frontend/src/shared/lib/useManagedList.ts
+++ b/frontend/src/shared/lib/useManagedList.ts
@@ -31,6 +31,11 @@ export function useManagedList<T>(fetcher: () => Promise<T[]>, errorMessage: str
 
   useEffect(() => {
     void refetch();
+    return () => {
+      // requestIdRef is a request counter, not a DOM ref.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      requestIdRef.current++;
+    };
   }, [refetch]);
 
   return { items, isLoading, refetch };

--- a/frontend/src/shared/lib/useManagedList.ts
+++ b/frontend/src/shared/lib/useManagedList.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'react-hot-toast';
+
+/**
+ * 管理系一覧ページ共通の取得ライフサイクル（初回取得 / loading / 失敗トースト / 再取得）。
+ * fetcher は毎レンダー最新のクロージャを参照するため、検索条件の state をそのまま閉じ込めてよい。
+ * テーブルの markup は各ページの責務（汎用テーブル化はしない）。
+ */
+export function useManagedList<T>(fetcher: () => Promise<T[]>, errorMessage: string) {
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+  const [items, setItems] = useState<T[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refetch = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setItems(await fetcherRef.current());
+    } catch {
+      toast.error(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [errorMessage]);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  return { items, isLoading, refetch };
+}


### PR DESCRIPTION
## Summary

[docs/architecture-deepening-plan.md](../blob/refactor/architecture-deepening-backend/docs/architecture-deepening-plan.md) の PR-C（C6）。

- **shared/lib `getApiErrorMessage()`** — axios エラー抽出の 3 副本（PasswordChangeForm / central-settings SettingsPage / tenant-register RegisterForm インライン）を統一。副本間で `error` / `message` フィールドの扱いが既に漂流していたため、両対応で吸収
- **shared/lib `useManagedList()`** — 一覧ページ共通の初回取得 / loading / 失敗トースト / 再取得ライフサイクル。CastsPage / OrdersPage が採用（CustomersPage はページネーション形状が異なるため対象外 — 無理に合わせると interface が広がるだけ）
- **OrdersPage の死んだ UI を削除** — 未配線の検索バー（state もハンドラも無し、バックエンドに注文テキスト検索も無し）、onClick の無い Eye / Trash ボタン
- **汎用テーブルコンポーネントは作らない**（計画に明記: interface が implementation と同幅になる shallow module 化のため）

## Test plan

- ✅ Jest 25 suites / 84 tests（新規: apiError 3 / useManagedList 3 — 最新クロージャでの refetch、失敗トースト含む）
- ✅ `task lint`（ESLint + Steiger + Prettier）/ `task test service=frontend`（カバレッジ閾値）
- ✅ Next.js 本番ビルド（イメージ再ビルド）— hook の 'use client' 境界を検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)