### PR TITLE
ci(review): track_progress を false にし claude-review の指摘を行内 threads で投稿させる (refs #263)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -71,9 +71,11 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          # 指摘ゼロでもトラッキングコメントが残り、「無発見」と「無言」を区別できる
-          track_progress: true
-          # --comment: 指摘を resolve 可能な行内 threads として投稿する（#263）
+          # track_progress は tracking comment の tag モードを強制し、指摘を単一コメントへ集約して
+          # 行内 threads を抑制する（既定 false）。--comment による行内レビューを活かすため false にする。
+          # 「無発見」は --comment 時に code-review が "No issues found" summary を投稿するため区別可能（#263）。
+          track_progress: false
+          # --comment: 投稿の必須フラグ。指摘ありは行内コメント(create_inline_comment)、無しは summary を投稿する（#263）
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # allowedTools が無いと投稿系ツールがすべて拒否され、レビューが PR に残らない（#251）
           claude_args: |


### PR DESCRIPTION
## 概要

claude-review の指摘が行内 threads ではなく単一コメントに集約される原因は `track_progress: true` だった（action.yml: "Force tag mode with tracking comments"）。これが tag モードを強制し指摘を1コメントへ集約、行内 threads を抑制していた。`track_progress` を既定の `false` に戻し、`--comment` による行内レビュー（`create_inline_comment`）を活かす。`--comment` は投稿の必須フラグのため残す。

Refs #263

## 変更内容

- `.github/workflows/claude-code-review.yml`: `track_progress: true` → `false`。付随コメントを実測・doc 根拠に更新（track_progress が行内を抑制する旨、`--comment` が投稿必須フラグである旨）。`--comment` / `allowedTools` / model は不変。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e`（対象外: 本変更は `claude-code-review.yml` のみで実行時挙動に無関係）

行内 threads の**実挙動は本 PR では検証不可**: PR が `claude-code-review.yml` 自身を変更するため claude-code-action の workflow 検証で当該 PR の review は内部 skip される（check は pass 表示だが投稿 0）。**マージ後の次の通常 PR で行内 threads の復活を確認し、確認後に #263 をクローズする。**

### 視覚確認（UI 変更時）

UI 変更なし（CI レビュー workflow の設定変更）のため対象外。

## 決定ログ

- **一次情報で確定**: upstream `code-review` コマンド doc は「`--comment` 無し → GitHub に一切投稿しない／`--comment` + 指摘あり → `create_inline_comment` で行内投稿」。action.yml は `track_progress` を「Force tag mode with **tracking comments**」（既定 `false`）と定義。→ 行内を出すには **`--comment` 維持 + `track_progress` を false** が doc 支持の構成。
- **#273（`--comment` 除去）は誤りで close 済み**: `--comment` を外すと投稿ゼロになる（Codex の P1 指摘が正しかった）。行内が出ない原因は `--comment` ではなく `track_progress` 側だった。
- **`track_progress` 既定は false** なので本変更は既定へ戻す方向＝ `--comment` 除去のような投稿ゼロ化リスクは低い。「無発見」は `--comment` 時の "No issues found" summary で区別可能。
- 過去の観測（#248/#262 が `--comment` 前に行内を出していた）は upstream プラグインの版漂移由来で現行の判断材料にしない。判断は一次 doc に統一した。

## 備考 / レビュー観点

- **本 PR 自身の claude-review は内部 skip**（`.github/workflows/claude-code-review.yml` 改変のため）。行内 threads 復活の確認はマージ後の次の通常 PR で行う。
- `#252` が track_progress を「投稿を可能にする」として導入した経緯があるが、それは `--comment` 導入前の話。現在は `--comment` が投稿機構のため track_progress は不要と判断。万一マージ後の次 PR で投稿が出なければ revert（可逆）。
- **#264 への波及**: 行内 threads が復活すれば、#264 の「未 resolve thread」を退出/分診の信号に使う設計が再評価可能。
