### PR TITLE
fix(ci): claude-review を Lint and Test 成功後にのみ実行する

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,6 +24,8 @@ jobs:
       # レビュー結果を PR に投稿するため write が必要（read だと投稿が 403 で全滅する — #249）
       pull-requests: write
       issues: write
+      # Lint and Test の check-run 状態を読むため（#253）
+      checks: read
       id-token: write
 
     steps:
@@ -32,7 +34,37 @@ jobs:
         with:
           fetch-depth: 1
 
+      # 決定論的ゲートが先、AI レビューは後（#253）。
+      # Lint and Test が success になるまで待ち、失敗/タイムアウト時はレビューをスキップする。
+      - name: Wait for Lint and Test
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          for i in $(seq 1 60); do
+            run_info=$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/check-runs" \
+              --jq '[.check_runs[] | select(.name=="Lint and Test")][0] | "\(.status)|\(.conclusion)"' 2>/dev/null || echo "")
+            st="${run_info%%|*}"
+            conclusion="${run_info##*|}"
+            if [ "$st" = "completed" ]; then
+              if [ "$conclusion" = "success" ]; then
+                echo "Lint and Test: success — レビューを実行します"
+                echo "proceed=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "Lint and Test: ${conclusion} — ゲート赤のためレビューをスキップします"
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Lint and Test: ${st:-not-started} — 待機中 ($i/60)"
+            sleep 30
+          done
+          echo "タイムアウト（30 分）— レビューをスキップします"
+          echo "proceed=false" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code Review
+        if: steps.gate.outputs.proceed == 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## 概要

claude-review が Lint and Test と並列に走り、ゲート赤のコミットにも数ドル・数分のレビューを消費していた。決定論的ゲートを先に、AI レビューを後に、の層構造に合わせて実行順序を直列化する。

Closes #253

## 変更内容

- `claude-code-review.yml` にゲートステップを追加: 同一 head SHA の「Lint and Test」check-run を gh CLI でポーリング（30 秒間隔・最大 30 分）
  - success → レビュー実行 / failure・timeout → 理由をログに残してスキップ（ジョブは緑）
- permissions に `checks: read` を追加

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e`（未導入 — #247 で整備予定のため対象外）
- YAML 構文は ruby YAML.load_file で検証済み。実効検証はマージ後の次 PR（workflow 変更 PR では claude-review 自身がスキップされるため）

## 決定ログ

- `workflow_run` イベントへの移行案は見送り — claude-code-action の workflow_run 対応が不明で、pull_request コンテキスト（インラインコメント等）を壊すリスクがあるため、イベントは維持しジョブ内ゲートで直列化
- ゲート赤のときレビュージョブを fail ではなく skip 扱い（緑）にした — 失敗の原因は Lint and Test 側に表示されており、二重に赤くする意味がないため

## 備考 / レビュー観点

- ポーリングは runner 分を消費する（Lint and Test は通常 4〜5 分）が、レビュー 1 回のコスト（約 $5）より安い
- gradle wrapper の配布 zip ダウンロードが 10 秒でタイムアウトする問題（今回 CI と手元で各 1 回発生）は別件 — 頻発するなら gradle-wrapper.properties の networkTimeout 引き上げを別 issue で
