### PR TITLE
fix(backend): シードの明示 id 挿入で進まない IDENTITY シーケンスを MAX(id) へ整合する

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/menu/MenuCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/menu/MenuCrossTenantIT.java
@@ -18,7 +18,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
  * StoreMenu のクロステナント分離を本物の PostgreSQL で検証する統合テスト（issue #227）。
@@ -36,20 +35,12 @@ class MenuCrossTenantIT extends CrossTenantTestSupport {
 
   @Autowired private TenantRepository tenantRepository;
   @Autowired private StoreMenuRepository menuRepository;
-  @Autowired private JdbcTemplate jdbcTemplate;
 
   /** 保存後に採番された第二テナントの実 id（定数 TENANT_B は使わない）。 */
   private long tenantBId;
 
   @BeforeEach
   void prepareSecondTenantWithMenu() {
-    // シードは central_tenants に明示 id=1 で投入しており IDENTITY シーケンスが
-    // 進んでいない（issue #237）。save が id=1 と衝突しないよう先に補正する。
-    jdbcTemplate.queryForObject(
-        "select setval(pg_get_serial_sequence('central_tenants','id'),"
-            + " (select max(id) from central_tenants))",
-        Long.class);
-
     Tenant tenantB =
         tenantRepository
             .findByDomain(TENANT_B_DOMAIN)

--- a/backend/src/integrationTest/java/com/kizuna/tenant/SeedSequenceAlignmentIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/tenant/SeedSequenceAlignmentIT.java
@@ -1,0 +1,87 @@
+package com.kizuna.tenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * シード（明示 id 挿入）後に IDENTITY シーケンスが MAX(id) へ整合されることを本物の PostgreSQL で検証する統合テスト（issue #237）。
+ *
+ * <p>使い捨て tmpfs DB（{@code docker-compose.test.yml}）に対して毎回全新初期化された状態で走るため、issue の再現条件（seed が明示 id=1
+ * を挿入し IDENTITY シーケンスが未進行）がそのまま成立する。changeset で setval 整合されていれば、中央 API からの初回テナント作成が リトライ不要で成功し、5
+ * 表のシーケンスが全て MAX(id) を上回る。
+ *
+ * <p>{@link com.kizuna.shared.CrossTenantTestSupport} は tenant ログイン前提のため継承せず、中央ログインを自前で行う。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SeedSequenceAlignmentIT {
+
+  /** 明示 id を播種している autoIncrement 5 表（issue #237 の setval 対象）。 */
+  private static final List<String> SEEDED_IDENTITY_TABLES =
+      List.of(
+          "central_users",
+          "central_roles",
+          "central_permissions",
+          "central_tenants",
+          "central_menus");
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  private String centralLogin() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/central/login",
+            new HttpEntity<>("{\"username\": \"admin\", \"password\": \"pass\"}", headers),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).as("前提: 中央 admin でのログインが成功すること").isEqualTo(HttpStatus.OK);
+    String token = res.getBody().path("token").asText();
+    assertThat(token).isNotBlank();
+    return token;
+  }
+
+  @Test
+  @DisplayName("全新 DB で中央 API から初回テナント作成がリトライ不要で 204 になること")
+  void firstTenantCreationSucceedsOnFreshDb() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.setBearerAuth(centralLogin());
+    String body =
+        "{\"name\": \"シード整合テストテナント\","
+            + " \"domain\": \"seed-seq-it.kizuna.test\","
+            + " \"email\": \"seed-seq-it@kizuna.test\"}";
+
+    ResponseEntity<Void> res =
+        rest.postForEntity("/central/tenant", new HttpEntity<>(body, headers), Void.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+  }
+
+  @Test
+  @DisplayName("明示 id 播種の autoIncrement 5 表のシーケンスが全て MAX(id) を上回ること")
+  void seededIdentitySequencesAreAligned() {
+    for (String table : SEEDED_IDENTITY_TABLES) {
+      // 使い捨て DB なので nextval の消費は無害。nextval > MAX(id) は実行順に依存しない述語。
+      String sql =
+          String.format(
+              "SELECT nextval(pg_get_serial_sequence('%1$s','id')) > (SELECT MAX(id) FROM %1$s)",
+              table);
+      Boolean aligned = jdbcTemplate.queryForObject(sql, Boolean.class);
+      assertThat(aligned).as("%s のシーケンスが MAX(id) 以下のままになっている", table).isTrue();
+    }
+  }
+}

--- a/backend/src/integrationTest/java/com/kizuna/tenant/SeedSequenceAlignmentIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/tenant/SeedSequenceAlignmentIT.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,10 +61,14 @@ class SeedSequenceAlignmentIT {
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
     headers.setBearerAuth(centralLogin());
+    // domain には一意制約（uq_central_tenants_domain）があるため、
+    // 同一 DB へ手動で再実行しても衝突しないよう実行ごとに一意化する
     String body =
-        "{\"name\": \"シード整合テストテナント\","
-            + " \"domain\": \"seed-seq-it.kizuna.test\","
-            + " \"email\": \"seed-seq-it@kizuna.test\"}";
+        String.format(
+            "{\"name\": \"シード整合テストテナント\","
+                + " \"domain\": \"seed-seq-it-%s.kizuna.test\","
+                + " \"email\": \"seed-seq-it@kizuna.test\"}",
+            UUID.randomUUID());
 
     ResponseEntity<Void> res =
         rest.postForEntity("/central/tenant", new HttpEntity<>(body, headers), Void.class);

--- a/backend/src/main/resources/db/changelog/releases/v0.2.0/central/02-seed-sequence-sync.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.2.0/central/02-seed-sequence-sync.yaml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+  - changeSet:
+      id: central-008-seed-sequence-sync
+      author: kanghouchao
+      changes:
+        # シードが明示 id で挿入した autoIncrement 表は IDENTITY シーケンスが未進行のため、
+        # 初回の @GeneratedValue 採番が seed id と衝突する（issue #237）。
+        # 各表のシーケンスを MAX(id) へ整合させる（seed 行は必ず存在し MAX(id) は非 NULL、
+        # 既存運用行があっても MAX(id) がそれを反映するので永続 DB でも安全）。
+        - sql:
+            sql: SELECT setval(pg_get_serial_sequence('central_users','id'), (SELECT MAX(id) FROM central_users))
+        - sql:
+            sql: SELECT setval(pg_get_serial_sequence('central_roles','id'), (SELECT MAX(id) FROM central_roles))
+        - sql:
+            sql: SELECT setval(pg_get_serial_sequence('central_permissions','id'), (SELECT MAX(id) FROM central_permissions))
+        - sql:
+            sql: SELECT setval(pg_get_serial_sequence('central_tenants','id'), (SELECT MAX(id) FROM central_tenants))
+        - sql:
+            sql: SELECT setval(pg_get_serial_sequence('central_menus','id'), (SELECT MAX(id) FROM central_menus))

--- a/backend/src/main/resources/db/changelog/releases/v0.2.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.2.0/master.yaml
@@ -3,5 +3,8 @@ databaseChangeLog:
       file: central/01-event-publication.yaml
       relativeToChangelogFile: true
   - include:
+      file: central/02-seed-sequence-sync.yaml
+      relativeToChangelogFile: true
+  - include:
       file: tenant/01-store-profile-site-fields.yaml
       relativeToChangelogFile: true


### PR DESCRIPTION
## 概要

Liquibase シードが autoIncrement（IDENTITY）表へ明示 id で insert したまま序列を進めていないため、全新初期化した DB では中央 API からの初回テナント作成が nextval=1 と seed id=1 の主キー衝突で必ず一度失敗していた。シード後に 5 表の序列を `MAX(id)` へ整合する changeset を追加し、統合テストで固定した。

Closes #237

## 変更内容

- `releases/v0.2.0/central/02-seed-sequence-sync.yaml`（新規）: changeSet `central-008-seed-sequence-sync`。明示 id で播種された 5 表（`central_users` / `central_roles` / `central_permissions` / `central_tenants` / `central_menus`）に `SELECT setval(pg_get_serial_sequence('<table>','id'), (SELECT MAX(id) FROM <table>))` を実行。
- `releases/v0.2.0/master.yaml`: 上記 changeset の include を追加。
- `SeedSequenceAlignmentIT`（新規・統合テスト）: 全新 tmpfs DB 上で (1) 中央ログイン → `POST /central/tenant` が**一発で 204**、(2) 5 表それぞれ `nextval > MAX(id)` を断言。修正前は両方失敗（赤）→ changeset 追加で緑を確認済み。テナントの domain は実行ごとに UUID で一意化してあり、同一 DB へ手動で再実行しても一意制約（`uq_central_tenants_domain`）に衝突しない（同一 DB 連続 2 回実行で赤→修正→緑を確認済み）。
- `MenuCrossTenantIT`: #227 で入れた setval 兜底（本 issue の暫定対応と自己申告していた箇所）を削除。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（frontend Jest + backend 単体 + 統合スイート全体。統合は毎回全新の tmpfs PostgreSQL）
- [x] `task build` exit 0
- [ ] `task e2e`（e2e 基盤が未整備のため対象外。行動的受入基準は `SeedSequenceAlignmentIT` で固定）

## 決定ログ

- **changeset の置き場所は v0.2.0**: v0.1.0 は適用済み環境があるためディレクトリを触らず、開発中リリースへ追加。全新 DB でもシード（v0.1.0）→ 整合（v0.2.0）の順で実行されるため順序は成立する。id は central 側の通し番号慣例（`central-007` の次）に従い `central-008`。
- **setval 対象は 5 表で全部（盤点済み）**: `central_configs` はシードが id を指定せず序列が正常に進む。連結表（`central_user_roles` 等）は id 列なし。tenant 側シードは全て varchar 主キー。v0.2.0 の既存 changeset（event_publication / addColumn）に該当パターンなし。
- **既存環境への適用も安全**: シード行が必ず存在するため `MAX(id)` は非 NULL。運用データがある環境でも `MAX(id)` がそれを反映し、序列を後退させて衝突を生む余地はない。
- **5 文を 1 changeSet 内の個別 `sql` change として記述**: `splitStatements` の分割挙動に依存せず、既存の複数 change 構成（`central-007`）の体裁に合わせた。
- **検証は統合テストで固定（BDD シナリオなし）**: UI 面がなく e2e 基盤も未整備。`docker-compose.test.yml` の tmpfs DB は実行ごとに全新のため「新装環境の初回作成」という再現条件がそのまま毎回成立する。

## 備考 / レビュー観点

- 今後シードへ明示 id の insert を追加する場合は、対応する setval も同時に追加する必要がある（`central-008` は追加時点の整合であり、将来分は面倒を見ない）。
- `SeedSequenceAlignmentIT` の序列断言は `nextval` を 1 つ消費するが、使い捨て DB のため無害（id の欠番は仕様上問題ない）。
