### PR TITLE
fix(ci): e2e の task up 失敗を task build --load で修正し gateway alias を example に反映 (refs #241, closes #271)

### DIFF
--- a/backend/Taskfile.yml
+++ b/backend/Taskfile.yml
@@ -62,7 +62,8 @@ tasks:
     desc: バックエンドDockerイメージをビルド
     cmds:
       - echo "🏗️  バックエンドDockerイメージをビルド中..."
-      - docker buildx build -t {{.DOCKER_IMAGE}}:{{.DOCKER_TAG}} .
+      # --load: docker-container ドライバでも runtime イメージを docker デーモンへ載せる（task up が参照するため）
+      - docker buildx build --load -t {{.DOCKER_IMAGE}}:{{.DOCKER_TAG}} .
 
   clean:
     desc: Dockerイメージを削除

--- a/frontend/Taskfile.yml
+++ b/frontend/Taskfile.yml
@@ -20,7 +20,8 @@ tasks:
     desc: フロントエンドDockerイメージをビルド
     cmds:
       - echo "🏗️  フロントエンドDockerイメージをビルド中..."
-      - docker buildx build -t {{.DOCKER_IMAGE}}:{{.DOCKER_TAG}} .
+      # --load: docker-container ドライバでも runtime イメージを docker デーモンへ載せる（task up が参照するため）
+      - docker buildx build --load -t {{.DOCKER_IMAGE}}:{{.DOCKER_TAG}} .
 
   lint:
     desc: ESLint を実行（Docker lint ステージ経由）

--- a/infrastructure/docker-compose.example.yml
+++ b/infrastructure/docker-compose.example.yml
@@ -120,7 +120,12 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "./traefik/:/etc/traefik/:ro"
     networks:
-      - network
+      network:
+        # E2E（issue #247）が Host ヘッダで tenant/central を解決できるよう、
+        # gateway に跨プロジェクトで解決可能な network alias を付与する。
+        aliases:
+          - store1.kizuna.test
+          - kizuna.test
     depends_on:
       backend:
         condition: service_healthy


### PR DESCRIPTION
## 概要

#272（#241 Phase D）で新設した `verify-master.yml` の **E2E job が初回 push→master 実行で失敗**した。`task e2e` → `task up` が `kizuna-backend`/`kizuna-frontend` を解決できず `pull access denied` になる。根因は `task build` が buildx の docker-container ドライバ下で `--load` を持たず、イメージをビルドキャッシュに置くだけで docker デーモンに載せないこと。`task build` に `--load` を付けて修正する。あわせて #271（example-first 規約整合: gateway alias を baseline example へ反映）を同梱する。

Refs #241
Closes #271

## 変更内容

- **`backend/Taskfile.yml` / `frontend/Taskfile.yml`**: `task build` の `docker buildx build` に **`--load`** を追加（同 Taskfile の `test` ターゲットが既に持つ流儀に統一）。docker-container ドライバでも runtime イメージが docker デーモンに載り、`task up` が参照できる。
- **`infrastructure/docker-compose.example.yml`（#271）**: gateway サービスの networks を短縮形 `- network` から development 同様の alias 付き long form（`store1.kizuna.test` / `kizuna.test`、E2E 用コメント付き）へ。example-first 規約と整合。release/ は実 HTTPS ドメインで実 Host を受けるため不変更。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e`（フル実行はマージ後 verify-master で確認。下記の docker-container 再現で修正機序を実証済み）

**修正の実証（CI 相当環境）**: ローカルに **docker-container ドライバ**（CI の `Set up Docker Buildx` と同一）を立てて `task build`（`--load` 付き）を実行 → `docker images` に **`kizuna-backend:latest` / `kizuna-frontend:latest` が load される**ことを確認（`--load` 無しでは載らない＝元のバグ）。よって `task up` のイメージ解決失敗は解消する。フル `task e2e` の CI 実行はマージ後の `verify-master` push→master で確認する。

**#271 検証**: `docker-compose.example.yml` を YAML パース OK、gateway に alias 反映を確認。example はテンプレートのため `task` からは未使用（lint/test/build に影響なし）。

### 視覚確認（UI 変更時）

UI 変更なし（CI/tooling/infra 設定）のため対象外。

## 決定ログ

- **root cause**: `verify-master` の e2e job は lint-and-test と同様 `Set up Docker Buildx`（docker-container ドライバ）を使う。このドライバは `--load` 無しだとビルド結果をデーモンに載せない（ログに "Build result will only remain in the build cache ... use --load" 警告 → 後続 `task up` が `pull access denied for kizuna-backend`）。ローカル QA が通ったのは既定 docker ドライバが load するため＝CI 特有で、e2e を CI で走らせて初めて露呈した（#272 で予見済みリスク）。
- **修正方針**: `task build` に `--load`。同 Taskfile の `test` ターゲット（`--target test ... --load`）と同じパターンで、ドライバ非依存に runtime イメージをデーモンへ載せる。lint-and-test の build ゲートへの影響は load 分のみで軽微。
- **代替案却下**: e2e job から `Set up Docker Buildx` を外して既定ドライバに載せる案もあるが、`task build` 自体を正しくする方が全呼び出し元（local/CI）で一貫し、既存 `--load` パターンにも沿う。
- **#271**: infrastructure/CLAUDE.md の example-first 規約（構造変更はまず example → development/release へミラー）に沿い、#247 の development 変更を baseline へ後追い反映。

## 備考 / レビュー観点

- 本 PR は **#274（`track_progress: false`）マージ後に最初にレビューされる通常 PR**。claude-review が指摘を**行内 threads**（または無指摘なら "No issues found" summary）で投稿するかを観察する＝#274 の効果検証を兼ねる。
- マージ後、`verify-master` の push→master 実行で e2e job が緑になることを確認する（本修正の最終検証）。
