### PR TITLE
ci(review): claude-review の実行モデルを claude-opus-4-8 に変更

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -77,7 +77,7 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # allowedTools が無いと投稿系ツールがすべて拒否され、レビューが PR に残らない（#251）
           claude_args: |
-            --model claude-fable-5
+            --model claude-opus-4-8
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## 概要

claude-review workflow の実行モデルを `claude-fable-5` から `claude-opus-4-8` に変更する。PR #265（`--comment` 化）で入った fable-5 指定を差し替える単一行の変更。

Refs #263

## 変更内容

- `.github/workflows/claude-code-review.yml`: `claude_args` の `--model` を `claude-fable-5` → `claude-opus-4-8` に変更（1 行）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: なし — CI workflow のモデル文字列変更のみで runtime 非接触のため未実行）

YAML 構文妥当性: Ruby Psych でパース成功（exit 0）。

### 視覚確認（UI 変更時）

UI 変更なしのため対象外。

## 決定ログ

- 実行モデルを Opus 4.8 に変更した理由: code review 用途では Opus 4.8 で十分（プラグインが内部で haiku/sonnet サブエージェントに処理を分担する構成）かつ fable-5（$10/$50 per MTok）より入出力単価が安い（$5/$25）
- モデル ID は `claude-opus-4-8`（連字符表記）。当初検討された `claude-opus-5.8` は実在しない ID で、指定すると claude-code-action の CLI 起動時に 404 になる（Opus 系列の最新は 4.8）
- fable-5 を維持する選択肢もあった（最上位モデル）が、レビュー品質と単価のバランスで Opus 4.8 を採用

## 備考 / レビュー観点

- workflow 変更 PR のため、claude-code-action は workflow 検証で本 PR 上のレビュー実行を skip する（default branch と一致しない workflow は実行されない安全機構）。新モデルでの実挙動はマージ後の最初の実 PR で確認される
