### PR TITLE
test(tenant): Cast / Order クロステナント負向統合テスト (#226)

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/cast/CastCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/cast/CastCrossTenantIT.java
@@ -1,0 +1,92 @@
+package com.kizuna.cast;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.kizuna.shared.CrossTenantTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Cast のクロステナント分離を本物の PostgreSQL で検証する統合テスト（issue #226）。
+ *
+ * <p>PR-B の手動 curl 検証の自動化。tenant A の Cast を tenant B が ID 指定で 読取・更新できないことを固定する（5b39c06
+ * applyToLoadByKey 修正の対象経路）。
+ */
+class CastCrossTenantIT extends CrossTenantTestSupport {
+
+  private String createCastAs(long tenantId, String name) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/tenant/casts",
+            new HttpEntity<>("{\"name\": \"" + name + "\"}", tenantHeaders(tenantId)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful())
+        .as("前提: tenant %d でのキャスト作成が成功すること", tenantId)
+        .isTrue();
+    String id = created.getBody().path("id").asText();
+    assertThat(id).isNotBlank();
+    return id;
+  }
+
+  @Test
+  @DisplayName("他テナントのキャスト ID を GET しても取得できないこと")
+  void otherTenantCannotReadForeignCastById() {
+    String id = createCastAs(TENANT_A, "統合テストキャスト（読取）");
+
+    ResponseEntity<JsonNode> own =
+        rest.exchange(
+            "/tenant/casts/" + id,
+            HttpMethod.GET,
+            new HttpEntity<>(tenantHeaders(TENANT_A)),
+            JsonNode.class);
+    assertThat(own.getStatusCode()).as("正向対照: 自テナントでは読める").isEqualTo(HttpStatus.OK);
+
+    ResponseEntity<JsonNode> leaked =
+        rest.exchange(
+            "/tenant/casts/" + id,
+            HttpMethod.GET,
+            new HttpEntity<>(tenantHeaders(TENANT_B)),
+            JsonNode.class);
+    // 200 でデータが漏れないことが本質（ServiceException → 400）
+    assertThat(leaked.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("他テナントのキャストを更新できず、データも変わらないこと")
+  void otherTenantCannotUpdateForeignCast() {
+    // 正向対照: 同一ボディ形式で自テナントの更新は成功する（負向 400 がバリデーション起因でない証明）
+    String controlId = createCastAs(TENANT_A, "統合テストキャスト（対照）");
+    ResponseEntity<JsonNode> ownUpdate =
+        rest.exchange(
+            "/tenant/casts/" + controlId,
+            HttpMethod.PUT,
+            new HttpEntity<>("{\"name\": \"統合テストキャスト（対照・更新後）\"}", tenantHeaders(TENANT_A)),
+            JsonNode.class);
+    assertThat(ownUpdate.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    // 負向: tenant B は tenant A のキャストを更新できない
+    String id = createCastAs(TENANT_A, "統合テストキャスト（更新前）");
+    ResponseEntity<JsonNode> tampered =
+        rest.exchange(
+            "/tenant/casts/" + id,
+            HttpMethod.PUT,
+            new HttpEntity<>("{\"name\": \"統合テストキャスト（改ざん）\"}", tenantHeaders(TENANT_B)),
+            JsonNode.class);
+    assertThat(tampered.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+    // データ不変: tenant A から見て名前が変わっていない
+    ResponseEntity<JsonNode> after =
+        rest.exchange(
+            "/tenant/casts/" + id,
+            HttpMethod.GET,
+            new HttpEntity<>(tenantHeaders(TENANT_A)),
+            JsonNode.class);
+    assertThat(after.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(after.getBody().path("name").asText()).isEqualTo("統合テストキャスト（更新前）");
+  }
+}

--- a/backend/src/integrationTest/java/com/kizuna/customer/CustomerCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/CustomerCrossTenantIT.java
@@ -3,17 +3,12 @@ package com.kizuna.customer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.jupiter.api.BeforeEach;
+import com.kizuna.shared.CrossTenantTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 /**
@@ -22,46 +17,9 @@ import org.springframework.http.ResponseEntity;
  * <p>commit 5b39c06（tenantFilter の applyToLoadByKey=true 補完）の回帰テスト。 tenant A が作成した Customer を
  * tenant B が GET /tenant/customers/{id}（findById 経由） で読めないことを固定する。PR-B の手動 curl 検証の自動化（issue #225）。
  *
- * <p>認証はシードユーザー admin@store1.kizuna.com/pass（tenant 1）のログインで得た JWT。テナント文脈は X-Tenant-ID
- * ヘッダで切り替える（認証=JWT、 テナント解決=ヘッダという本番構造どおり。5b39c06 の curl 検証と同構）。Bearer ヘッダ付きリクエストは CSRF 免除。
+ * <p>認証・テナントヘッダ組立は {@link CrossTenantTestSupport} に共通化（issue #226 で 3 クラス目の重複を抽出）。
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class CustomerCrossTenantIT {
-
-  private static final long TENANT_A = 1L;
-  private static final long TENANT_B = 2L;
-
-  @Autowired private TestRestTemplate rest;
-
-  private String token;
-
-  @BeforeEach
-  void login() {
-    HttpHeaders headers = new HttpHeaders();
-    headers.setContentType(MediaType.APPLICATION_JSON);
-    headers.set("X-Role", "tenant");
-    headers.set("X-Tenant-ID", String.valueOf(TENANT_A));
-    ResponseEntity<JsonNode> res =
-        rest.postForEntity(
-            "/tenant/login",
-            new HttpEntity<>(
-                "{\"username\": \"admin@store1.kizuna.com\", \"password\": \"pass\"}", headers),
-            JsonNode.class);
-    assertThat(res.getStatusCode())
-        .as("前提: シードユーザー admin@store1.kizuna.com/pass でのログインが成功すること")
-        .isEqualTo(HttpStatus.OK);
-    token = res.getBody().path("token").asText();
-    assertThat(token).isNotBlank();
-  }
-
-  private HttpHeaders tenantHeaders(long tenantId) {
-    HttpHeaders headers = new HttpHeaders();
-    headers.setContentType(MediaType.APPLICATION_JSON);
-    headers.set("X-Role", "tenant");
-    headers.set("X-Tenant-ID", String.valueOf(tenantId));
-    headers.setBearerAuth(token);
-    return headers;
-  }
+class CustomerCrossTenantIT extends CrossTenantTestSupport {
 
   private String createCustomerAs(long tenantId, String name) {
     ResponseEntity<JsonNode> created =

--- a/backend/src/integrationTest/java/com/kizuna/order/OrderCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/OrderCrossTenantIT.java
@@ -1,0 +1,121 @@
+package com.kizuna.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.kizuna.shared.CrossTenantTestSupport;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Order のクロステナント分離を本物の PostgreSQL で検証する統合テスト（issue #226）。
+ *
+ * <p>PR-B の手動 curl 検証の自動化。tenant A の Order を tenant B が ID 指定で 読取・更新できないことを固定する（5b39c06
+ * applyToLoadByKey 修正の対象経路）。
+ */
+class OrderCrossTenantIT extends CrossTenantTestSupport {
+
+  /** tenant/08-initial-data.yaml のシードユーザー（受付担当として使用）。 */
+  private static final String SEED_RECEPTIONIST_ID = "user-1";
+
+  private String createCastAs(long tenantId, String name) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/tenant/casts",
+            new HttpEntity<>("{\"name\": \"" + name + "\"}", tenantHeaders(tenantId)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful())
+        .as("前提: tenant %d でのキャスト作成が成功すること", tenantId)
+        .isTrue();
+    return created.getBody().path("id").asText();
+  }
+
+  private String orderBody(String castId, String remarks) {
+    return "{\"receptionist_id\": \""
+        + SEED_RECEPTIONIST_ID
+        + "\", \"business_date\": \""
+        + LocalDate.now()
+        + "\", \"cast_id\": \""
+        + castId
+        + "\", \"remarks\": \""
+        + remarks
+        + "\"}";
+  }
+
+  private String createOrderAs(long tenantId, String castId) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/tenant/orders",
+            new HttpEntity<>(orderBody(castId, "統合テスト受注"), tenantHeaders(tenantId)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful())
+        .as("前提: tenant %d での受注作成が成功すること", tenantId)
+        .isTrue();
+    String id = created.getBody().path("id").asText();
+    assertThat(id).isNotBlank();
+    return id;
+  }
+
+  @Test
+  @DisplayName("他テナントの受注 ID を GET しても取得できないこと")
+  void otherTenantCannotReadForeignOrderById() {
+    String castId = createCastAs(TENANT_A, "統合テストキャスト（受注読取用）");
+    String orderId = createOrderAs(TENANT_A, castId);
+
+    ResponseEntity<JsonNode> own =
+        rest.exchange(
+            "/tenant/orders/" + orderId,
+            HttpMethod.GET,
+            new HttpEntity<>(tenantHeaders(TENANT_A)),
+            JsonNode.class);
+    assertThat(own.getStatusCode()).as("正向対照: 自テナントでは読める").isEqualTo(HttpStatus.OK);
+
+    ResponseEntity<JsonNode> leaked =
+        rest.exchange(
+            "/tenant/orders/" + orderId,
+            HttpMethod.GET,
+            new HttpEntity<>(tenantHeaders(TENANT_B)),
+            JsonNode.class);
+    assertThat(leaked.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("他テナントの受注を更新できないこと")
+  void otherTenantCannotUpdateForeignOrder() {
+    String castId = createCastAs(TENANT_A, "統合テストキャスト（受注更新用）");
+
+    // 正向対照: 同一ボディ形式で自テナントの更新は成功する（負向 400 がバリデーション起因でない証明）
+    String controlId = createOrderAs(TENANT_A, castId);
+    ResponseEntity<JsonNode> ownUpdate =
+        rest.exchange(
+            "/tenant/orders/" + controlId,
+            HttpMethod.PUT,
+            new HttpEntity<>(orderBody(castId, "対照・更新後"), tenantHeaders(TENANT_A)),
+            JsonNode.class);
+    assertThat(ownUpdate.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    // 負向: tenant B は tenant A の受注を更新できない
+    String orderId = createOrderAs(TENANT_A, castId);
+    ResponseEntity<JsonNode> tampered =
+        rest.exchange(
+            "/tenant/orders/" + orderId,
+            HttpMethod.PUT,
+            new HttpEntity<>(orderBody(castId, "改ざん"), tenantHeaders(TENANT_B)),
+            JsonNode.class);
+    assertThat(tampered.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+    // tenant A からは引き続き読める（レコード自体は健在）
+    ResponseEntity<JsonNode> after =
+        rest.exchange(
+            "/tenant/orders/" + orderId,
+            HttpMethod.GET,
+            new HttpEntity<>(tenantHeaders(TENANT_A)),
+            JsonNode.class);
+    assertThat(after.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+}

--- a/backend/src/integrationTest/java/com/kizuna/shared/CrossTenantTestSupport.java
+++ b/backend/src/integrationTest/java/com/kizuna/shared/CrossTenantTestSupport.java
@@ -1,0 +1,60 @@
+package com.kizuna.shared;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * クロステナント統合テストの共通土台。
+ *
+ * <p>シードユーザー admin@store1.kizuna.com/pass（tenant 1）でログインして JWT を保持し、 認証 = JWT / テナント文脈 =
+ * X-Tenant-ID ヘッダという本番構造どおりのリクエストヘッダを組み立てる （Bearer ヘッダ付きリクエストは CSRF 免除）。issue #225 の
+ * CustomerCrossTenantIT から抽出（3 クラス目の重複解消）。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class CrossTenantTestSupport {
+
+  protected static final long TENANT_A = 1L;
+  protected static final long TENANT_B = 2L;
+
+  @Autowired protected TestRestTemplate rest;
+
+  protected String token;
+
+  @BeforeEach
+  void loginAsSeedUser() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.set("X-Role", "tenant");
+    headers.set("X-Tenant-ID", String.valueOf(TENANT_A));
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/tenant/login",
+            new HttpEntity<>(
+                "{\"username\": \"admin@store1.kizuna.com\", \"password\": \"pass\"}", headers),
+            JsonNode.class);
+    assertThat(res.getStatusCode())
+        .as("前提: シードユーザーでのログインが成功すること")
+        .isEqualTo(HttpStatus.OK);
+    token = res.getBody().path("token").asText();
+    assertThat(token).isNotBlank();
+  }
+
+  protected HttpHeaders tenantHeaders(long tenantId) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.set("X-Role", "tenant");
+    headers.set("X-Tenant-ID", String.valueOf(tenantId));
+    headers.setBearerAuth(token);
+    return headers;
+  }
+}

--- a/backend/src/integrationTest/java/com/kizuna/shared/CrossTenantTestSupport.java
+++ b/backend/src/integrationTest/java/com/kizuna/shared/CrossTenantTestSupport.java
@@ -42,9 +42,7 @@ public abstract class CrossTenantTestSupport {
             new HttpEntity<>(
                 "{\"username\": \"admin@store1.kizuna.com\", \"password\": \"pass\"}", headers),
             JsonNode.class);
-    assertThat(res.getStatusCode())
-        .as("前提: シードユーザーでのログインが成功すること")
-        .isEqualTo(HttpStatus.OK);
+    assertThat(res.getStatusCode()).as("前提: シードユーザーでのログインが成功すること").isEqualTo(HttpStatus.OK);
     token = res.getBody().path("token").asText();
     assertThat(token).isNotBlank();
   }


### PR DESCRIPTION
## 概要

Closes #226

#225 で構築した統合テスト基盤（compose ネットワーク接入）を再利用し、PR-B で手動 curl 検証のみだった Cast / Order のクロステナント負向シナリオを自動化した。基盤・本番コードは一切変更なし（diff は \`backend/src/integrationTest/\` のみ）。

## 実装

- **CrossTenantTestSupport 抽出**: ログイン（シードユーザーの実 JWT 取得）・テナントヘッダ組立が 3 クラス目の重複になったため共通土台化し、CustomerCrossTenantIT も載せ替え（テスト挙動は無変更）
- **CastCrossTenantIT**: tenant B は tenant A の Cast を GET できない（400、200 漏洩なし）／PUT できない＋**データ不変断言**（tenant A から見て名前が改ざんされていない）
- **OrderCrossTenantIT**: 同構造で Order の GET / PUT 負向を固定（受付=シード user-1、前提データとして Cast を作成）
- 各負向テストは**正向対照**（同一ボディ形式で自テナントは成功）を内包し、400 がバリデーション起因でないことを担保

## テスト

- integrationTest 6 件（Customer 2 + Cast 2 + Order 2）全緑、\`task test service=backend\` 連続 2 回とも exit 0・毎回実実行
- QA 独立検証 7 項目 PASS（lint / 連跑 / XML 産物 / Docker 残骸ゼロ / コード走査）
- \`task lint\` + \`task test\`（frontend + backend 全量）exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)