### PR TITLE
ci(review): claude-review の指摘を行内 threads で投稿する（--comment 追加）

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -73,7 +73,8 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           # 指摘ゼロでもトラッキングコメントが残り、「無発見」と「無言」を区別できる
           track_progress: true
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # --comment: 指摘を resolve 可能な行内 threads として投稿する（#263）
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # allowedTools が無いと投稿系ツールがすべて拒否され、レビューが PR に残らない（#251）
           claude_args: |
             --model claude-fable-5


### PR DESCRIPTION
## 概要

claude-code-review workflow の code-review プラグイン呼び出しに `--comment` を追加し、レビュー指摘を resolve 可能な行内 review threads として投稿させる。#263 の第 1 段（機構検証）。

Refs #263

## 変更内容

- `.github/workflows/claude-code-review.yml`: `prompt:` 行末尾に ` --comment` を追加し、直前に理由注記コメントを 1 行挿入（計 2 insertions / 1 deletion）
- `track_progress: true`・allowedTools・「Lint and Test 成功待ち」ゲートステップは非接触

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: なし — workflow 定義のみの変更で runtime 非接触のため未実行。実挙動の検証は本 PR 上の CI 観察が本体（備考参照））

QA（静的検証）: diff スコープ（変更が上記 2 点のみ）・YAML 構文妥当性（Ruby Psych, exit 0）・commit 構成（master から 1 commit）いずれも PASS。

### 視覚確認（UI 変更時）

UI 変更なしのため対象外。

## 決定ログ

- `--comment` は CI が実際に使う `anthropics/claude-code` リポジトリ側 code-review プラグインに実在するスイッチ（コマンド原文を確認済み）。**無しではプラグインは PR へ一切投稿しない** — 既存の輪次 summary は `track_progress` の tracking comment だったことを PR #260 の実コメントで確認
- 必要ツール（`mcp__github_inline_comment__create_inline_comment` / `gh pr comment`）は既存 allowedTools に含まれるため許可変更なし
- プラグイン step 1 の「Claude 既コメント → 停止」前置ゲートが synchronize 再レビューを止める既知リスクに対し、**予防的 prompt 上書きは見送り（観察優先）** — 実測結果を issue #263 コメントへ記録し、後続設計（#264）の入力とする
- `Closes` ではなく `Refs` を採用 — 第 2 段観察（#241-A の PR での行内 threads 実測）の記録を残すため issue #263 は意図的に開けたまま

## 備考 / レビュー観点

- 本 PR 自身が第 1 段観察の被験体: ①gate 連鎖不変（Lint and Test 成功後にのみレビュー実行）②tracking comment 継続 ③指摘ゼロ時「No issues found」摘要の投稿 ④レビュー第 1 輪完了後に観察用空コミットを push し、synchronize 第 2 輪の実行有無を観察
- 第 2 段観察（行内 threads の実投稿・再レビューでの旧指摘の表現）は次の実コード PR（#241-A）で実施
- 後続 issue: #264（watch-pr の threads 駆動化 — 退出条件「未解決 thread ゼロ」の確定化）
