### PR TITLE
test(tenant): クロステナント統合テスト基盤 + Customer 負向テスト (#225)

### DIFF
--- a/backend/Taskfile.yml
+++ b/backend/Taskfile.yml
@@ -44,7 +44,9 @@ tasks:
           --load \
           .
       - echo "🧪  バックエンドの統合テストを実行中（compose ネットワーク接続）..."
-      - defer: docker compose -f docker-compose.test.yml down -v
+      # -v を付けない: 唯一のボリュームは gradle キャッシュで、消すと毎回フル再取得になり
+      # 依存解決の flaky 要因になる。DB は tmpfs のためコンテナ削除だけで使い捨てが成立する
+      - defer: docker compose -f docker-compose.test.yml down
       - docker compose -f docker-compose.test.yml run --rm integration-test
 
   test-copy-artifacts:

--- a/backend/Taskfile.yml
+++ b/backend/Taskfile.yml
@@ -36,13 +36,16 @@ tasks:
   test:
     desc: バックエンドの全テストを実行し、reports/backend に収集
     cmds:
-      - echo "🧪  バックエンドのテストを実行中..."
+      - echo "🧪  バックエンドの単体テストを実行中..."
       - |
         docker buildx build \
           --target test \
           -t {{.DOCKER_IMAGE}}-test:{{.DOCKER_TAG}} \
           --load \
           .
+      - echo "🧪  バックエンドの統合テストを実行中（compose ネットワーク接続）..."
+      - defer: docker compose -f docker-compose.test.yml down -v
+      - docker compose -f docker-compose.test.yml run --rm integration-test
 
   test-copy-artifacts:
     desc: テスト成果物を REPORT_DIR/backend にコピー

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -126,3 +126,29 @@ jar {
     archiveBaseName.set(rootProject.name)
     archiveVersion.set(version.toString())
 }
+
+// 統合テスト（本物の PostgreSQL/Redis に接続。docker-compose.test.yml 経由で実行する）
+// check には紐づけない: 単体テストは従来どおり Dockerfile test ステージで完結させ、
+// 統合テストは compose ネットワーク内のランナーからのみ実行する（issue #225 の方式決定）
+sourceSets {
+    integrationTest {
+        java.srcDir 'src/integrationTest/java'
+        resources.srcDir 'src/integrationTest/resources'
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+}
+
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
+tasks.register('integrationTest', Test) {
+    description = '統合テスト（compose ネットワーク内で実行すること。task -d backend test 参照）'
+    group = 'verification'
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    useJUnitPlatform()
+    shouldRunAfter test
+}

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -150,5 +150,7 @@ tasks.register('integrationTest', Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     useJUnitPlatform()
+    // 統合テストの入力は compose で毎回作り直す DB（Gradle から不可視の外部状態）のため、増分判定を無効化して毎回実行する
+    outputs.upToDateWhen { false }
     shouldRunAfter test
 }

--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -45,7 +45,8 @@ services:
       REDIS_HOST: cache
       REDIS_PORT: "6379"
       REDIS_PASSWORD: password
-      APP_JWT_SECRET: integration-test-secret
+      # HMAC-SHA256 の要件（RFC 7518）で 256bit 以上必要（JwtUtil は raw bytes 解釈）
+      APP_JWT_SECRET: integration-test-secret-0123456789abcdef
     depends_on:
       database:
         condition: service_healthy

--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -1,0 +1,57 @@
+# 統合テスト専用 compose（issue #225）
+# 開発用スタック（プロジェクト名 kizuna）とは独立したプロジェクト名で、
+# データは tmpfs のみ（ボリューム永続化なし）。実行ごとに down -v で使い捨てる。
+name: kizuna-backend-test
+
+services:
+  database:
+    image: postgres:18-alpine
+    tmpfs:
+      - /var/lib/postgresql
+    environment:
+      POSTGRES_DB: kizuna
+      POSTGRES_USER: kizuna
+      POSTGRES_PASSWORD: password
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U kizuna -d kizuna"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  cache:
+    image: redis:8.8.0-alpine3.23
+    command: redis-server --requirepass password
+    environment:
+      REDISCLI_AUTH: password
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep -q PONG"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  integration-test:
+    image: gradle:9.2.1-jdk21-ubi-minimal
+    user: root # bind mount への build/ 書き込みのため（rules/backend.md の Spotless Docker 実行と同じ流儀）
+    working_dir: /app
+    volumes:
+      - .:/app
+      - gradle-it-cache:/root/.gradle
+    environment:
+      DB_HOST: database
+      DB_PORT: "5432"
+      DB_NAME: kizuna
+      DB_USERNAME: kizuna
+      DB_PASSWORD: password
+      REDIS_HOST: cache
+      REDIS_PORT: "6379"
+      REDIS_PASSWORD: password
+      APP_JWT_SECRET: integration-test-secret
+    depends_on:
+      database:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
+    command: ./gradlew integrationTest --no-daemon
+
+volumes:
+  gradle-it-cache:

--- a/backend/docker-compose.test.yml
+++ b/backend/docker-compose.test.yml
@@ -1,6 +1,7 @@
 # 統合テスト専用 compose（issue #225）
 # 開発用スタック（プロジェクト名 kizuna）とは独立したプロジェクト名で、
-# データは tmpfs のみ（ボリューム永続化なし）。実行ごとに down -v で使い捨てる。
+# データは tmpfs のみ（ボリューム永続化なし）。実行ごとに down で使い捨てる
+# （gradle キャッシュボリュームだけは依存再取得の flaky 回避のため保持する）。
 name: kizuna-backend-test
 
 services:

--- a/backend/src/integrationTest/java/com/kizuna/customer/CustomerCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/CustomerCrossTenantIT.java
@@ -1,0 +1,112 @@
+package com.kizuna.customer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Customer のクロステナント分離を本物の PostgreSQL で検証する統合テスト。
+ *
+ * <p>commit 5b39c06（tenantFilter の applyToLoadByKey=true 補完）の回帰テスト。 tenant A が作成した Customer を
+ * tenant B が GET /tenant/customers/{id}（findById 経由） で読めないことを固定する。PR-B の手動 curl 検証の自動化（issue #225）。
+ *
+ * <p>認証はシードユーザー admin@store1.kizuna.com/pass（tenant 1）のログインで得た JWT。テナント文脈は X-Tenant-ID
+ * ヘッダで切り替える（認証=JWT、 テナント解決=ヘッダという本番構造どおり。5b39c06 の curl 検証と同構）。Bearer ヘッダ付きリクエストは CSRF 免除。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CustomerCrossTenantIT {
+
+  private static final long TENANT_A = 1L;
+  private static final long TENANT_B = 2L;
+
+  @Autowired private TestRestTemplate rest;
+
+  private String token;
+
+  @BeforeEach
+  void login() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.set("X-Role", "tenant");
+    headers.set("X-Tenant-ID", String.valueOf(TENANT_A));
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/tenant/login",
+            new HttpEntity<>(
+                "{\"username\": \"admin@store1.kizuna.com\", \"password\": \"pass\"}", headers),
+            JsonNode.class);
+    assertThat(res.getStatusCode())
+        .as("前提: シードユーザー admin@store1.kizuna.com/pass でのログインが成功すること")
+        .isEqualTo(HttpStatus.OK);
+    token = res.getBody().path("token").asText();
+    assertThat(token).isNotBlank();
+  }
+
+  private HttpHeaders tenantHeaders(long tenantId) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.set("X-Role", "tenant");
+    headers.set("X-Tenant-ID", String.valueOf(tenantId));
+    headers.setBearerAuth(token);
+    return headers;
+  }
+
+  private String createCustomerAs(long tenantId, String name) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/tenant/customers",
+            new HttpEntity<>("{\"name\": \"" + name + "\"}", tenantHeaders(tenantId)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful())
+        .as("前提: tenant %d での顧客作成が成功すること", tenantId)
+        .isTrue();
+    String id = created.getBody().path("id").asText();
+    assertThat(id).isNotBlank();
+    return id;
+  }
+
+  @Test
+  @DisplayName("自テナントで作成した顧客は GET /tenant/customers/{id} で取得できること")
+  void ownTenantCanReadOwnCustomer() {
+    String id = createCustomerAs(TENANT_A, "統合テスト顧客（正向）");
+
+    ResponseEntity<JsonNode> got =
+        rest.exchange(
+            "/tenant/customers/" + id,
+            HttpMethod.GET,
+            new HttpEntity<>(tenantHeaders(TENANT_A)),
+            JsonNode.class);
+
+    assertThat(got.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(got.getBody().path("id").asText()).isEqualTo(id);
+  }
+
+  @Test
+  @DisplayName("他テナントの顧客 ID を GET しても取得できないこと（applyToLoadByKey 回帰）")
+  void otherTenantCannotReadForeignCustomerById() {
+    String id = createCustomerAs(TENANT_A, "統合テスト顧客（負向）");
+
+    ResponseEntity<JsonNode> leaked =
+        rest.exchange(
+            "/tenant/customers/" + id,
+            HttpMethod.GET,
+            new HttpEntity<>(tenantHeaders(TENANT_B)),
+            JsonNode.class);
+
+    // ServiceException(@ResponseStatus BAD_REQUEST) → 400。
+    // 重要なのは 200 でデータが漏れないこと（5b39c06 修正前は 200 で漏洩していた）
+    assertThat(leaked.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+}


### PR DESCRIPTION
## 概要

Closes #225

\`task test\` が本物の PostgreSQL に接続する統合テストを実行できる基盤を新設し、Customer のクロステナント負向テスト（commit 5b39c06 の \`applyToLoadByKey\` 修正の回帰テスト）を最初の実例として自動化した。

## 方式決定（受入基準 1）

**compose ネットワーク接入を採用、Testcontainers は不採用。**

理由: 現行の backend テストは \`docker buildx build --target test\` のビルド内実行であり、ビルドサンドボックスには Docker socket も compose ネットワークも無い。Testcontainers 化はテスト実行を build から外した上で socket マウント（DooD）とコンテナ間ネットワーク調整を mac ローカル / CI の両方で行う必要があり、基盤の複雑度と flaky リスクが高い。compose 接入は本番と同版の postgres:18-alpine / redis イメージを再利用し、既存の task + Docker 一元化アーキテクチャに完全に沿い、**CI ワークフローは無改修**（\`task test\` を呼ぶだけ、実際に本 PR は .github/ に一切触れていない）。トレードオフ（テスト DB の隔離・後始末の自前管理）は「独立 compose プロジェクト名 + DB は tmpfs のみ + 実行ごとに down」で吸収した。

## 実装

- \`build.gradle\`: \`integrationTest\` ソースセット / タスク新設。\`check\` には紐づけず単体テストゲートの挙動は不変。統合テストの入力は Gradle から不可視の外部 DB のため \`outputs.upToDateWhen { false }\` で毎回実行
- \`docker-compose.test.yml\`（新規）: postgres + redis + gradle ランナー。独立プロジェクト名 \`kizuna-backend-test\`、DB は tmpfs（永続化なし）、gradle キャッシュのみ名前付きボリュームで保持（依存の毎回全量再取得による flaky を回避）
- \`Taskfile.yml\`: \`test\` を単体（docker build）→ 統合（compose run、defer で down 保証）の 2 段に
- \`CustomerCrossTenantIT\`: シードユーザーの実ログインで JWT を取得（Bearer 付きは CSRF 免除）、認証 = JWT / テナント文脈 = X-Tenant-ID ヘッダという本番構造どおりの HTTP 全スタックテスト。tenant 1 が作成した Customer を tenant 2 が GET → 400（200 漏洩しない）を固定

## テスト（受入基準 2〜4）

- **test-the-test**: \`applyToLoadByKey\` を一時的に false に戻すと負向テストが \`expected: 400 BAD_REQUEST but was: 200 OK\` で失敗することを実証（= 5b39c06 修正前の漏洩を確実に検出できる）。既存単体 \`TenantIsolationTests\` と合わせて二層防御
- **非 flaky**: \`task test service=backend\` 連続 2 回とも exit 0、いずれも統合テスト実実行（executed）を確認
- **QA 独立検証**: lint / 全量 test / 連跑 / Docker 残骸ゼロ / 開発スタック DB 非汚染（\`t_customers\` にテストデータ 0 件）の 7 項目 PASS
- \`task lint\` + \`task test\`（frontend + backend 全量）exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)