### PR TITLE
fix(frontend): ログインページを RSC 化し hydration mismatch を解消 (#228)

### DIFF
--- a/frontend/src/_pages/login/__tests__/LoginPage.test.tsx
+++ b/frontend/src/_pages/login/__tests__/LoginPage.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import LoginPage from '../ui/LoginPage';
+
+// Cookie ストアのモック（server-client.test.ts と同パターン）
+const mockCookieStore = { get: jest.fn() };
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(() => Promise.resolve(mockCookieStore)),
+}));
+
+// LoginForm はタイトル判定と無関係のためスタブ化
+jest.mock('@/features/auth-login', () => ({
+  LoginForm: () => <div data-testid="login-form" />,
+}));
+
+function setCookies(values: Record<string, string>) {
+  mockCookieStore.get.mockImplementation((name: string) =>
+    values[name] !== undefined ? { name, value: values[name] } : undefined
+  );
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('central ロールでは管理者ログインを表示すること', async () => {
+    setCookies({ 'x-mw-role': 'central' });
+    render(await LoginPage());
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('管理者ログイン');
+    expect(
+      screen.getByText('プラットフォーム管理者アカウントでログインしてください')
+    ).toBeInTheDocument();
+  });
+
+  it('tenant ロールでは店名をタイトルに表示すること', async () => {
+    setCookies({ 'x-mw-role': 'tenant', 'x-mw-tenant-name': 'Sample Tenant' });
+    render(await LoginPage());
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Sample Tenant');
+  });
+
+  it('tenant ロールで店名 Cookie がない場合は店舗ログインを表示すること', async () => {
+    setCookies({ 'x-mw-role': 'tenant' });
+    render(await LoginPage());
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('店舗ログイン');
+  });
+
+  it('URL エンコードされた店名をデコードして表示すること', async () => {
+    setCookies({
+      'x-mw-role': 'tenant',
+      'x-mw-tenant-name': '%E3%81%8D%E3%81%9A%E3%81%AA',
+    });
+    render(await LoginPage());
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('きずな');
+  });
+
+  it('ログインフォームを描画すること', async () => {
+    setCookies({ 'x-mw-role': 'central' });
+    render(await LoginPage());
+    expect(screen.getByTestId('login-form')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/_pages/login/ui/LoginPage.tsx
+++ b/frontend/src/_pages/login/ui/LoginPage.tsx
@@ -1,14 +1,35 @@
-'use client';
-
-import Cookies from 'js-cookie';
+import { cookies } from 'next/headers';
 import { LoginForm } from '@/features/auth-login';
-import { isTenantDomain } from '@/shared/lib';
 import { AuthLayout } from '@/shared/ui';
 
-export default function LoginPage() {
-  const isTenant = isTenantDomain();
-  const tenantName = Cookies.get('x-mw-tenant-name');
-  const pageTitle = isTenant ? (tenantName ? `${tenantName}` : '店舗ログイン') : '管理者ログイン';
+/**
+ * Cookie 値のデコード。js-cookie の読み取り互換（decodeURIComponent + 失敗時は原文）。
+ * proxy が response.cookies.set で書き込む際にエンコードされるため、
+ * デコードしないと日本語店名がエンコードされたまま表示される。
+ */
+function decodeCookieValue(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * ログインページ（サーバーコンポーネント）
+ *
+ * タイトル文言はサーバー側で Cookie（x-mw-role / x-mw-tenant-name）から確定させる。
+ * 以前はクライアントで document.cookie と window.location を読んでいたため、
+ * SSR 出力と初回 hydration の内容が食い違い React error #418 が発生、
+ * フォームが再マウントされて入力値が消えていた（issue #228）。
+ */
+export default async function LoginPage() {
+  const cookieStore = await cookies();
+  const isTenant = cookieStore.get('x-mw-role')?.value === 'tenant';
+  const rawTenantName = cookieStore.get('x-mw-tenant-name')?.value;
+  const tenantName = rawTenantName ? decodeCookieValue(rawTenantName) : undefined;
+
+  const pageTitle = isTenant ? tenantName || '店舗ログイン' : '管理者ログイン';
   const pageSubtitle = isTenant
     ? '店舗アカウントでログインしてください'
     : 'プラットフォーム管理者アカウントでログインしてください';


### PR DESCRIPTION
## 概要

Closes #228

ログインページ読み込み時に React error #418（hydration mismatch）が発生し、開場アニメーション中の入力値が消える問題を修正。

## 根因

`LoginPage`（旧 'use client'）のレンダー中に SSR/client 不一致源が 2 つあった:

1. `isTenantDomain()` が SSR では `typeof window === 'undefined'` で常に false → 店舗ドメインでも SSR は「管理者ログイン」系文言を出力
2. `Cookies.get('x-mw-tenant-name')`（js-cookie）が SSR では undefined → client 初回描画で店名に変化

タイトルテキスト不一致 → React がサブツリーを client 再描画 → `LoginForm` 再マウントで `useState` の入力値が消失。

## 対応

- `LoginPage` をサーバーコンポーネント化し、タイトル判定を `cookies()`（`x-mw-role` / `x-mw-tenant-name`）によるサーバー側確定に変更（`app/page.tsx` の既存パターン踏襲）。SSR 出力と client 初回描画が構造的に一致
- js-cookie 読み取り互換のデコード（`decodeURIComponent` + 失敗時原文フォールバック）
- `suppressHydrationWarning` による隠蔽はしない（issue の明示要件）
- 変更は `frontend/src/_pages/login/` 配下の 2 ファイルのみ。`AuthLayout` / `LoginForm` はレンダー出力が動的値に依存しないため変更不要

## テスト

- 新規 Jest 5 件（central タイトル / 店名タイトル / 店名なしフォールバック / URL デコード / フォーム描画）— TDD で失敗確認後に実装
- フロント全 26 suites / 92 tests 緑、カバレッジ閾値クリア
- `task lint` / `task test service=frontend` exit 0（実装後・検証時の 2 回独立実行）
- ブラウザ受入（手動、`task up` 環境）: `store1.kizuna.test/login` ハードリロードで console に #418 なし / アニメーション中の入力値保持 / 店舗タイトル=店名・central タイトル=管理者ログイン / admin ログイン→ `/tenant/dashboard/` 遷移 すべて確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)