### PR TITLE
feat(cms): modern / classic 模版と _sections 全色トークン化 — #223 Phase 3

### DIFF
--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -30,9 +30,29 @@ Never mix the two vocabularies: no gold-serif storefront styling in admin screen
 | Danger | `red-600` | Destructive actions, errors |
 | Icon chips | `bg-blue-500` / `bg-green-500` / `bg-orange-500` / `bg-purple-500` | Stat-card icons; one hue per metric, white icon |
 
-### Public storefront (default template)
+### Public storefront (three templates)
 
-Defined in `templates/default/theme.css` as CSS custom properties. Current vocabulary: background `#080808` (`--storefront-bg`), gold accent `#C9A84C`, light text `#F8F4F0` at reduced opacities. New color needs = new `--storefront-*` token in theme.css, never inline hex in sections. modern / classic templates (issue #223 Phase 3) get their own `theme.css` token tables; templates may only differ via tokens and page layout, never by forking `_sections/` components.
+Each template owns a `templates/<key>/theme.css` that defines the same `--storefront-*` token contract on a `.storefront-<key>` class; the shared `_sections/` read only these tokens — never raw hex/rgba (sections use `var()` for solid colors and `color-mix(in srgb, var(--token) N%, transparent)` for opacities). Templates differ only via token values and page layout, never by forking `_sections/`. New color needs = a new `--storefront-*` token added to **all** template theme.css files in the same PR, never inline hex in sections.
+
+| token | default (dark luxury) | modern (dark vivid) | classic (light) |
+|---|---|---|---|
+| `--storefront-bg` | `#080808` | `#0b0b12` | `#faf7f2` |
+| `--storefront-fg` | `#f8f4f0` | `#f2eff4` | `#2a2a28` |
+| `--storefront-accent` | `#c9a84c` gold | `#e64980` rose | `#4e8da6` teal |
+| `--storefront-muted` | `#a89880` | `#8a87a0` | `#7a776e` |
+| `--storefront-neutral` | `#484848` | `#3a3a48` | `#d8d4cc` |
+| `--storefront-subtle` | `#252525` | `#1e1e29` | `#ebe7e1` |
+| `--storefront-danger` | `#8b1a2e` | `#8b1a2e` | `#b0453a` |
+| `--storefront-bg-deep` | `#050505` | `#07070c` | `#efe8dc` |
+| `--storefront-surface-1` | `#0a0a0a` | `#10101a` | `#f4f0e9` |
+| `--storefront-surface-2` | `#0d0d0d` | `#13131e` | `#f0ebe2` |
+| `--storefront-surface-3` | `#0f0f0f` | `#161622` | `#ece6db` |
+| `--storefront-line` | `#2a2a2a` | `#24242f` | `#e2ddd3` |
+| `--storefront-bg-glow` | `#130d08` | `#170d14` | `#fffdf8` |
+| `--storefront-hairline` | `rgba(255,255,255,0.04)` | `rgba(255,255,255,0.05)` | `rgba(0,0,0,0.06)` |
+| `--storefront-font-display` | `'Noto Serif JP', …, serif` | `'Noto Sans JP', …, sans-serif` | `'Noto Serif JP', …, serif` |
+
+`surface-1/2/3` step away from `bg` toward higher contrast (dark templates lighten, classic sinks). `bg-deep` is the Footer band below `bg`; `line` is a weaker border than `neutral`; `bg-glow` is the AgeVerification radial-gradient center; `hairline` is an ultra-thin rule; `subtle` is the faintest near-background text/border tone (legal fine print, copyright line).
 
 ## Fonts
 

--- a/frontend/src/_pages/store-site/templates/_sections/Advertisement.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/Advertisement.tsx
@@ -37,26 +37,30 @@ export default function Advertisement({ ads }: AdvertisementProps) {
     <section
       id="campaign"
       className="py-12 md:py-20 px-5 sm:px-6"
-      style={{ background: '#0A0A0A' }}
+      style={{ background: 'var(--storefront-surface-1)' }}
     >
       <div className="max-w-7xl mx-auto">
         {/* セクションヘッダー */}
         <div className="text-center mb-10 md:mb-14">
-          <p className="text-[#C9A84C]/40 text-[9px] tracking-[0.6em] uppercase mb-3">Campaign</p>
+          <p className="text-[color-mix(in_srgb,var(--storefront-accent)_40%,transparent)] text-[9px] tracking-[0.6em] uppercase mb-3">
+            Campaign
+          </p>
           <h2
-            className="text-xl md:text-2xl font-light tracking-[0.2em] text-[#F8F4F0]/85"
-            style={{ fontFamily: "'Noto Serif JP', 'Hiragino Mincho Pro', serif" }}
+            className="text-xl md:text-2xl font-light tracking-[0.2em] text-[color-mix(in_srgb,var(--storefront-fg)_85%,transparent)]"
+            style={{ fontFamily: 'var(--storefront-font-display)' }}
           >
             キャンペーン情報
           </h2>
           <div className="flex items-center justify-center gap-3 mt-4 md:mt-5 mb-3">
-            <div className="h-px w-10 md:w-12 bg-linear-to-r from-transparent to-[#C9A84C]/35" />
-            <span className="text-[#C9A84C]/40 text-[10px]">◆</span>
-            <div className="h-px w-10 md:w-12 bg-linear-to-l from-transparent to-[#C9A84C]/35" />
+            <div className="h-px w-10 md:w-12 bg-linear-to-r from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_35%,transparent)]" />
+            <span className="text-[color-mix(in_srgb,var(--storefront-accent)_40%,transparent)] text-[10px]">
+              ◆
+            </span>
+            <div className="h-px w-10 md:w-12 bg-linear-to-l from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_35%,transparent)]" />
           </div>
           <p
-            className="text-[#F8F4F0]/30 text-[11px] md:text-xs tracking-wider"
-            style={{ fontFamily: "'Noto Serif JP', serif" }}
+            className="text-[color-mix(in_srgb,var(--storefront-fg)_30%,transparent)] text-[11px] md:text-xs tracking-wider"
+            style={{ fontFamily: 'var(--storefront-font-display)' }}
           >
             お得な情報をお見逃しなく
           </p>
@@ -69,16 +73,18 @@ export default function Advertisement({ ads }: AdvertisementProps) {
               key={ad.id}
               className="group relative overflow-hidden"
               style={{
-                background: '#0F0F0F',
-                border: '1px solid rgba(201,168,76,0.1)',
+                background: 'var(--storefront-surface-3)',
+                border: '1px solid color-mix(in srgb, var(--storefront-accent) 10%, transparent)',
               }}
             >
               {/* 連番バッジ */}
               <div
                 className="absolute top-3 left-3 md:top-4 md:left-4 w-6 h-6 md:w-7 md:h-7 flex items-center justify-center z-10"
-                style={{ border: '1px solid rgba(201,168,76,0.3)' }}
+                style={{
+                  border: '1px solid color-mix(in srgb, var(--storefront-accent) 30%, transparent)',
+                }}
               >
-                <span className="text-[#C9A84C]/60 text-[8px] md:text-[9px] font-medium">
+                <span className="text-[color-mix(in_srgb,var(--storefront-accent)_60%,transparent)] text-[8px] md:text-[9px] font-medium">
                   {String(index + 1).padStart(2, '0')}
                 </span>
               </div>
@@ -86,7 +92,7 @@ export default function Advertisement({ ads }: AdvertisementProps) {
               {/* 画像エリア */}
               <div
                 className="h-36 sm:h-40 md:h-44 relative overflow-hidden"
-                style={{ background: '#0D0D0D' }}
+                style={{ background: 'var(--storefront-surface-2)' }}
               >
                 {ad.imageUrl ? (
                   <Image
@@ -101,10 +107,10 @@ export default function Advertisement({ ads }: AdvertisementProps) {
                     <div
                       className="w-full h-full opacity-5"
                       style={{
-                        backgroundImage: `repeating-linear-gradient(45deg, rgba(201,168,76,0.5) 0px, rgba(201,168,76,0.5) 1px, transparent 1px, transparent 12px)`,
+                        backgroundImage: `repeating-linear-gradient(45deg, color-mix(in srgb, var(--storefront-accent) 50%, transparent) 0px, color-mix(in srgb, var(--storefront-accent) 50%, transparent) 1px, transparent 1px, transparent 12px)`,
                       }}
                     />
-                    <span className="absolute text-[#C9A84C]/20 text-[9px] md:text-[10px] tracking-[0.3em]">
+                    <span className="absolute text-[color-mix(in_srgb,var(--storefront-accent)_20%,transparent)] text-[9px] md:text-[10px] tracking-[0.3em]">
                       CAMPAIGN
                     </span>
                   </div>
@@ -112,24 +118,25 @@ export default function Advertisement({ ads }: AdvertisementProps) {
                 <div
                   className="absolute inset-0"
                   style={{
-                    background: 'linear-gradient(to bottom, transparent 40%, #0F0F0F 100%)',
+                    background:
+                      'linear-gradient(to bottom, transparent 40%, var(--storefront-surface-3) 100%)',
                   }}
                 />
               </div>
 
               {/* コンテンツ */}
               <div className="px-4 pb-4 pt-3 md:px-5 md:pb-5 md:pt-4">
-                <div className="w-5 md:w-6 h-px bg-[#C9A84C]/40 mb-3 md:mb-4" />
+                <div className="w-5 md:w-6 h-px bg-[color-mix(in_srgb,var(--storefront-accent)_40%,transparent)] mb-3 md:mb-4" />
                 <h3
-                  className="text-[#F8F4F0]/85 text-sm font-light tracking-wider mb-2 md:mb-3 leading-relaxed"
-                  style={{ fontFamily: "'Noto Serif JP', serif" }}
+                  className="text-[color-mix(in_srgb,var(--storefront-fg)_85%,transparent)] text-sm font-light tracking-wider mb-2 md:mb-3 leading-relaxed"
+                  style={{ fontFamily: 'var(--storefront-font-display)' }}
                 >
                   {ad.title}
                 </h3>
                 {ad.description && (
                   <p
-                    className="text-[#F8F4F0]/35 text-[10px] md:text-[11px] leading-relaxed mb-3 md:mb-4"
-                    style={{ fontFamily: "'Noto Serif JP', serif" }}
+                    className="text-[color-mix(in_srgb,var(--storefront-fg)_35%,transparent)] text-[10px] md:text-[11px] leading-relaxed mb-3 md:mb-4"
+                    style={{ fontFamily: 'var(--storefront-font-display)' }}
                   >
                     {ad.description}
                   </p>
@@ -139,7 +146,7 @@ export default function Advertisement({ ads }: AdvertisementProps) {
                     href={ad.linkUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-[#C9A84C]/60 text-[9px] tracking-[0.3em] uppercase hover:text-[#C9A84C] transition-colors duration-200"
+                    className="text-[color-mix(in_srgb,var(--storefront-accent)_60%,transparent)] text-[9px] tracking-[0.3em] uppercase hover:text-[var(--storefront-accent)] transition-colors duration-200"
                   >
                     詳細を見る →
                   </a>
@@ -149,7 +156,10 @@ export default function Advertisement({ ads }: AdvertisementProps) {
               {/* ホバー時ゴールドボーダー */}
               <div
                 className="absolute inset-0 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-                style={{ boxShadow: 'inset 0 0 0 1px rgba(201,168,76,0.25)' }}
+                style={{
+                  boxShadow:
+                    'inset 0 0 0 1px color-mix(in srgb, var(--storefront-accent) 25%, transparent)',
+                }}
               />
             </div>
           ))}

--- a/frontend/src/_pages/store-site/templates/_sections/AgeVerification.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/AgeVerification.tsx
@@ -36,14 +36,15 @@ export default function AgeGate({ storeName }: AgeGateProps) {
 
   // ローディング中は黒い画面を表示
   if (phase === 'loading') {
-    return <div className="fixed inset-0 bg-[#080808] z-[9999]" />;
+    return <div className="fixed inset-0 bg-[var(--storefront-bg)] z-[9999]" />;
   }
 
   return (
     <div
       className="fixed inset-0 z-[9999] flex items-center justify-center p-6"
       style={{
-        background: 'radial-gradient(ellipse at 50% 35%, #130d08 0%, #080808 65%)',
+        background:
+          'radial-gradient(ellipse at 50% 35%, var(--storefront-bg-glow) 0%, var(--storefront-bg) 65%)',
         opacity: exiting ? 0 : mounted ? 1 : 0,
         transition: 'opacity 0.7s ease',
       }}
@@ -57,10 +58,10 @@ export default function AgeGate({ storeName }: AgeGateProps) {
       />
 
       {/* コーナーオーナメント */}
-      <div className="absolute top-8 left-8 w-14 h-14 border-t border-l border-[#C9A84C]/25" />
-      <div className="absolute top-8 right-8 w-14 h-14 border-t border-r border-[#C9A84C]/25" />
-      <div className="absolute bottom-8 left-8 w-14 h-14 border-b border-l border-[#C9A84C]/25" />
-      <div className="absolute bottom-8 right-8 w-14 h-14 border-b border-r border-[#C9A84C]/25" />
+      <div className="absolute top-8 left-8 w-14 h-14 border-t border-l border-[color-mix(in_srgb,var(--storefront-accent)_25%,transparent)]" />
+      <div className="absolute top-8 right-8 w-14 h-14 border-t border-r border-[color-mix(in_srgb,var(--storefront-accent)_25%,transparent)]" />
+      <div className="absolute bottom-8 left-8 w-14 h-14 border-b border-l border-[color-mix(in_srgb,var(--storefront-accent)_25%,transparent)]" />
+      <div className="absolute bottom-8 right-8 w-14 h-14 border-b border-r border-[color-mix(in_srgb,var(--storefront-accent)_25%,transparent)]" />
 
       {/* メインコンテンツ */}
       <div
@@ -74,7 +75,7 @@ export default function AgeGate({ storeName }: AgeGateProps) {
           <>
             {/* 英語サブタイトル */}
             <p
-              className="text-[#C9A84C]/45 text-[9px] tracking-[0.6em] uppercase mb-5"
+              className="text-[color-mix(in_srgb,var(--storefront-accent)_45%,transparent)] text-[9px] tracking-[0.6em] uppercase mb-5"
               style={{ letterSpacing: '0.5em' }}
             >
               Premium Entertainment
@@ -82,39 +83,41 @@ export default function AgeGate({ storeName }: AgeGateProps) {
 
             {/* 店舗名 */}
             <h1
-              className="text-[28px] text-[#F8F4F0] font-light tracking-[0.2em] mb-7"
-              style={{ fontFamily: "'Noto Serif JP', 'Hiragino Mincho Pro', 'Yu Mincho', serif" }}
+              className="text-[28px] text-[var(--storefront-fg)] font-light tracking-[0.2em] mb-7"
+              style={{ fontFamily: 'var(--storefront-font-display)' }}
             >
               {storeName}
             </h1>
 
             {/* ゴールド区切り線 */}
             <div className="flex items-center justify-center gap-3 mb-8">
-              <div className="h-px w-16 bg-linear-to-r from-transparent to-[#C9A84C]/45" />
-              <span className="text-[#C9A84C]/55 text-[11px]">◆</span>
-              <div className="h-px w-16 bg-linear-to-l from-transparent to-[#C9A84C]/45" />
+              <div className="h-px w-16 bg-linear-to-r from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_45%,transparent)]" />
+              <span className="text-[color-mix(in_srgb,var(--storefront-accent)_55%,transparent)] text-[11px]">
+                ◆
+              </span>
+              <div className="h-px w-16 bg-linear-to-l from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_45%,transparent)]" />
             </div>
 
             {/* 年齢確認ボックス */}
-            <div className="border border-[#C9A84C]/12 bg-[#F8F4F0]/[0.02] px-6 py-5 mb-7">
+            <div className="border border-[color-mix(in_srgb,var(--storefront-accent)_12%,transparent)] bg-[color-mix(in_srgb,var(--storefront-fg)_2%,transparent)] px-6 py-5 mb-7">
               <p
-                className="text-[#F8F4F0]/85 text-sm font-light mb-1.5 leading-relaxed"
-                style={{ fontFamily: "'Noto Serif JP', serif" }}
+                className="text-[color-mix(in_srgb,var(--storefront-fg)_85%,transparent)] text-sm font-light mb-1.5 leading-relaxed"
+                style={{ fontFamily: 'var(--storefront-font-display)' }}
               >
                 このサイトは18歳以上の方のみ閲覧可能です
               </p>
-              <p className="text-[#A89880]/55 text-[10px] tracking-wider">
+              <p className="text-[color-mix(in_srgb,var(--storefront-muted)_55%,transparent)] text-[10px] tracking-wider">
                 This website is restricted to individuals aged 18 and over
               </p>
             </div>
 
             <p
-              className="text-[#F8F4F0]/65 text-sm font-light mb-1"
-              style={{ fontFamily: "'Noto Serif JP', serif" }}
+              className="text-[color-mix(in_srgb,var(--storefront-fg)_65%,transparent)] text-sm font-light mb-1"
+              style={{ fontFamily: 'var(--storefront-font-display)' }}
             >
               あなたは18歳以上ですか？
             </p>
-            <p className="text-[#A89880]/45 text-[10px] tracking-wider mb-8">
+            <p className="text-[color-mix(in_srgb,var(--storefront-muted)_45%,transparent)] text-[10px] tracking-wider mb-8">
               Are you 18 years of age or older?
             </p>
 
@@ -122,20 +125,20 @@ export default function AgeGate({ storeName }: AgeGateProps) {
             <div className="grid grid-cols-2 gap-3">
               <button
                 onClick={handleAccept}
-                className="py-3.5 border border-[#C9A84C]/70 text-[#C9A84C] text-[10px] tracking-[0.35em] uppercase transition-all duration-300 hover:bg-[#C9A84C] hover:text-[#080808] hover:border-[#C9A84C] font-medium"
+                className="py-3.5 border border-[color-mix(in_srgb,var(--storefront-accent)_70%,transparent)] text-[var(--storefront-accent)] text-[10px] tracking-[0.35em] uppercase transition-all duration-300 hover:bg-[var(--storefront-accent)] hover:text-[var(--storefront-bg)] hover:border-[var(--storefront-accent)] font-medium"
               >
                 はい &nbsp; YES
               </button>
               <button
                 onClick={handleDecline}
-                className="py-3.5 border border-[#2A2A2A] text-[#484848] text-[10px] tracking-[0.35em] uppercase transition-all duration-300 hover:border-[#484848] hover:text-[#A89880] font-medium"
+                className="py-3.5 border border-[var(--storefront-line)] text-[var(--storefront-neutral)] text-[10px] tracking-[0.35em] uppercase transition-all duration-300 hover:border-[var(--storefront-neutral)] hover:text-[var(--storefront-muted)] font-medium"
               >
                 いいえ &nbsp; NO
               </button>
             </div>
 
             {/* 法的注記 */}
-            <p className="text-[#252525] text-[9px] mt-8 leading-relaxed tracking-wider">
+            <p className="text-[var(--storefront-subtle)] text-[9px] mt-8 leading-relaxed tracking-wider">
               日本の法律により、18歳未満の方の閲覧を禁止しています
             </p>
           </>
@@ -143,31 +146,33 @@ export default function AgeGate({ storeName }: AgeGateProps) {
           /* アクセス拒否状態 */
           <>
             <div className="flex items-center justify-center gap-3 mb-8">
-              <div className="h-px w-16 bg-linear-to-r from-transparent to-[#8B1A2E]/45" />
-              <span className="text-[#8B1A2E]/55 text-[11px]">◆</span>
-              <div className="h-px w-16 bg-linear-to-l from-transparent to-[#8B1A2E]/45" />
+              <div className="h-px w-16 bg-linear-to-r from-transparent to-[color-mix(in_srgb,var(--storefront-danger)_45%,transparent)]" />
+              <span className="text-[color-mix(in_srgb,var(--storefront-danger)_55%,transparent)] text-[11px]">
+                ◆
+              </span>
+              <div className="h-px w-16 bg-linear-to-l from-transparent to-[color-mix(in_srgb,var(--storefront-danger)_45%,transparent)]" />
             </div>
             <p
-              className="text-[#F8F4F0] text-lg font-light tracking-[0.25em] mb-2"
-              style={{ fontFamily: "'Noto Serif JP', serif" }}
+              className="text-[var(--storefront-fg)] text-lg font-light tracking-[0.25em] mb-2"
+              style={{ fontFamily: 'var(--storefront-font-display)' }}
             >
               アクセス制限
             </p>
-            <p className="text-[#A89880]/60 text-[9px] tracking-[0.5em] uppercase mb-8">
+            <p className="text-[color-mix(in_srgb,var(--storefront-muted)_60%,transparent)] text-[9px] tracking-[0.5em] uppercase mb-8">
               Access Restricted
             </p>
             <p
-              className="text-[#F8F4F0]/55 text-sm font-light mb-2 leading-relaxed"
-              style={{ fontFamily: "'Noto Serif JP', serif" }}
+              className="text-[color-mix(in_srgb,var(--storefront-fg)_55%,transparent)] text-sm font-light mb-2 leading-relaxed"
+              style={{ fontFamily: 'var(--storefront-font-display)' }}
             >
               18歳未満の方はご利用いただけません
             </p>
-            <p className="text-[#A89880]/45 text-[10px] mb-10 leading-relaxed">
+            <p className="text-[color-mix(in_srgb,var(--storefront-muted)_45%,transparent)] text-[10px] mb-10 leading-relaxed">
               You must be 18 years or older to access this site
             </p>
             <button
               onClick={() => window.close()}
-              className="py-2.5 px-8 border border-[#252525] text-[#484848] text-[9px] tracking-[0.3em] uppercase transition-all duration-300 hover:border-[#484848] hover:text-[#A89880]"
+              className="py-2.5 px-8 border border-[var(--storefront-subtle)] text-[var(--storefront-neutral)] text-[9px] tracking-[0.3em] uppercase transition-all duration-300 hover:border-[var(--storefront-neutral)] hover:text-[var(--storefront-muted)]"
             >
               ウィンドウを閉じる
             </button>

--- a/frontend/src/_pages/store-site/templates/_sections/Banner.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/Banner.tsx
@@ -23,7 +23,7 @@ export default function Banner({ tenantName, bannerUrl, description }: BannerPro
   return (
     <section className="relative min-h-[85vh] md:min-h-[90vh] flex items-center justify-center overflow-hidden">
       {/* 背景 */}
-      <div className="absolute inset-0" style={{ background: '#080808' }}>
+      <div className="absolute inset-0" style={{ background: 'var(--storefront-bg)' }}>
         {safeBannerUrl && (
           <div
             className="absolute inset-0 bg-cover bg-center opacity-35"
@@ -35,7 +35,7 @@ export default function Banner({ tenantName, bannerUrl, description }: BannerPro
           className="absolute inset-0"
           style={{
             background:
-              'linear-gradient(to bottom, rgba(8,8,8,0.4) 0%, rgba(8,8,8,0.5) 50%, rgba(8,8,8,0.95) 100%)',
+              'linear-gradient(to bottom, color-mix(in srgb, var(--storefront-bg) 40%, transparent) 0%, color-mix(in srgb, var(--storefront-bg) 50%, transparent) 50%, color-mix(in srgb, var(--storefront-bg) 95%, transparent) 100%)',
           }}
         />
         {/* 放射状グロー */}
@@ -43,43 +43,45 @@ export default function Banner({ tenantName, bannerUrl, description }: BannerPro
           className="absolute inset-0 pointer-events-none"
           style={{
             background:
-              'radial-gradient(ellipse at 50% 40%, rgba(201,168,76,0.04) 0%, transparent 65%)',
+              'radial-gradient(ellipse at 50% 40%, color-mix(in srgb, var(--storefront-accent) 4%, transparent) 0%, transparent 65%)',
           }}
         />
       </div>
 
       {/* コーナーオーナメント（lg以上のみ） */}
-      <div className="absolute top-10 left-10 w-16 h-16 border-t border-l border-[#C9A84C]/20 hidden lg:block" />
-      <div className="absolute top-10 right-10 w-16 h-16 border-t border-r border-[#C9A84C]/20 hidden lg:block" />
-      <div className="absolute bottom-10 left-10 w-16 h-16 border-b border-l border-[#C9A84C]/20 hidden lg:block" />
-      <div className="absolute bottom-10 right-10 w-16 h-16 border-b border-r border-[#C9A84C]/20 hidden lg:block" />
+      <div className="absolute top-10 left-10 w-16 h-16 border-t border-l border-[color-mix(in_srgb,var(--storefront-accent)_20%,transparent)] hidden lg:block" />
+      <div className="absolute top-10 right-10 w-16 h-16 border-t border-r border-[color-mix(in_srgb,var(--storefront-accent)_20%,transparent)] hidden lg:block" />
+      <div className="absolute bottom-10 left-10 w-16 h-16 border-b border-l border-[color-mix(in_srgb,var(--storefront-accent)_20%,transparent)] hidden lg:block" />
+      <div className="absolute bottom-10 right-10 w-16 h-16 border-b border-r border-[color-mix(in_srgb,var(--storefront-accent)_20%,transparent)] hidden lg:block" />
 
       {/* メインコンテンツ */}
       <div className="relative z-10 text-center px-5 sm:px-8 max-w-3xl mx-auto w-full">
         {/* 英語サブタイトル */}
-        <p className="text-[#C9A84C]/50 text-[8px] sm:text-[9px] tracking-[0.5em] sm:tracking-[0.7em] uppercase mb-6 md:mb-8">
+        <p className="text-[color-mix(in_srgb,var(--storefront-accent)_50%,transparent)] text-[8px] sm:text-[9px] tracking-[0.5em] sm:tracking-[0.7em] uppercase mb-6 md:mb-8">
           Premium Entertainment Club
         </p>
 
         {/* 店舗名 */}
         <h1
-          className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-light tracking-[0.12em] sm:tracking-[0.15em] text-[#F8F4F0] mb-3 md:mb-4"
-          style={{ fontFamily: "'Noto Serif JP', 'Hiragino Mincho Pro', 'Yu Mincho', serif" }}
+          className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-light tracking-[0.12em] sm:tracking-[0.15em] text-[var(--storefront-fg)] mb-3 md:mb-4"
+          style={{ fontFamily: 'var(--storefront-font-display)' }}
         >
           {tenantName}
         </h1>
 
         {/* ゴールド区切り */}
         <div className="flex items-center justify-center gap-3 sm:gap-4 my-6 md:my-8">
-          <div className="h-px w-16 sm:w-24 bg-linear-to-r from-transparent to-[#C9A84C]/50" />
-          <span className="text-[#C9A84C]/65 text-[10px] sm:text-xs">◆</span>
-          <div className="h-px w-16 sm:w-24 bg-linear-to-l from-transparent to-[#C9A84C]/50" />
+          <div className="h-px w-16 sm:w-24 bg-linear-to-r from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_50%,transparent)]" />
+          <span className="text-[color-mix(in_srgb,var(--storefront-accent)_65%,transparent)] text-[10px] sm:text-xs">
+            ◆
+          </span>
+          <div className="h-px w-16 sm:w-24 bg-linear-to-l from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_50%,transparent)]" />
         </div>
 
         {/* 説明文 */}
         <p
-          className="text-[#F8F4F0]/50 text-xs sm:text-sm md:text-base font-light leading-relaxed mb-8 md:mb-12 max-w-xs sm:max-w-xl mx-auto"
-          style={{ fontFamily: "'Noto Serif JP', serif" }}
+          className="text-[color-mix(in_srgb,var(--storefront-fg)_50%,transparent)] text-xs sm:text-sm md:text-base font-light leading-relaxed mb-8 md:mb-12 max-w-xs sm:max-w-xl mx-auto"
+          style={{ fontFamily: 'var(--storefront-font-display)' }}
         >
           {description || '最高のおもてなしと上質な時間をご提供する、大人のための特別な空間'}
         </p>
@@ -88,15 +90,15 @@ export default function Banner({ tenantName, bannerUrl, description }: BannerPro
         <div className="flex flex-col sm:flex-row justify-center items-center gap-3 sm:gap-4">
           <a
             href="#cast"
-            className="w-full sm:w-auto px-8 py-3 border border-[#C9A84C]/60 text-[#C9A84C] text-[10px] tracking-[0.4em] uppercase hover:bg-[#C9A84C] hover:text-[#080808] transition-all duration-300 text-center"
-            style={{ fontFamily: "'Noto Serif JP', serif" }}
+            className="w-full sm:w-auto px-8 py-3 border border-[color-mix(in_srgb,var(--storefront-accent)_60%,transparent)] text-[var(--storefront-accent)] text-[10px] tracking-[0.4em] uppercase hover:bg-[var(--storefront-accent)] hover:text-[var(--storefront-bg)] transition-all duration-300 text-center"
+            style={{ fontFamily: 'var(--storefront-font-display)' }}
           >
             キャストを見る
           </a>
           <a
             href="#campaign"
-            className="w-full sm:w-auto px-8 py-3 border border-[#F8F4F0]/15 text-[#F8F4F0]/50 text-[10px] tracking-[0.4em] uppercase hover:border-[#F8F4F0]/30 hover:text-[#F8F4F0]/80 transition-all duration-300 text-center"
-            style={{ fontFamily: "'Noto Serif JP', serif" }}
+            className="w-full sm:w-auto px-8 py-3 border border-[color-mix(in_srgb,var(--storefront-fg)_15%,transparent)] text-[color-mix(in_srgb,var(--storefront-fg)_50%,transparent)] text-[10px] tracking-[0.4em] uppercase hover:border-[color-mix(in_srgb,var(--storefront-fg)_30%,transparent)] hover:text-[color-mix(in_srgb,var(--storefront-fg)_80%,transparent)] transition-all duration-300 text-center"
+            style={{ fontFamily: 'var(--storefront-font-display)' }}
           >
             キャンペーン
           </a>
@@ -105,8 +107,10 @@ export default function Banner({ tenantName, bannerUrl, description }: BannerPro
 
       {/* スクロール示唆 */}
       <div className="absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2">
-        <span className="text-[#C9A84C]/30 text-[8px] tracking-[0.4em]">SCROLL</span>
-        <div className="w-px h-6 sm:h-8 bg-linear-to-b from-[#C9A84C]/30 to-transparent" />
+        <span className="text-[color-mix(in_srgb,var(--storefront-accent)_30%,transparent)] text-[8px] tracking-[0.4em]">
+          SCROLL
+        </span>
+        <div className="w-px h-6 sm:h-8 bg-linear-to-b from-[color-mix(in_srgb,var(--storefront-accent)_30%,transparent)] to-transparent" />
       </div>
     </section>
   );

--- a/frontend/src/_pages/store-site/templates/_sections/CastDetailSection.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/CastDetailSection.tsx
@@ -19,12 +19,15 @@ export default function CastDetailSection({ cast }: CastDetailSectionProps) {
   if (cast.hip) profile.push({ label: 'ヒップ', value: `${cast.hip}` });
 
   return (
-    <section className="py-12 md:py-20 px-5 sm:px-6" style={{ background: '#080808' }}>
+    <section className="py-12 md:py-20 px-5 sm:px-6" style={{ background: 'var(--storefront-bg)' }}>
       <div className="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12">
         {/* 写真 */}
         <div
           className="aspect-3/4 relative overflow-hidden"
-          style={{ background: '#0F0F0F', boxShadow: '0 0 0 1px rgba(201,168,76,0.15)' }}
+          style={{
+            background: 'var(--storefront-surface-3)',
+            boxShadow: '0 0 0 1px color-mix(in srgb, var(--storefront-accent) 15%, transparent)',
+          }}
         >
           {cast.photo_url ? (
             <Image
@@ -36,7 +39,11 @@ export default function CastDetailSection({ cast }: CastDetailSectionProps) {
             />
           ) : (
             <div className="absolute inset-0 flex items-center justify-center">
-              <svg className="w-16 h-16" fill="rgba(201,168,76,0.15)" viewBox="0 0 24 24">
+              <svg
+                className="w-16 h-16"
+                fill="color-mix(in srgb, var(--storefront-accent) 15%, transparent)"
+                viewBox="0 0 24 24"
+              >
                 <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
               </svg>
             </div>
@@ -50,14 +57,14 @@ export default function CastDetailSection({ cast }: CastDetailSectionProps) {
               {profile.map(({ label, value }) => (
                 <div
                   key={label}
-                  className="flex items-center justify-between border-b border-[#C9A84C]/10 pb-2"
+                  className="flex items-center justify-between border-b border-[color-mix(in_srgb,var(--storefront-accent)_10%,transparent)] pb-2"
                 >
-                  <dt className="text-[#C9A84C]/60 text-[10px] tracking-[0.3em] uppercase">
+                  <dt className="text-[color-mix(in_srgb,var(--storefront-accent)_60%,transparent)] text-[10px] tracking-[0.3em] uppercase">
                     {label}
                   </dt>
                   <dd
-                    className="text-[#F8F4F0]/80 text-sm tracking-wider"
-                    style={{ fontFamily: "'Noto Serif JP', serif" }}
+                    className="text-[color-mix(in_srgb,var(--storefront-fg)_80%,transparent)] text-sm tracking-wider"
+                    style={{ fontFamily: 'var(--storefront-font-display)' }}
                   >
                     {value}
                   </dd>
@@ -68,8 +75,8 @@ export default function CastDetailSection({ cast }: CastDetailSectionProps) {
 
           {cast.introduction && (
             <p
-              className="text-[#F8F4F0]/50 text-sm leading-loose whitespace-pre-line"
-              style={{ fontFamily: "'Noto Serif JP', serif" }}
+              className="text-[color-mix(in_srgb,var(--storefront-fg)_50%,transparent)] text-sm leading-loose whitespace-pre-line"
+              style={{ fontFamily: 'var(--storefront-font-display)' }}
             >
               {cast.introduction}
             </p>
@@ -80,8 +87,8 @@ export default function CastDetailSection({ cast }: CastDetailSectionProps) {
       <div className="text-center mt-12 md:mt-16">
         <Link
           href="/casts"
-          className="inline-block border border-[#C9A84C]/40 text-[#C9A84C] text-[9px] tracking-[0.4em] uppercase px-8 md:px-10 py-3 hover:bg-[#C9A84C] hover:text-[#080808] transition-all duration-300"
-          style={{ fontFamily: "'Noto Serif JP', serif" }}
+          className="inline-block border border-[color-mix(in_srgb,var(--storefront-accent)_40%,transparent)] text-[var(--storefront-accent)] text-[9px] tracking-[0.4em] uppercase px-8 md:px-10 py-3 hover:bg-[var(--storefront-accent)] hover:text-[var(--storefront-bg)] transition-all duration-300"
+          style={{ fontFamily: 'var(--storefront-font-display)' }}
         >
           ← キャスト一覧へ
         </Link>

--- a/frontend/src/_pages/store-site/templates/_sections/CastGrid.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/CastGrid.tsx
@@ -12,12 +12,12 @@ interface CastGridProps {
  */
 export default function CastGrid({ casts }: CastGridProps) {
   return (
-    <section className="py-12 md:py-20 px-5 sm:px-6" style={{ background: '#080808' }}>
+    <section className="py-12 md:py-20 px-5 sm:px-6" style={{ background: 'var(--storefront-bg)' }}>
       <div className="max-w-7xl mx-auto">
         {casts.length === 0 ? (
           <p
-            className="text-center text-[#F8F4F0]/30 text-sm tracking-wider py-16"
-            style={{ fontFamily: "'Noto Serif JP', serif" }}
+            className="text-center text-[color-mix(in_srgb,var(--storefront-fg)_30%,transparent)] text-sm tracking-wider py-16"
+            style={{ fontFamily: 'var(--storefront-font-display)' }}
           >
             キャスト情報は準備中です
           </p>
@@ -27,7 +27,11 @@ export default function CastGrid({ casts }: CastGridProps) {
               <Link key={cast.id} href={`/casts/${cast.id}`} className="group/card block">
                 <div
                   className="aspect-3/4 relative overflow-hidden mb-2 md:mb-3"
-                  style={{ background: '#0F0F0F', boxShadow: '0 0 0 1px rgba(201,168,76,0.1)' }}
+                  style={{
+                    background: 'var(--storefront-surface-3)',
+                    boxShadow:
+                      '0 0 0 1px color-mix(in srgb, var(--storefront-accent) 10%, transparent)',
+                  }}
                 >
                   {cast.photo_url ? (
                     <Image
@@ -41,7 +45,7 @@ export default function CastGrid({ casts }: CastGridProps) {
                     <div className="absolute inset-0 flex items-center justify-center">
                       <svg
                         className="w-10 h-10 md:w-14 md:h-14"
-                        fill="rgba(201,168,76,0.15)"
+                        fill="color-mix(in srgb, var(--storefront-accent) 15%, transparent)"
                         viewBox="0 0 24 24"
                       >
                         <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
@@ -50,18 +54,23 @@ export default function CastGrid({ casts }: CastGridProps) {
                   )}
                   <div
                     className="absolute inset-0 opacity-0 group-hover/card:opacity-100 transition-opacity duration-300"
-                    style={{ boxShadow: 'inset 0 0 0 1px rgba(201,168,76,0.4)' }}
+                    style={{
+                      boxShadow:
+                        'inset 0 0 0 1px color-mix(in srgb, var(--storefront-accent) 40%, transparent)',
+                    }}
                   />
                 </div>
                 <div className="text-center px-1">
                   <h3
-                    className="text-[#F8F4F0]/85 text-xs md:text-sm font-light tracking-wider mb-1"
-                    style={{ fontFamily: "'Noto Serif JP', serif" }}
+                    className="text-[color-mix(in_srgb,var(--storefront-fg)_85%,transparent)] text-xs md:text-sm font-light tracking-wider mb-1"
+                    style={{ fontFamily: 'var(--storefront-font-display)' }}
                   >
                     {cast.name}
                   </h3>
                   {cast.age && (
-                    <p className="text-[9px] md:text-[10px] text-[#C9A84C]/50">{cast.age}歳</p>
+                    <p className="text-[9px] md:text-[10px] text-[color-mix(in_srgb,var(--storefront-accent)_50%,transparent)]">
+                      {cast.age}歳
+                    </p>
                   )}
                 </div>
               </Link>

--- a/frontend/src/_pages/store-site/templates/_sections/CastSection.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/CastSection.tsx
@@ -34,25 +34,33 @@ export default function CastSection({ casts }: CastSectionProps) {
   };
 
   return (
-    <section id="cast" className="py-12 md:py-20 px-5 sm:px-6" style={{ background: '#080808' }}>
+    <section
+      id="cast"
+      className="py-12 md:py-20 px-5 sm:px-6"
+      style={{ background: 'var(--storefront-bg)' }}
+    >
       <div className="max-w-7xl mx-auto">
         {/* セクションヘッダー */}
         <div className="text-center mb-10 md:mb-14">
-          <p className="text-[#C9A84C]/40 text-[9px] tracking-[0.6em] uppercase mb-3">Our Cast</p>
+          <p className="text-[color-mix(in_srgb,var(--storefront-accent)_40%,transparent)] text-[9px] tracking-[0.6em] uppercase mb-3">
+            Our Cast
+          </p>
           <h2
-            className="text-xl md:text-2xl font-light tracking-[0.2em] text-[#F8F4F0]/85"
-            style={{ fontFamily: "'Noto Serif JP', 'Hiragino Mincho Pro', serif" }}
+            className="text-xl md:text-2xl font-light tracking-[0.2em] text-[color-mix(in_srgb,var(--storefront-fg)_85%,transparent)]"
+            style={{ fontFamily: 'var(--storefront-font-display)' }}
           >
             キャスト紹介
           </h2>
           <div className="flex items-center justify-center gap-3 mt-4 md:mt-5 mb-3">
-            <div className="h-px w-10 md:w-12 bg-linear-to-r from-transparent to-[#C9A84C]/35" />
-            <span className="text-[#C9A84C]/40 text-[10px]">◆</span>
-            <div className="h-px w-10 md:w-12 bg-linear-to-l from-transparent to-[#C9A84C]/35" />
+            <div className="h-px w-10 md:w-12 bg-linear-to-r from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_35%,transparent)]" />
+            <span className="text-[color-mix(in_srgb,var(--storefront-accent)_40%,transparent)] text-[10px]">
+              ◆
+            </span>
+            <div className="h-px w-10 md:w-12 bg-linear-to-l from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_35%,transparent)]" />
           </div>
           <p
-            className="text-[#F8F4F0]/30 text-[11px] md:text-xs tracking-wider"
-            style={{ fontFamily: "'Noto Serif JP', serif" }}
+            className="text-[color-mix(in_srgb,var(--storefront-fg)_30%,transparent)] text-[11px] md:text-xs tracking-wider"
+            style={{ fontFamily: 'var(--storefront-font-display)' }}
           >
             当店自慢のキャストをご紹介します
           </p>
@@ -63,11 +71,11 @@ export default function CastSection({ casts }: CastSectionProps) {
           {/* 左矢印（md以上でホバー時表示） */}
           <button
             onClick={() => scroll('left')}
-            className="absolute left-0 top-1/2 -translate-y-1/2 z-10 w-8 h-8 md:w-9 md:h-9 border border-[#C9A84C]/30 flex items-center justify-center md:opacity-0 md:group-hover:opacity-100 transition-all duration-300 -ml-3 md:-ml-4 hover:bg-[#C9A84C]/10"
-            style={{ background: 'rgba(8,8,8,0.9)' }}
+            className="absolute left-0 top-1/2 -translate-y-1/2 z-10 w-8 h-8 md:w-9 md:h-9 border border-[color-mix(in_srgb,var(--storefront-accent)_30%,transparent)] flex items-center justify-center md:opacity-0 md:group-hover:opacity-100 transition-all duration-300 -ml-3 md:-ml-4 hover:bg-[color-mix(in_srgb,var(--storefront-accent)_10%,transparent)]"
+            style={{ background: 'color-mix(in srgb, var(--storefront-bg) 90%, transparent)' }}
             aria-label="前へ"
           >
-            <ChevronLeftIcon className="h-3.5 w-3.5 md:h-4 md:w-4 text-[#C9A84C]" />
+            <ChevronLeftIcon className="h-3.5 w-3.5 md:h-4 md:w-4 text-[var(--storefront-accent)]" />
           </button>
 
           {/* スクロールエリア */}
@@ -85,8 +93,9 @@ export default function CastSection({ casts }: CastSectionProps) {
                 <div
                   className="aspect-3/4 relative overflow-hidden mb-2 md:mb-3"
                   style={{
-                    background: '#0F0F0F',
-                    boxShadow: '0 0 0 1px rgba(201,168,76,0.1)',
+                    background: 'var(--storefront-surface-3)',
+                    boxShadow:
+                      '0 0 0 1px color-mix(in srgb, var(--storefront-accent) 10%, transparent)',
                   }}
                 >
                   {cast.photo_url ? (
@@ -101,7 +110,7 @@ export default function CastSection({ casts }: CastSectionProps) {
                     <div className="absolute inset-0 flex items-center justify-center">
                       <svg
                         className="w-10 h-10 md:w-14 md:h-14"
-                        fill="rgba(201,168,76,0.15)"
+                        fill="color-mix(in srgb, var(--storefront-accent) 15%, transparent)"
                         viewBox="0 0 24 24"
                       >
                         <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
@@ -112,30 +121,34 @@ export default function CastSection({ casts }: CastSectionProps) {
                   <div
                     className="absolute inset-0 opacity-0 group-hover/card:opacity-100 transition-opacity duration-300"
                     style={{
-                      background: 'linear-gradient(to top, rgba(8,8,8,0.8) 0%, transparent 50%)',
+                      background:
+                        'linear-gradient(to top, color-mix(in srgb, var(--storefront-bg) 80%, transparent) 0%, transparent 50%)',
                     }}
                   />
                   {/* ゴールドボーダー（ホバー） */}
                   <div
                     className="absolute inset-0 opacity-0 group-hover/card:opacity-100 transition-opacity duration-300"
-                    style={{ boxShadow: 'inset 0 0 0 1px rgba(201,168,76,0.4)' }}
+                    style={{
+                      boxShadow:
+                        'inset 0 0 0 1px color-mix(in srgb, var(--storefront-accent) 40%, transparent)',
+                    }}
                   />
                 </div>
 
                 {/* キャスト情報 */}
                 <div className="text-center px-1">
                   <h3
-                    className="text-[#F8F4F0]/85 text-xs md:text-sm font-light tracking-wider mb-1"
-                    style={{ fontFamily: "'Noto Serif JP', serif" }}
+                    className="text-[color-mix(in_srgb,var(--storefront-fg)_85%,transparent)] text-xs md:text-sm font-light tracking-wider mb-1"
+                    style={{ fontFamily: 'var(--storefront-font-display)' }}
                   >
                     {cast.name}
                   </h3>
-                  <div className="text-[9px] md:text-[10px] text-[#C9A84C]/50 space-x-1.5">
+                  <div className="text-[9px] md:text-[10px] text-[color-mix(in_srgb,var(--storefront-accent)_50%,transparent)] space-x-1.5">
                     {cast.age && <span>{cast.age}歳</span>}
                     {cast.height && <span>T{cast.height}</span>}
                   </div>
                   {cast.bust && cast.waist && cast.hip && (
-                    <p className="text-[8px] md:text-[9px] text-[#F8F4F0]/20 mt-0.5">
+                    <p className="text-[8px] md:text-[9px] text-[color-mix(in_srgb,var(--storefront-fg)_20%,transparent)] mt-0.5">
                       B{cast.bust} · W{cast.waist} · H{cast.hip}
                     </p>
                   )}
@@ -147,11 +160,11 @@ export default function CastSection({ casts }: CastSectionProps) {
           {/* 右矢印 */}
           <button
             onClick={() => scroll('right')}
-            className="absolute right-0 top-1/2 -translate-y-1/2 z-10 w-8 h-8 md:w-9 md:h-9 border border-[#C9A84C]/30 flex items-center justify-center md:opacity-0 md:group-hover:opacity-100 transition-all duration-300 -mr-3 md:-mr-4 hover:bg-[#C9A84C]/10"
-            style={{ background: 'rgba(8,8,8,0.9)' }}
+            className="absolute right-0 top-1/2 -translate-y-1/2 z-10 w-8 h-8 md:w-9 md:h-9 border border-[color-mix(in_srgb,var(--storefront-accent)_30%,transparent)] flex items-center justify-center md:opacity-0 md:group-hover:opacity-100 transition-all duration-300 -mr-3 md:-mr-4 hover:bg-[color-mix(in_srgb,var(--storefront-accent)_10%,transparent)]"
+            style={{ background: 'color-mix(in srgb, var(--storefront-bg) 90%, transparent)' }}
             aria-label="次へ"
           >
-            <ChevronRightIcon className="h-3.5 w-3.5 md:h-4 md:w-4 text-[#C9A84C]" />
+            <ChevronRightIcon className="h-3.5 w-3.5 md:h-4 md:w-4 text-[var(--storefront-accent)]" />
           </button>
         </div>
 
@@ -159,8 +172,8 @@ export default function CastSection({ casts }: CastSectionProps) {
         <div className="text-center mt-10 md:mt-14">
           <Link
             href="/login"
-            className="inline-block border border-[#C9A84C]/40 text-[#C9A84C] text-[9px] tracking-[0.4em] uppercase px-8 md:px-10 py-3 hover:bg-[#C9A84C] hover:text-[#080808] transition-all duration-300"
-            style={{ fontFamily: "'Noto Serif JP', serif" }}
+            className="inline-block border border-[color-mix(in_srgb,var(--storefront-accent)_40%,transparent)] text-[var(--storefront-accent)] text-[9px] tracking-[0.4em] uppercase px-8 md:px-10 py-3 hover:bg-[var(--storefront-accent)] hover:text-[var(--storefront-bg)] transition-all duration-300"
+            style={{ fontFamily: 'var(--storefront-font-display)' }}
           >
             全てのキャストを見る
           </Link>

--- a/frontend/src/_pages/store-site/templates/_sections/Footer.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/Footer.tsx
@@ -14,26 +14,29 @@ export default function Footer({ tenantName, partnerLinks, snsLinks }: FooterPro
   return (
     <footer
       id="contact"
-      style={{ background: '#050505', borderTop: '1px solid rgba(201,168,76,0.1)' }}
+      style={{
+        background: 'var(--storefront-bg-deep)',
+        borderTop: '1px solid color-mix(in srgb, var(--storefront-accent) 10%, transparent)',
+      }}
     >
       {/* メインフッター */}
       <div className="max-w-7xl mx-auto px-5 sm:px-6 lg:px-10 py-12 md:py-16">
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8 md:gap-12">
           {/* 店舗情報 */}
           <div className="sm:col-span-2 md:col-span-1">
-            <p className="text-[#C9A84C]/40 text-[8px] tracking-[0.5em] uppercase mb-3 md:mb-4">
+            <p className="text-[color-mix(in_srgb,var(--storefront-accent)_40%,transparent)] text-[8px] tracking-[0.5em] uppercase mb-3 md:mb-4">
               Premium Entertainment
             </p>
             <h3
-              className="text-lg md:text-xl font-light tracking-[0.25em] text-[#C9A84C] mb-4 md:mb-5"
-              style={{ fontFamily: "'Noto Serif JP', 'Hiragino Mincho Pro', serif" }}
+              className="text-lg md:text-xl font-light tracking-[0.25em] text-[var(--storefront-accent)] mb-4 md:mb-5"
+              style={{ fontFamily: 'var(--storefront-font-display)' }}
             >
               {tenantName}
             </h3>
-            <div className="w-8 h-px bg-[#C9A84C]/30 mb-4 md:mb-5" />
+            <div className="w-8 h-px bg-[color-mix(in_srgb,var(--storefront-accent)_30%,transparent)] mb-4 md:mb-5" />
             <p
-              className="text-[#F8F4F0]/30 text-xs leading-relaxed"
-              style={{ fontFamily: "'Noto Serif JP', serif" }}
+              className="text-[color-mix(in_srgb,var(--storefront-fg)_30%,transparent)] text-xs leading-relaxed"
+              style={{ fontFamily: 'var(--storefront-font-display)' }}
             >
               お客様に最高のサービスを提供することをお約束します。
             </p>
@@ -41,7 +44,7 @@ export default function Footer({ tenantName, partnerLinks, snsLinks }: FooterPro
 
           {/* パートナーリンク */}
           <div>
-            <p className="text-[#C9A84C]/50 text-[9px] tracking-[0.4em] uppercase mb-4 md:mb-5">
+            <p className="text-[color-mix(in_srgb,var(--storefront-accent)_50%,transparent)] text-[9px] tracking-[0.4em] uppercase mb-4 md:mb-5">
               Partner Links
             </p>
             {partners.length > 0 ? (
@@ -52,8 +55,8 @@ export default function Footer({ tenantName, partnerLinks, snsLinks }: FooterPro
                       href={partner.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-[#F8F4F0]/30 text-xs hover:text-[#C9A84C]/70 transition-colors duration-200 tracking-wider"
-                      style={{ fontFamily: "'Noto Serif JP', serif" }}
+                      className="text-[color-mix(in_srgb,var(--storefront-fg)_30%,transparent)] text-xs hover:text-[color-mix(in_srgb,var(--storefront-accent)_70%,transparent)] transition-colors duration-200 tracking-wider"
+                      style={{ fontFamily: 'var(--storefront-font-display)' }}
                     >
                       {partner.name}
                     </a>
@@ -61,13 +64,15 @@ export default function Footer({ tenantName, partnerLinks, snsLinks }: FooterPro
                 ))}
               </ul>
             ) : (
-              <p className="text-[#F8F4F0]/15 text-xs">—</p>
+              <p className="text-[color-mix(in_srgb,var(--storefront-fg)_15%,transparent)] text-xs">
+                —
+              </p>
             )}
           </div>
 
           {/* SNSリンク */}
           <div>
-            <p className="text-[#C9A84C]/50 text-[9px] tracking-[0.4em] uppercase mb-4 md:mb-5">
+            <p className="text-[color-mix(in_srgb,var(--storefront-accent)_50%,transparent)] text-[9px] tracking-[0.4em] uppercase mb-4 md:mb-5">
               Follow Us
             </p>
             {sns.length > 0 ? (
@@ -78,7 +83,7 @@ export default function Footer({ tenantName, partnerLinks, snsLinks }: FooterPro
                     href={item.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-[#F8F4F0]/25 hover:text-[#C9A84C]/70 transition-colors duration-200"
+                    className="text-[color-mix(in_srgb,var(--storefront-fg)_25%,transparent)] hover:text-[color-mix(in_srgb,var(--storefront-accent)_70%,transparent)] transition-colors duration-200"
                     aria-label={item.platform}
                   >
                     {getSnsIcon(item.platform)}
@@ -86,23 +91,27 @@ export default function Footer({ tenantName, partnerLinks, snsLinks }: FooterPro
                 ))}
               </div>
             ) : (
-              <p className="text-[#F8F4F0]/15 text-xs">—</p>
+              <p className="text-[color-mix(in_srgb,var(--storefront-fg)_15%,transparent)] text-xs">
+                —
+              </p>
             )}
           </div>
         </div>
       </div>
 
       {/* コピーライト */}
-      <div style={{ borderTop: '1px solid rgba(255,255,255,0.04)' }}>
+      <div style={{ borderTop: '1px solid var(--storefront-hairline)' }}>
         <div className="max-w-7xl mx-auto px-5 sm:px-6 lg:px-10 py-5 md:py-6">
           <div className="flex flex-col sm:flex-row justify-between items-center gap-2 sm:gap-3">
             <div className="flex items-center gap-3">
-              <span className="text-[#C9A84C]/25 text-[10px]">◆</span>
-              <p className="text-[#F8F4F0]/20 text-[10px] tracking-wider">
+              <span className="text-[color-mix(in_srgb,var(--storefront-accent)_25%,transparent)] text-[10px]">
+                ◆
+              </span>
+              <p className="text-[color-mix(in_srgb,var(--storefront-fg)_20%,transparent)] text-[10px] tracking-wider">
                 © {year} {tenantName}. All rights reserved.
               </p>
             </div>
-            <p className="text-[#F8F4F0]/10 text-[9px] tracking-widest">
+            <p className="text-[color-mix(in_srgb,var(--storefront-fg)_10%,transparent)] text-[9px] tracking-widest">
               Powered by Kizuna Platform
             </p>
           </div>

--- a/frontend/src/_pages/store-site/templates/_sections/Header.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/Header.tsx
@@ -27,9 +27,9 @@ export default function Header({ tenantName, logoUrl }: HeaderProps) {
       <header
         className="sticky top-0 z-50 border-b"
         style={{
-          background: 'rgba(8, 8, 8, 0.97)',
+          background: 'color-mix(in srgb, var(--storefront-bg) 97%, transparent)',
           backdropFilter: 'blur(16px)',
-          borderBottomColor: 'rgba(201, 168, 76, 0.12)',
+          borderBottomColor: 'color-mix(in srgb, var(--storefront-accent) 12%, transparent)',
         }}
       >
         <div className="max-w-7xl mx-auto px-5 lg:px-10">
@@ -46,8 +46,8 @@ export default function Header({ tenantName, logoUrl }: HeaderProps) {
                 />
               ) : (
                 <span
-                  className="text-base md:text-lg tracking-[0.25em] md:tracking-[0.3em] text-[#C9A84C]"
-                  style={{ fontFamily: "'Noto Serif JP', 'Hiragino Mincho Pro', serif" }}
+                  className="text-base md:text-lg tracking-[0.25em] md:tracking-[0.3em] text-[var(--storefront-accent)]"
+                  style={{ fontFamily: 'var(--storefront-font-display)' }}
                 >
                   {tenantName}
                 </span>
@@ -60,8 +60,8 @@ export default function Header({ tenantName, logoUrl }: HeaderProps) {
                 <Link
                   key={href}
                   href={href}
-                  className="text-[10px] tracking-[0.25em] text-[#F8F4F0]/40 hover:text-[#C9A84C] transition-colors duration-300"
-                  style={{ fontFamily: "'Noto Serif JP', serif" }}
+                  className="text-[10px] tracking-[0.25em] text-[color-mix(in_srgb,var(--storefront-fg)_40%,transparent)] hover:text-[var(--storefront-accent)] transition-colors duration-300"
+                  style={{ fontFamily: 'var(--storefront-font-display)' }}
                 >
                   {label}
                 </Link>
@@ -73,8 +73,8 @@ export default function Header({ tenantName, logoUrl }: HeaderProps) {
               {/* ログインボタン（sm以上で表示） */}
               <Link
                 href="/login"
-                className="hidden sm:block text-[9px] tracking-[0.3em] border border-[#C9A84C]/40 text-[#C9A84C] px-4 py-1.5 md:px-5 md:py-2 hover:bg-[#C9A84C] hover:text-[#080808] transition-all duration-300"
-                style={{ fontFamily: "'Noto Serif JP', serif" }}
+                className="hidden sm:block text-[9px] tracking-[0.3em] border border-[color-mix(in_srgb,var(--storefront-accent)_40%,transparent)] text-[var(--storefront-accent)] px-4 py-1.5 md:px-5 md:py-2 hover:bg-[var(--storefront-accent)] hover:text-[var(--storefront-bg)] transition-all duration-300"
+                style={{ fontFamily: 'var(--storefront-font-display)' }}
               >
                 ログイン
               </Link>
@@ -87,21 +87,21 @@ export default function Header({ tenantName, logoUrl }: HeaderProps) {
                 aria-expanded={menuOpen}
               >
                 <span
-                  className="block w-[18px] h-px bg-[#C9A84C]"
+                  className="block w-[18px] h-px bg-[var(--storefront-accent)]"
                   style={{
                     transition: 'transform 0.25s ease, opacity 0.25s ease',
                     transform: menuOpen ? 'translateY(6px) rotate(45deg)' : 'none',
                   }}
                 />
                 <span
-                  className="block w-[18px] h-px bg-[#C9A84C]"
+                  className="block w-[18px] h-px bg-[var(--storefront-accent)]"
                   style={{
                     transition: 'opacity 0.25s ease',
                     opacity: menuOpen ? 0 : 1,
                   }}
                 />
                 <span
-                  className="block w-[18px] h-px bg-[#C9A84C]"
+                  className="block w-[18px] h-px bg-[var(--storefront-accent)]"
                   style={{
                     transition: 'transform 0.25s ease',
                     transform: menuOpen ? 'translateY(-6px) rotate(-45deg)' : 'none',
@@ -118,7 +118,7 @@ export default function Header({ tenantName, logoUrl }: HeaderProps) {
         className="fixed inset-0 z-40 md:hidden flex flex-col pointer-events-none"
         style={{
           top: '56px',
-          background: 'rgba(8, 8, 8, 0.98)',
+          background: 'color-mix(in srgb, var(--storefront-bg) 98%, transparent)',
           opacity: menuOpen ? 1 : 0,
           transition: 'opacity 0.3s ease',
           pointerEvents: menuOpen ? 'auto' : 'none',
@@ -131,9 +131,9 @@ export default function Header({ tenantName, logoUrl }: HeaderProps) {
               key={href}
               href={href}
               onClick={closeMenu}
-              className="text-[#F8F4F0]/60 text-base tracking-[0.35em] hover:text-[#C9A84C] transition-colors duration-200"
+              className="text-[color-mix(in_srgb,var(--storefront-fg)_60%,transparent)] text-base tracking-[0.35em] hover:text-[var(--storefront-accent)] transition-colors duration-200"
               style={{
-                fontFamily: "'Noto Serif JP', serif",
+                fontFamily: 'var(--storefront-font-display)',
                 transitionDelay: menuOpen ? `${i * 60}ms` : '0ms',
                 transform: menuOpen ? 'translateY(0)' : 'translateY(8px)',
                 opacity: menuOpen ? 1 : 0,
@@ -146,17 +146,19 @@ export default function Header({ tenantName, logoUrl }: HeaderProps) {
 
           {/* 区切り */}
           <div className="flex items-center gap-3 my-2">
-            <div className="h-px w-10 bg-linear-to-r from-transparent to-[#C9A84C]/25" />
-            <span className="text-[#C9A84C]/30 text-[10px]">◆</span>
-            <div className="h-px w-10 bg-linear-to-l from-transparent to-[#C9A84C]/25" />
+            <div className="h-px w-10 bg-linear-to-r from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_25%,transparent)]" />
+            <span className="text-[color-mix(in_srgb,var(--storefront-accent)_30%,transparent)] text-[10px]">
+              ◆
+            </span>
+            <div className="h-px w-10 bg-linear-to-l from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_25%,transparent)]" />
           </div>
 
           {/* ログインボタン（xs） */}
           <Link
             href="/login"
             onClick={closeMenu}
-            className="text-[10px] tracking-[0.4em] border border-[#C9A84C]/40 text-[#C9A84C] px-8 py-3 hover:bg-[#C9A84C] hover:text-[#080808] transition-all duration-300"
-            style={{ fontFamily: "'Noto Serif JP', serif" }}
+            className="text-[10px] tracking-[0.4em] border border-[color-mix(in_srgb,var(--storefront-accent)_40%,transparent)] text-[var(--storefront-accent)] px-8 py-3 hover:bg-[var(--storefront-accent)] hover:text-[var(--storefront-bg)] transition-all duration-300"
+            style={{ fontFamily: 'var(--storefront-font-display)' }}
           >
             ログイン
           </Link>
@@ -164,8 +166,8 @@ export default function Header({ tenantName, logoUrl }: HeaderProps) {
 
         {/* 下部コピーライト */}
         <p
-          className="text-center text-[#252525] text-[9px] tracking-wider pb-8"
-          style={{ fontFamily: "'Noto Serif JP', serif" }}
+          className="text-center text-[var(--storefront-subtle)] text-[9px] tracking-wider pb-8"
+          style={{ fontFamily: 'var(--storefront-font-display)' }}
         >
           18歳以上限定 / For Adults Only
         </p>

--- a/frontend/src/_pages/store-site/templates/_sections/MVSection.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/MVSection.tsx
@@ -9,23 +9,28 @@ export default function MVSection({ mvUrl, mvType = 'image' }: MVSectionProps) {
   const hasMedia = !!mvUrl;
 
   return (
-    <section className="py-12 md:py-20 px-5 sm:px-6" style={{ background: '#0A0A0A' }}>
+    <section
+      className="py-12 md:py-20 px-5 sm:px-6"
+      style={{ background: 'var(--storefront-surface-1)' }}
+    >
       <div className="max-w-5xl mx-auto">
         {/* セクションヘッダー */}
         <div className="text-center mb-8 md:mb-12">
-          <p className="text-[#C9A84C]/40 text-[9px] tracking-[0.6em] uppercase mb-3">
+          <p className="text-[color-mix(in_srgb,var(--storefront-accent)_40%,transparent)] text-[9px] tracking-[0.6em] uppercase mb-3">
             Main Visual
           </p>
           <h2
-            className="text-xl md:text-2xl font-light tracking-[0.2em] text-[#F8F4F0]/80"
-            style={{ fontFamily: "'Noto Serif JP', 'Hiragino Mincho Pro', serif" }}
+            className="text-xl md:text-2xl font-light tracking-[0.2em] text-[color-mix(in_srgb,var(--storefront-fg)_80%,transparent)]"
+            style={{ fontFamily: 'var(--storefront-font-display)' }}
           >
             メインビジュアル
           </h2>
           <div className="flex items-center justify-center gap-3 mt-4 md:mt-5">
-            <div className="h-px w-10 md:w-12 bg-linear-to-r from-transparent to-[#C9A84C]/35" />
-            <span className="text-[#C9A84C]/40 text-[10px]">◆</span>
-            <div className="h-px w-10 md:w-12 bg-linear-to-l from-transparent to-[#C9A84C]/35" />
+            <div className="h-px w-10 md:w-12 bg-linear-to-r from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_35%,transparent)]" />
+            <span className="text-[color-mix(in_srgb,var(--storefront-accent)_40%,transparent)] text-[10px]">
+              ◆
+            </span>
+            <div className="h-px w-10 md:w-12 bg-linear-to-l from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_35%,transparent)]" />
           </div>
         </div>
 
@@ -35,10 +40,10 @@ export default function MVSection({ mvUrl, mvType = 'image' }: MVSectionProps) {
           style={{
             padding: '1px',
             background:
-              'linear-gradient(135deg, rgba(201,168,76,0.25) 0%, rgba(201,168,76,0.05) 50%, rgba(201,168,76,0.25) 100%)',
+              'linear-gradient(135deg, color-mix(in srgb, var(--storefront-accent) 25%, transparent) 0%, color-mix(in srgb, var(--storefront-accent) 5%, transparent) 50%, color-mix(in srgb, var(--storefront-accent) 25%, transparent) 100%)',
           }}
         >
-          <div className="relative" style={{ background: '#0F0F0F' }}>
+          <div className="relative" style={{ background: 'var(--storefront-surface-3)' }}>
             {hasMedia ? (
               mvType === 'video' ? (
                 <div className="aspect-video">
@@ -66,18 +71,20 @@ export default function MVSection({ mvUrl, mvType = 'image' }: MVSectionProps) {
             ) : (
               <div
                 className="aspect-video flex items-center justify-center"
-                style={{ background: '#0D0D0D' }}
+                style={{ background: 'var(--storefront-surface-2)' }}
               >
                 <div className="text-center">
                   <div className="flex items-center justify-center gap-3 mb-4 md:mb-6">
-                    <div className="h-px w-8 md:w-10 bg-linear-to-r from-transparent to-[#C9A84C]/25" />
-                    <span className="text-[#C9A84C]/30 text-xs">◆</span>
-                    <div className="h-px w-8 md:w-10 bg-linear-to-l from-transparent to-[#C9A84C]/25" />
+                    <div className="h-px w-8 md:w-10 bg-linear-to-r from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_25%,transparent)]" />
+                    <span className="text-[color-mix(in_srgb,var(--storefront-accent)_30%,transparent)] text-xs">
+                      ◆
+                    </span>
+                    <div className="h-px w-8 md:w-10 bg-linear-to-l from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_25%,transparent)]" />
                   </div>
                   <svg
                     className="w-10 h-10 md:w-12 md:h-12 mx-auto mb-3 md:mb-4"
                     fill="none"
-                    stroke="rgba(201,168,76,0.2)"
+                    stroke="color-mix(in srgb, var(--storefront-accent) 20%, transparent)"
                     viewBox="0 0 24 24"
                   >
                     <path
@@ -88,8 +95,8 @@ export default function MVSection({ mvUrl, mvType = 'image' }: MVSectionProps) {
                     />
                   </svg>
                   <p
-                    className="text-[#C9A84C]/25 text-[10px] md:text-xs tracking-widest"
-                    style={{ fontFamily: "'Noto Serif JP', serif" }}
+                    className="text-[color-mix(in_srgb,var(--storefront-accent)_25%,transparent)] text-[10px] md:text-xs tracking-widest"
+                    style={{ fontFamily: 'var(--storefront-font-display)' }}
                   >
                     メインビジュアル
                   </p>
@@ -99,10 +106,10 @@ export default function MVSection({ mvUrl, mvType = 'image' }: MVSectionProps) {
           </div>
 
           {/* コーナーオーナメント */}
-          <div className="absolute top-2 left-2 md:top-3 md:left-3 w-5 h-5 md:w-6 md:h-6 border-t border-l border-[#C9A84C]/50" />
-          <div className="absolute top-2 right-2 md:top-3 md:right-3 w-5 h-5 md:w-6 md:h-6 border-t border-r border-[#C9A84C]/50" />
-          <div className="absolute bottom-2 left-2 md:bottom-3 md:left-3 w-5 h-5 md:w-6 md:h-6 border-b border-l border-[#C9A84C]/50" />
-          <div className="absolute bottom-2 right-2 md:bottom-3 md:right-3 w-5 h-5 md:w-6 md:h-6 border-b border-r border-[#C9A84C]/50" />
+          <div className="absolute top-2 left-2 md:top-3 md:left-3 w-5 h-5 md:w-6 md:h-6 border-t border-l border-[color-mix(in_srgb,var(--storefront-accent)_50%,transparent)]" />
+          <div className="absolute top-2 right-2 md:top-3 md:right-3 w-5 h-5 md:w-6 md:h-6 border-t border-r border-[color-mix(in_srgb,var(--storefront-accent)_50%,transparent)]" />
+          <div className="absolute bottom-2 left-2 md:bottom-3 md:left-3 w-5 h-5 md:w-6 md:h-6 border-b border-l border-[color-mix(in_srgb,var(--storefront-accent)_50%,transparent)]" />
+          <div className="absolute bottom-2 right-2 md:bottom-3 md:right-3 w-5 h-5 md:w-6 md:h-6 border-b border-r border-[color-mix(in_srgb,var(--storefront-accent)_50%,transparent)]" />
         </div>
       </div>
     </section>

--- a/frontend/src/_pages/store-site/templates/_sections/PageHero.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/PageHero.tsx
@@ -5,29 +5,31 @@ interface PageHeroProps {
 
 /**
  * 各サブページ先頭の見出しバンド（Server Component）。
- * 既存区块と同じ暗色系トーン（#080808 / #C9A84C / Noto Serif JP）で統一する。
+ * 既存区块と同じ暗色系トーン（var(--storefront-bg) / var(--storefront-accent) / Noto Serif JP）で統一する。
  */
 export default function PageHero({ title, subtitle }: PageHeroProps) {
   return (
     <section
       className="pt-24 md:pt-32 pb-12 md:pb-16 px-5 sm:px-6 text-center"
-      style={{ background: '#080808' }}
+      style={{ background: 'var(--storefront-bg)' }}
     >
       <h1
-        className="text-2xl md:text-3xl font-light tracking-[0.25em] text-[#F8F4F0]/90"
-        style={{ fontFamily: "'Noto Serif JP', 'Hiragino Mincho Pro', serif" }}
+        className="text-2xl md:text-3xl font-light tracking-[0.25em] text-[color-mix(in_srgb,var(--storefront-fg)_90%,transparent)]"
+        style={{ fontFamily: 'var(--storefront-font-display)' }}
       >
         {title}
       </h1>
       <div className="flex items-center justify-center gap-3 mt-5 mb-3">
-        <div className="h-px w-10 md:w-12 bg-linear-to-r from-transparent to-[#C9A84C]/35" />
-        <span className="text-[#C9A84C]/40 text-[10px]">◆</span>
-        <div className="h-px w-10 md:w-12 bg-linear-to-l from-transparent to-[#C9A84C]/35" />
+        <div className="h-px w-10 md:w-12 bg-linear-to-r from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_35%,transparent)]" />
+        <span className="text-[color-mix(in_srgb,var(--storefront-accent)_40%,transparent)] text-[10px]">
+          ◆
+        </span>
+        <div className="h-px w-10 md:w-12 bg-linear-to-l from-transparent to-[color-mix(in_srgb,var(--storefront-accent)_35%,transparent)]" />
       </div>
       {subtitle && (
         <p
-          className="text-[#F8F4F0]/30 text-[11px] md:text-xs tracking-wider"
-          style={{ fontFamily: "'Noto Serif JP', serif" }}
+          className="text-[color-mix(in_srgb,var(--storefront-fg)_30%,transparent)] text-[11px] md:text-xs tracking-wider"
+          style={{ fontFamily: 'var(--storefront-font-display)' }}
         >
           {subtitle}
         </p>

--- a/frontend/src/_pages/store-site/templates/_sections/PricingSection.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/PricingSection.tsx
@@ -7,19 +7,19 @@ interface PricingSectionProps {
  */
 export default function PricingSection({ pricingDescription }: PricingSectionProps) {
   return (
-    <section className="py-12 md:py-20 px-5 sm:px-6" style={{ background: '#080808' }}>
+    <section className="py-12 md:py-20 px-5 sm:px-6" style={{ background: 'var(--storefront-bg)' }}>
       <div className="max-w-3xl mx-auto">
         {pricingDescription ? (
           <p
-            className="text-[#F8F4F0]/70 text-sm md:text-base leading-loose whitespace-pre-line tracking-wider"
-            style={{ fontFamily: "'Noto Serif JP', serif" }}
+            className="text-[color-mix(in_srgb,var(--storefront-fg)_70%,transparent)] text-sm md:text-base leading-loose whitespace-pre-line tracking-wider"
+            style={{ fontFamily: 'var(--storefront-font-display)' }}
           >
             {pricingDescription}
           </p>
         ) : (
           <p
-            className="text-center text-[#F8F4F0]/30 text-sm tracking-wider py-16"
-            style={{ fontFamily: "'Noto Serif JP', serif" }}
+            className="text-center text-[color-mix(in_srgb,var(--storefront-fg)_30%,transparent)] text-sm tracking-wider py-16"
+            style={{ fontFamily: 'var(--storefront-font-display)' }}
           >
             料金情報は準備中です
           </p>

--- a/frontend/src/_pages/store-site/templates/_sections/SchedulePlaceholder.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/SchedulePlaceholder.tsx
@@ -1,22 +1,22 @@
 /**
  * 出勤表の空状態プレースホルダ（Server Component）。
  *
- * ponytail: 出勤スケジュールの実データ源は #168（排班機能）実装後に接続する。
+ * ponytail: 出勤スケジュールの実データ源は issue 168（排班機能）実装後に接続する。
  * 現時点は API が無いため固定の空状態のみ表示する。
  */
 export default function SchedulePlaceholder() {
   return (
-    <section className="py-16 md:py-24 px-5 sm:px-6" style={{ background: '#080808' }}>
+    <section className="py-16 md:py-24 px-5 sm:px-6" style={{ background: 'var(--storefront-bg)' }}>
       <div className="max-w-2xl mx-auto text-center">
         <p
-          className="text-[#F8F4F0]/70 text-base md:text-lg font-light tracking-[0.15em] mb-4"
-          style={{ fontFamily: "'Noto Serif JP', 'Hiragino Mincho Pro', serif" }}
+          className="text-[color-mix(in_srgb,var(--storefront-fg)_70%,transparent)] text-base md:text-lg font-light tracking-[0.15em] mb-4"
+          style={{ fontFamily: 'var(--storefront-font-display)' }}
         >
           本日の出勤情報はありません
         </p>
         <p
-          className="text-[#F8F4F0]/30 text-xs md:text-sm leading-relaxed tracking-wider"
-          style={{ fontFamily: "'Noto Serif JP', serif" }}
+          className="text-[color-mix(in_srgb,var(--storefront-fg)_30%,transparent)] text-xs md:text-sm leading-relaxed tracking-wider"
+          style={{ fontFamily: 'var(--storefront-font-display)' }}
         >
           出勤情報は準備中です。最新の情報はお電話でお問い合わせください。
         </p>

--- a/frontend/src/_pages/store-site/templates/_sections/StoreInfoSection.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/StoreInfoSection.tsx
@@ -16,7 +16,10 @@ export default function StoreInfoSection({ siteConfig, accessNote }: StoreInfoSe
     rows.push({
       label: '電話',
       node: (
-        <a href={`tel:${siteConfig.phone}`} className="hover:text-[#C9A84C] transition-colors">
+        <a
+          href={`tel:${siteConfig.phone}`}
+          className="hover:text-[var(--storefront-accent)] transition-colors"
+        >
           {siteConfig.phone}
         </a>
       ),
@@ -24,17 +27,17 @@ export default function StoreInfoSection({ siteConfig, accessNote }: StoreInfoSe
   if (siteConfig.business_hours) rows.push({ label: '営業時間', node: siteConfig.business_hours });
 
   return (
-    <section className="py-12 md:py-20 px-5 sm:px-6" style={{ background: '#080808' }}>
+    <section className="py-12 md:py-20 px-5 sm:px-6" style={{ background: 'var(--storefront-bg)' }}>
       <div className="max-w-2xl mx-auto">
-        <dl className="divide-y divide-[#C9A84C]/10 border-t border-b border-[#C9A84C]/10">
+        <dl className="divide-y divide-[color-mix(in_srgb,var(--storefront-accent)_10%,transparent)] border-t border-b border-[color-mix(in_srgb,var(--storefront-accent)_10%,transparent)]">
           {rows.map(({ label, node }) => (
             <div key={label} className="grid grid-cols-3 gap-4 py-4 md:py-5">
-              <dt className="text-[#C9A84C]/60 text-[10px] tracking-[0.3em] uppercase pt-0.5">
+              <dt className="text-[color-mix(in_srgb,var(--storefront-accent)_60%,transparent)] text-[10px] tracking-[0.3em] uppercase pt-0.5">
                 {label}
               </dt>
               <dd
-                className="col-span-2 text-[#F8F4F0]/75 text-sm tracking-wider"
-                style={{ fontFamily: "'Noto Serif JP', serif" }}
+                className="col-span-2 text-[color-mix(in_srgb,var(--storefront-fg)_75%,transparent)] text-sm tracking-wider"
+                style={{ fontFamily: 'var(--storefront-font-display)' }}
               >
                 {node}
               </dd>
@@ -42,12 +45,12 @@ export default function StoreInfoSection({ siteConfig, accessNote }: StoreInfoSe
           ))}
           {accessNote && (
             <div className="grid grid-cols-3 gap-4 py-4 md:py-5">
-              <dt className="text-[#C9A84C]/60 text-[10px] tracking-[0.3em] uppercase pt-0.5">
+              <dt className="text-[color-mix(in_srgb,var(--storefront-accent)_60%,transparent)] text-[10px] tracking-[0.3em] uppercase pt-0.5">
                 アクセス
               </dt>
               <dd
-                className="col-span-2 text-[#F8F4F0]/75 text-sm leading-relaxed whitespace-pre-line tracking-wider"
-                style={{ fontFamily: "'Noto Serif JP', serif" }}
+                className="col-span-2 text-[color-mix(in_srgb,var(--storefront-fg)_75%,transparent)] text-sm leading-relaxed whitespace-pre-line tracking-wider"
+                style={{ fontFamily: 'var(--storefront-font-display)' }}
               >
                 {accessNote}
               </dd>

--- a/frontend/src/_pages/store-site/templates/classic/about.tsx
+++ b/frontend/src/_pages/store-site/templates/classic/about.tsx
@@ -1,0 +1,37 @@
+import { cookies } from 'next/headers';
+import { storefrontService } from '../../api/storefront';
+import AgeGate from '../_sections/AgeVerification';
+import Footer from '../_sections/Footer';
+import Header from '../_sections/Header';
+import PageHero from '../_sections/PageHero';
+import StoreInfoSection from '../_sections/StoreInfoSection';
+import './theme.css';
+
+/** 店舗情報・アクセスページ（classic 模版）。 */
+export default async function ClassicAboutPage() {
+  const cookieStore = await cookies();
+  const tenantName = cookieStore.get('x-mw-tenant-name')?.value || 'Store';
+  const siteConfig = await storefrontService.fetchSiteConfig();
+
+  return (
+    <div
+      className="storefront-classic min-h-screen flex flex-col"
+      style={{ background: 'var(--storefront-bg)' }}
+    >
+      <AgeGate storeName={tenantName} />
+      <Header tenantName={tenantName} logoUrl={siteConfig.logo_url} />
+      <main className="grow">
+        <PageHero title="店舗情報・アクセス" />
+        <StoreInfoSection
+          siteConfig={siteConfig}
+          accessNote={siteConfig.custom_texts?.['access_note']}
+        />
+      </main>
+      <Footer
+        tenantName={tenantName}
+        snsLinks={siteConfig.sns_links}
+        partnerLinks={siteConfig.partner_links}
+      />
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-site/templates/classic/cast-detail.tsx
+++ b/frontend/src/_pages/store-site/templates/classic/cast-detail.tsx
@@ -1,0 +1,46 @@
+import { cookies } from 'next/headers';
+import { notFound } from 'next/navigation';
+import { storefrontService } from '../../api/storefront';
+import AgeGate from '../_sections/AgeVerification';
+import CastDetailSection from '../_sections/CastDetailSection';
+import Footer from '../_sections/Footer';
+import Header from '../_sections/Header';
+import PageHero from '../_sections/PageHero';
+import './theme.css';
+
+interface ClassicCastDetailPageProps {
+  castId: string;
+}
+
+/** キャスト詳細ページ（classic 模版）。 */
+export default async function ClassicCastDetailPage({ castId }: ClassicCastDetailPageProps) {
+  const cookieStore = await cookies();
+  const tenantName = cookieStore.get('x-mw-tenant-name')?.value || 'Store';
+  const [cast, siteConfig] = await Promise.all([
+    storefrontService.fetchCast(castId),
+    storefrontService.fetchSiteConfig(),
+  ]);
+
+  if (!cast) {
+    notFound();
+  }
+
+  return (
+    <div
+      className="storefront-classic min-h-screen flex flex-col"
+      style={{ background: 'var(--storefront-bg)' }}
+    >
+      <AgeGate storeName={tenantName} />
+      <Header tenantName={tenantName} logoUrl={siteConfig.logo_url} />
+      <main className="grow">
+        <PageHero title={cast.name} />
+        <CastDetailSection cast={cast} />
+      </main>
+      <Footer
+        tenantName={tenantName}
+        snsLinks={siteConfig.sns_links}
+        partnerLinks={siteConfig.partner_links}
+      />
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-site/templates/classic/casts.tsx
+++ b/frontend/src/_pages/store-site/templates/classic/casts.tsx
@@ -1,0 +1,34 @@
+import { cookies } from 'next/headers';
+import { storefrontService } from '../../api/storefront';
+import AgeGate from '../_sections/AgeVerification';
+import CastGrid from '../_sections/CastGrid';
+import Footer from '../_sections/Footer';
+import Header from '../_sections/Header';
+import PageHero from '../_sections/PageHero';
+import './theme.css';
+
+/** キャスト一覧ページ（classic 模版）。 */
+export default async function ClassicCastsPage() {
+  const cookieStore = await cookies();
+  const tenantName = cookieStore.get('x-mw-tenant-name')?.value || 'Store';
+  const { casts, siteConfig } = await storefrontService.getPageData();
+
+  return (
+    <div
+      className="storefront-classic min-h-screen flex flex-col"
+      style={{ background: 'var(--storefront-bg)' }}
+    >
+      <AgeGate storeName={tenantName} />
+      <Header tenantName={tenantName} logoUrl={siteConfig.logo_url} />
+      <main className="grow">
+        <PageHero title="キャスト一覧" />
+        <CastGrid casts={casts} />
+      </main>
+      <Footer
+        tenantName={tenantName}
+        snsLinks={siteConfig.sns_links}
+        partnerLinks={siteConfig.partner_links}
+      />
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-site/templates/classic/menu.tsx
+++ b/frontend/src/_pages/store-site/templates/classic/menu.tsx
@@ -1,0 +1,34 @@
+import { cookies } from 'next/headers';
+import { storefrontService } from '../../api/storefront';
+import AgeGate from '../_sections/AgeVerification';
+import Footer from '../_sections/Footer';
+import Header from '../_sections/Header';
+import PageHero from '../_sections/PageHero';
+import PricingSection from '../_sections/PricingSection';
+import './theme.css';
+
+/** 料金ページ（classic 模版）。 */
+export default async function ClassicMenuPage() {
+  const cookieStore = await cookies();
+  const tenantName = cookieStore.get('x-mw-tenant-name')?.value || 'Store';
+  const siteConfig = await storefrontService.fetchSiteConfig();
+
+  return (
+    <div
+      className="storefront-classic min-h-screen flex flex-col"
+      style={{ background: 'var(--storefront-bg)' }}
+    >
+      <AgeGate storeName={tenantName} />
+      <Header tenantName={tenantName} logoUrl={siteConfig.logo_url} />
+      <main className="grow">
+        <PageHero title="料金" />
+        <PricingSection pricingDescription={siteConfig.pricing_description} />
+      </main>
+      <Footer
+        tenantName={tenantName}
+        snsLinks={siteConfig.sns_links}
+        partnerLinks={siteConfig.partner_links}
+      />
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-site/templates/classic/page.tsx
+++ b/frontend/src/_pages/store-site/templates/classic/page.tsx
@@ -10,18 +10,19 @@ import MVSection from '../_sections/MVSection';
 import './theme.css';
 
 /**
- * デフォルトのテナントページ模版 (Server Component)
+ * classic 模版のテナントページ (Server Component)
  *
- * 構成:
+ * 構成（排布差: キャッチコピー帯を Banner の直上に置き明るい第一印象を作る）:
  * 1. AgeGate    - 年齢確認オーバーレイ（Client Component / localStorage）
  * 2. Header     - スティッキーヘッダー
- * 3. Banner     - フルスクリーンヒーローセクション
- * 4. MVSection  - メインビジュアル
- * 5. CastSection - キャスト紹介カルーセル
- * 6. Advertisement - キャンペーン情報
- * 7. Footer     - フッター
+ * 3. キャッチコピー帯（設定時のみ）
+ * 4. Banner     - フルスクリーンヒーローセクション
+ * 5. MVSection  - メインビジュアル
+ * 6. CastSection - キャスト紹介カルーセル
+ * 7. Advertisement - キャンペーン情報
+ * 8. Footer     - フッター
  */
-export default async function DefaultTemplate() {
+export default async function ClassicTemplate() {
   const cookieStore = await cookies();
   const tenantName = cookieStore.get('x-mw-tenant-name')?.value || 'Store';
 
@@ -30,7 +31,7 @@ export default async function DefaultTemplate() {
 
   return (
     <div
-      className="storefront-default min-h-screen flex flex-col"
+      className="storefront-classic min-h-screen flex flex-col"
       style={{ background: 'var(--storefront-bg)' }}
     >
       {/* 年齢確認ゲート（クライアントサイドのフルスクリーンオーバーレイ） */}
@@ -39,13 +40,7 @@ export default async function DefaultTemplate() {
       <Header tenantName={tenantName} logoUrl={siteConfig.logo_url} />
 
       <main className="grow">
-        <Banner
-          tenantName={tenantName}
-          bannerUrl={siteConfig.banner_url}
-          description={siteConfig.description}
-        />
-
-        {/* キャッチコピー帯（設定されている場合のみ表示） */}
+        {/* キャッチコピー帯（設定されている場合のみ表示、Banner の直上） */}
         {siteConfig.catch_copy && (
           <section
             className="py-10 md:py-14 px-5 sm:px-6 text-center"
@@ -59,6 +54,12 @@ export default async function DefaultTemplate() {
             </p>
           </section>
         )}
+
+        <Banner
+          tenantName={tenantName}
+          bannerUrl={siteConfig.banner_url}
+          description={siteConfig.description}
+        />
 
         <MVSection mvUrl={siteConfig.mv_url} mvType={siteConfig.mv_type} />
 

--- a/frontend/src/_pages/store-site/templates/classic/schedule.tsx
+++ b/frontend/src/_pages/store-site/templates/classic/schedule.tsx
@@ -1,0 +1,34 @@
+import { cookies } from 'next/headers';
+import { storefrontService } from '../../api/storefront';
+import AgeGate from '../_sections/AgeVerification';
+import Footer from '../_sections/Footer';
+import Header from '../_sections/Header';
+import PageHero from '../_sections/PageHero';
+import SchedulePlaceholder from '../_sections/SchedulePlaceholder';
+import './theme.css';
+
+/** 出勤表ページ（classic 模版）。 */
+export default async function ClassicSchedulePage() {
+  const cookieStore = await cookies();
+  const tenantName = cookieStore.get('x-mw-tenant-name')?.value || 'Store';
+  const siteConfig = await storefrontService.fetchSiteConfig();
+
+  return (
+    <div
+      className="storefront-classic min-h-screen flex flex-col"
+      style={{ background: 'var(--storefront-bg)' }}
+    >
+      <AgeGate storeName={tenantName} />
+      <Header tenantName={tenantName} logoUrl={siteConfig.logo_url} />
+      <main className="grow">
+        <PageHero title="出勤表" />
+        <SchedulePlaceholder />
+      </main>
+      <Footer
+        tenantName={tenantName}
+        snsLinks={siteConfig.sns_links}
+        partnerLinks={siteConfig.partner_links}
+      />
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-site/templates/classic/theme.css
+++ b/frontend/src/_pages/store-site/templates/classic/theme.css
@@ -1,0 +1,22 @@
+/* classic 模版のテーマトークン（issue #223 Phase 3、暖白×松石藍×Noto Serif JP）。
+   値は承認済みパレット A から外推。模版差はこのトークンと排布のみ（.claude/rules/design.md）。
+   明色地のため surface は bg より沈む方向、hairline は暗色側の極薄罫線。
+   注: --storefront-subtle は計画のパレット比較表に classic 値の記載が無かったため、
+   default の bg→neutral 関係（極薄の近背景トーン）に合わせて外推した値。 */
+.storefront-classic {
+  --storefront-bg: #faf7f2;
+  --storefront-fg: #2a2a28;
+  --storefront-accent: #4e8da6;
+  --storefront-muted: #7a776e;
+  --storefront-neutral: #d8d4cc;
+  --storefront-subtle: #ebe7e1;
+  --storefront-danger: #b0453a;
+  --storefront-bg-deep: #efe8dc;
+  --storefront-surface-1: #f4f0e9;
+  --storefront-surface-2: #f0ebe2;
+  --storefront-surface-3: #ece6db;
+  --storefront-line: #e2ddd3;
+  --storefront-bg-glow: #fffdf8;
+  --storefront-hairline: rgba(0, 0, 0, 0.06);
+  --storefront-font-display: 'Noto Serif JP', 'Hiragino Mincho Pro', serif;
+}

--- a/frontend/src/_pages/store-site/templates/default/theme.css
+++ b/frontend/src/_pages/store-site/templates/default/theme.css
@@ -1,6 +1,19 @@
-/* default 模版のテーマトークン（issue #223 Phase 1）。
-   Phase 3 で modern / classic が独自の theme.css を持つ。
-   トークンは実際に模版間で差分が必要になった時点で追加する（現時点は背景色のみ）。 */
+/* default 模版のテーマトークン（issue #223 Phase 3 で全色トークン化）。
+   模版はこのトークン表と排布のみで差別化する（.claude/rules/design.md）。 */
 .storefront-default {
   --storefront-bg: #080808;
+  --storefront-fg: #f8f4f0;
+  --storefront-accent: #c9a84c;
+  --storefront-muted: #a89880;
+  --storefront-neutral: #484848;
+  --storefront-subtle: #252525;
+  --storefront-danger: #8b1a2e;
+  --storefront-bg-deep: #050505;
+  --storefront-surface-1: #0a0a0a;
+  --storefront-surface-2: #0d0d0d;
+  --storefront-surface-3: #0f0f0f;
+  --storefront-line: #2a2a2a;
+  --storefront-bg-glow: #130d08;
+  --storefront-hairline: rgba(255, 255, 255, 0.04);
+  --storefront-font-display: 'Noto Serif JP', 'Hiragino Mincho Pro', serif;
 }

--- a/frontend/src/_pages/store-site/templates/modern/about.tsx
+++ b/frontend/src/_pages/store-site/templates/modern/about.tsx
@@ -1,0 +1,37 @@
+import { cookies } from 'next/headers';
+import { storefrontService } from '../../api/storefront';
+import AgeGate from '../_sections/AgeVerification';
+import Footer from '../_sections/Footer';
+import Header from '../_sections/Header';
+import PageHero from '../_sections/PageHero';
+import StoreInfoSection from '../_sections/StoreInfoSection';
+import './theme.css';
+
+/** 店舗情報・アクセスページ（modern 模版）。 */
+export default async function ModernAboutPage() {
+  const cookieStore = await cookies();
+  const tenantName = cookieStore.get('x-mw-tenant-name')?.value || 'Store';
+  const siteConfig = await storefrontService.fetchSiteConfig();
+
+  return (
+    <div
+      className="storefront-modern min-h-screen flex flex-col"
+      style={{ background: 'var(--storefront-bg)' }}
+    >
+      <AgeGate storeName={tenantName} />
+      <Header tenantName={tenantName} logoUrl={siteConfig.logo_url} />
+      <main className="grow">
+        <PageHero title="店舗情報・アクセス" />
+        <StoreInfoSection
+          siteConfig={siteConfig}
+          accessNote={siteConfig.custom_texts?.['access_note']}
+        />
+      </main>
+      <Footer
+        tenantName={tenantName}
+        snsLinks={siteConfig.sns_links}
+        partnerLinks={siteConfig.partner_links}
+      />
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-site/templates/modern/cast-detail.tsx
+++ b/frontend/src/_pages/store-site/templates/modern/cast-detail.tsx
@@ -1,0 +1,46 @@
+import { cookies } from 'next/headers';
+import { notFound } from 'next/navigation';
+import { storefrontService } from '../../api/storefront';
+import AgeGate from '../_sections/AgeVerification';
+import CastDetailSection from '../_sections/CastDetailSection';
+import Footer from '../_sections/Footer';
+import Header from '../_sections/Header';
+import PageHero from '../_sections/PageHero';
+import './theme.css';
+
+interface ModernCastDetailPageProps {
+  castId: string;
+}
+
+/** キャスト詳細ページ（modern 模版）。 */
+export default async function ModernCastDetailPage({ castId }: ModernCastDetailPageProps) {
+  const cookieStore = await cookies();
+  const tenantName = cookieStore.get('x-mw-tenant-name')?.value || 'Store';
+  const [cast, siteConfig] = await Promise.all([
+    storefrontService.fetchCast(castId),
+    storefrontService.fetchSiteConfig(),
+  ]);
+
+  if (!cast) {
+    notFound();
+  }
+
+  return (
+    <div
+      className="storefront-modern min-h-screen flex flex-col"
+      style={{ background: 'var(--storefront-bg)' }}
+    >
+      <AgeGate storeName={tenantName} />
+      <Header tenantName={tenantName} logoUrl={siteConfig.logo_url} />
+      <main className="grow">
+        <PageHero title={cast.name} />
+        <CastDetailSection cast={cast} />
+      </main>
+      <Footer
+        tenantName={tenantName}
+        snsLinks={siteConfig.sns_links}
+        partnerLinks={siteConfig.partner_links}
+      />
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-site/templates/modern/casts.tsx
+++ b/frontend/src/_pages/store-site/templates/modern/casts.tsx
@@ -1,0 +1,34 @@
+import { cookies } from 'next/headers';
+import { storefrontService } from '../../api/storefront';
+import AgeGate from '../_sections/AgeVerification';
+import CastGrid from '../_sections/CastGrid';
+import Footer from '../_sections/Footer';
+import Header from '../_sections/Header';
+import PageHero from '../_sections/PageHero';
+import './theme.css';
+
+/** キャスト一覧ページ（modern 模版）。 */
+export default async function ModernCastsPage() {
+  const cookieStore = await cookies();
+  const tenantName = cookieStore.get('x-mw-tenant-name')?.value || 'Store';
+  const { casts, siteConfig } = await storefrontService.getPageData();
+
+  return (
+    <div
+      className="storefront-modern min-h-screen flex flex-col"
+      style={{ background: 'var(--storefront-bg)' }}
+    >
+      <AgeGate storeName={tenantName} />
+      <Header tenantName={tenantName} logoUrl={siteConfig.logo_url} />
+      <main className="grow">
+        <PageHero title="キャスト一覧" />
+        <CastGrid casts={casts} />
+      </main>
+      <Footer
+        tenantName={tenantName}
+        snsLinks={siteConfig.sns_links}
+        partnerLinks={siteConfig.partner_links}
+      />
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-site/templates/modern/menu.tsx
+++ b/frontend/src/_pages/store-site/templates/modern/menu.tsx
@@ -1,0 +1,34 @@
+import { cookies } from 'next/headers';
+import { storefrontService } from '../../api/storefront';
+import AgeGate from '../_sections/AgeVerification';
+import Footer from '../_sections/Footer';
+import Header from '../_sections/Header';
+import PageHero from '../_sections/PageHero';
+import PricingSection from '../_sections/PricingSection';
+import './theme.css';
+
+/** 料金ページ（modern 模版）。 */
+export default async function ModernMenuPage() {
+  const cookieStore = await cookies();
+  const tenantName = cookieStore.get('x-mw-tenant-name')?.value || 'Store';
+  const siteConfig = await storefrontService.fetchSiteConfig();
+
+  return (
+    <div
+      className="storefront-modern min-h-screen flex flex-col"
+      style={{ background: 'var(--storefront-bg)' }}
+    >
+      <AgeGate storeName={tenantName} />
+      <Header tenantName={tenantName} logoUrl={siteConfig.logo_url} />
+      <main className="grow">
+        <PageHero title="料金" />
+        <PricingSection pricingDescription={siteConfig.pricing_description} />
+      </main>
+      <Footer
+        tenantName={tenantName}
+        snsLinks={siteConfig.sns_links}
+        partnerLinks={siteConfig.partner_links}
+      />
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-site/templates/modern/page.tsx
+++ b/frontend/src/_pages/store-site/templates/modern/page.tsx
@@ -10,18 +10,18 @@ import MVSection from '../_sections/MVSection';
 import './theme.css';
 
 /**
- * デフォルトのテナントページ模版 (Server Component)
+ * modern 模版のテナントページ (Server Component)
  *
- * 構成:
+ * 構成（排布差: CastSection を MVSection より先に置きキャストを前面に）:
  * 1. AgeGate    - 年齢確認オーバーレイ（Client Component / localStorage）
  * 2. Header     - スティッキーヘッダー
  * 3. Banner     - フルスクリーンヒーローセクション
- * 4. MVSection  - メインビジュアル
- * 5. CastSection - キャスト紹介カルーセル
+ * 4. CastSection - キャスト紹介カルーセル
+ * 5. MVSection  - メインビジュアル
  * 6. Advertisement - キャンペーン情報
  * 7. Footer     - フッター
  */
-export default async function DefaultTemplate() {
+export default async function ModernTemplate() {
   const cookieStore = await cookies();
   const tenantName = cookieStore.get('x-mw-tenant-name')?.value || 'Store';
 
@@ -30,7 +30,7 @@ export default async function DefaultTemplate() {
 
   return (
     <div
-      className="storefront-default min-h-screen flex flex-col"
+      className="storefront-modern min-h-screen flex flex-col"
       style={{ background: 'var(--storefront-bg)' }}
     >
       {/* 年齢確認ゲート（クライアントサイドのフルスクリーンオーバーレイ） */}
@@ -60,9 +60,9 @@ export default async function DefaultTemplate() {
           </section>
         )}
 
-        <MVSection mvUrl={siteConfig.mv_url} mvType={siteConfig.mv_type} />
-
         <CastSection casts={casts} />
+
+        <MVSection mvUrl={siteConfig.mv_url} mvType={siteConfig.mv_type} />
 
         <Advertisement />
       </main>

--- a/frontend/src/_pages/store-site/templates/modern/schedule.tsx
+++ b/frontend/src/_pages/store-site/templates/modern/schedule.tsx
@@ -1,0 +1,34 @@
+import { cookies } from 'next/headers';
+import { storefrontService } from '../../api/storefront';
+import AgeGate from '../_sections/AgeVerification';
+import Footer from '../_sections/Footer';
+import Header from '../_sections/Header';
+import PageHero from '../_sections/PageHero';
+import SchedulePlaceholder from '../_sections/SchedulePlaceholder';
+import './theme.css';
+
+/** 出勤表ページ（modern 模版）。 */
+export default async function ModernSchedulePage() {
+  const cookieStore = await cookies();
+  const tenantName = cookieStore.get('x-mw-tenant-name')?.value || 'Store';
+  const siteConfig = await storefrontService.fetchSiteConfig();
+
+  return (
+    <div
+      className="storefront-modern min-h-screen flex flex-col"
+      style={{ background: 'var(--storefront-bg)' }}
+    >
+      <AgeGate storeName={tenantName} />
+      <Header tenantName={tenantName} logoUrl={siteConfig.logo_url} />
+      <main className="grow">
+        <PageHero title="出勤表" />
+        <SchedulePlaceholder />
+      </main>
+      <Footer
+        tenantName={tenantName}
+        snsLinks={siteConfig.sns_links}
+        partnerLinks={siteConfig.partner_links}
+      />
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-site/templates/modern/theme.css
+++ b/frontend/src/_pages/store-site/templates/modern/theme.css
@@ -1,0 +1,21 @@
+/* modern 模版のテーマトークン（issue #223 Phase 3、藍黒×薔薇紅×Noto Sans JP）。
+   値は承認済みパレット A から外推。模版差はこのトークンと排布のみ（.claude/rules/design.md）。
+   注: --storefront-subtle は計画のパレット比較表に modern 値の記載が無かったため、
+   default の bg→neutral 関係（極薄の近背景トーン）に合わせて外推した値。 */
+.storefront-modern {
+  --storefront-bg: #0b0b12;
+  --storefront-fg: #f2eff4;
+  --storefront-accent: #e64980;
+  --storefront-muted: #8a87a0;
+  --storefront-neutral: #3a3a48;
+  --storefront-subtle: #1e1e29;
+  --storefront-danger: #8b1a2e;
+  --storefront-bg-deep: #07070c;
+  --storefront-surface-1: #10101a;
+  --storefront-surface-2: #13131e;
+  --storefront-surface-3: #161622;
+  --storefront-line: #24242f;
+  --storefront-bg-glow: #170d14;
+  --storefront-hairline: rgba(255, 255, 255, 0.05);
+  --storefront-font-display: 'Noto Sans JP', 'Hiragino Kaku Gothic ProN', sans-serif;
+}

--- a/frontend/src/entities/store-profile/__tests__/templateMeta.test.ts
+++ b/frontend/src/entities/store-profile/__tests__/templateMeta.test.ts
@@ -5,6 +5,10 @@ describe('getTemplateMeta', () => {
     expect(getTemplateMeta('default').name).toBe('デフォルト');
   });
 
+  it('modern 模版キーはそのメタを返すこと', () => {
+    expect(getTemplateMeta('modern').name).toBe('モダン');
+  });
+
   it('未知の模版キーは default にフォールバックすること', () => {
     expect(getTemplateMeta('no-such-template').key).toBe('default');
   });

--- a/frontend/src/entities/store-profile/model/templateMeta.ts
+++ b/frontend/src/entities/store-profile/model/templateMeta.ts
@@ -22,7 +22,16 @@ const TEMPLATE_METAS: Record<string, StoreTemplateMeta> = {
     name: 'デフォルト',
     textSlots: [{ key: 'access_note', label: 'アクセス補足（店舗情報ページに表示）' }],
   },
-  // modern / classic は #223 Phase 3 で追加する
+  modern: {
+    key: 'modern',
+    name: 'モダン',
+    textSlots: [{ key: 'access_note', label: 'アクセス補足（店舗情報ページに表示）' }],
+  },
+  classic: {
+    key: 'classic',
+    name: 'クラシック',
+    textSlots: [{ key: 'access_note', label: 'アクセス補足（店舗情報ページに表示）' }],
+  },
 };
 
 /** 未知の key は default のメタにフォールバックする。 */


### PR DESCRIPTION
## 概要（Refs #223 / Phase 3）

- `_sections/` 13 コンポーネント + default 6 ページのハードコード色（金 `#C9A84C` 系 6 色 + 近黒サーフェス系 7 色）を `templates/<key>/theme.css` の `--storefront-*` トークン（`var()` / `color-mix()`）へ完全移行。**default はピクセル等価**（同一計算値の置換のみ）
- **modern**（藍黒 `#0B0B12` × 薔薇紅 `#E64980` × Noto Sans JP）/ **classic**（暖白 `#FAF7F2` × 松石藍 `#4E8DA6` × Noto Serif JP）の 2 模版を追加。模版差はトークンと TOP の排布のみ（modern: CastSection を MVSection より先に / classic: キャッチコピー帯を Banner 直上に）。`_sections/` の fork なし
- `templateMeta.ts` に modern（モダン）/ classic（クラシック）を登録、`.claude/rules/design.md` のトークン表を 3 模版に更新

## 検証

- grep 門禁: `_sections/` + 全模版 dir の `*.tsx` に hex / rgba **0 件**
- `npm run format` / `lint` / `test`（100 passed）/ `build`、`task lint` / `task test` / `task build` すべて exit 0
- QA（E2E）: コンパイル済み CSS chunk に `.storefront-modern` / `.storefront-classic` の全トークンが配信されることを確認。default 表示は従来どおり

## 既知の制約（本 PR のスコープ外、フォローアップで修正）

QA が発見: `PUT /tenant/config` で template_key を切替えても公開サイトの模版が切り替わらない。原因は Phase 1 以前からの配線欠陥 — `resolveTenant()` が参照する `GET /central/tenant?domain=` の `TenantVO` に `template_key` が含まれていない（フロント側は `data.template_key` を読む実装済み）。バックエンド修正 PR を直後に提出する。選択 UI の復活は Phase 4。

🤖 Generated with [Claude Code](https://claude.com/claude-code)