### PR TITLE
ci: PR レビューのモデルを claude-fable-5 に固定

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: '--model claude-fable-5'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## 概要

Claude Code Review ワークフローに \`claude_args: '--model claude-fable-5'\` を追加し、PR 自動レビューを Fable 5 で実行するようにする（従来はモデル未指定＝アクションのデフォルト）。

\`claude.yml\`（@claude メンション応答）は対象外・従来どおり。

## 検証

- 本 PR 自身の claude-review 実行が変更後のワークフロー定義で走るため、チェックが緑になればモデル指定の有効性も確認できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)