### PR TITLE
feat: 出勤管理（店舗シフトの登録・編集 + カレンダー/タイムライン）を追加する

### DIFF
--- a/backend/docs/modulith/all-docs.adoc
+++ b/backend/docs/modulith/all-docs.adoc
@@ -49,3 +49,7 @@ include::module-notification.adoc[]
 plantuml::module-order.puml[,,format=svg]
 include::module-order.adoc[]
 
+== Shift
+plantuml::module-shift.puml[,,format=svg]
+include::module-shift.adoc[]
+

--- a/backend/docs/modulith/components.puml
+++ b/backend/docs/modulith/components.puml
@@ -14,6 +14,7 @@ Container_Boundary("Application.Application_boundary", "Application", $tags="") 
   Component(Application.Application.Customer, "Customer", $techn="Module", $descr="", $tags="", $link="")
   Component(Application.Application.Notification, "Notification", $techn="Module", $descr="", $tags="", $link="")
   Component(Application.Application.Order, "Order", $techn="Module", $descr="", $tags="", $link="")
+  Component(Application.Application.Shift, "Shift", $techn="Module", $descr="", $tags="", $link="")
   Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
   Component(Application.Application.Settings, "Settings", $techn="Module", $descr="", $tags="", $link="")
   Component(Application.Application.Storage, "Storage", $techn="Module", $descr="", $tags="", $link="")
@@ -47,6 +48,9 @@ Rel(Application.Application.Order, Application.Application.User, "uses", $techn=
 Rel(Application.Application.Order, Application.Application.Tenant, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Order, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Settings, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
+Rel(Application.Application.Shift, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Shift, Application.Application.Tenant, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Shift, Application.Application.Cast, "uses", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)
 @enduml

--- a/backend/docs/modulith/module-cast.adoc
+++ b/backend/docs/modulith/module-cast.adoc
@@ -3,7 +3,11 @@
 |Base package
 |`com.kizuna.cast`
 |Spring components
-|_Repositories_
+|_Services_
+
+* `c.k.c.application.CastService`
+
+_Repositories_
 
 * `c.k.c.domain.CastRepository`
 |Bean references

--- a/backend/docs/modulith/module-shift.adoc
+++ b/backend/docs/modulith/module-shift.adoc
@@ -1,0 +1,9 @@
+[%autowidth.stretch, cols="h,a"]
+|===
+|Base package
+|`com.kizuna.shift`
+|Bean references
+|* `c.k.s.tenancy.TenantContext` (in Shared)
+* `c.k.t.domain.TenantRepository` (in Tenant)
+* `c.k.c.application.CastService` (in Cast)
+|===

--- a/backend/docs/modulith/module-shift.puml
+++ b/backend/docs/modulith/module-shift.puml
@@ -1,0 +1,26 @@
+@startuml
+set separator none
+title Shift
+
+top to bottom direction
+
+!include <C4/C4>
+!include <C4/C4_Context>
+!include <C4/C4_Component>
+
+Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+  Component(Application.Application.Cast, "Cast", $techn="Module", $descr="", $tags="", $link="")
+  Component(Application.Application.Shift, "Shift", $techn="Module", $descr="", $tags="", $link="")
+  Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
+  Component(Application.Application.Tenant, "Tenant", $techn="Module", $descr="", $tags="", $link="")
+}
+
+Rel(Application.Application.Shift, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Shift, Application.Application.Tenant, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Shift, Application.Application.Cast, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Tenant, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Cast, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Cast, Application.Application.Tenant, "uses", $techn="", $tags="", $link="")
+
+SHOW_LEGEND(true)
+@enduml

--- a/backend/src/integrationTest/java/com/kizuna/shift/ShiftCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/shift/ShiftCrossTenantIT.java
@@ -1,0 +1,149 @@
+package com.kizuna.shift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.kizuna.shared.CrossTenantTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Shift のクロステナント分離を本物の PostgreSQL で検証する統合テスト（issue #278）。
+ *
+ * <p>CastCrossTenantIT をミラー。tenant A のシフトを tenant B が 区間 GET で閲覧・PUT・DELETE できないことを固定し、 作成時の既定ステータス
+ * TENTATIVE と区間 GET ラウンドトリップも合わせて検証する。 シフト API は GET /{id} を持たない（区間 GET のみ）ため、読取隔離は「区間 GET
+ * に現れないこと」で確認する。
+ */
+class ShiftCrossTenantIT extends CrossTenantTestSupport {
+
+  private String createCastAs(long tenantId, String name) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/tenant/casts",
+            new HttpEntity<>("{\"name\": \"" + name + "\"}", tenantHeaders(tenantId)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful())
+        .as("前提: tenant %d でのキャスト作成が成功すること", tenantId)
+        .isTrue();
+    String id = created.getBody().path("id").asText();
+    assertThat(id).isNotBlank();
+    return id;
+  }
+
+  private String shiftBody(String castId, String workDate, String startTime, String endTime) {
+    return "{\"cast_id\": \""
+        + castId
+        + "\", \"work_date\": \""
+        + workDate
+        + "\", \"start_time\": \""
+        + startTime
+        + "\", \"end_time\": \""
+        + endTime
+        + "\"}";
+  }
+
+  private boolean rangeContains(long tenantId, String range, String shiftId) {
+    ResponseEntity<JsonNode> res =
+        rest.exchange(
+            "/tenant/shifts?" + range,
+            HttpMethod.GET,
+            new HttpEntity<>(tenantHeaders(tenantId)),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    for (JsonNode node : res.getBody()) {
+      if (shiftId.equals(node.path("id").asText())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Test
+  @DisplayName("シフト作成は既定 TENTATIVE で、区間 GET に作成分が返ること")
+  void createDefaultsToTentativeAndListedInRange() {
+    String castId = createCastAs(TENANT_A, "統合テストキャスト（作成）");
+
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/tenant/shifts",
+            new HttpEntity<>(
+                shiftBody(castId, "2026-07-08", "18:00:00", "23:00:00"), tenantHeaders(TENANT_A)),
+            JsonNode.class);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(created.getBody().path("status").asText())
+        .as("既定ステータスは TENTATIVE")
+        .isEqualTo("TENTATIVE");
+    String shiftId = created.getBody().path("id").asText();
+    assertThat(shiftId).isNotBlank();
+
+    // 区間 GET（日=from==to）に作成分が返る
+    assertThat(rangeContains(TENANT_A, "from=2026-07-08&to=2026-07-08", shiftId)).isTrue();
+  }
+
+  @Test
+  @DisplayName("他テナントはシフトを区間 GET で閲覧・更新・削除できず、データも変わらないこと")
+  void otherTenantCannotReadUpdateOrDeleteForeignShift() {
+    String castId = createCastAs(TENANT_A, "統合テストキャスト（隔離）");
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/tenant/shifts",
+            new HttpEntity<>(
+                shiftBody(castId, "2026-07-10", "19:00:00", "23:00:00"), tenantHeaders(TENANT_A)),
+            JsonNode.class);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    String shiftId = created.getBody().path("id").asText();
+
+    // 読取隔離: tenant B の区間 GET には現れない
+    assertThat(rangeContains(TENANT_B, "from=2026-07-10&to=2026-07-10", shiftId)).isFalse();
+
+    // 正向対照: 同一ボディ形式で自テナントの更新は成功する（負向 400 がバリデーション起因でない証明）
+    ResponseEntity<JsonNode> ownUpdate =
+        rest.exchange(
+            "/tenant/shifts/" + shiftId,
+            HttpMethod.PUT,
+            new HttpEntity<>("{\"status\": \"CONFIRMED\"}", tenantHeaders(TENANT_A)),
+            JsonNode.class);
+    assertThat(ownUpdate.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(ownUpdate.getBody().path("status").asText()).isEqualTo("CONFIRMED");
+
+    // 負向: tenant B は更新できない（ServiceException → 400）
+    ResponseEntity<JsonNode> tampered =
+        rest.exchange(
+            "/tenant/shifts/" + shiftId,
+            HttpMethod.PUT,
+            new HttpEntity<>("{\"status\": \"TENTATIVE\"}", tenantHeaders(TENANT_B)),
+            JsonNode.class);
+    assertThat(tampered.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+    // 負向: tenant B は削除できない（ServiceException → 400）
+    ResponseEntity<JsonNode> deleted =
+        rest.exchange(
+            "/tenant/shifts/" + shiftId,
+            HttpMethod.DELETE,
+            new HttpEntity<>(tenantHeaders(TENANT_B)),
+            JsonNode.class);
+    assertThat(deleted.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+    // データ不変: tenant A からはまだ存在し、status は tenant A が設定した CONFIRMED のまま
+    ResponseEntity<JsonNode> after =
+        rest.exchange(
+            "/tenant/shifts?from=2026-07-10&to=2026-07-10",
+            HttpMethod.GET,
+            new HttpEntity<>(tenantHeaders(TENANT_A)),
+            JsonNode.class);
+    assertThat(after.getStatusCode()).isEqualTo(HttpStatus.OK);
+    JsonNode found = null;
+    for (JsonNode node : after.getBody()) {
+      if (shiftId.equals(node.path("id").asText())) {
+        found = node;
+        break;
+      }
+    }
+    assertThat(found).as("tenant B の操作後も tenant A のシフトは残っていること").isNotNull();
+    assertThat(found.path("status").asText()).isEqualTo("CONFIRMED");
+  }
+}

--- a/backend/src/integrationTest/java/com/kizuna/shift/ShiftCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/shift/ShiftCrossTenantIT.java
@@ -46,6 +46,36 @@ class ShiftCrossTenantIT extends CrossTenantTestSupport {
         + "\"}";
   }
 
+  private String createShiftAs(
+      long tenantId, String castId, String workDate, String startTime, String endTime) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/tenant/shifts",
+            new HttpEntity<>(
+                shiftBody(castId, workDate, startTime, endTime), tenantHeaders(tenantId)),
+            JsonNode.class);
+    assertThat(created.getStatusCode())
+        .as("前提: tenant %d でのシフト作成が成功すること", tenantId)
+        .isEqualTo(HttpStatus.CREATED);
+    return created.getBody().path("id").asText();
+  }
+
+  private JsonNode findInRange(long tenantId, String range, String shiftId) {
+    ResponseEntity<JsonNode> res =
+        rest.exchange(
+            "/tenant/shifts?" + range,
+            HttpMethod.GET,
+            new HttpEntity<>(tenantHeaders(tenantId)),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    for (JsonNode node : res.getBody()) {
+      if (shiftId.equals(node.path("id").asText())) {
+        return node;
+      }
+    }
+    return null;
+  }
+
   private boolean rangeContains(long tenantId, String range, String shiftId) {
     ResponseEntity<JsonNode> res =
         rest.exchange(
@@ -145,5 +175,51 @@ class ShiftCrossTenantIT extends CrossTenantTestSupport {
     }
     assertThat(found).as("tenant B の操作後も tenant A のシフトは残っていること").isNotNull();
     assertThat(found.path("status").asText()).isEqualTo("CONFIRMED");
+  }
+
+  @Test
+  @DisplayName("他テナントのキャスト id ではシフトを作成できず、区間 GET にも現れないこと")
+  void cannotCreateShiftWithOtherTenantCast() {
+    String foreignCastId = createCastAs(TENANT_B, "他店キャスト（作成不可）");
+
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/tenant/shifts",
+            new HttpEntity<>(
+                shiftBody(foreignCastId, "2026-07-12", "18:00:00", "23:00:00"),
+                tenantHeaders(TENANT_A)),
+            JsonNode.class);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+    // 作成されていないこと（区間 GET が空）
+    ResponseEntity<JsonNode> range =
+        rest.exchange(
+            "/tenant/shifts?from=2026-07-12&to=2026-07-12",
+            HttpMethod.GET,
+            new HttpEntity<>(tenantHeaders(TENANT_A)),
+            JsonNode.class);
+    assertThat(range.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(range.getBody().size()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("自店シフトを他テナントのキャストに付け替えられず、cast_id が変わらないこと")
+  void cannotUpdateShiftToOtherTenantCast() {
+    String ownCastId = createCastAs(TENANT_A, "自店キャスト（付替元）");
+    String shiftId = createShiftAs(TENANT_A, ownCastId, "2026-07-13", "18:00:00", "23:00:00");
+    String foreignCastId = createCastAs(TENANT_B, "他店キャスト（付替先）");
+
+    ResponseEntity<JsonNode> put =
+        rest.exchange(
+            "/tenant/shifts/" + shiftId,
+            HttpMethod.PUT,
+            new HttpEntity<>("{\"cast_id\": \"" + foreignCastId + "\"}", tenantHeaders(TENANT_A)),
+            JsonNode.class);
+    assertThat(put.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+    // データ不変: cast_id は自店のキャストのまま
+    JsonNode found = findInRange(TENANT_A, "from=2026-07-13&to=2026-07-13", shiftId);
+    assertThat(found).isNotNull();
+    assertThat(found.path("cast_id").asText()).isEqualTo(ownCastId);
   }
 }

--- a/backend/src/main/java/com/kizuna/cast/application/CastService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastService.java
@@ -46,6 +46,16 @@ public class CastService {
         .orElseThrow(() -> new ServiceException("キャストが見つかりません: " + id));
   }
 
+  /**
+   * 指定 id のキャストが現在テナントに属するか判定する（他モジュールからの帰属チェック用ポート）。 tenantFilter が効くため、他テナントのキャストは存在しないものとして
+   * false を返す。
+   */
+  @TenantScoped
+  @Transactional(readOnly = true)
+  public boolean existsForCurrentTenant(String id) {
+    return castRepository.findById(id).isPresent();
+  }
+
   @TenantScoped
   @Transactional
   public CastResponse create(CastCreateRequest request) {

--- a/backend/src/main/java/com/kizuna/cast/application/package-info.java
+++ b/backend/src/main/java/com/kizuna/cast/application/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * cast モジュールのアプリケーション層。
+ *
+ * <p>named interface 公開は過渡措置: shift モジュールが出勤登録時に「当該キャストが現在テナントに属するか」を CastService 経由で確認するため。読み側 API
+ * の整備後に公開面を狭める。
+ */
+@org.springframework.modulith.NamedInterface("application")
+package com.kizuna.cast.application;

--- a/backend/src/main/java/com/kizuna/shift/api/dto/ShiftCreateRequest.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/ShiftCreateRequest.java
@@ -1,0 +1,16 @@
+package com.kizuna.shift.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Data;
+
+@Data
+public class ShiftCreateRequest {
+  @NotBlank private String castId;
+  @NotNull private LocalDate workDate;
+  @NotNull private LocalTime startTime;
+  @NotNull private LocalTime endTime;
+  private String status;
+}

--- a/backend/src/main/java/com/kizuna/shift/api/dto/ShiftMapper.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/ShiftMapper.java
@@ -1,0 +1,18 @@
+package com.kizuna.shift.api.dto;
+
+import com.kizuna.shift.domain.Shift;
+import com.kizuna.shift.domain.ShiftPatch;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ShiftMapper {
+
+  ShiftResponse toResponse(Shift shift);
+
+  @Mapping(target = "status", defaultValue = "TENTATIVE")
+  Shift toEntity(ShiftCreateRequest request);
+
+  /** 更新リクエストをドメインの部分更新コマンドに変換します。null フィールドは「変更しない」。 */
+  ShiftPatch toPatch(ShiftUpdateRequest request);
+}

--- a/backend/src/main/java/com/kizuna/shift/api/dto/ShiftResponse.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/ShiftResponse.java
@@ -1,0 +1,24 @@
+package com.kizuna.shift.api.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShiftResponse {
+  private String id;
+  private String castId;
+  private LocalDate workDate;
+  private LocalTime startTime;
+  private LocalTime endTime;
+  private String status;
+  private OffsetDateTime createdAt;
+  private OffsetDateTime updatedAt;
+}

--- a/backend/src/main/java/com/kizuna/shift/api/dto/ShiftUpdateRequest.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/ShiftUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.kizuna.shift.api.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Data;
+
+@Data
+public class ShiftUpdateRequest {
+  private String castId;
+  private LocalDate workDate;
+  private LocalTime startTime;
+  private LocalTime endTime;
+  private String status;
+}

--- a/backend/src/main/java/com/kizuna/shift/api/store/ShiftController.java
+++ b/backend/src/main/java/com/kizuna/shift/api/store/ShiftController.java
@@ -1,0 +1,59 @@
+package com.kizuna.shift.api.store;
+
+import com.kizuna.shift.api.dto.ShiftCreateRequest;
+import com.kizuna.shift.api.dto.ShiftResponse;
+import com.kizuna.shift.api.dto.ShiftUpdateRequest;
+import com.kizuna.shift.application.ShiftService;
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/tenant/shifts")
+@RequiredArgsConstructor
+public class ShiftController {
+
+  private final ShiftService shiftService;
+
+  @GetMapping
+  @PreAuthorize("hasAuthority('CAST_MANAGE')")
+  public ResponseEntity<List<ShiftResponse>> list(
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+    return ResponseEntity.ok(shiftService.list(from, to));
+  }
+
+  @PostMapping
+  @PreAuthorize("hasAuthority('CAST_MANAGE')")
+  public ResponseEntity<ShiftResponse> create(@Valid @RequestBody ShiftCreateRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(shiftService.create(request));
+  }
+
+  @PutMapping("/{id}")
+  @PreAuthorize("hasAuthority('CAST_MANAGE')")
+  public ResponseEntity<ShiftResponse> update(
+      @PathVariable String id, @Valid @RequestBody ShiftUpdateRequest request) {
+    return ResponseEntity.ok(shiftService.update(id, request));
+  }
+
+  @DeleteMapping("/{id}")
+  @PreAuthorize("hasAuthority('CAST_MANAGE')")
+  public ResponseEntity<Void> delete(@PathVariable String id) {
+    shiftService.delete(id);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
@@ -1,5 +1,6 @@
 package com.kizuna.shift.application;
 
+import com.kizuna.cast.application.CastService;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.tenancy.TenantContext;
 import com.kizuna.shared.tenancy.TenantScoped;
@@ -24,6 +25,7 @@ public class ShiftService {
   private final ShiftMapper shiftMapper;
   private final TenantContext tenantContext;
   private final TenantRepository tenantRepository;
+  private final CastService castService;
 
   @TenantScoped
   @Transactional(readOnly = true)
@@ -38,6 +40,9 @@ public class ShiftService {
   public ShiftResponse create(ShiftCreateRequest request) {
     if (request.getStartTime().equals(request.getEndTime())) {
       throw new ServiceException("開始時刻と終了時刻が同一です");
+    }
+    if (!castService.existsForCurrentTenant(request.getCastId())) {
+      throw new ServiceException("キャストが見つかりません: " + request.getCastId());
     }
 
     Shift shift = shiftMapper.toEntity(request);
@@ -56,6 +61,10 @@ public class ShiftService {
   public ShiftResponse update(String id, ShiftUpdateRequest request) {
     Shift shift =
         shiftRepository.findById(id).orElseThrow(() -> new ServiceException("シフトが見つかりません: " + id));
+
+    if (request.getCastId() != null && !castService.existsForCurrentTenant(request.getCastId())) {
+      throw new ServiceException("キャストが見つかりません: " + request.getCastId());
+    }
 
     if (request.getStartTime() != null && request.getStartTime().equals(request.getEndTime())) {
       throw new ServiceException("開始時刻と終了時刻が同一です");

--- a/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
@@ -1,0 +1,77 @@
+package com.kizuna.shift.application;
+
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.tenancy.TenantContext;
+import com.kizuna.shared.tenancy.TenantScoped;
+import com.kizuna.shift.api.dto.ShiftCreateRequest;
+import com.kizuna.shift.api.dto.ShiftMapper;
+import com.kizuna.shift.api.dto.ShiftResponse;
+import com.kizuna.shift.api.dto.ShiftUpdateRequest;
+import com.kizuna.shift.domain.Shift;
+import com.kizuna.shift.domain.ShiftRepository;
+import com.kizuna.tenant.domain.TenantRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftService {
+
+  private final ShiftRepository shiftRepository;
+  private final ShiftMapper shiftMapper;
+  private final TenantContext tenantContext;
+  private final TenantRepository tenantRepository;
+
+  @TenantScoped
+  @Transactional(readOnly = true)
+  public List<ShiftResponse> list(LocalDate from, LocalDate to) {
+    return shiftRepository.findByWorkDateBetween(from, to).stream()
+        .map(shiftMapper::toResponse)
+        .toList();
+  }
+
+  @TenantScoped
+  @Transactional
+  public ShiftResponse create(ShiftCreateRequest request) {
+    if (request.getStartTime().equals(request.getEndTime())) {
+      throw new ServiceException("開始時刻と終了時刻が同一です");
+    }
+
+    Shift shift = shiftMapper.toEntity(request);
+
+    shift.setTenantId(
+        tenantRepository
+            .findById(tenantContext.getTenantId())
+            .orElseThrow(() -> new ServiceException("テナントが見つかりません"))
+            .getId());
+
+    return shiftMapper.toResponse(shiftRepository.save(shift));
+  }
+
+  @TenantScoped
+  @Transactional
+  public ShiftResponse update(String id, ShiftUpdateRequest request) {
+    Shift shift =
+        shiftRepository.findById(id).orElseThrow(() -> new ServiceException("シフトが見つかりません: " + id));
+
+    if (request.getStartTime() != null && request.getStartTime().equals(request.getEndTime())) {
+      throw new ServiceException("開始時刻と終了時刻が同一です");
+    }
+
+    shift.apply(shiftMapper.toPatch(request));
+
+    return shiftMapper.toResponse(shiftRepository.save(shift));
+  }
+
+  @TenantScoped
+  @Transactional
+  public void delete(String id) {
+    if (!shiftRepository.existsById(id)) {
+      throw new ServiceException("シフトが見つかりません: " + id);
+    }
+    shiftRepository.deleteById(id);
+  }
+}

--- a/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
@@ -14,6 +14,7 @@ import com.kizuna.tenant.domain.TenantRepository;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class ShiftService {
+
+  private static final Set<String> ALLOWED_STATUSES = Set.of("TENTATIVE", "CONFIRMED");
 
   private final ShiftRepository shiftRepository;
   private final ShiftMapper shiftMapper;
@@ -42,6 +45,7 @@ public class ShiftService {
     if (request.getStartTime().equals(request.getEndTime())) {
       throw new ServiceException("開始時刻と終了時刻が同一です");
     }
+    validateStatus(request.getStatus());
     if (!castService.existsForCurrentTenant(request.getCastId())) {
       throw new ServiceException("キャストが見つかりません: " + request.getCastId());
     }
@@ -63,6 +67,7 @@ public class ShiftService {
     Shift shift =
         shiftRepository.findById(id).orElseThrow(() -> new ServiceException("シフトが見つかりません: " + id));
 
+    validateStatus(request.getStatus());
     if (request.getCastId() != null && !castService.existsForCurrentTenant(request.getCastId())) {
       throw new ServiceException("キャストが見つかりません: " + request.getCastId());
     }
@@ -88,5 +93,12 @@ public class ShiftService {
       throw new ServiceException("シフトが見つかりません: " + id);
     }
     shiftRepository.deleteById(id);
+  }
+
+  /** status が指定された場合、許可値（TENTATIVE / CONFIRMED）以外を拒否する。null は不変更として許容。 */
+  private void validateStatus(String status) {
+    if (status != null && !ALLOWED_STATUSES.contains(status)) {
+      throw new ServiceException("不正なステータスです: " + status);
+    }
   }
 }

--- a/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
@@ -12,6 +12,7 @@ import com.kizuna.shift.domain.Shift;
 import com.kizuna.shift.domain.ShiftRepository;
 import com.kizuna.tenant.domain.TenantRepository;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -66,7 +67,12 @@ public class ShiftService {
       throw new ServiceException("キャストが見つかりません: " + request.getCastId());
     }
 
-    if (request.getStartTime() != null && request.getStartTime().equals(request.getEndTime())) {
+    // 部分更新のマージ結果（実効の開始・終了）で判定する。片方だけ来て既存値と一致する穴を塞ぐ。
+    LocalTime effectiveStart =
+        request.getStartTime() != null ? request.getStartTime() : shift.getStartTime();
+    LocalTime effectiveEnd =
+        request.getEndTime() != null ? request.getEndTime() : shift.getEndTime();
+    if (effectiveStart != null && effectiveStart.equals(effectiveEnd)) {
       throw new ServiceException("開始時刻と終了時刻が同一です");
     }
 

--- a/backend/src/main/java/com/kizuna/shift/domain/Shift.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/Shift.java
@@ -1,0 +1,75 @@
+package com.kizuna.shift.domain;
+
+import com.kizuna.shared.persistence.TenantScopedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Filter;
+
+@Entity
+@Table(name = "t_shifts")
+@Filter(name = "tenantFilter", condition = "tenant_id = :tenantId")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Shift extends TenantScopedEntity {
+
+  @Column(name = "cast_id", nullable = false, length = 64)
+  private String castId;
+
+  @Column(name = "work_date", nullable = false)
+  private LocalDate workDate;
+
+  @Column(name = "start_time", nullable = false)
+  private LocalTime startTime;
+
+  /** 終了時刻。start_time 以下の場合は翌日にまたがる勤務として扱う（解釈は表示側）。 */
+  @Column(name = "end_time", nullable = false)
+  private LocalTime endTime;
+
+  @Column(name = "status", nullable = false, length = 20)
+  private String status;
+
+  /** 部分更新コマンドを適用する。null のフィールドは変更しない。 */
+  public void apply(ShiftPatch patch) {
+    if (patch.castId() != null) {
+      this.castId = patch.castId();
+    }
+    if (patch.workDate() != null) {
+      this.workDate = patch.workDate();
+    }
+    if (patch.startTime() != null) {
+      this.startTime = patch.startTime();
+    }
+    if (patch.endTime() != null) {
+      this.endTime = patch.endTime();
+    }
+    if (patch.status() != null) {
+      this.status = patch.status();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "Shift(id="
+        + getId()
+        + ", castId="
+        + castId
+        + ", workDate="
+        + workDate
+        + ", startTime="
+        + startTime
+        + ", endTime="
+        + endTime
+        + ", status="
+        + status
+        + ")";
+  }
+}

--- a/backend/src/main/java/com/kizuna/shift/domain/ShiftPatch.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/ShiftPatch.java
@@ -1,0 +1,8 @@
+package com.kizuna.shift.domain;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/** シフトの部分更新コマンド。null のフィールドは「変更しない」を意味する（CastPatch と同じ意味論）。 */
+public record ShiftPatch(
+    String castId, LocalDate workDate, LocalTime startTime, LocalTime endTime, String status) {}

--- a/backend/src/main/java/com/kizuna/shift/domain/ShiftRepository.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/ShiftRepository.java
@@ -1,0 +1,12 @@
+package com.kizuna.shift.domain;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface ShiftRepository
+    extends JpaRepository<Shift, String>, JpaSpecificationExecutor<Shift> {
+
+  List<Shift> findByWorkDateBetween(LocalDate from, LocalDate to);
+}

--- a/backend/src/main/java/com/kizuna/shift/domain/package-info.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/package-info.java
@@ -1,0 +1,2 @@
+/** shift モジュールのドメイン層。t_casts と同じテナント作用域で出勤（シフト）集約を保持する。 */
+package com.kizuna.shift.domain;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5,3 +5,6 @@ databaseChangeLog:
   - include:
       file: releases/v0.2.0/master.yaml
       relativeToChangelogFile: true
+  - include:
+      file: releases/v0.3.0/master.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.3.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.3.0/master.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      file: tenant/01-shift-schema.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.3.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.3.0/master.yaml
@@ -2,3 +2,6 @@ databaseChangeLog:
   - include:
       file: tenant/01-shift-schema.yaml
       relativeToChangelogFile: true
+  - include:
+      file: tenant/02-shift-menu-seed.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.3.0/tenant/01-shift-schema.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.3.0/tenant/01-shift-schema.yaml
@@ -1,0 +1,89 @@
+databaseChangeLog:
+  - changeSet:
+      id: tenant-v030-001-shift-schema
+      author: kanghouchao
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - createTable:
+            tableName: t_shifts
+            remarks: 出勤（シフト）情報テーブル
+            columns:
+              - column:
+                  name: id
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_t_shifts
+              - column:
+                  name: tenant_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: cast_id
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+                  remarks: 出勤するキャスト
+              - column:
+                  name: work_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+                  remarks: 勤務日
+              - column:
+                  name: start_time
+                  type: TIME
+                  constraints:
+                    nullable: false
+                  remarks: 開始時刻
+              - column:
+                  name: end_time
+                  type: TIME
+                  constraints:
+                    nullable: false
+                  remarks: 終了時刻（start_time 以下なら翌日にまたがる勤務）
+              - column:
+                  name: status
+                  type: VARCHAR(20)
+                  defaultValue: 'TENTATIVE'
+                  constraints:
+                    nullable: false
+                  remarks: ステータス（TENTATIVE=仮/CONFIRMED=確定）
+              - column:
+                  name: created_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            constraintName: fk_t_shifts_tenant
+            baseTableName: t_shifts
+            baseColumnNames: tenant_id
+            referencedTableName: central_tenants
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            constraintName: fk_t_shifts_cast
+            baseTableName: t_shifts
+            baseColumnNames: cast_id
+            referencedTableName: t_casts
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - createIndex:
+            indexName: idx_t_shifts_tenant_work_date
+            tableName: t_shifts
+            columns:
+              - column:
+                  name: tenant_id
+              - column:
+                  name: work_date

--- a/backend/src/main/resources/db/changelog/releases/v0.3.0/tenant/02-shift-menu-seed.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.3.0/tenant/02-shift-menu-seed.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: tenant-v030-002-shift-menu-seed
+      author: kanghouchao
+      changes:
+        # v0.1.0 で入った未実装プレースホルダ（label「シフト管理」/権限なし）を
+        # CAST_MANAGE でゲートした「出勤管理」に置き換える（/tenant/shifts への重複メニューを避ける）。
+        - delete:
+            tableName: t_menus
+            where: "id = 't1-shift'"
+        - insert:
+            tableName: t_menus
+            columns:
+              - column: { name: id, value: "t1-shifts" }
+              - column: { name: tenant_id, valueNumeric: 1 }
+              - column: { name: parent_id, value: "t1-hrm" }
+              - column: { name: label, value: "出勤管理" }
+              - column: { name: path, value: "/tenant/shifts" }
+              - column: { name: icon, value: "ClockIcon" }
+              - column: { name: permission, value: "CAST_MANAGE" }
+              - column: { name: sort_order, valueNumeric: 2 }

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
@@ -190,6 +190,21 @@ class ShiftServiceTest {
   }
 
   @Test
+  void update_rejectsWhenPartialUpdateMergesToEqualTimes() {
+    // 既存 18:00-22:00 に start だけ 22:00 → 既存 end 22:00 とマージで一致 → 拒否
+    Shift s = Shift.builder().startTime(LocalTime.of(18, 0)).endTime(LocalTime.of(22, 0)).build();
+    s.setId("s1");
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(s));
+
+    ShiftUpdateRequest req = new ShiftUpdateRequest();
+    req.setStartTime(LocalTime.of(22, 0));
+
+    assertThatThrownBy(() -> shiftService.update("s1", req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("開始時刻と終了時刻");
+  }
+
+  @Test
   void delete_removes() {
     when(shiftRepository.existsById("s1")).thenReturn(true);
     shiftService.delete("s1");

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
@@ -1,0 +1,177 @@
+package com.kizuna.shift.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.tenancy.TenantContext;
+import com.kizuna.shift.api.dto.ShiftCreateRequest;
+import com.kizuna.shift.api.dto.ShiftMapper;
+import com.kizuna.shift.api.dto.ShiftResponse;
+import com.kizuna.shift.api.dto.ShiftUpdateRequest;
+import com.kizuna.shift.domain.Shift;
+import com.kizuna.shift.domain.ShiftPatch;
+import com.kizuna.shift.domain.ShiftRepository;
+import com.kizuna.tenant.domain.Tenant;
+import com.kizuna.tenant.domain.TenantRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ShiftServiceTest {
+
+  @Mock private ShiftRepository shiftRepository;
+  @Mock private ShiftMapper shiftMapper;
+  @Mock private TenantContext tenantContext;
+  @Mock private TenantRepository tenantRepository;
+
+  @InjectMocks private ShiftService shiftService;
+
+  private ShiftCreateRequest validCreateRequest() {
+    ShiftCreateRequest req = new ShiftCreateRequest();
+    req.setCastId("c1");
+    req.setWorkDate(LocalDate.of(2026, 7, 8));
+    req.setStartTime(LocalTime.of(18, 0));
+    req.setEndTime(LocalTime.of(23, 0));
+    return req;
+  }
+
+  @Test
+  void list_returnsShiftsInRange() {
+    LocalDate from = LocalDate.of(2026, 7, 1);
+    LocalDate to = LocalDate.of(2026, 7, 31);
+    Shift s = Shift.builder().castId("c1").build();
+
+    when(shiftRepository.findByWorkDateBetween(from, to)).thenReturn(List.of(s));
+    ShiftResponse resp = new ShiftResponse();
+    resp.setId("s1");
+    when(shiftMapper.toResponse(s)).thenReturn(resp);
+
+    List<ShiftResponse> result = shiftService.list(from, to);
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getId()).isEqualTo("s1");
+  }
+
+  @Test
+  void create_setsTenantIdAndSaves() {
+    ShiftCreateRequest req = validCreateRequest();
+
+    Shift entity = Shift.builder().castId("c1").status("TENTATIVE").build();
+    Tenant tenant = new Tenant();
+    tenant.setId(1L);
+
+    when(shiftMapper.toEntity(req)).thenReturn(entity);
+    when(tenantContext.getTenantId()).thenReturn(1L);
+    when(tenantRepository.findById(1L)).thenReturn(Optional.of(tenant));
+    when(shiftRepository.save(any()))
+        .thenAnswer(
+            i -> {
+              Shift s = i.getArgument(0);
+              s.setId("s_new");
+              return s;
+            });
+
+    ShiftResponse resp = new ShiftResponse();
+    resp.setId("s_new");
+    when(shiftMapper.toResponse(any())).thenReturn(resp);
+
+    ShiftResponse res = shiftService.create(req);
+    assertThat(res.getId()).isEqualTo("s_new");
+    assertThat(entity.getTenantId()).isEqualTo(1L);
+  }
+
+  @Test
+  void create_rejectsWhenEndEqualsStart() {
+    ShiftCreateRequest req = validCreateRequest();
+    req.setStartTime(LocalTime.of(20, 0));
+    req.setEndTime(LocalTime.of(20, 0));
+
+    assertThatThrownBy(() -> shiftService.create(req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("開始時刻と終了時刻");
+  }
+
+  @Test
+  void create_throwsWhenTenantNotFound() {
+    ShiftCreateRequest req = validCreateRequest();
+
+    when(shiftMapper.toEntity(req)).thenReturn(Shift.builder().build());
+    when(tenantContext.getTenantId()).thenReturn(1L);
+    when(tenantRepository.findById(1L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> shiftService.create(req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("テナントが見つかりません");
+  }
+
+  @Test
+  void update_appliesPatchAndSaves() {
+    Shift s = Shift.builder().castId("c1").status("TENTATIVE").build();
+    s.setId("s1");
+
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(s));
+    when(shiftRepository.save(any())).thenReturn(s);
+
+    ShiftUpdateRequest req = new ShiftUpdateRequest();
+    req.setStatus("CONFIRMED");
+    when(shiftMapper.toPatch(req)).thenReturn(new ShiftPatch(null, null, null, null, "CONFIRMED"));
+
+    ShiftResponse resp = new ShiftResponse();
+    resp.setStatus("CONFIRMED");
+    when(shiftMapper.toResponse(s)).thenReturn(resp);
+
+    ShiftResponse result = shiftService.update("s1", req);
+    assertThat(result.getStatus()).isEqualTo("CONFIRMED");
+    assertThat(s.getStatus()).isEqualTo("CONFIRMED");
+  }
+
+  @Test
+  void update_throwsWhenNotFound() {
+    when(shiftRepository.findById("missing")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> shiftService.update("missing", new ShiftUpdateRequest()))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("シフトが見つかりません");
+  }
+
+  @Test
+  void update_rejectsWhenEndEqualsStart() {
+    Shift s = Shift.builder().build();
+    s.setId("s1");
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(s));
+
+    ShiftUpdateRequest req = new ShiftUpdateRequest();
+    req.setStartTime(LocalTime.of(20, 0));
+    req.setEndTime(LocalTime.of(20, 0));
+
+    assertThatThrownBy(() -> shiftService.update("s1", req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("開始時刻と終了時刻");
+  }
+
+  @Test
+  void delete_removes() {
+    when(shiftRepository.existsById("s1")).thenReturn(true);
+    shiftService.delete("s1");
+    verify(shiftRepository).deleteById("s1");
+  }
+
+  @Test
+  void delete_throwsWhenNotFound() {
+    when(shiftRepository.existsById("missing")).thenReturn(false);
+
+    assertThatThrownBy(() -> shiftService.delete("missing"))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("シフトが見つかりません");
+  }
+}

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
@@ -205,6 +205,30 @@ class ShiftServiceTest {
   }
 
   @Test
+  void create_rejectsInvalidStatus() {
+    ShiftCreateRequest req = validCreateRequest();
+    req.setStatus("BOGUS");
+
+    assertThatThrownBy(() -> shiftService.create(req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("不正なステータス");
+  }
+
+  @Test
+  void update_rejectsInvalidStatus() {
+    Shift s = Shift.builder().castId("c1").build();
+    s.setId("s1");
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(s));
+
+    ShiftUpdateRequest req = new ShiftUpdateRequest();
+    req.setStatus("BOGUS");
+
+    assertThatThrownBy(() -> shiftService.update("s1", req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("不正なステータス");
+  }
+
+  @Test
   void delete_removes() {
     when(shiftRepository.existsById("s1")).thenReturn(true);
     shiftService.delete("s1");

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.kizuna.cast.application.CastService;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.tenancy.TenantContext;
 import com.kizuna.shift.api.dto.ShiftCreateRequest;
@@ -34,6 +35,7 @@ class ShiftServiceTest {
   @Mock private ShiftMapper shiftMapper;
   @Mock private TenantContext tenantContext;
   @Mock private TenantRepository tenantRepository;
+  @Mock private CastService castService;
 
   @InjectMocks private ShiftService shiftService;
 
@@ -70,6 +72,7 @@ class ShiftServiceTest {
     Tenant tenant = new Tenant();
     tenant.setId(1L);
 
+    when(castService.existsForCurrentTenant("c1")).thenReturn(true);
     when(shiftMapper.toEntity(req)).thenReturn(entity);
     when(tenantContext.getTenantId()).thenReturn(1L);
     when(tenantRepository.findById(1L)).thenReturn(Optional.of(tenant));
@@ -105,6 +108,7 @@ class ShiftServiceTest {
   void create_throwsWhenTenantNotFound() {
     ShiftCreateRequest req = validCreateRequest();
 
+    when(castService.existsForCurrentTenant("c1")).thenReturn(true);
     when(shiftMapper.toEntity(req)).thenReturn(Shift.builder().build());
     when(tenantContext.getTenantId()).thenReturn(1L);
     when(tenantRepository.findById(1L)).thenReturn(Optional.empty());
@@ -112,6 +116,17 @@ class ShiftServiceTest {
     assertThatThrownBy(() -> shiftService.create(req))
         .isInstanceOf(ServiceException.class)
         .hasMessageContaining("テナントが見つかりません");
+  }
+
+  @Test
+  void create_rejectsWhenCastNotInTenant() {
+    ShiftCreateRequest req = validCreateRequest();
+
+    when(castService.existsForCurrentTenant("c1")).thenReturn(false);
+
+    assertThatThrownBy(() -> shiftService.create(req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("キャストが見つかりません");
   }
 
   @Test
@@ -142,6 +157,21 @@ class ShiftServiceTest {
     assertThatThrownBy(() -> shiftService.update("missing", new ShiftUpdateRequest()))
         .isInstanceOf(ServiceException.class)
         .hasMessageContaining("シフトが見つかりません");
+  }
+
+  @Test
+  void update_rejectsWhenCastNotInTenant() {
+    Shift s = Shift.builder().castId("c1").build();
+    s.setId("s1");
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(s));
+    when(castService.existsForCurrentTenant("foreign")).thenReturn(false);
+
+    ShiftUpdateRequest req = new ShiftUpdateRequest();
+    req.setCastId("foreign");
+
+    assertThatThrownBy(() -> shiftService.update("s1", req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("キャストが見つかりません");
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/shift/domain/ShiftTest.java
+++ b/backend/src/test/java/com/kizuna/shift/domain/ShiftTest.java
@@ -1,0 +1,63 @@
+package com.kizuna.shift.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.Test;
+
+class ShiftTest {
+
+  private Shift baseShift() {
+    return Shift.builder()
+        .castId("c1")
+        .workDate(LocalDate.of(2026, 7, 8))
+        .startTime(LocalTime.of(18, 0))
+        .endTime(LocalTime.of(23, 0))
+        .status("TENTATIVE")
+        .build();
+  }
+
+  @Test
+  void apply_updatesOnlyNonNullFields() {
+    Shift shift = baseShift();
+
+    shift.apply(new ShiftPatch(null, null, null, LocalTime.of(1, 0), "CONFIRMED"));
+
+    // null のフィールドは変更されない
+    assertThat(shift.getCastId()).isEqualTo("c1");
+    assertThat(shift.getWorkDate()).isEqualTo(LocalDate.of(2026, 7, 8));
+    assertThat(shift.getStartTime()).isEqualTo(LocalTime.of(18, 0));
+    // 非 null のフィールドだけ更新される
+    assertThat(shift.getEndTime()).isEqualTo(LocalTime.of(1, 0));
+    assertThat(shift.getStatus()).isEqualTo("CONFIRMED");
+  }
+
+  @Test
+  void apply_withAllFields_replacesAll() {
+    Shift shift = baseShift();
+
+    shift.apply(
+        new ShiftPatch(
+            "c2", LocalDate.of(2026, 7, 9), LocalTime.of(19, 0), LocalTime.of(2, 0), "CONFIRMED"));
+
+    assertThat(shift.getCastId()).isEqualTo("c2");
+    assertThat(shift.getWorkDate()).isEqualTo(LocalDate.of(2026, 7, 9));
+    assertThat(shift.getStartTime()).isEqualTo(LocalTime.of(19, 0));
+    assertThat(shift.getEndTime()).isEqualTo(LocalTime.of(2, 0));
+    assertThat(shift.getStatus()).isEqualTo("CONFIRMED");
+  }
+
+  @Test
+  void apply_withEmptyPatch_changesNothing() {
+    Shift shift = baseShift();
+
+    shift.apply(new ShiftPatch(null, null, null, null, null));
+
+    assertThat(shift.getCastId()).isEqualTo("c1");
+    assertThat(shift.getWorkDate()).isEqualTo(LocalDate.of(2026, 7, 8));
+    assertThat(shift.getStartTime()).isEqualTo(LocalTime.of(18, 0));
+    assertThat(shift.getEndTime()).isEqualTo(LocalTime.of(23, 0));
+    assertThat(shift.getStatus()).isEqualTo("TENTATIVE");
+  }
+}

--- a/frontend/src/_pages/store-shifts/index.ts
+++ b/frontend/src/_pages/store-shifts/index.ts
@@ -1,0 +1,1 @@
+export { default as ShiftsPage } from './ui/ShiftsPage';

--- a/frontend/src/_pages/store-shifts/lib/datetime.ts
+++ b/frontend/src/_pages/store-shifts/lib/datetime.ts
@@ -1,0 +1,44 @@
+/** 出勤管理ページ内で共有する日付・時刻ユーティリティ。 */
+
+/** Date を 'yyyy-MM-dd'（ローカルタイム基準）に整形する。 */
+export function toDateStr(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/** その月の初日〜末日を 'yyyy-MM-dd' の区間で返す。 */
+export function monthRange(month: Date): { from: string; to: string } {
+  const first = new Date(month.getFullYear(), month.getMonth(), 1);
+  const last = new Date(month.getFullYear(), month.getMonth() + 1, 0);
+  return { from: toDateStr(first), to: toDateStr(last) };
+}
+
+/** 月カレンダーのグリッド（日曜開始・6 週 = 42 セル）。各セルは日付と当月フラグを持つ。 */
+export function monthGrid(month: Date): { date: Date; inMonth: boolean }[] {
+  const first = new Date(month.getFullYear(), month.getMonth(), 1);
+  const start = new Date(first);
+  start.setDate(first.getDate() - first.getDay());
+  const days: { date: Date; inMonth: boolean }[] = [];
+  for (let i = 0; i < 42; i++) {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    days.push({ date: d, inMonth: d.getMonth() === month.getMonth() });
+  }
+  return days;
+}
+
+/** 'HH:mm:ss' または 'HH:mm' を深夜 0 時からの分に変換する。 */
+export function timeToMinutes(time: string): number {
+  const [h, m] = time.split(':');
+  return Number(h) * 60 + Number(m);
+}
+
+/** シフトの [開始分, 終了分]。終了 <= 開始 は翌日にまたがる勤務として +1440 する。 */
+export function shiftSpan(startTime: string, endTime: string): { start: number; end: number } {
+  const start = timeToMinutes(startTime);
+  let end = timeToMinutes(endTime);
+  if (end <= start) end += 24 * 60;
+  return { start, end };
+}

--- a/frontend/src/_pages/store-shifts/ui/ShiftCalendar.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftCalendar.tsx
@@ -44,7 +44,7 @@ export function ShiftCalendar({
             type="button"
             onClick={onPrevMonth}
             aria-label="前の月"
-            className="rounded-md p-2 text-gray-500 hover:bg-gray-50"
+            className="rounded-md p-2 text-gray-500 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
             <ChevronLeftIcon className="h-5 w-5" />
           </button>
@@ -52,7 +52,7 @@ export function ShiftCalendar({
             type="button"
             onClick={onNextMonth}
             aria-label="次の月"
-            className="rounded-md p-2 text-gray-500 hover:bg-gray-50"
+            className="rounded-md p-2 text-gray-500 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
             <ChevronRightIcon className="h-5 w-5" />
           </button>

--- a/frontend/src/_pages/store-shifts/ui/ShiftCalendar.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftCalendar.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import { ShiftResponse } from '@/entities/shift';
+import { monthGrid, toDateStr } from '../lib/datetime';
+
+interface ShiftCalendarProps {
+  month: Date;
+  shifts: ShiftResponse[];
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+  /** 日セルのクリックで 'yyyy-MM-dd' を通知する（タイムラインへ遷移）。 */
+  onSelectDate: (date: string) => void;
+}
+
+const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土'];
+
+/** 月の出勤件数を俯瞰するカレンダー。日クリックでその日のタイムラインへ遷移する。 */
+export function ShiftCalendar({
+  month,
+  shifts,
+  onPrevMonth,
+  onNextMonth,
+  onSelectDate,
+}: ShiftCalendarProps) {
+  const byDate = new Map<string, { total: number; confirmed: number }>();
+  for (const s of shifts) {
+    const agg = byDate.get(s.work_date) ?? { total: 0, confirmed: 0 };
+    agg.total += 1;
+    if (s.status === 'CONFIRMED') agg.confirmed += 1;
+    byDate.set(s.work_date, agg);
+  }
+
+  const days = monthGrid(month);
+  const today = toDateStr(new Date());
+  const title = `${month.getFullYear()}年${month.getMonth() + 1}月`;
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+      <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4">
+        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={onPrevMonth}
+            aria-label="前の月"
+            className="rounded-md p-2 text-gray-500 hover:bg-gray-50"
+          >
+            <ChevronLeftIcon className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            onClick={onNextMonth}
+            aria-label="次の月"
+            className="rounded-md p-2 text-gray-500 hover:bg-gray-50"
+          >
+            <ChevronRightIcon className="h-5 w-5" />
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-7 border-b border-gray-200 bg-gray-50">
+        {WEEKDAYS.map((w, i) => (
+          <div
+            key={w}
+            className={`px-2 py-2 text-center text-xs font-medium ${
+              i === 0 ? 'text-red-500' : i === 6 ? 'text-blue-500' : 'text-gray-500'
+            }`}
+          >
+            {w}
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7">
+        {days.map(({ date, inMonth }) => {
+          const ds = toDateStr(date);
+          const agg = byDate.get(ds);
+          const isToday = ds === today;
+          const tentative = agg ? agg.total - agg.confirmed : 0;
+          return (
+            <button
+              type="button"
+              key={ds}
+              onClick={() => onSelectDate(ds)}
+              className={`h-24 border-b border-r border-gray-100 p-2 text-left align-top transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500 ${
+                inMonth ? 'bg-white' : 'bg-gray-50'
+              }`}
+            >
+              <span
+                className={`text-sm ${
+                  isToday
+                    ? 'flex h-6 w-6 items-center justify-center rounded-full bg-blue-600 font-semibold text-white'
+                    : inMonth
+                      ? 'text-gray-900'
+                      : 'text-gray-400'
+                }`}
+              >
+                {date.getDate()}
+              </span>
+              {agg && (
+                <div className="mt-1 space-y-1">
+                  <span className="inline-flex items-center rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
+                    {agg.total}名
+                  </span>
+                  <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[10px] text-gray-500">
+                    <span className="inline-flex items-center gap-0.5">
+                      <span className="inline-block h-1.5 w-1.5 rounded-full bg-green-500" />
+                      確定
+                      {agg.confirmed}
+                    </span>
+                    {tentative > 0 && (
+                      <span className="inline-flex items-center gap-0.5">
+                        <span className="inline-block h-1.5 w-1.5 rounded-full bg-yellow-400" />
+                        未確定
+                        {tentative}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
+import { CastResponse } from '@/entities/cast';
+import { ShiftResponse, shiftApi } from '@/entities/shift';
+
+interface ShiftFormValues {
+  cast_id: string;
+  work_date: string;
+  start_time: string;
+  end_time: string;
+  status: string;
+}
+
+interface ShiftFormModalProps {
+  open: boolean;
+  onClose: () => void;
+  casts: CastResponse[];
+  /** 編集対象。null なら新規作成。 */
+  editing: ShiftResponse | null;
+  /** 新規作成時の初期日付 'yyyy-MM-dd'。 */
+  defaultDate: string;
+  /** 保存・削除の成功後に呼ばれる（一覧の再取得用）。 */
+  onSaved: () => void;
+}
+
+const STATUS_OPTIONS = [
+  { value: 'TENTATIVE', label: '未確定' },
+  { value: 'CONFIRMED', label: '確定' },
+];
+
+const inputClass =
+  'w-full rounded-md border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500';
+
+/** シフトの追加・編集モーダル。 */
+export function ShiftFormModal({
+  open,
+  onClose,
+  casts,
+  editing,
+  defaultDate,
+  onSaved,
+}: ShiftFormModalProps) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { isSubmitting },
+  } = useForm<ShiftFormValues>();
+
+  useEffect(() => {
+    if (!open) return;
+    if (editing) {
+      reset({
+        cast_id: editing.cast_id,
+        work_date: editing.work_date,
+        start_time: editing.start_time.slice(0, 5),
+        end_time: editing.end_time.slice(0, 5),
+        status: editing.status,
+      });
+    } else {
+      reset({
+        cast_id: casts[0]?.id ?? '',
+        work_date: defaultDate,
+        start_time: '18:00',
+        end_time: '23:00',
+        status: 'TENTATIVE',
+      });
+    }
+  }, [open, editing, defaultDate, casts, reset]);
+
+  const submit = async (values: ShiftFormValues) => {
+    const payload = {
+      cast_id: values.cast_id,
+      work_date: values.work_date,
+      start_time: `${values.start_time}:00`,
+      end_time: `${values.end_time}:00`,
+      status: values.status,
+    };
+    try {
+      if (editing) {
+        await shiftApi.update(editing.id, payload);
+        toast.success('シフトを更新しました');
+      } else {
+        await shiftApi.create(payload);
+        toast.success('シフトを追加しました');
+      }
+      onSaved();
+      onClose();
+    } catch {
+      toast.error('シフトの保存に失敗しました');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!editing) return;
+    if (!confirm('このシフトを削除しますか？')) return;
+    try {
+      await shiftApi.delete(editing.id);
+      toast.success('シフトを削除しました');
+      onSaved();
+      onClose();
+    } catch {
+      toast.error('シフトの削除に失敗しました');
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} className="relative z-50">
+      <div className="fixed inset-0 bg-gray-900/40" aria-hidden="true" />
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <DialogPanel className="w-full max-w-md rounded-[10px] border border-gray-200 bg-white shadow-lg">
+          <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
+            {editing ? 'シフトを編集' : 'シフトを追加'}
+          </DialogTitle>
+          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">キャスト</label>
+              <select {...register('cast_id', { required: true })} className={inputClass}>
+                {casts.length === 0 && <option value="">キャストが未登録です</option>}
+                {casts.map(c => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">日付</label>
+              <input
+                type="date"
+                {...register('work_date', { required: true })}
+                className={inputClass}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="mb-1 block text-sm font-medium text-gray-700">開始</label>
+                <input
+                  type="time"
+                  {...register('start_time', { required: true })}
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-gray-700">終了</label>
+                <input
+                  type="time"
+                  {...register('end_time', { required: true })}
+                  className={inputClass}
+                />
+              </div>
+            </div>
+            <p className="text-xs text-gray-500">
+              終了が開始以前のときは翌日にまたがる勤務として扱います。
+            </p>
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">ステータス</label>
+              <select {...register('status')} className={inputClass}>
+                {STATUS_OPTIONS.map(o => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-center justify-between border-t border-gray-200 pt-4">
+              <div>
+                {editing && (
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    className="text-sm font-medium text-red-600 hover:text-red-700"
+                  >
+                    削除
+                  </button>
+                )}
+              </div>
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                >
+                  キャンセル
+                </button>
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {isSubmitting ? '保存中...' : '保存する'}
+                </button>
+              </div>
+            </div>
+          </form>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+}

--- a/frontend/src/_pages/store-shifts/ui/ShiftTimeline.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftTimeline.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { PlusIcon } from '@heroicons/react/24/outline';
+import { CastResponse } from '@/entities/cast';
+import { ShiftResponse } from '@/entities/shift';
+import { shiftSpan, toDateStr } from '../lib/datetime';
+
+interface ShiftTimelineProps {
+  /** 表示日 'yyyy-MM-dd'。 */
+  date: string;
+  shifts: ShiftResponse[];
+  casts: CastResponse[];
+  loading: boolean;
+  onAddShift: () => void;
+  onEditShift: (shift: ShiftResponse) => void;
+}
+
+const SLOT_MINUTES = 30;
+const LABEL_COL = 'w-28';
+const LABEL_OFFSET = 'ml-28';
+
+/** その日の最早出勤〜最遅終了に自動フィットする出勤タイムライン。 */
+export function ShiftTimeline({
+  date,
+  shifts,
+  casts,
+  loading,
+  onAddShift,
+  onEditShift,
+}: ShiftTimelineProps) {
+  const castName = (id: string) => casts.find(c => c.id === id)?.name ?? '不明';
+  const fmt = (t: string) => t.slice(0, 5);
+  const hourLabel = (min: number) => `${String(Math.floor((min % 1440) / 60)).padStart(2, '0')}:00`;
+
+  const spans = shifts.map(s => shiftSpan(s.start_time, s.end_time));
+  const hasShifts = spans.length > 0;
+
+  // 軸レンジ（時間境界へ丸める）。シフトが無い場合は代表的な夜帯を仮表示。
+  const minStart = hasShifts ? Math.min(...spans.map(s => s.start)) : 18 * 60;
+  const maxEnd = hasShifts ? Math.max(...spans.map(s => s.end)) : 24 * 60;
+  const axisStart = Math.floor(minStart / 60) * 60;
+  const axisEnd = Math.ceil(maxEnd / 60) * 60;
+  const total = Math.max(axisEnd - axisStart, 60);
+  const pct = (min: number) => ((min - axisStart) / total) * 100;
+
+  const hourMarks: number[] = [];
+  for (let m = axisStart; m <= axisEnd; m += 60) hourMarks.push(m);
+
+  // 同時出勤数（30 分刻み）
+  const coverage: { at: number; count: number }[] = [];
+  for (let m = axisStart; m < axisEnd; m += SLOT_MINUTES) {
+    coverage.push({ at: m, count: spans.filter(s => s.start <= m && m < s.end).length });
+  }
+  const peak = Math.max(1, ...coverage.map(c => c.count));
+
+  // 現在時刻線（表示日が今日で、軸レンジ内のときだけ）
+  const now = new Date();
+  const nowMin = now.getHours() * 60 + now.getMinutes();
+  const showNow = date === toDateStr(now) && nowMin >= axisStart && nowMin <= axisEnd;
+
+  const rowIds = Array.from(new Set(shifts.map(s => s.cast_id)));
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
+      <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4">
+        <h2 className="text-lg font-semibold text-gray-900">{date} の出勤</h2>
+        <button
+          type="button"
+          onClick={onAddShift}
+          className="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          <PlusIcon className="h-5 w-5" />
+          シフト追加
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="p-8 text-center text-gray-500">読み込み中...</div>
+      ) : !hasShifts ? (
+        <div className="p-12 text-center">
+          <p className="text-gray-500">この日のシフトはまだありません。</p>
+          <button
+            type="button"
+            onClick={onAddShift}
+            className="mt-3 text-sm font-medium text-blue-600 hover:text-blue-700"
+          >
+            シフトを追加する
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-4 p-6">
+          {/* 同時出勤数カバレッジ */}
+          <div>
+            <div className="mb-1 flex items-center justify-between text-xs text-gray-500">
+              <span>同時出勤数</span>
+              <span>ピーク {peak}名</span>
+            </div>
+            <div className={`flex h-10 items-end gap-px ${LABEL_OFFSET}`}>
+              {coverage.map(c => (
+                <div
+                  key={c.at}
+                  className="flex-1 rounded-t bg-blue-500/80"
+                  style={{ height: `${(c.count / peak) * 100}%` }}
+                  title={`${hourLabel(c.at)} ${c.count}名`}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div className="relative">
+            {/* 時間目盛 */}
+            <div className={`relative h-5 ${LABEL_OFFSET}`}>
+              {hourMarks.map(m => (
+                <span
+                  key={m}
+                  className="absolute -translate-x-1/2 text-[10px] text-gray-400"
+                  style={{ left: `${pct(m)}%` }}
+                >
+                  {hourLabel(m)}
+                </span>
+              ))}
+            </div>
+
+            {/* キャスト行 */}
+            <div className="space-y-2">
+              {rowIds.map(castId => {
+                const rowShifts = shifts.filter(s => s.cast_id === castId);
+                return (
+                  <div key={castId} className="flex items-center">
+                    <div
+                      className={`${LABEL_COL} shrink-0 truncate pr-2 text-sm font-medium text-gray-700`}
+                    >
+                      {castName(castId)}
+                    </div>
+                    <div className="relative h-9 flex-1 rounded bg-gray-50">
+                      {hourMarks.map(m => (
+                        <div
+                          key={m}
+                          className="absolute top-0 h-full border-l border-gray-100"
+                          style={{ left: `${pct(m)}%` }}
+                        />
+                      ))}
+                      {rowShifts.map(s => {
+                        const { start, end } = shiftSpan(s.start_time, s.end_time);
+                        const confirmed = s.status === 'CONFIRMED';
+                        return (
+                          <button
+                            type="button"
+                            key={s.id}
+                            onClick={() => onEditShift(s)}
+                            className={`absolute top-1 flex h-7 items-center overflow-hidden rounded px-2 text-xs font-medium shadow-sm ${
+                              confirmed
+                                ? 'bg-green-500 text-white hover:bg-green-600'
+                                : 'bg-yellow-400 text-yellow-900 hover:bg-yellow-500'
+                            }`}
+                            style={{
+                              left: `${pct(start)}%`,
+                              width: `${Math.max(pct(end) - pct(start), 4)}%`,
+                            }}
+                            title={`${castName(castId)} ${fmt(s.start_time)}–${fmt(s.end_time)}`}
+                          >
+                            <span className="truncate">
+                              {fmt(s.start_time)}–{fmt(s.end_time)}
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* 現在時刻線 */}
+            {showNow && (
+              <div className="pointer-events-none absolute inset-y-0 right-0 left-28">
+                <div
+                  className="absolute top-0 bottom-0 w-px bg-red-500"
+                  style={{ left: `${pct(nowMin)}%` }}
+                >
+                  <span className="absolute -top-0.5 -translate-x-1/2 rounded bg-red-500 px-1 text-[9px] font-medium text-white">
+                    現在
+                  </span>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
@@ -92,7 +92,7 @@ export default function ShiftsPage() {
   };
 
   const tabClass = (selected: boolean) =>
-    `border-b-2 px-1 py-3 text-sm font-medium outline-none ${
+    `border-b-2 px-1 py-3 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 ${
       selected
         ? 'border-blue-600 text-blue-600'
         : 'border-transparent text-gray-500 hover:text-gray-700'

--- a/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
@@ -28,12 +28,23 @@ export default function ShiftsPage() {
   const [modalOpen, setModalOpen] = useState(false);
   const [editing, setEditing] = useState<ShiftResponse | null>(null);
 
-  // キャスト一覧（フォームの選択肢 + タイムラインの名前解決）
+  // キャスト一覧（フォームの選択肢 + タイムラインの名前解決）。101 人以上でも氏名を解決できるよう全ページ取得する。
   useEffect(() => {
-    castApi
-      .list({ size: 100, sort: 'displayOrder,asc' })
-      .then(page => setCasts(page.content))
-      .catch(() => toast.error('キャストの取得に失敗しました'));
+    const loadAllCasts = async () => {
+      try {
+        const size = 200;
+        const all: CastResponse[] = [];
+        for (let page = 0; ; page += 1) {
+          const res = await castApi.list({ page, size, sort: 'displayOrder,asc' });
+          all.push(...res.content);
+          if (res.content.length < size) break; // 最終ページ
+        }
+        setCasts(all);
+      } catch {
+        toast.error('キャストの取得に失敗しました');
+      }
+    };
+    void loadAllCasts();
   }, []);
 
   // 表示中のタブに応じた取得区間（カレンダー = 月、タイムライン = 単日）

--- a/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
@@ -2,7 +2,7 @@
 
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react';
 import { CalendarDaysIcon, ClockIcon } from '@heroicons/react/24/outline';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { CastResponse, castApi } from '@/entities/cast';
 import { ShiftResponse, shiftApi } from '@/entities/shift';
@@ -53,20 +53,30 @@ export default function ShiftsPage() {
     [tab, month, selectedDate]
   );
 
-  const loadShifts = useCallback(async () => {
-    setLoading(true);
-    try {
-      setShifts(await shiftApi.list(range));
-    } catch {
-      toast.error('シフトの取得に失敗しました');
-    } finally {
-      setLoading(false);
-    }
-  }, [range]);
+  // range 変更や保存後の再取得。素早い月切替・日クリックで古いリクエストが後から解決しても、
+  // 現在の range に対応する応答だけを反映する（stale 応答による上書き防止）。
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
-    void loadShifts();
-  }, [loadShifts]);
+    let ignore = false;
+    setLoading(true);
+    shiftApi
+      .list(range)
+      .then(result => {
+        if (!ignore) setShifts(result);
+      })
+      .catch(() => {
+        if (!ignore) toast.error('シフトの取得に失敗しました');
+      })
+      .finally(() => {
+        if (!ignore) setLoading(false);
+      });
+    return () => {
+      ignore = true;
+    };
+  }, [range, reloadKey]);
+
+  const reloadShifts = () => setReloadKey(key => key + 1);
 
   const openAdd = () => {
     setEditing(null);
@@ -139,7 +149,7 @@ export default function ShiftsPage() {
         casts={casts}
         editing={editing}
         defaultDate={selectedDate}
-        onSaved={loadShifts}
+        onSaved={reloadShifts}
       />
     </div>
   );

--- a/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react';
+import { CalendarDaysIcon, ClockIcon } from '@heroicons/react/24/outline';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { CastResponse, castApi } from '@/entities/cast';
+import { ShiftResponse, shiftApi } from '@/entities/shift';
+import { monthRange, toDateStr } from '../lib/datetime';
+import { ShiftCalendar } from './ShiftCalendar';
+import { ShiftFormModal } from './ShiftFormModal';
+import { ShiftTimeline } from './ShiftTimeline';
+
+const CALENDAR_TAB = 0;
+const TIMELINE_TAB = 1;
+
+/** 出勤管理ページ。カレンダー俯瞰と日別タイムラインをタブで切り替える。 */
+export default function ShiftsPage() {
+  const [tab, setTab] = useState(CALENDAR_TAB);
+  const [month, setMonth] = useState(() => {
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth(), 1);
+  });
+  const [selectedDate, setSelectedDate] = useState(() => toDateStr(new Date()));
+  const [shifts, setShifts] = useState<ShiftResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [casts, setCasts] = useState<CastResponse[]>([]);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editing, setEditing] = useState<ShiftResponse | null>(null);
+
+  // キャスト一覧（フォームの選択肢 + タイムラインの名前解決）
+  useEffect(() => {
+    castApi
+      .list({ size: 100, sort: 'displayOrder,asc' })
+      .then(page => setCasts(page.content))
+      .catch(() => toast.error('キャストの取得に失敗しました'));
+  }, []);
+
+  // 表示中のタブに応じた取得区間（カレンダー = 月、タイムライン = 単日）
+  const range = useMemo(
+    () => (tab === CALENDAR_TAB ? monthRange(month) : { from: selectedDate, to: selectedDate }),
+    [tab, month, selectedDate]
+  );
+
+  const loadShifts = useCallback(async () => {
+    setLoading(true);
+    try {
+      setShifts(await shiftApi.list(range));
+    } catch {
+      toast.error('シフトの取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, [range]);
+
+  useEffect(() => {
+    void loadShifts();
+  }, [loadShifts]);
+
+  const openAdd = () => {
+    setEditing(null);
+    setModalOpen(true);
+  };
+  const openEdit = (shift: ShiftResponse) => {
+    setEditing(shift);
+    setModalOpen(true);
+  };
+  const selectDay = (date: string) => {
+    setSelectedDate(date);
+    setTab(TIMELINE_TAB);
+  };
+
+  const tabClass = (selected: boolean) =>
+    `border-b-2 px-1 py-3 text-sm font-medium outline-none ${
+      selected
+        ? 'border-blue-600 text-blue-600'
+        : 'border-transparent text-gray-500 hover:text-gray-700'
+    }`;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">出勤管理</h1>
+        <p className="mt-1 text-sm text-gray-500">キャストの出勤シフトを登録・確認できます。</p>
+      </div>
+
+      <TabGroup selectedIndex={tab} onChange={setTab}>
+        <TabList className="flex gap-6 border-b border-gray-200">
+          <Tab className={({ selected }) => tabClass(selected)}>
+            <span className="inline-flex items-center gap-1.5">
+              <CalendarDaysIcon className="h-4 w-4" />
+              カレンダー
+            </span>
+          </Tab>
+          <Tab className={({ selected }) => tabClass(selected)}>
+            <span className="inline-flex items-center gap-1.5">
+              <ClockIcon className="h-4 w-4" />
+              タイムライン
+            </span>
+          </Tab>
+        </TabList>
+        <TabPanels className="mt-6">
+          <TabPanel>
+            <ShiftCalendar
+              month={month}
+              shifts={shifts}
+              onPrevMonth={() => setMonth(m => new Date(m.getFullYear(), m.getMonth() - 1, 1))}
+              onNextMonth={() => setMonth(m => new Date(m.getFullYear(), m.getMonth() + 1, 1))}
+              onSelectDate={selectDay}
+            />
+          </TabPanel>
+          <TabPanel>
+            <ShiftTimeline
+              date={selectedDate}
+              shifts={shifts}
+              casts={casts}
+              loading={loading}
+              onAddShift={openAdd}
+              onEditShift={openEdit}
+            />
+          </TabPanel>
+        </TabPanels>
+      </TabGroup>
+
+      <ShiftFormModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        casts={casts}
+        editing={editing}
+        defaultDate={selectedDate}
+        onSaved={loadShifts}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/tenant/shifts/page.tsx
+++ b/frontend/src/app/tenant/shifts/page.tsx
@@ -1,0 +1,1 @@
+export { ShiftsPage as default } from '@/_pages/store-shifts';

--- a/frontend/src/entities/shift/__tests__/shift-api.test.ts
+++ b/frontend/src/entities/shift/__tests__/shift-api.test.ts
@@ -1,0 +1,39 @@
+import { shiftApi } from '@/entities/shift';
+
+jest.mock('@/shared/api/client', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(async (url: string) => ({ data: { ok: true, url } })),
+    post: jest.fn(async (url: string) => ({ data: { ok: true, url } })),
+    put: jest.fn(async (url: string) => ({ data: { ok: true, url } })),
+    delete: jest.fn(async (url: string) => ({ data: undefined })),
+  },
+}));
+
+describe('shiftApi', () => {
+  it('list は /tenant/shifts を GET する', async () => {
+    expect(await shiftApi.list({ from: '2026-07-01', to: '2026-07-31' })).toEqual({
+      ok: true,
+      url: '/tenant/shifts',
+    });
+  });
+  it('create は /tenant/shifts を POST する', async () => {
+    expect(
+      await shiftApi.create({
+        cast_id: 'c1',
+        work_date: '2026-07-08',
+        start_time: '18:00:00',
+        end_time: '23:00:00',
+      })
+    ).toEqual({ ok: true, url: '/tenant/shifts' });
+  });
+  it('update は /tenant/shifts/:id を PUT する', async () => {
+    expect(await shiftApi.update('s1', { status: 'CONFIRMED' })).toEqual({
+      ok: true,
+      url: '/tenant/shifts/s1',
+    });
+  });
+  it('delete は /tenant/shifts/:id を DELETE する', async () => {
+    await expect(shiftApi.delete('s1')).resolves.toBeUndefined();
+  });
+});

--- a/frontend/src/entities/shift/api/shift.ts
+++ b/frontend/src/entities/shift/api/shift.ts
@@ -1,0 +1,24 @@
+import { apiClient } from '@/shared/api';
+import { ShiftCreateRequest, ShiftResponse, ShiftUpdateRequest } from '../model/types';
+
+export const shiftApi = {
+  /** 期間内のシフト一覧を取得する（from==to で単日、月初〜月末で月間） */
+  list: async (params: { from: string; to: string }): Promise<ShiftResponse[]> => {
+    const response = await apiClient.get('/tenant/shifts', { params });
+    return response.data;
+  },
+  /** シフトを新規作成する */
+  create: async (data: ShiftCreateRequest): Promise<ShiftResponse> => {
+    const response = await apiClient.post('/tenant/shifts', data);
+    return response.data;
+  },
+  /** シフトを更新する */
+  update: async (id: string, data: ShiftUpdateRequest): Promise<ShiftResponse> => {
+    const response = await apiClient.put(`/tenant/shifts/${id}`, data);
+    return response.data;
+  },
+  /** シフトを削除する */
+  delete: async (id: string): Promise<void> => {
+    await apiClient.delete(`/tenant/shifts/${id}`);
+  },
+};

--- a/frontend/src/entities/shift/index.ts
+++ b/frontend/src/entities/shift/index.ts
@@ -1,0 +1,2 @@
+export * from './model/types';
+export { shiftApi } from './api/shift';

--- a/frontend/src/entities/shift/model/types.ts
+++ b/frontend/src/entities/shift/model/types.ts
@@ -1,0 +1,29 @@
+// シフト（Shift）レスポンス。時刻は ISO 文字列（work_date=yyyy-MM-dd / start_time・end_time=HH:mm:ss）。
+export interface ShiftResponse {
+  id: string;
+  cast_id: string;
+  work_date: string;
+  start_time: string;
+  end_time: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// シフト作成リクエスト（status 省略時はサーバ側で TENTATIVE）
+export interface ShiftCreateRequest {
+  cast_id: string;
+  work_date: string;
+  start_time: string;
+  end_time: string;
+  status?: string;
+}
+
+// シフト更新リクエスト
+export interface ShiftUpdateRequest {
+  cast_id?: string;
+  work_date?: string;
+  start_time?: string;
+  end_time?: string;
+  status?: string;
+}


### PR DESCRIPTION
## 概要

店舗管理者が自店キャストのシフト（出勤予定）を登録・編集・削除し、月カレンダー（件数概覧）と日別タイムライン（時間軸 + 同時出勤数 + 現在時刻線）で把握できる **出勤管理** を追加する。新規 `Shift` 集約（テナント作用域、`Cast` と同じ隔離）+ 店舗 CRUD API + フロント出勤管理ページ。#168 出勤管理の第一刀（店舗側）。公開出勤表の点灯は #279。

Closes #278

## 変更内容

- **backend**: `shift` モジュール新設 — `Shift` 集約 / `t_shifts` マイグレーション（v0.3.0）/ 店舗 CRUD `/tenant/shifts`（区間 GET・POST・PUT・DELETE、権限は `CAST_MANAGE` 再利用）/ ShiftService・DTO・Mapper。
- **backend**: `cast_id` のテナント帰属検証 — `CastService.existsForCurrentTenant` を `@NamedInterface("application")` で公開し、ShiftService から port 経由で create/update 時に検証。
- **backend**: 出勤管理メニューを `t_menus` にシード — #184 由来の未実装プレースホルダ `t1-shift`（権限なし・実装なし）を統合削除の上、`CAST_MANAGE` ゲート付き「出勤管理」（`/tenant/shifts`, ClockIcon）を追加。
- **frontend**: `entities/shift` + 出勤管理ページ（`_pages/store-shifts`：カレンダー/タイムライン タブ切替、シフト追加/編集モーダル）+ 薄シェル `/tenant/shifts`。

## 検証

- [x] `task lint`（exit 0、独立再実行）
- [x] `task test`（exit 0、unit + integration）— ShiftServiceTest 14 / ShiftTest 3 / ShiftCrossTenantIT 4 / front 109。**ShiftCrossTenantIT（integration = CI 非実行）を実 Postgres で独立再実行し、新規タイムスタンプ（07:33Z）で真の実行を確認**（4 tests / 0 failures、cast_id クロステナント作成・付け替え拒否を含む）。
- [x] `task build`（exit 0）
- `task e2e`: 本スライスは `.feature` 追加なし（公開側 e2e は #279）。QA が回帰 3 シナリオ（公開サイト表示 / 模版切替 / テナント管理画面ログイン）を exit 0 で実行。

### 視覚確認（UI 変更あり）

QA ブラウザ検証で全基準 PASS（スクリーンショット `.playwright-mcp/` 配下、disposable）:
サイドバー「出勤管理」1件のみ（重複なし）/ カレンダー件数サマリー（キャスト非列挙）/ 日クリック→タイムライン遷移 / 跨午夜（20:00–02:00）が連続1本のバー / 確定=緑・未確定=黄 / 同時出勤数ピーク表示 / 現在時刻線 / モーダル既定 TENTATIVE / 作成→反映・編集（色変化）・削除。

## 決定ログ

- **店舗側録入 + 中央只読集約は分離**。本 PR は店舗側のみ。中央グループ集約ビュー・統計カード・競合検出・周期テンプレ・交換/休暇・エクスポート・給与連携は第一刀外（#168 に残す）。
- **データモデル**: `work_date DATE` + `start_time`/`end_time TIME`。`end <= start` を翌日にまたがる扱い（表示は連続1本、`end=00:00` は 24:00 表記）。status `TENTATIVE`（既定）/`CONFIRMED`。索引 `(tenant_id, work_date)`、`t_casts` と同じテナント隔離（`@Filter` + `tenant_id`）。
- **クロステナントは 400**（`ServiceException`、Cast と同一慣行）。#278 本文の「404」は不採用。
- **権限は `CAST_MANAGE` 再利用**（auth シード非変更、出勤管理はキャスト管理配下）。`ShiftResponse` に cast 名は含めず、フロントがページ層で cast 一覧と突合（FSD 準拠、全 cast 取得で 101 人以上も解決）。
- **敵対的プレレビュー（high-risk）の指摘を修正**:
  - `cast_id` テナント帰属を create/update で検証（未検証だと店舗 A が B の cast_id でシフト作成可能、`fk_t_shifts_cast` の CASCADE で B の cast 削除時に A のシフトが巻き込まれる）。cast モジュールに `@NamedInterface("application")` の公開ポートを新設（Modulith 適合、`ModularityTests` 緑）。
  - 部分更新の `end==start` を**マージ後の実効値**で判定（`PUT {start_time:...}` 単独更新での回避を封鎖）。
  - `status` を許可値 `{TENTATIVE, CONFIRMED}` に限定。
- サイドバーは `t_menus` シード駆動のため、メニュー追加は seed（`Sidebar.tsx` 非編集）。

## 備考 / レビュー観点

- **フォローアップ候補（本 PR 外）**: `frontend/DESIGN.md` はステータス pill 色のみ定義し、タイムラインの塗りバー色 token が未定義。今回は Tailwind セマンティック（`green-500`/`yellow-400`、raw hex なし）で実装。DESIGN.md への token 追記は別途検討の余地。
- `ShiftCrossTenantIT` は integration（`task test-integration` = CI 非門禁、PR 前ローカル実行の対象）。本 PR ではローカルで独立再実行して隔離修正を実証済み。
