### PR TITLE
fix(ci): claude-review に allowedTools と track_progress を付与し、レビュー投稿を可能にする

### DIFF
--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -71,7 +71,7 @@ Each template owns a `templates/<key>/theme.css` that defines the same `--storef
 - **Status pill**: fully rounded, 12px text, `bg-green-100 text-green-800` (確定) / `bg-yellow-100 text-yellow-800` (保留); add hues per new status semantics, always `*-100` bg + `*-800` text.
 - **Progress bar**: track `bg-gray-200 h-2 rounded-full`, fill `bg-blue-600`.
 - **Ranking row**: 32px circular rank chip (`bg-blue-50 text-blue-600`), name + area line (12px icon + gray-500), right-aligned amount (bold) over count (gray-500).
-- **Selectable preview card**: `<label>` wrapping an `sr-only` radio; `rounded-[10px] border p-3 cursor-pointer`. Unselected `border-gray-200 hover:bg-gray-50`; selected `border-blue-600 ring-2 ring-blue-600 bg-blue-50`. Body = thumbnail image (`w-full rounded border-gray-200`) → name (`text-sm font-medium`, selected `text-blue-600`) → description (`text-xs text-gray-500`); keyboard focus via `has-[:focus-visible]:ring-blue-500`.
+- **Selectable preview card**: `<label>` wrapping an `sr-only` radio; `rounded-[10px] border p-3 cursor-pointer`. Unselected `border-gray-200 hover:bg-gray-50`; selected `border-blue-600 ring-2 ring-blue-600 bg-blue-50`. Body = thumbnail image (`w-full rounded border border-gray-200`) → name (`text-sm font-medium`, selected `text-blue-600`) → description (`text-xs text-gray-500`); keyboard focus via `has-[:focus-visible]:ring-blue-500`.
 
 Component states (hover / focus / disabled) must always be styled: hover darkens one step (e.g. `hover:bg-blue-700`), focus uses ring (`focus:ring-blue-500`), disabled uses `disabled:opacity-50`.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,8 +39,13 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
+          # 指摘ゼロでもトラッキングコメントが残り、「無発見」と「無言」を区別できる
+          track_progress: true
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: '--model claude-fable-5'
+          # allowedTools が無いと投稿系ツールがすべて拒否され、レビューが PR に残らない（#251）
+          claude_args: |
+            --model claude-fable-5
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## 概要

write 権限化（#250）後も claude-review がレビュー結果を PR に投稿できていなかった。拒否の正体は GitHub API の 403 ではなく **Claude Code エージェント自身のツール許可**（`--allowedTools` 未設定）。公式サンプル準拠のツール白名単を付与し、`track_progress` を有効化する。

Closes #251

## 変更内容

- `claude_args` に `--allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"` を追加（anthropics/claude-code-action `examples/pr-review-comprehensive.yml` 準拠）
- `track_progress: true` を有効化 — 指摘ゼロでも進捗トラッキングコメントが必ず残り、「無発見」と「無言」を区別できる
- （同乗）`docs/design-md-preview-card-border` ブランチをマージ: Selectable preview card のサムネイル class に `border` を補記（`.claude/rules/design.md` 1 行）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e`（未導入 — #247 で整備予定のため対象外）
- 根拠: run 28765082604（write 権限で実走）が 11 ターン・$4.78 を消費しつつ `permission_denials_count: 44`・投稿ゼロ。ツール拒否が原因であることを確認済み

## 決定ログ

- 許可ツールは公式サンプルの 4 つに限定（`gh api` 等の広い許可は与えない — レビューは読み取り + コメント投稿だけで完結する）
- プロンプト（code-review プラグイン）とモデル指定は変更しない — 最小差分
- track_progress は「常に痕跡を残す」ための採用。これで沈黙レビュアー問題（監査不能）も同時に解消する見込み

## 備考 / レビュー観点

- workflow 変更 PR では claude-review 自身がスキップされるため（デフォルトブランチとの同一性検証）、効果検証はマージ後に #248 を reopen して行う
