### PR TITLE
fix(ci): claude-review に pull-requests/issues の write 権限を付与

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # レビュー結果を PR に投稿するため write が必要（read だと投稿が 403 で全滅する — #249）
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## 概要

PR ごとに実行される claude-review が、権限不足でレビュー結果を PR に投稿できていなかった（実行はされるが全投稿が拒否され、痕跡ゼロで green 終了）。permissions を write に引き上げる。

Closes #249

## 変更内容

- `.github/workflows/claude-code-review.yml` の permissions: `pull-requests` と `issues` を `read` → `write`

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e`（未導入 — #247 で整備予定のため対象外）
- 根拠ログ: run 28762924367 に `"permission_denials_count": 26` と `No buffered inline comments`（レビューは生成されたが投稿がすべて権限拒否）

## 決定ログ

- 最小修正として permissions のみ変更。プロンプト強化（「指摘ゼロでも要約コメントを必ず残す」等）は、write 化後の次の PR で実際の投稿挙動を見てから判断する
- `contents: read` は据え置き（レビューはコード変更不要）

## 備考 / レビュー観点

- workflow ファイルを変更する PR では claude-review 自身が安全のためスキップされるため、効果検証は本 PR マージ後の次の PR で行う（#248 の次の PR が初回検証になる）
