### PR TITLE
fix(frontend): 公開サイトの模版切替が効かない配線欠陥を修正 — Refs #223

### DIFF
--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -43,7 +43,13 @@ export async function proxy(request: NextRequest) {
       .split(':')[0]
       .toLowerCase();
     response.cookies.set('x-mw-tenant-domain', hostname, cookieOptions);
-    response.cookies.set('x-mw-tenant-template', tenantData.templateKey, cookieOptions);
+    // template cookie のみ maxAge 60 秒（ISR revalidate 60 秒と揃える）。
+    // session cookie のままだと一度立った模版が既存訪問者に永久固定され、
+    // 模版変更が伝播しない。短命化して最大 ~2 分で全訪問者へ反映させる。
+    response.cookies.set('x-mw-tenant-template', tenantData.templateKey, {
+      ...cookieOptions,
+      maxAge: 60,
+    });
     if (tenantData.tenantId) {
       response.cookies.set('x-mw-tenant-id', tenantData.tenantId, cookieOptions);
     }

--- a/frontend/src/shared/lib/proxy/__tests__/tenantResolver.test.ts
+++ b/frontend/src/shared/lib/proxy/__tests__/tenantResolver.test.ts
@@ -153,4 +153,79 @@ describe('tenantResolver', () => {
     expect(global.fetch).toHaveBeenCalled();
     expect(result.tenantData?.tenantId).toBe('api-tenant-id');
   });
+
+  it('fetches template_key from tenant config when central response lacks it', async () => {
+    // 現実のバックエンド応答（TenantVO）は template_key を返さない
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (String(url).includes('config/public')) {
+        return Promise.resolve({
+          json: () => Promise.resolve({ template_key: 'modern' }),
+        });
+      }
+      return Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            id: 't1',
+            name: 'Tenant 1',
+            domain: 'store.test',
+            email: 'owner@store.test',
+          }),
+      });
+    });
+
+    const req = createRequest('store.test');
+    const result = await resolveTenant(req);
+
+    expect(result.tenantData?.templateKey).toBe('modern');
+    // 追撃 fetch は X-Role: tenant + X-Tenant-ID ヘッダで行う
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('config/public'),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Role': 'tenant', 'X-Tenant-ID': 't1' }),
+      })
+    );
+  });
+
+  it('falls back to default when tenant config fetch fails', async () => {
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (String(url).includes('config/public')) {
+        return Promise.reject(new Error('config down'));
+      }
+      return Promise.resolve({
+        json: () => Promise.resolve({ id: 't1', name: 'Tenant 1', domain: 'store.test' }),
+      });
+    });
+
+    const req = createRequest('store.test');
+    const result = await resolveTenant(req);
+
+    expect(result.tenantData?.isValid).toBe(true);
+    expect(result.tenantData?.templateKey).toBe('default');
+  });
+
+  it('does not short-circuit when template cookie is missing', async () => {
+    const cookies = {
+      'x-mw-tenant-id': 'cookie-tenant-id',
+      'x-mw-tenant-domain': 'store.test', // ドメインは一致するが template cookie が無い
+    };
+    const req = createRequest('store.test', cookies);
+
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (String(url).includes('config/public')) {
+        return Promise.resolve({
+          json: () => Promise.resolve({ template_key: 'classic' }),
+        });
+      }
+      return Promise.resolve({
+        json: () =>
+          Promise.resolve({ id: 'api-tenant-id', name: 'API Tenant', domain: 'store.test' }),
+      });
+    });
+
+    const result = await resolveTenant(req);
+
+    // 短絡せずバックエンド再解決に落ちる
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('domain=store.test'));
+    expect(result.tenantData?.tenantId).toBe('api-tenant-id');
+  });
 });

--- a/frontend/src/shared/lib/proxy/tenantResolver.ts
+++ b/frontend/src/shared/lib/proxy/tenantResolver.ts
@@ -24,13 +24,16 @@ export async function resolveTenant(request: NextRequest): Promise<{
   }
 
   // Cookie のテナント情報を優先使用（重複クエリを回避）
-  // ただし、Cookie に保存されたドメインと現在のホスト名が一致する場合のみ信頼する
+  // ただし、Cookie に保存されたドメインと現在のホスト名が一致し、
+  // かつ template cookie が存在する場合のみ信頼する。
+  // template cookie が無い場合は黙って 'default' 扱いにせず、
+  // バックエンド再解決に落として正しい template_key を取得し直す。
   const existingTenantId = request.cookies.get('x-mw-tenant-id')?.value;
   const existingDomain = request.cookies.get('x-mw-tenant-domain')?.value;
+  const existingTemplate = request.cookies.get('x-mw-tenant-template')?.value;
 
-  if (existingTenantId && existingDomain === hostname) {
+  if (existingTenantId && existingDomain === hostname && existingTemplate) {
     const existingTenantName = request.cookies.get('x-mw-tenant-name')?.value || '';
-    const existingTemplate = request.cookies.get('x-mw-tenant-template')?.value || 'default';
     return {
       role: 'tenant',
       tenantData: {
@@ -52,10 +55,18 @@ export async function resolveTenant(request: NextRequest): Promise<{
     const data = await res.json().catch(() => null);
 
     if (data && typeof data === 'object') {
-      const templateKey = String((data.template_key ?? 'default') || 'default');
       const tenantId = String(data.tenant_id ?? data.id ?? '');
       const tenantName = String(data.tenant_name ?? data.name ?? '');
       const isValid = Boolean(tenantId || tenantName || data.domain);
+
+      // 中央応答（TenantVO）は template_key を返さないため、含まれていれば従来どおり採用し、
+      // 無ければテナント側の /tenant/config/public を追撃取得する（キャッシュ無しで鮮度が高い）。
+      let templateKey = 'default';
+      if (data.template_key) {
+        templateKey = String(data.template_key);
+      } else if (isValid && tenantId) {
+        templateKey = await fetchTemplateKey(tenantId);
+      }
 
       return {
         role: 'tenant',
@@ -80,4 +91,29 @@ export async function resolveTenant(request: NextRequest): Promise<{
       tenantName: '',
     },
   };
+}
+
+// テナント側の StoreProfile から template_key を取得する。
+// 認証トークン不要・キャッシュ無しで、X-Role/X-Tenant-ID ヘッダのみで動作する公開エンドポイント。
+// 取得失敗・欠落時は 'default' に回落し、決して throw しない。
+async function fetchTemplateKey(tenantId: string): Promise<string> {
+  const configApiUrl =
+    process.env.TENANT_CONFIG_API_URL || 'http://backend:8080/tenant/config/public';
+
+  try {
+    const res = await fetch(configApiUrl, {
+      headers: {
+        'X-Role': 'tenant',
+        'X-Tenant-ID': tenantId,
+      },
+    });
+    const config = await res.json().catch(() => null);
+    if (config && typeof config === 'object' && config.template_key) {
+      return String(config.template_key);
+    }
+  } catch (error) {
+    console.error('🚨 テナント設定の取得に失敗:', error);
+  }
+
+  return 'default';
 }


### PR DESCRIPTION
## 概要（Refs #223）

Phase 3 QA が発見した欠陥の修正: `PUT /tenant/config` で template_key を変えても公開サイトの模版が切り替わらない（Phase 1 以前から存在、模版が default しか無かったため露見せず）。

**根本原因**: 模版選択を行う `resolveTenant()` は `GET /central/tenant?domain=` 応答の `template_key` を読むが、バックエンド `TenantVO` にこのフィールドが無く常に `'default'` へ回落していた。さらに `x-mw-tenant-template` cookie が session 級のため、一度立つと模版変更が既存訪問者へ永久に伝播しない問題も併存。

**修正（フロントエンドのみ）**:
- 中央応答に `template_key` が無い場合、テナント側 `/tenant/config/public`（X-Role + X-Tenant-ID、キャッシュ無し）を追撃取得
- `x-mw-tenant-template` cookie を maxAge 60 秒に（ISR revalidate 60 秒と整合、模版変更は最大 ~2 分で全訪問者へ伝播）
- template cookie 欠落時に黙って default 扱いにせず再解決するよう Cookie 短絡条件を修正

バックエンド側で `TenantVO` に template_key を足す代替案は、storeprofile モジュールへの公開ファサード新設 + `tenantByDomain` キャッシュ失効の跨モジュールイベントが必要で面が大きく却下。

## 検証

- TDD: 再現テストが修正前に `Expected: "modern" / Received: "default"` で失敗することを確認してから実装（tenantResolver テスト 3 本追加）
- `npm run format` / `lint` / `test`（103 tests）/ `build`、`task lint` / `task test` / `task build` すべて exit 0
- QA（E2E 実測）: template_key を modern → classic → default と切替え、**3 模版 × 6 ページ = 18 セル全 PASS**（各ページ 200 + 正しい `storefront-<key>` クラスのみ出現）+ 排布差 2 件確認（modern: CastSection が MVSection より先 / classic: キャッチコピー帯が Banner 直上）。検証後 default へ復元し config 完全一致を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)