### PR TITLE
fix: テナント分離が X-Tenant-ID ヘッダのみで決定され JWT の tenantId claim と照合されていない問題を修正

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/cast/CastCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/cast/CastCrossTenantIT.java
@@ -52,14 +52,14 @@ class CastCrossTenantIT extends CrossTenantTestSupport {
             HttpMethod.GET,
             new HttpEntity<>(tenantHeaders(TENANT_B)),
             JsonNode.class);
-    // 200 でデータが漏れないことが本質（ServiceException → 400）
-    assertThat(leaked.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    // 200 でデータが漏れないことが本質（越権はインターセプタが拒否 → 403）
+    assertThat(leaked.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
   }
 
   @Test
   @DisplayName("他テナントのキャストを更新できず、データも変わらないこと")
   void otherTenantCannotUpdateForeignCast() {
-    // 正向対照: 同一ボディ形式で自テナントの更新は成功する（負向 400 がバリデーション起因でない証明）
+    // 正向対照: 同一ボディ形式で自テナントの更新は成功する（負向 403 がバリデーション起因でない証明）
     String controlId = createCastAs(TENANT_A, "統合テストキャスト（対照）");
     ResponseEntity<JsonNode> ownUpdate =
         rest.exchange(
@@ -77,7 +77,7 @@ class CastCrossTenantIT extends CrossTenantTestSupport {
             HttpMethod.PUT,
             new HttpEntity<>("{\"name\": \"統合テストキャスト（改ざん）\"}", tenantHeaders(TENANT_B)),
             JsonNode.class);
-    assertThat(tampered.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(tampered.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
 
     // データ不変: tenant A から見て名前が変わっていない
     ResponseEntity<JsonNode> after =

--- a/backend/src/integrationTest/java/com/kizuna/customer/CustomerCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/CustomerCrossTenantIT.java
@@ -63,8 +63,8 @@ class CustomerCrossTenantIT extends CrossTenantTestSupport {
             new HttpEntity<>(tenantHeaders(TENANT_B)),
             JsonNode.class);
 
-    // ServiceException(@ResponseStatus BAD_REQUEST) → 400。
+    // 越権はインターセプタが JWT と X-Tenant-ID の不一致を拒否 → 403。
     // 重要なのは 200 でデータが漏れないこと（5b39c06 修正前は 200 で漏洩していた）
-    assertThat(leaked.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(leaked.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
   }
 }

--- a/backend/src/integrationTest/java/com/kizuna/menu/MenuCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/menu/MenuCrossTenantIT.java
@@ -72,13 +72,21 @@ class MenuCrossTenantIT extends CrossTenantTestSupport {
   }
 
   @Test
-  @DisplayName("tenant B のメニュー取得に tenant A のシードメニューが混入しないこと")
-  void tenantBCannotSeeTenantAMenus() {
-    List<String> names = rootMenuNames(tenantBId);
+  @DisplayName("tenant A の JWT に X-Tenant-ID: B を偽装しても 403 で拒否され、tenant B のデータも返らないこと")
+  void spoofedTenantHeaderIsRejectedWithoutLeakingData() {
+    // tenant A のシードユーザーで発行した JWT（tenantId claim = tenant A）に、
+    // X-Tenant-ID ヘッダだけ tenant B を詐称したリクエスト。修正前は 200 で tenant B のメニューが漏れていた。
+    ResponseEntity<String> res =
+        rest.exchange(
+            "/tenant/menus/me",
+            HttpMethod.GET,
+            new HttpEntity<>(tenantHeaders(tenantBId)),
+            String.class);
 
-    // 漏洩がないことが本 issue の受入条件。containsExactly で「自分の分だけ」も同時に固定する
-    assertThat(names).doesNotContainAnyElementsOf(TENANT_A_SEED_ROOT_LABELS);
-    assertThat(names).containsExactly(TENANT_B_MENU_LABEL);
+    // JWT の tenantId claim と X-Tenant-ID ヘッダの不一致は TenantIdInterceptor が拒否する。
+    // コントローラに到達しないため、tenant B のデータも本文も一切返らない。
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(res.getBody()).as("拒否時は本文を返さない（いずれのテナントのデータも含まない）").isNullOrEmpty();
   }
 
   @Test

--- a/backend/src/integrationTest/java/com/kizuna/order/OrderCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/OrderCrossTenantIT.java
@@ -81,7 +81,7 @@ class OrderCrossTenantIT extends CrossTenantTestSupport {
             HttpMethod.GET,
             new HttpEntity<>(tenantHeaders(TENANT_B)),
             JsonNode.class);
-    assertThat(leaked.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(leaked.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
   }
 
   @Test
@@ -89,7 +89,7 @@ class OrderCrossTenantIT extends CrossTenantTestSupport {
   void otherTenantCannotUpdateForeignOrder() {
     String castId = createCastAs(TENANT_A, "統合テストキャスト（受注更新用）");
 
-    // 正向対照: 同一ボディ形式で自テナントの更新は成功する（負向 400 がバリデーション起因でない証明）
+    // 正向対照: 同一ボディ形式で自テナントの更新は成功する（負向 403 がバリデーション起因でない証明）
     String controlId = createOrderAs(TENANT_A, castId);
     ResponseEntity<JsonNode> ownUpdate =
         rest.exchange(
@@ -107,7 +107,7 @@ class OrderCrossTenantIT extends CrossTenantTestSupport {
             HttpMethod.PUT,
             new HttpEntity<>(orderBody(castId, "改ざん"), tenantHeaders(TENANT_B)),
             JsonNode.class);
-    assertThat(tampered.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(tampered.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
 
     // tenant A からは引き続き読める（レコード自体は健在）
     ResponseEntity<JsonNode> after =

--- a/backend/src/integrationTest/java/com/kizuna/shift/ShiftCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/shift/ShiftCrossTenantIT.java
@@ -3,9 +3,12 @@ package com.kizuna.shift;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.kizuna.cast.domain.Cast;
+import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.CrossTenantTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -19,6 +22,19 @@ import org.springframework.http.ResponseEntity;
  * に現れないこと」で確認する。
  */
 class ShiftCrossTenantIT extends CrossTenantTestSupport {
+
+  @Autowired private CastRepository castRepository;
+
+  /**
+   * 他テナント（tenant B）の Cast をリポジトリ直挿しで用意する。 HTTP 経由の作成は tenant A の JWT + X-Tenant-ID: B が
+   * TenantIdInterceptor に 403 で弾かれるようになったため、{@code @TenantScoped} を経由せず tenantFilter が無効な
+   * リポジトリ直接呼び出しで他テナントのデータを書く（MenuCrossTenantIT と同型）。
+   */
+  private String createForeignCast(String name) {
+    Cast cast = Cast.builder().name(name).build();
+    cast.setTenantId(TENANT_B);
+    return castRepository.save(cast).getId();
+  }
 
   private String createCastAs(long tenantId, String name) {
     ResponseEntity<JsonNode> created =
@@ -127,10 +143,16 @@ class ShiftCrossTenantIT extends CrossTenantTestSupport {
     assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     String shiftId = created.getBody().path("id").asText();
 
-    // 読取隔離: tenant B の区間 GET には現れない
-    assertThat(rangeContains(TENANT_B, "from=2026-07-10&to=2026-07-10", shiftId)).isFalse();
+    // 読取隔離: tenant A の JWT に X-Tenant-ID: B を詐称した区間 GET は 403 で拒否され、tenant A のシフトに到達できない
+    ResponseEntity<JsonNode> foreignRange =
+        rest.exchange(
+            "/tenant/shifts?from=2026-07-10&to=2026-07-10",
+            HttpMethod.GET,
+            new HttpEntity<>(tenantHeaders(TENANT_B)),
+            JsonNode.class);
+    assertThat(foreignRange.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
 
-    // 正向対照: 同一ボディ形式で自テナントの更新は成功する（負向 400 がバリデーション起因でない証明）
+    // 正向対照: 同一ボディ形式で自テナントの更新は成功する（負向 403 がバリデーション起因でない証明）
     ResponseEntity<JsonNode> ownUpdate =
         rest.exchange(
             "/tenant/shifts/" + shiftId,
@@ -140,23 +162,23 @@ class ShiftCrossTenantIT extends CrossTenantTestSupport {
     assertThat(ownUpdate.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(ownUpdate.getBody().path("status").asText()).isEqualTo("CONFIRMED");
 
-    // 負向: tenant B は更新できない（ServiceException → 400）
+    // 負向: tenant B は更新できない（越権はインターセプタが拒否 → 403）
     ResponseEntity<JsonNode> tampered =
         rest.exchange(
             "/tenant/shifts/" + shiftId,
             HttpMethod.PUT,
             new HttpEntity<>("{\"status\": \"TENTATIVE\"}", tenantHeaders(TENANT_B)),
             JsonNode.class);
-    assertThat(tampered.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(tampered.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
 
-    // 負向: tenant B は削除できない（ServiceException → 400）
+    // 負向: tenant B は削除できない（越権はインターセプタが拒否 → 403）
     ResponseEntity<JsonNode> deleted =
         rest.exchange(
             "/tenant/shifts/" + shiftId,
             HttpMethod.DELETE,
             new HttpEntity<>(tenantHeaders(TENANT_B)),
             JsonNode.class);
-    assertThat(deleted.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(deleted.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
 
     // データ不変: tenant A からはまだ存在し、status は tenant A が設定した CONFIRMED のまま
     ResponseEntity<JsonNode> after =
@@ -180,7 +202,7 @@ class ShiftCrossTenantIT extends CrossTenantTestSupport {
   @Test
   @DisplayName("他テナントのキャスト id ではシフトを作成できず、区間 GET にも現れないこと")
   void cannotCreateShiftWithOtherTenantCast() {
-    String foreignCastId = createCastAs(TENANT_B, "他店キャスト（作成不可）");
+    String foreignCastId = createForeignCast("他店キャスト（作成不可）");
 
     ResponseEntity<JsonNode> created =
         rest.postForEntity(
@@ -207,7 +229,7 @@ class ShiftCrossTenantIT extends CrossTenantTestSupport {
   void cannotUpdateShiftToOtherTenantCast() {
     String ownCastId = createCastAs(TENANT_A, "自店キャスト（付替元）");
     String shiftId = createShiftAs(TENANT_A, ownCastId, "2026-07-13", "18:00:00", "23:00:00");
-    String foreignCastId = createCastAs(TENANT_B, "他店キャスト（付替先）");
+    String foreignCastId = createForeignCast("他店キャスト（付替先）");
 
     ResponseEntity<JsonNode> put =
         rest.exchange(

--- a/backend/src/main/java/com/kizuna/shared/tenancy/TenantIdInterceptor.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/TenantIdInterceptor.java
@@ -1,5 +1,6 @@
 package com.kizuna.shared.tenancy;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
@@ -7,6 +8,8 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -29,9 +32,27 @@ public class TenantIdInterceptor implements HandlerInterceptor {
     if (HEADER_ROLE_TENANT.equals(request.getHeader(HEADER_ROLE))
         && StringUtils.isNotBlank(request.getHeader(HEADER_TENANT_ID))
         && StringUtils.isNumeric(request.getHeader(HEADER_TENANT_ID))) {
-      this.tenantContext.setTenantId(Long.parseLong(request.getHeader(HEADER_TENANT_ID)));
+      long headerTenantId = Long.parseLong(request.getHeader(HEADER_TENANT_ID));
+      Long jwtTenantId = authenticatedTenantId();
+      if (jwtTenantId != null && !jwtTenantId.equals(headerTenantId)) {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        return false;
+      }
+      this.tenantContext.setTenantId(headerTenantId);
     }
     return true;
+  }
+
+  /**
+   * 認証済みリクエストの JWT に埋め込まれた tenantId claim を返す。未認証、または details に {@link Claims}
+   * を持たない（匿名認証やログイン前など）場合は null を返し、呼び出し側は従来通りヘッダのみで文脈を設定する。
+   */
+  private Long authenticatedTenantId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication != null && authentication.getDetails() instanceof Claims claims) {
+      return claims.get("tenantId", Long.class);
+    }
+    return null;
   }
 
   @Override

--- a/backend/src/main/java/com/kizuna/shared/tenancy/TenantIdInterceptor.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/TenantIdInterceptor.java
@@ -29,16 +29,25 @@ public class TenantIdInterceptor implements HandlerInterceptor {
       @NonNull HttpServletRequest request,
       @NonNull HttpServletResponse response,
       @NonNull Object handler) {
-    if (HEADER_ROLE_TENANT.equals(request.getHeader(HEADER_ROLE))
-        && StringUtils.isNotBlank(request.getHeader(HEADER_TENANT_ID))
-        && StringUtils.isNumeric(request.getHeader(HEADER_TENANT_ID))) {
-      long headerTenantId = Long.parseLong(request.getHeader(HEADER_TENANT_ID));
-      Long jwtTenantId = authenticatedTenantId();
-      if (jwtTenantId != null && !jwtTenantId.equals(headerTenantId)) {
+    Long jwtTenantId = authenticatedTenantId();
+    if (jwtTenantId != null) {
+      // 認証済みテナント JWT: claim を正としてテナント文脈を確定する。ヘッダの有無・形式には依存させない
+      // （X-Role/X-Tenant-ID を省略・改変してこの検証と分離を素通りされるのを防ぐため）。
+      String headerTenantId = request.getHeader(HEADER_TENANT_ID);
+      if (StringUtils.isNumeric(headerTenantId)
+          && !jwtTenantId.equals(Long.parseLong(headerTenantId))) {
+        // X-Tenant-ID が別テナントを指す明確な詐称は拒否する。
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         return false;
       }
-      this.tenantContext.setTenantId(headerTenantId);
+      this.tenantContext.setTenantId(jwtTenantId);
+      return true;
+    }
+    // 認証前（ログイン等）または tenantId claim を持たないトークン: 従来通りヘッダのみで信用する。
+    if (HEADER_ROLE_TENANT.equals(request.getHeader(HEADER_ROLE))
+        && StringUtils.isNotBlank(request.getHeader(HEADER_TENANT_ID))
+        && StringUtils.isNumeric(request.getHeader(HEADER_TENANT_ID))) {
+      this.tenantContext.setTenantId(Long.parseLong(request.getHeader(HEADER_TENANT_ID)));
     }
     return true;
   }

--- a/backend/src/test/java/com/kizuna/shared/tenancy/TenantIdInterceptorTest.java
+++ b/backend/src/test/java/com/kizuna/shared/tenancy/TenantIdInterceptorTest.java
@@ -129,6 +129,46 @@ class TenantIdInterceptorTest {
   }
 
   @Test
+  @DisplayName("認証済みで tenantId claim があれば X-Tenant-ID ヘッダが無くても claim からテナント文脈を設定すること")
+  void preHandle_setsTenantIdFromClaimWhenHeaderMissing() {
+    authenticateWithTenantId(5L);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat(result).isTrue();
+    assertThat(tenantContext.getTenantId()).isEqualTo(5L);
+  }
+
+  @Test
+  @DisplayName("認証済みで tenantId claim があれば X-Tenant-ID が不正形式でも claim からテナント文脈を設定すること")
+  void preHandle_setsTenantIdFromClaimWhenHeaderMalformed() {
+    authenticateWithTenantId(5L);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("X-Tenant-ID", "not-a-number");
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat(result).isTrue();
+    assertThat(tenantContext.getTenantId()).isEqualTo(5L);
+  }
+
+  @Test
+  @DisplayName("認証済みで X-Tenant-ID が別テナントを指すなら X-Role の有無に関係なく 403 で拒否すること")
+  void preHandle_rejectsMismatchEvenWithoutRoleHeader() {
+    authenticateWithTenantId(1L);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("X-Tenant-ID", "2");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, new Object());
+
+    assertThat(result).isFalse();
+    assertThat(response.getStatus()).isEqualTo(403);
+    assertThat(tenantContext.isTenant()).isFalse();
+  }
+
+  @Test
   @DisplayName("afterCompletion でテナント文脈がクリアされること")
   void afterCompletion_clearsTenantContext() {
     tenantContext.setTenantId(42L);

--- a/backend/src/test/java/com/kizuna/shared/tenancy/TenantIdInterceptorTest.java
+++ b/backend/src/test/java/com/kizuna/shared/tenancy/TenantIdInterceptorTest.java
@@ -2,11 +2,19 @@ package com.kizuna.shared.tenancy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
 class TenantIdInterceptorTest {
 
@@ -17,6 +25,21 @@ class TenantIdInterceptorTest {
   void setUp() {
     tenantContext = new TenantContext();
     interceptor = new TenantIdInterceptor(tenantContext);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  /** 認証済みリクエストを模擬する（details に tenantId claim を持つ実 Claims をセット）。 */
+  private void authenticateWithTenantId(long tenantId) {
+    Claims claims = Jwts.claims().add("tenantId", tenantId).build();
+    PreAuthenticatedAuthenticationToken authentication =
+        new PreAuthenticatedAuthenticationToken(
+            "user", "token", List.of(new SimpleGrantedAuthority("STORE_USER")));
+    authentication.setDetails(claims);
+    SecurityContextHolder.getContext().setAuthentication(authentication);
   }
 
   @Test
@@ -56,6 +79,53 @@ class TenantIdInterceptorTest {
 
     assertThat(result).isTrue();
     assertThat(tenantContext.isTenant()).isFalse();
+  }
+
+  @Test
+  @DisplayName("認証済みで JWT の tenantId claim と X-Tenant-ID ヘッダが不一致なら 403 で拒否し文脈を設定しないこと")
+  void preHandle_rejectsWhenJwtTenantIdMismatchesHeader() {
+    authenticateWithTenantId(1L);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("X-Role", "tenant");
+    request.addHeader("X-Tenant-ID", "2");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, new Object());
+
+    assertThat(result).isFalse();
+    assertThat(response.getStatus()).isEqualTo(403);
+    assertThat(tenantContext.isTenant()).isFalse();
+  }
+
+  @Test
+  @DisplayName("認証済みで JWT の tenantId claim と X-Tenant-ID ヘッダが一致すればテナント文脈を設定すること")
+  void preHandle_allowsWhenJwtTenantIdMatchesHeader() {
+    authenticateWithTenantId(42L);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("X-Role", "tenant");
+    request.addHeader("X-Tenant-ID", "42");
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat(result).isTrue();
+    assertThat(tenantContext.getTenantId()).isEqualTo(42L);
+  }
+
+  @Test
+  @DisplayName("認証はあるが details に Claims を持たない場合は従来通りヘッダのみでテナント文脈を設定すること")
+  void preHandle_fallsBackToHeaderWhenAuthenticationHasNoClaims() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new AnonymousAuthenticationToken(
+                "key", "anonymous", List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("X-Role", "tenant");
+    request.addHeader("X-Tenant-ID", "7");
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat(result).isTrue();
+    assertThat(tenantContext.getTenantId()).isEqualTo(7L);
   }
 
   @Test


### PR DESCRIPTION
## 概要

`TenantIdInterceptor` が `X-Tenant-ID` リクエストヘッダのみでテナント文脈を決定し、認証済み JWT の `tenantId` claim と一切照合していなかったクロステナント越権を修正する。JWT に `tenantId` claim があれば、ヘッダの有無・形式に関わらずそれを常にテナント文脈の正とし、ヘッダとの不一致のみ 403 で拒否する。

Closes #285

## 変更内容

- `TenantIdInterceptor`: 認証済み JWT の `tenantId` claim を最優先でテナント文脈に採用し、`X-Tenant-ID` ヘッダとの不一致を 403 で拒否。未認証（ログイン等）は従来通りヘッダのみで動作
- `TenantIdInterceptorTest`: 一致/不一致/ヘッダ欠落/ヘッダ形式不正/未認証フォールバックの各ケースを新規追加（計10ケース）
- `MenuCrossTenantIT`: 越権シナリオの期待値を「200で漏洩」から「403で拒否・データなし」に反転
- `CastCrossTenantIT` / `OrderCrossTenantIT` / `CustomerCrossTenantIT` / `ShiftCrossTenantIT`: 越権時のステータスコードを `400`→`403` に更新（インターセプタ段階で拒否されるようになったため）。`ShiftCrossTenantIT` は他テナント fixture の作成方法を、脆弱だった経路（`X-Tenant-ID` 切替）からリポジトリ直挿しへ変更

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: 対象外 — UI変更なし、純粋なバックエンドのセキュリティ修正。振る舞いは `task test` に含まれる単体・統合テスト〔実 PostgreSQL 接続〕で固定）

## 決定ログ

- **対抗的事前レビュー 2 巡実施**（high-risk: 認証・テナント分離のため）。1巡目で「JWT検証がヘッダ形状ゲートの内側にあり、ヘッダを省略・改変すると素通りする」という、元の脆弱性より広範な blocking 欠陥を検出 → `54fe9ee` で修正（TDDで3ベクトルを赤テスト化してから実装）。2巡目（修正後の再レビュー）と QA 再検証（no-cache 強制再実行込み）で解消を確認、新たな欠陥なし。
- **既存のクロステナント負向テスト（Cast/Order/Customer）は、実は本脆弱性を検証していなかった**と判明（テナントA所有レコードがテナントBの文脈で「見つからない」ことを見ているだけで、テナントB自身の実データが漏洩するかは未検証）。実際に漏洩を実証していたのは `MenuCrossTenantIT` のみ。ステータスコード更新に留め、検証意図自体は変更していない。
- **範囲外と判断し別issueに切り出したもの**（本PRでは修正しない）:
  - **#287**（優先度高）: 完全匿名（JWTなし）で `@PermitAll` な公開エンドポイントが、ゲートウェイ注入ヘッダ欠落時に `@TenantScoped` を fail-open でクロステナント漏洩しうる。本PRの修正対象（認証済みJWTとヘッダの不一致）とは機構が異なり、この diff は匿名経路の挙動を一切変えていないことをコード追跡で確認済み。fail-closed化には公開ストアフロント全体に影響する別設計が必要
  - **#288**（優先度低）: `X-Tenant-ID` に桁あふれする数値を渡すと未捕捉 `NumberFormatException` で素の500になる。修正前のmasterから存在する既存コードで、データ漏洩なし（fail-closed）、本PRのdiffとは無関係

## 備考 / レビュー観点

- high-risk 変更のため、通常の watch-pr に加えて対抗的事前レビューの詳細な発見内容はコミット `54fe9ee` とこのPRの会話で追跡可能
- 重点的に見てほしい箇所: `TenantIdInterceptor.preHandle` の分岐構造（JWT claim 優先、ヘッダのみへのフォールバックは未認証時のみ）
