### PR TITLE
feat(cms): 模版選択をサムネイル付き予覧カードに刷新 — #223 Phase 4

### DIFF
--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -71,6 +71,7 @@ Each template owns a `templates/<key>/theme.css` that defines the same `--storef
 - **Status pill**: fully rounded, 12px text, `bg-green-100 text-green-800` (確定) / `bg-yellow-100 text-yellow-800` (保留); add hues per new status semantics, always `*-100` bg + `*-800` text.
 - **Progress bar**: track `bg-gray-200 h-2 rounded-full`, fill `bg-blue-600`.
 - **Ranking row**: 32px circular rank chip (`bg-blue-50 text-blue-600`), name + area line (12px icon + gray-500), right-aligned amount (bold) over count (gray-500).
+- **Selectable preview card**: `<label>` wrapping an `sr-only` radio; `rounded-[10px] border p-3 cursor-pointer`. Unselected `border-gray-200 hover:bg-gray-50`; selected `border-blue-600 ring-2 ring-blue-600 bg-blue-50`. Body = thumbnail image (`w-full rounded border-gray-200`) → name (`text-sm font-medium`, selected `text-blue-600`) → description (`text-xs text-gray-500`); keyboard focus via `has-[:focus-visible]:ring-blue-500`.
 
 Component states (hover / focus / disabled) must always be styled: hover darkens one step (e.g. `hover:bg-blue-700`), focus uses ring (`focus:ring-blue-500`), disabled uses `disabled:opacity-50`.
 

--- a/frontend/public/templates/classic.svg
+++ b/frontend/public/templates/classic.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 150" role="img">
+  <!-- classic 模版: 暖白×松石藍。キャッチ線を最上部に配置 -->
+  <rect width="240" height="150" fill="#faf7f2"/>
+  <!-- 最上部の accent キャッチ線 -->
+  <rect x="0" y="0" width="240" height="6" fill="#4e8da6"/>
+  <!-- ヘッダー帯: fg 細線 -->
+  <rect x="20" y="18" width="40" height="3" fill="#2a2a28"/>
+  <rect x="180" y="18" width="40" height="2" fill="#7a776e"/>
+  <!-- ヒーロー帯: muted 副線 -->
+  <rect x="60" y="44" width="120" height="4" fill="#7a776e"/>
+  <rect x="80" y="56" width="80" height="3" fill="#7a776e"/>
+  <!-- カード 3 枚並び: surface-3 面 + accent 縁 -->
+  <rect x="20" y="88" width="60" height="34" fill="#ece6db" stroke="#4e8da6" stroke-width="1"/>
+  <rect x="90" y="88" width="60" height="34" fill="#ece6db" stroke="#4e8da6" stroke-width="1"/>
+  <rect x="160" y="88" width="60" height="34" fill="#ece6db" stroke="#4e8da6" stroke-width="1"/>
+  <!-- フッター帯: bg-deep -->
+  <rect x="0" y="134" width="240" height="16" fill="#efe8dc"/>
+</svg>

--- a/frontend/public/templates/default.svg
+++ b/frontend/public/templates/default.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 150" role="img">
+  <!-- default 模版: 黒×金ラグジュアリー。標準排布（ヒーロー→カード列→フッター） -->
+  <rect width="240" height="150" fill="#080808"/>
+  <!-- ヘッダー帯: fg の細線でロゴ/ナビを模式化 -->
+  <rect x="20" y="12" width="40" height="3" fill="#f8f4f0"/>
+  <rect x="180" y="12" width="40" height="2" fill="#a89880"/>
+  <!-- ヒーロー帯: accent のキャッチ線 + muted 副線 -->
+  <rect x="40" y="40" width="160" height="6" fill="#c9a84c"/>
+  <rect x="70" y="54" width="100" height="3" fill="#a89880"/>
+  <!-- カード 3 枚並び: surface-3 面 + accent 縁 -->
+  <rect x="20" y="88" width="60" height="34" fill="#0f0f0f" stroke="#c9a84c" stroke-width="1"/>
+  <rect x="90" y="88" width="60" height="34" fill="#0f0f0f" stroke="#c9a84c" stroke-width="1"/>
+  <rect x="160" y="88" width="60" height="34" fill="#0f0f0f" stroke="#c9a84c" stroke-width="1"/>
+  <!-- フッター帯: bg-deep -->
+  <rect x="0" y="134" width="240" height="16" fill="#050505"/>
+</svg>

--- a/frontend/public/templates/modern.svg
+++ b/frontend/public/templates/modern.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 150" role="img">
+  <!-- modern 模版: 藍黒×薔薇紅ビビッド。カード列をヒーロー直下に前置 -->
+  <rect width="240" height="150" fill="#0b0b12"/>
+  <!-- ヘッダー帯 -->
+  <rect x="20" y="12" width="40" height="3" fill="#f2eff4"/>
+  <rect x="180" y="12" width="40" height="2" fill="#8a87a0"/>
+  <!-- ヒーロー帯: accent キャッチ線 + muted 副線 -->
+  <rect x="40" y="32" width="160" height="6" fill="#e64980"/>
+  <rect x="70" y="46" width="100" height="3" fill="#8a87a0"/>
+  <!-- カード 3 枚: ヒーロー直下に前置（CastSection 前置の排布差） -->
+  <rect x="20" y="60" width="60" height="34" fill="#161622" stroke="#e64980" stroke-width="1"/>
+  <rect x="90" y="60" width="60" height="34" fill="#161622" stroke="#e64980" stroke-width="1"/>
+  <rect x="160" y="60" width="60" height="34" fill="#161622" stroke="#e64980" stroke-width="1"/>
+  <!-- 下部コンテンツ帯: muted -->
+  <rect x="40" y="108" width="160" height="4" fill="#8a87a0"/>
+  <!-- フッター帯: bg-deep -->
+  <rect x="0" y="134" width="240" height="16" fill="#07070c"/>
+</svg>

--- a/frontend/src/_pages/store-settings/ui/StoreProfileForm.tsx
+++ b/frontend/src/_pages/store-settings/ui/StoreProfileForm.tsx
@@ -2,6 +2,7 @@
 
 import { useForm, useFieldArray, Controller } from 'react-hook-form';
 import {
+  getAllTemplateMetas,
   getTemplateMeta,
   PartnerLink,
   SnsLink,
@@ -102,15 +103,46 @@ export function StoreProfileForm({ initialData, onSubmit, isSubmitting }: StoreP
           基本設定
         </h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          <div>
+          <div className="col-span-2">
             <label className="block text-sm font-medium text-gray-700 mb-2">テンプレート</label>
-            <select
-              {...register('template_key')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            >
-              {/* modern / classic は #223 Phase 3 で実装され、Phase 4 でカード選択 UI とともに復活する */}
-              <option value="default">デフォルト</option>
-            </select>
+            {/* サムネイル付き予覧カードで模版を選択。選択中の key は既存 watch で
+                模版テキスト欄の描画に連動する（追加配線は不要） */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {getAllTemplateMetas().map(meta => {
+                const selected = templateKey === meta.key;
+                return (
+                  <label
+                    key={meta.key}
+                    className={`block rounded-[10px] border p-3 cursor-pointer transition-colors has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-blue-500 ${
+                      selected
+                        ? 'border-blue-600 ring-2 ring-blue-600 bg-blue-50'
+                        : 'border-gray-200 hover:bg-gray-50'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      value={meta.key}
+                      {...register('template_key')}
+                      className="sr-only"
+                    />
+                    {/* eslint-disable-next-line @next/next/no-img-element -- 静的サムネイル、最適化不要 */}
+                    <img
+                      src={meta.thumbnail}
+                      alt={meta.name}
+                      className="w-full rounded border border-gray-200"
+                    />
+                    <p
+                      className={`mt-2 text-sm font-medium ${
+                        selected ? 'text-blue-600' : 'text-gray-900'
+                      }`}
+                    >
+                      {meta.name}
+                    </p>
+                    <p className="text-xs text-gray-500">{meta.description}</p>
+                  </label>
+                );
+              })}
+            </div>
           </div>
           <div className="col-span-2">
             <label className="block text-sm font-medium text-gray-700 mb-2">店舗説明文</label>

--- a/frontend/src/entities/store-profile/__tests__/templateMeta.test.ts
+++ b/frontend/src/entities/store-profile/__tests__/templateMeta.test.ts
@@ -1,4 +1,4 @@
-import { getTemplateMeta } from '../model/templateMeta';
+import { getAllTemplateMetas, getTemplateMeta } from '../model/templateMeta';
 
 describe('getTemplateMeta', () => {
   it('既知の模版キーはそのメタを返すこと', () => {
@@ -11,5 +11,17 @@ describe('getTemplateMeta', () => {
 
   it('未知の模版キーは default にフォールバックすること', () => {
     expect(getTemplateMeta('no-such-template').key).toBe('default');
+  });
+
+  it('modern 模版はカード表示用の description / thumbnail を持つこと', () => {
+    const meta = getTemplateMeta('modern');
+    expect(meta.description.length).toBeGreaterThan(0);
+    expect(meta.thumbnail.length).toBeGreaterThan(0);
+  });
+});
+
+describe('getAllTemplateMetas', () => {
+  it('3 模版すべてを配列で返すこと', () => {
+    expect(getAllTemplateMetas().map(m => m.key)).toEqual(['default', 'modern', 'classic']);
   });
 });

--- a/frontend/src/entities/store-profile/index.ts
+++ b/frontend/src/entities/store-profile/index.ts
@@ -1,4 +1,4 @@
 export * from './model/types';
 export { storeProfileApi } from './api/store-profile';
-export { getTemplateMeta } from './model/templateMeta';
+export { getTemplateMeta, getAllTemplateMetas } from './model/templateMeta';
 export type { StoreTemplateMeta, TemplateTextSlot } from './model/templateMeta';

--- a/frontend/src/entities/store-profile/model/templateMeta.ts
+++ b/frontend/src/entities/store-profile/model/templateMeta.ts
@@ -13,6 +13,10 @@ export interface TemplateTextSlot {
 export interface StoreTemplateMeta {
   key: string;
   name: string;
+  /** カードに表示する風格説明。 */
+  description: string;
+  /** サムネイル画像の public パス。 */
+  thumbnail: string;
   textSlots: TemplateTextSlot[];
 }
 
@@ -20,16 +24,22 @@ const TEMPLATE_METAS: Record<string, StoreTemplateMeta> = {
   default: {
     key: 'default',
     name: 'デフォルト',
+    description: '黒×金のラグジュアリー系。セリフ体で高級感を演出',
+    thumbnail: '/templates/default.svg',
     textSlots: [{ key: 'access_note', label: 'アクセス補足（店舗情報ページに表示）' }],
   },
   modern: {
     key: 'modern',
     name: 'モダン',
+    description: '藍黒×薔薇紅のビビッド系。サンセリフ体でモダンな印象',
+    thumbnail: '/templates/modern.svg',
     textSlots: [{ key: 'access_note', label: 'アクセス補足（店舗情報ページに表示）' }],
   },
   classic: {
     key: 'classic',
     name: 'クラシック',
+    description: '暖白×松石藍の明るく清潔な印象。セリフ体で上品に',
+    thumbnail: '/templates/classic.svg',
     textSlots: [{ key: 'access_note', label: 'アクセス補足（店舗情報ページに表示）' }],
   },
 };
@@ -37,4 +47,9 @@ const TEMPLATE_METAS: Record<string, StoreTemplateMeta> = {
 /** 未知の key は default のメタにフォールバックする。 */
 export function getTemplateMeta(templateKey: string): StoreTemplateMeta {
   return TEMPLATE_METAS[templateKey] ?? TEMPLATE_METAS['default'];
+}
+
+/** カード選択 UI 用に全模版メタを配列で返す。 */
+export function getAllTemplateMetas(): StoreTemplateMeta[] {
+  return Object.values(TEMPLATE_METAS);
 }


### PR DESCRIPTION
## 概要（Closes #223 — 最終 Phase）

- 店舗設定の模版ドロップダウン（default のみ）を **3 模版の予覧カード**に置換: 静的サムネイル（手書き SVG、各模版の theme.css パレット準拠・排布差も反映）+ 名称 + 風格説明。選択保存で即反映（配線は PR #245 で修正済み、伝播最大 ~2 分）
- `templateMeta` に `description` / `thumbnail` を追加、`getAllTemplateMetas()` を entities 公開 API に追加（FSD: store-settings は store-site に触れない、steiger 機械検証済み）
- カードは design.md の Admin UI 規範どおり（選択中 `border-blue-600 ring-2 bg-blue-50`、focus は `has-[:focus-visible]:ring-blue-500`、触った箇所のみ indigo→blue 移行）。design.md の Components 表に Selectable preview card を追記

これで issue #223 の 4 Phase すべて完了:
1. Phase 1 (#239) — dispatch 抽出 + 404 回退修正 + _sections 分割
2. Phase 2 (#240) — 5 ページ + コンテンツモデル（固定欄 + custom_texts JSONB）
3. Phase 3 (#244) — 全色トークン化 + modern / classic 模版、(#245) 切替配線修正
4. Phase 4（本 PR）— 予覧カード選択 UI

## 検証

- `npm run format` / `lint` / `test`（105 tests, templateMeta 100%）/ `build`、`task lint`（steiger 含む）/ `task test` / `task build` すべて exit 0
- QA（E2E）: サムネイル 3 件の配信（200 + image/svg+xml）、設定ページの認証ガード確認、API 回帰（modern へ切替 → 公開サイト `storefront-modern` 反映 → default 復元 → config 完全一致）すべて PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)