### PR TITLE
docs(dev): CLAUDE.md 監査 — task up の再ビルド注記ほか 3 点を補足

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ task lint                           # check
 task format                         # auto-fix
 
 # Local startup
-task up                             # start full stack
+task up                             # start full stack (does NOT rebuild images — run task build first to pick up code changes)
 task down                           # stop
 task logs service=backend           # view logs
 ```

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -25,7 +25,11 @@ frontend/src/
 - **Layer dependencies point downward only**: app → _pages → widgets → features → entities → shared.
 - **Entities must not import each other**. Composition spanning multiple entities (e.g. store-site's storefrontService) is the page layer's responsibility.
 - **server-only modules** (those depending on next/headers, etc.) are not exported from the normal index but from a separate `index.server.ts` entry (e.g. serverClient in `shared/api/index.server.ts`).
-- **Public storefront templates live at `_pages/store-site/templates/<key>/<page>.tsx`** where `<page>` is one of `page` (TOP) / `casts` / `cast-detail` / `schedule` / `menu` / `about`. This is the dynamic-import contract keyed by the cookie's templateKey (dispatched via `loadTemplatePage`, which falls back to the default template's same page for unknown keys), so do not change the path structure. Top-level public routes under `app/` (`/casts`, `/schedule`, `/menu`, `/about`) are thin shells rendering `StoreSitePage`. Shared section components live in `templates/_sections/` (an underscore dir, never a template key); each template dir holds only its `theme.css` and page layouts. Template text-slot metadata lives in `entities/store-profile` (`getTemplateMeta`) because both store-site and store-settings consume it.
+- **Public storefront templates live at `_pages/store-site/templates/<key>/<page>.tsx`** where `<page>` is one of `page` (TOP) / `casts` / `cast-detail` / `schedule` / `menu` / `about`:
+  - This is the dynamic-import contract keyed by the cookie's templateKey (dispatched via `loadTemplatePage`, which falls back to the default template's same page for unknown keys), so do not change the path structure.
+  - Top-level public routes under `app/` (`/casts`, `/schedule`, `/menu`, `/about`) are thin shells rendering `StoreSitePage`.
+  - Shared section components live in `templates/_sections/` (an underscore dir, never a template key); each template dir holds only its `theme.css` and page layouts.
+  - Template text-slot metadata lives in `entities/store-profile` (`getTemplateMeta`) because both store-site and store-settings consume it.
 - **alias**: `@/*` → `./src/*` (configured in both tsconfig and jest).
 
 ## Code Conventions

--- a/infrastructure/CLAUDE.md
+++ b/infrastructure/CLAUDE.md
@@ -1,6 +1,7 @@
 # Infrastructure Conventions
 
 - **Environment directories**: `infrastructure/development/` (HTTP only) and `infrastructure/release/` (HTTPS, Let's Encrypt, web→websecure redirect). Copy `infrastructure/.env.example` into each environment directory as `.env`. Switch with `task up env=release` (default is development).
+- **`infrastructure/docker-compose.example.yml`** is the baseline compose template (same service structure as the per-environment files): apply structural service changes there first, then mirror them into `development/` and `release/`.
 - **Traefik routing**: because `exposedByDefault: false`, a service to be exposed must carry the `traefik.enable=true` label (without it, it is silently not exposed). Paths are dispatched by `PathPrefix` (backend = `/api`, static = `/static`, frontend = everything else). If an app is unaware of its prefix, add a `stripPrefix` middleware (e.g. `backend-strip`).
 - **DB / Redis**: referenced by the service names `database` / `cache`. Migrations are Liquibase (`backend/src/main/resources/db/changelog/`).
 - **Secrets**: `.env` must not be committed.


### PR DESCRIPTION
## 概要

全 CLAUDE.md（ルート / frontend / backend / infrastructure）を監査し、記載内容をコードベースの実態と照合。判明した 3 点の欠落・可読性問題を補修した。backend は修正不要。

Closes # （関連 issue なし・監査による自発的補修）

## 変更内容

- **ルート `CLAUDE.md`**: `task up` はイメージを再ビルドしない旨を追記（実体は `--build` なしの `docker compose up -d`。コード変更後は先に `task build` が必要）
- **`frontend/CLAUDE.md`**: 店舗テンプレート契約の長文段落（約 120 語）を 4 つの箇条書きに分割。内容は一字不変、純粋な可読性改善
- **`infrastructure/CLAUDE.md`**: `docker-compose.example.yml` が各環境 compose の基準テンプレートである旨を 1 行追記（development との service 構造一致を diff で確認済み）

## 検証

- [ ] `task lint` exit 0 — 対象外（Markdown のみの変更、コード変更なし）
- [ ] `task test` exit 0 — 対象外（同上）
- [ ] `task build` exit 0 — 対象外（同上）
- [ ] `task e2e` exit 0 — 対象外（同上）

記載内容の裏取りとして実施した検証:
- Taskfile 全タスク・FSD ディレクトリ構成・`_pages`/`entities` スライス一覧・backend 全 12 モジュール・`loadTemplatePage`/`getTemplateMeta`/`AppProperties` の実在を個別に確認
- `task up` → `infrastructure/<env>/Taskfile.yml` の `docker compose up -d`（`--build` なし）であることを確認
- `docker-compose.example.yml` と `development/docker-compose.yml` の service 構造一致を diff で確認

## 決定ログ

- 監査で検出した実質的欠落は「`task up` が再ビルドしない」の 1 点のみ。他 2 点（段落分割・example.yml の説明）は可読性・網羅性の小補修に留めた
- 全 4 ファイルは PR #248 で整理直後のため大規模改稿は不要と判断。外科的な最小差分（+7/−2 行）のみ適用
- undocumented な Taskfile タスク（`ps` / `exec` / `restart` / `reports` / `clean`）の追記は見送り — `task --list` で発見可能なため

## 備考 / レビュー観点

- frontend の段落分割は意味変更ゼロであることを重点確認いただきたい（diff 上は 1 行削除 + 5 行追加に見えるが内容は同一）
- `task clean` は `docker rmi` のみで volume に触れないことも確認済み（ガードレールと矛盾なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)