### PR TITLE
ci(review): claude-review の prompt から --comment を外し行内 threads を復活させる (#263)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -73,8 +73,9 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           # 指摘ゼロでもトラッキングコメントが残り、「無発見」と「無言」を区別できる
           track_progress: true
-          # --comment: 指摘を resolve 可能な行内 threads として投稿する（#263）
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          # 行内 threads はプラグインの既定挙動（allowedTools の create_inline_comment + track_progress で出る）。
+          # prompt に --comment を付けると指摘が単一コメントに集約され行内 threads が出なくなるため付けない（#263 実測）。
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # allowedTools が無いと投稿系ツールがすべて拒否され、レビューが PR に残らない（#251）
           claude_args: |
             --model claude-opus-4-8


### PR DESCRIPTION
## 概要

claude-review が行内 threads を出さない原因が、prompt の `--comment` フラグだったことを実測で特定した。`--comment` は指摘を単一コメントに集約し**行内 threads を抑制する**（#265 でこれを付けたが、意図と逆の効果だった）。`--comment` を外し、プラグイン既定の resolve 可能な行内 threads を復活させる。

Closes #263

## 変更内容

- `.github/workflows/claude-code-review.yml`: `code-review` の prompt 末尾から `--comment` を除去。誤誘導だった旧コメント（「--comment: 指摘を resolve 可能な行内 threads として投稿する」）を、実測に基づく再発防止コメント（--comment を付けると threads が出なくなる旨）に差し替え。`track_progress` / `allowedTools` は不変。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e`（対象外: 本変更は `claude-code-review.yml` のみで実行時挙動に無関係）

### 視覚確認（UI 変更時）

UI 変更なし（CI レビュー workflow の設定変更）のため対象外。

## 決定ログ

- **`--comment` が原因である実証（交絡排除）**: repo 全体の inline review comments を集計すると `claude[bot]` は 5 件（**#248 に 3・#262 に 2、ともに `--comment` 導入前・fable-5**）。`--comment` 導入（#265, 2026-07-07 マージ）後の #268/#270（**同じ fable-5**）と #272（opus）は行内ゼロ＝単一摘要のみ。#268/#270 が #248/#262 と同モデルなのに出方が逆 → 両コホートの唯一の設定差は **`--comment` のみ**（モデルでも track_progress でもない）。
- **`--comment` のセマンティクスは「レビューを1コメントとして出す」**（＝行内注釈を出さないモード）。#265 のコミットメッセージ「--comment で行内 threads 化」は事実と逆だった。
- **`track_progress` は残す**: 進捗/トラッキングコメント（「無発見」と「無言」の区別）用で、行内 threads とは直交。allowedTools の `create_inline_comment` も残す（これがあって初めて既定で行内 threads が出る）。

## 備考 / レビュー観点

- **本 PR 自身の claude-review は skip される**: PR が `claude-code-review.yml` 自身を変更するため、claude-code-action の workflow 検証で当該 PR のレビューはスキップされる（default branch と不一致のため）。よって**復活した行内 threads 挙動は本 PR ではなく、マージ後の次の通常 PR で初めて観察できる**。
- **#264 への波及**: 行内 threads が復活すれば、#264 の「未 resolve thread」を退出/分診の信号に使う設計が再び成立し得る（要再評価）。
