### PR TITLE
chore(backend): Eclipse JDT LS が生成する .settings/ 等を .gitignore に追加

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -17,6 +17,11 @@ out/
 *.iml
 *.ipr
 *.iws
+# Eclipse JDT（VS Code 等の Java language server も生成する）
+.settings/
+.project
+.classpath
+.factorypath
 
 # Logs
 logs/


### PR DESCRIPTION
## 概要

VS Code 等の Java language server（Eclipse JDT LS）が `backend/.settings/org.eclipse.jdt.core.prefs` を勝手に生成し、未追跡ファイルとして `git status` を汚していたため、Eclipse 系の生成物を `backend/.gitignore` に追加する（オーナーからの直接依頼。対応 issue なしの軽微な chore）。

## 変更内容

- `backend/.gitignore` の IDE セクションへ Eclipse JDT 系生成物 4 条目を追加: `.settings/` / `.project` / `.classpath` / `.factorypath`（`git check-ignore -v` で 4 パスとも命中を確認済み）

## 検証

- [x] `task lint` exit 0
- [ ] `task test`（対象外: ignore ルールのみの変更でコード・ビルドに影響なし。CI の Lint and Test は PR 上で実行される）
- [ ] `task build`（同上）
- [ ] `task e2e`（e2e 基盤未整備のため対象外）

## 決定ログ

- **置き場所は `backend/.gitignore` の IDE セクション**: 生成物は backend/ 直下にのみ現れる（JDT LS は Gradle プロジェクトルート単位で生成）。ルート .gitignore ではなく、`.idea/` 等の既存 IDE 条目と同じ場所に追記した。
- **`.git/info/exclude`（ローカル専用）ではなく共有 .gitignore**: JDT LS を使う環境なら誰の手元でも発生するため、リポジトリで共有する価値がある。
- **`.settings/` 単体ではなく Eclipse 系一式**: 同じツールが状況により `.project` / `.classpath` / `.factorypath` も生成するため定番セットで追加。`bin/` は既に Gradle セクションで無視済み。

## 備考 / レビュー観点

- 既存の追跡ファイルに影響なし（追加した 4 パターンに該当する追跡済みファイルは存在しない）。
