### PR TITLE
ci(build): 本番ビルドを PR ゲート化 — Lint and Test job に task build を追加（#241-A）

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -68,6 +68,13 @@ jobs:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
 
+      - name: Build
+        if: steps.diff.outputs.docs_only != 'true'
+        run: task build
+        env:
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_PROGRESS: plain
+
       - name: Create reports directory
         if: always() && steps.diff.outputs.docs_only != 'true'
         run: task reports

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ task logs service=backend           # view logs
 
 Use the Taskfile (Docker = CI parity) for final verification before committing. For fast red-green iteration use the local toolchains: `frontend/` → `npm test` / `npm run lint`; `backend/` → `./gradlew test` / `./gradlew spotlessApply`.
 
+`task build` also runs as a PR gate inside the Lint and Test job (`.github/workflows/lint-and-test.yml`): a production build failure turns that check red, so a change that breaks the production build cannot pass CI.
+
 ## Code Style & Conventions
 
 Per-directory `CLAUDE.md` files carry the area conventions and are auto-loaded when working there:


### PR DESCRIPTION
## 概要

本番ビルド（frontend の `next build` + backend イメージビルド）を PR ゲートに組み込む。PR #240 の Turbopack 生産ビルド panic が `task lint` / `task test` を全緑で通過した欠口（#241 Phase A）を塞ぐ。build は新規 job にせず、既存「Lint and Test」job 内のステップとして `task build` を追加する。

Refs #241

## 変更内容

- `.github/workflows/lint-and-test.yml`: `lint-and-test` job の「Test」ステップ直後に「Build」ステップ（`run: task build`）を追加。既存 Lint/Test と同一の docs-only スキップ gate・`DOCKER_BUILDKIT`/`BUILDKIT_PROGRESS` env を踏襲
- `CLAUDE.md`: Build,Test&Verify 節に、`task build` が Lint and Test job 内の PR ゲートとして実行され本番ビルド失敗が当該チェックを赤にする旨を追記

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: なし — CI workflow + docs のみで runtime プロダクトコード非接触のため未実行）

QA（静的 + build ゲート）: diff スコープ（対象 2 ファイル）・追加ステップの gate/env が既存 Lint/Test と一貫・YAML 構文（Ruby Psych, exit 0）・`task build` exit 0・commit 構成 いずれも PASS。

### 視覚確認（UI 変更時）

UI 変更なしのため対象外。

## 決定ログ

- **build を新規 job にせず「Lint and Test」job 内ステップとした**理由: Phase A（本 PR）はビルドゲートの導入のみが目的。パイプライン段階化（lint→unit→build→integration→e2e）と claude-review トリガー連鎖・required checks の一括更新は Phase D（#247 依存）で扱う。折り込み方式なら claude-review の「Lint and Test 成功待ち」連鎖（#254）と required checks を一切変更せずゲートを追加できる
- **ステップ順**: Phase D の予定順（lint→unit→build）に合わせ Test の後に配置
- `task build` は既存 Taskfile を流用（新規スクリプト無し）。因果チェーンで生産ビルドを実行: root `task build` → `frontend build` → `docker buildx build` → `Dockerfile:31 npm run build` → `next build`。Turbopack panic は `docker buildx build` を非ゼロ終了させ当該ステップを赤にする

## 備考 / レビュー観点

- **⚠️ マージ阻止には ruleset 更新（admin 操作）が別途必要**: 現在 master は ruleset「default」で保護され、required status checks は `claude-review` / `GitGuardian Security Checks` / `CodeQL` のみ。「Lint and Test」は required に含まれていないため、本 PR で build を折り込んでも「ビルドを壊す PR がマージできない」（受け入れ基準 3）は**未達**。ruleset の required checks に **「Lint and Test」を追加**する必要がある（リポジトリ owner/admin 作業）
- Phase D（CI 段階化・#247 依存）は本 PR 対象外
