### PR TITLE
fix: 公開エンドポイントがテナント文脈未解決時に fail-open していた問題を修正

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/shared/TenantContextFailClosedIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/shared/TenantContextFailClosedIT.java
@@ -1,0 +1,122 @@
+package com.kizuna.shared;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * 公開エンドポイントのテナント未解決時 fail-closed 化（#287）を本物の PostgreSQL/Redis で検証する統合テスト。
+ *
+ * <p>JWT の tenantId claim・X-Tenant-ID ヘッダのいずれからもテナント文脈を解決できないリクエストが、{@code @TenantOptional}
+ * の無いエンドポイント（casts/public・login）では 403 で拒否され、{@code @TenantOptional}
+ * 付きの例外（logout・init-admin-user）では 403 にならないことを固定する。
+ *
+ * <p><b>CSRF に関する注記</b>: logout / init-admin-user への「完全匿名（Authorization も無し）」な POST は、CsrfFilter が
+ * interceptor より先に 403 を返す（両者は CSRF 免除パスに含まれず、既定の XorCsrfTokenRequestAttributeHandler は トークン無しの
+ * POST を拒否する）。interceptor の {@code @TenantOptional} 挙動そのものを分離検証するため、これらのリクエストには 解析不能な Bearer
+ * トークンのみを付与する — Bearer の存在で CSRF 免除となり（本番の logout も失効対象トークンを Bearer で運ぶ）、
+ * かつ解析不能なため認証は成立せず、テナント文脈は未解決のまま interceptor に到達する。X-Role/X-Tenant-ID は一切付けない。
+ *
+ * <p><b>漏洩検証データに関する注記</b>: {@code t_casts.tenant_id} は {@code central_tenants(id)} への外部キーを持ち、シードには
+ * tenant 1 しか存在しない（tenant 2 のデータは #285 の interceptor がクロステナントヘッダを拒否するため API 経由でも作れない）。 よって漏洩の的には
+ * tenant A のアクティブなキャストを用いる。文脈を持たない匿名リクエストに対してそのデータが返らないことが、 fail-open（文脈未設定で全テナント行が返る）を閉じたことの実証になる。
+ */
+class TenantContextFailClosedIT extends CrossTenantTestSupport {
+
+  private static final String CASTS_PUBLIC = "/tenant/casts/public";
+
+  /** 認証・テナント文脈を一切持たない完全匿名ヘッダ。 */
+  private HttpHeaders anonymous() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+
+  /** 解析不能な Bearer のみを持つヘッダ（CSRF 免除のためだけ。認証は成立せずテナント文脈は未解決のまま）。 */
+  private HttpHeaders bearerOnly() {
+    HttpHeaders headers = anonymous();
+    headers.setBearerAuth("not-a-valid-jwt");
+    return headers;
+  }
+
+  private void createActiveCastAs(long tenantId, String name) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/tenant/casts",
+            new HttpEntity<>("{\"name\": \"" + name + "\"}", tenantHeaders(tenantId)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful())
+        .as("前提: tenant %d でのアクティブなキャスト作成が成功すること", tenantId)
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("完全匿名で GET /tenant/casts/public を叩くと 403 になり、既存キャストのデータが漏れないこと")
+  void anonymousPublicCastsIsForbiddenAndLeaksNoData() {
+    String castName = "漏洩検証キャスト_" + UUID.randomUUID();
+    createActiveCastAs(TENANT_A, castName);
+
+    // 正向対照: 適切なテナント文脈（X-Role/X-Tenant-ID）があれば公開エンドポイントは 200 でデータを返す。
+    HttpHeaders tenantContextHeaders = new HttpHeaders();
+    tenantContextHeaders.set("X-Role", "tenant");
+    tenantContextHeaders.set("X-Tenant-ID", String.valueOf(TENANT_A));
+    ResponseEntity<String> withContext =
+        rest.exchange(
+            CASTS_PUBLIC, HttpMethod.GET, new HttpEntity<>(tenantContextHeaders), String.class);
+    assertThat(withContext.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(withContext.getBody()).contains(castName);
+
+    // 負向: 文脈を一切持たない匿名リクエストは 403、かつ本文にキャストデータが漏れない。
+    ResponseEntity<String> anonymous =
+        rest.exchange(CASTS_PUBLIC, HttpMethod.GET, new HttpEntity<>(anonymous()), String.class);
+    assertThat(anonymous.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    // interceptor が false を返すため本文は空（null）になる。空であれば当然データは漏れていないが、
+    // 防御的に castName が含まれないことも確認する（null 安全に判定する）。
+    String body = anonymous.getBody();
+    assertThat(body == null || !body.contains(castName)).as("匿名リクエストの本文にキャストデータが漏れないこと").isTrue();
+  }
+
+  @Test
+  @DisplayName("テナント文脈を解決できない POST /tenant/login は 403 で拒否されること")
+  void anonymousLoginIsForbidden() {
+    ResponseEntity<String> res =
+        rest.postForEntity(
+            "/tenant/login",
+            new HttpEntity<>(
+                "{\"username\": \"admin@store1.kizuna.com\", \"password\": \"pass\"}", anonymous()),
+            String.class);
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("テナント文脈を解決できなくても @TenantOptional の POST /tenant/logout は 403 にならず正常応答すること")
+  void logoutIsNotForbiddenWithoutTenantContext() {
+    ResponseEntity<String> res =
+        rest.postForEntity("/tenant/logout", new HttpEntity<>(bearerOnly()), String.class);
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+  }
+
+  @Test
+  @DisplayName("テナント文脈を解決できなくても @TenantOptional の POST /tenant/init-admin-user は 403 にならないこと")
+  void initAdminUserIsNotForbiddenWithoutTenantContext() {
+    ResponseEntity<String> res =
+        rest.postForEntity(
+            "/tenant/init-admin-user",
+            new HttpEntity<>(
+                "{\"token\": \"invalid-registration-token-invalid-registration-token\", "
+                    + "\"email\": \"newadmin@example.com\", \"password\": \"password123\"}",
+                bearerOnly()),
+            String.class);
+    // 無効な登録トークンにより業務エラーにはなるが、interceptor による 403（fail-closed）ではないこと。
+    assertThat(res.getStatusCode()).isNotEqualTo(HttpStatus.FORBIDDEN);
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/api/store/AuthController.java
+++ b/backend/src/main/java/com/kizuna/auth/api/store/AuthController.java
@@ -6,6 +6,7 @@ import com.kizuna.auth.api.dto.TenantRegisterRequest;
 import com.kizuna.auth.api.dto.TenantRegisterResponse;
 import com.kizuna.auth.application.AuthSessionService;
 import com.kizuna.auth.application.TenantAuthService;
+import com.kizuna.shared.tenancy.TenantOptional;
 import com.kizuna.tenant.domain.Tenant;
 import jakarta.annotation.security.PermitAll;
 import jakarta.validation.Valid;
@@ -38,6 +39,7 @@ public class AuthController {
 
   @PostMapping("/logout")
   @PermitAll
+  @TenantOptional
   public ResponseEntity<?> logout(
       @RequestHeader(name = "Authorization", required = false) String authHeader) {
     authSessionService.invalidate(authHeader);
@@ -58,6 +60,7 @@ public class AuthController {
 
   @PostMapping("/init-admin-user")
   @PermitAll
+  @TenantOptional
   public ResponseEntity<TenantRegisterResponse> initializeAdminUser(
       @Valid @RequestBody TenantRegisterRequest tenantRegisterRequest) {
     Tenant tenant = authService.initializeAdminUser(tenantRegisterRequest);

--- a/backend/src/main/java/com/kizuna/shared/tenancy/TenantIdInterceptor.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/TenantIdInterceptor.java
@@ -11,6 +11,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Log4j2
@@ -48,8 +49,17 @@ public class TenantIdInterceptor implements HandlerInterceptor {
         && StringUtils.isNotBlank(request.getHeader(HEADER_TENANT_ID))
         && StringUtils.isNumeric(request.getHeader(HEADER_TENANT_ID))) {
       this.tenantContext.setTenantId(Long.parseLong(request.getHeader(HEADER_TENANT_ID)));
+      return true;
     }
-    return true;
+    // JWT claim・ヘッダのいずれからもテナント文脈を解決できなかった。文脈が無いまま素通りさせると
+    // tenantFilter が有効化されず @TenantScoped クエリが全テナントの行を返す（fail-open）ため、
+    // @TenantOptional を明示したエンドポイントに限り許可し、それ以外は 403 で拒否する（fail-closed）。
+    if (handler instanceof HandlerMethod handlerMethod
+        && handlerMethod.hasMethodAnnotation(TenantOptional.class)) {
+      return true;
+    }
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    return false;
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/shared/tenancy/TenantOptional.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/TenantOptional.java
@@ -1,0 +1,20 @@
+package com.kizuna.shared.tenancy;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * テナント文脈が解決できなくても処理を許可するエンドポイントにのみ付与するマーカーアノテーション。
+ *
+ * <p>{@link TenantIdInterceptor} は、JWT の tenantId claim でもヘッダでもテナントを解決できなかったリクエストを既定で 403
+ * として拒否する（fail-closed）。このアノテーションが付与されたハンドラメソッドに限り、テナント文脈が無いまま処理の継続を許可する。
+ *
+ * <p>付与してよいのは、テナント文脈をそもそも参照しない、または文脈をリクエストボディ等から独自に解決するエンドポイントのみ。 テナント分離の抜け穴になり得るため、安易に付与しないこと。
+ *
+ * @see TenantIdInterceptor
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TenantOptional {}

--- a/backend/src/main/java/com/kizuna/storage/api/store/FileUploadController.java
+++ b/backend/src/main/java/com/kizuna/storage/api/store/FileUploadController.java
@@ -2,6 +2,7 @@ package com.kizuna.storage.api.store;
 
 import com.kizuna.shared.config.AppProperties;
 import com.kizuna.shared.tenancy.TenantContext;
+import com.kizuna.shared.tenancy.TenantOptional;
 import com.kizuna.storage.api.dto.FileUploadResponse;
 import com.kizuna.storage.application.FileStorageService;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ public class FileUploadController {
 
   @PostMapping("/upload")
   @PreAuthorize("isAuthenticated()")
+  @TenantOptional
   public ResponseEntity<FileUploadResponse> upload(
       @RequestParam("file") MultipartFile file,
       @RequestParam(value = "bucket", defaultValue = "public") String bucket) {

--- a/backend/src/main/java/com/kizuna/storage/api/store/FileUploadController.java
+++ b/backend/src/main/java/com/kizuna/storage/api/store/FileUploadController.java
@@ -5,9 +5,13 @@ import com.kizuna.shared.tenancy.TenantContext;
 import com.kizuna.shared.tenancy.TenantOptional;
 import com.kizuna.storage.api.dto.FileUploadResponse;
 import com.kizuna.storage.application.FileStorageService;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,6 +23,10 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class FileUploadController {
 
+  // JwtUtil.ISSUER_TENANT と一致させること。storage → auth.infrastructure は Modulith 上不可視のため
+  // 定数を直接参照せずローカルに複製している（発行者名はトークンの署名対象で実質不変）。
+  private static final String TENANT_ISSUER = "TenantAuth";
+
   private final FileStorageService fileStorageService;
   private final TenantContext tenantContext;
   private final AppProperties appProperties;
@@ -29,8 +37,7 @@ public class FileUploadController {
   public ResponseEntity<FileUploadResponse> upload(
       @RequestParam("file") MultipartFile file,
       @RequestParam(value = "bucket", defaultValue = "public") String bucket) {
-    String prefix =
-        tenantContext.isTenant() ? String.valueOf(tenantContext.getTenantId()) : "central";
+    String prefix = resolveStoragePrefix();
     String relativePath = fileStorageService.store(prefix, bucket, file);
 
     FileUploadResponse response =
@@ -41,5 +48,29 @@ public class FileUploadController {
             .build();
 
     return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 保存先プレフィクスを決める。テナント文脈があればそのテナント配下、無ければ中央領域（central）へ保存する。
+   *
+   * <p>ただしテナント発行（TenantAuth）のトークンでテナント文脈を解決できない場合は、テナントの資産を中央共有領域へ誤って 保存しないよう 403 で拒否する。tenantId
+   * claim を持たないレガシートークンが {@code @TenantOptional} の許可経路に乗って 中央プレフィクスに落ちるのを防ぐ（#287 の fail-closed
+   * をこのエンドポイントにも適用）。中央発行（CentralAuth）は テナント文脈を持たないのが正当なため従来どおり central へ保存する。
+   */
+  private String resolveStoragePrefix() {
+    if (tenantContext.isTenant()) {
+      return String.valueOf(tenantContext.getTenantId());
+    }
+    if (isTenantIssuedToken()) {
+      throw new AccessDeniedException("テナント文脈を解決できないため、アップロードを拒否しました");
+    }
+    return "central";
+  }
+
+  private boolean isTenantIssuedToken() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    return authentication != null
+        && authentication.getDetails() instanceof Claims claims
+        && TENANT_ISSUER.equals(claims.getIssuer());
   }
 }

--- a/backend/src/test/java/com/kizuna/shared/tenancy/TenantIdInterceptorTest.java
+++ b/backend/src/test/java/com/kizuna/shared/tenancy/TenantIdInterceptorTest.java
@@ -15,6 +15,7 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.web.method.HandlerMethod;
 
 class TenantIdInterceptorTest {
 
@@ -42,6 +43,18 @@ class TenantIdInterceptorTest {
     SecurityContextHolder.getContext().setAuthentication(authentication);
   }
 
+  /** テスト用ハンドラ: {@link TenantOptional} の有無を切り替えて HandlerMethod を組み立てるための土台。 */
+  static class Handlers {
+    @TenantOptional
+    public void optional() {}
+
+    public void required() {}
+  }
+
+  private HandlerMethod handlerMethod(String methodName) throws NoSuchMethodException {
+    return new HandlerMethod(new Handlers(), Handlers.class.getMethod(methodName));
+  }
+
   @Test
   @DisplayName("X-Role が tenant かつ X-Tenant-ID が数値ならテナント文脈を設定すること")
   void preHandle_setsTenantIdForTenantRole() {
@@ -56,28 +69,32 @@ class TenantIdInterceptorTest {
   }
 
   @Test
-  @DisplayName("X-Role が tenant でなければテナント文脈を設定しないこと")
+  @DisplayName("X-Role が tenant でなければテナント文脈を設定せず、@TenantOptional の無いハンドラは 403 で拒否すること")
   void preHandle_ignoresNonTenantRole() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader("X-Role", "central");
     request.addHeader("X-Tenant-ID", "42");
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+    boolean result = interceptor.preHandle(request, response, new Object());
 
-    assertThat(result).isTrue();
+    assertThat(result).isFalse();
+    assertThat(response.getStatus()).isEqualTo(403);
     assertThat(tenantContext.isTenant()).isFalse();
   }
 
   @Test
-  @DisplayName("X-Tenant-ID が数値でなければテナント文脈を設定しないこと")
+  @DisplayName("X-Tenant-ID が数値でなければテナント文脈を設定せず、@TenantOptional の無いハンドラは 403 で拒否すること")
   void preHandle_ignoresNonNumericTenantId() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader("X-Role", "tenant");
     request.addHeader("X-Tenant-ID", "abc");
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+    boolean result = interceptor.preHandle(request, response, new Object());
 
-    assertThat(result).isTrue();
+    assertThat(result).isFalse();
+    assertThat(response.getStatus()).isEqualTo(403);
     assertThat(tenantContext.isTenant()).isFalse();
   }
 
@@ -159,6 +176,45 @@ class TenantIdInterceptorTest {
     authenticateWithTenantId(1L);
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader("X-Tenant-ID", "2");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, new Object());
+
+    assertThat(result).isFalse();
+    assertThat(response.getStatus()).isEqualTo(403);
+    assertThat(tenantContext.isTenant()).isFalse();
+  }
+
+  @Test
+  @DisplayName("テナント文脈を解決できなくても @TenantOptional 付きハンドラは素通りし、文脈を設定しないこと")
+  void preHandle_allowsTenantOptionalHandlerWhenContextUnresolved() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, handlerMethod("optional"));
+
+    assertThat(result).isTrue();
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(tenantContext.isTenant()).isFalse();
+  }
+
+  @Test
+  @DisplayName("テナント文脈を解決できず @TenantOptional も無いハンドラは 403 で拒否すること")
+  void preHandle_rejectsNonOptionalHandlerWhenContextUnresolved() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, handlerMethod("required"));
+
+    assertThat(result).isFalse();
+    assertThat(response.getStatus()).isEqualTo(403);
+    assertThat(tenantContext.isTenant()).isFalse();
+  }
+
+  @Test
+  @DisplayName("ハンドラが HandlerMethod でなく文脈も解決できない場合は 403 で拒否すること")
+  void preHandle_rejectsNonHandlerMethodWhenContextUnresolved() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
     MockHttpServletResponse response = new MockHttpServletResponse();
 
     boolean result = interceptor.preHandle(request, response, new Object());

--- a/backend/src/test/java/com/kizuna/storage/api/store/FileUploadControllerTest.java
+++ b/backend/src/test/java/com/kizuna/storage/api/store/FileUploadControllerTest.java
@@ -1,0 +1,108 @@
+package com.kizuna.storage.api.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.kizuna.shared.config.AppProperties;
+import com.kizuna.shared.tenancy.TenantContext;
+import com.kizuna.storage.api.dto.FileUploadResponse;
+import com.kizuna.storage.application.FileStorageService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class FileUploadControllerTest {
+
+  private static final String ISSUER_TENANT = "TenantAuth";
+  private static final String ISSUER_CENTRAL = "CentralAuth";
+
+  @Mock private FileStorageService fileStorageService;
+  @Mock private MultipartFile file;
+
+  private TenantContext tenantContext;
+  private FileUploadController controller;
+
+  @BeforeEach
+  void setUp() {
+    tenantContext = new TenantContext();
+    AppProperties appProperties = new AppProperties();
+    appProperties.setUpload(new AppProperties.Upload());
+    controller = new FileUploadController(fileStorageService, tenantContext, appProperties);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    tenantContext.clear();
+  }
+
+  /** 指定した issuer の JWT で認証済みリクエストを模擬する（details に実 Claims をセット）。 */
+  private void authenticateWithIssuer(String issuer) {
+    Claims claims = Jwts.claims().issuer(issuer).build();
+    PreAuthenticatedAuthenticationToken authentication =
+        new PreAuthenticatedAuthenticationToken(
+            "user", "token", List.of(new SimpleGrantedAuthority("STORE_USER")));
+    authentication.setDetails(claims);
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
+  @Test
+  @DisplayName("テナント発行トークンでテナント文脈を解決できない場合はアップロードを拒否し、central に保存しないこと")
+  void upload_rejectsTenantIssuedTokenWithoutTenantContext() {
+    // tenantId claim を持たない = テナント文脈は未解決のまま
+    authenticateWithIssuer(ISSUER_TENANT);
+
+    assertThatThrownBy(() -> controller.upload(file, "public"))
+        .isInstanceOf(AccessDeniedException.class);
+
+    verify(fileStorageService, never()).store(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("中央発行トークンはテナント文脈が無くても central 配下に保存すること")
+  void upload_storesUnderCentralForCentralIssuedToken() {
+    authenticateWithIssuer(ISSUER_CENTRAL);
+    when(fileStorageService.store("central", "public", file)).thenReturn("public/central/x.jpg");
+    when(file.getOriginalFilename()).thenReturn("x.jpg");
+    when(file.getSize()).thenReturn(3L);
+
+    ResponseEntity<FileUploadResponse> res = controller.upload(file, "public");
+
+    assertThat(res.getStatusCode().is2xxSuccessful()).isTrue();
+    verify(fileStorageService).store("central", "public", file);
+    assertThat(res.getBody().getUrl()).isEqualTo("/static/public/central/x.jpg");
+  }
+
+  @Test
+  @DisplayName("テナント文脈が解決済みならそのテナント配下に保存すること")
+  void upload_storesUnderTenantPrefixWhenContextResolved() {
+    tenantContext.setTenantId(5L);
+    authenticateWithIssuer(ISSUER_TENANT);
+    when(fileStorageService.store("5", "public", file)).thenReturn("public/5/y.jpg");
+    when(file.getOriginalFilename()).thenReturn("y.jpg");
+    when(file.getSize()).thenReturn(4L);
+
+    ResponseEntity<FileUploadResponse> res = controller.upload(file, "public");
+
+    assertThat(res.getStatusCode().is2xxSuccessful()).isTrue();
+    verify(fileStorageService).store("5", "public", file);
+  }
+}


### PR DESCRIPTION
## 概要

`#285` と同じ `TenantIdInterceptor` にあった、もう一つのクロステナント漏洩経路を修正する。JWT の `tenantId` claim・`X-Tenant-ID` ヘッダのいずれからもテナントを解決できない場合、これまでは黙って `TenantContext` 未設定のまま処理を続行していた（fail-open）。新設の `@TenantOptional` アノテーションで明示的に許可した3エンドポイント（logout / init-admin-user / files upload）以外は 403 で拒否する（fail-closed）。

Closes #287

## 変更内容

- `TenantOptional`（新規）: テナント文脈が無くても正当に処理してよいエンドポイントを示すメソッドアノテーション
- `TenantIdInterceptor`: JWT・ヘッダいずれでも解決できない場合、`@TenantOptional` の無いハンドラは 403 で拒否
- `AuthController.logout()` / `initializeAdminUser()`、`FileUploadController.upload()` に `@TenantOptional` を付与（副次効果: ヘッダ無しログインも 403 になり、`tenantId` claim を持たない欠陥 JWT が発行される経路も閉じる）
- `TenantIdInterceptorTest` に新規ケース追加、`TenantContextFailClosedIT`（新規）で匿名アクセスの拒否・データ非漏洩・3例外の非回帰を実HTTP/DBで固定

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: 対象外 — UI変更なし、純粋なバックエンドのセキュリティ修正）

## 決定ログ

- **`@TenantScoped` との統合は検討の上、見送った**（ユーザーとのグリリングで確定）。層（service vs controller）とデフォルトの安全側（「あれば使う」vs「無ければ拒否」）が逆であり、統合すると改修範囲が数倍に膨らむか、デフォルトを安全でない側（未標示=許可）に倒すことになる。
- **例外の表現方法は、`SecurityConfig` 内の `CSRF_IGNORED_MATCHERS` のような固定パスリストではなく、アノテーション方式を採用**（ユーザー指定）。エンドポイント定義側で自己文書化できる。
- 対抗的事前レビュー2巡（#285・本PR）に続き、本PRでも対抗的事前レビューを実施。**blocking な指摘なし**。`@TenantOptional` の3メソッドすべてについて、テナント文脈ゼロで実行しても `@TenantScoped` データに触れないことを個別に追跡・確認済み。
- **既存の単体テスト2件の期待値を変更**（`preHandle_ignoresNonTenantRole`、`preHandle_ignoresNonNumericTenantId`）: どちらも `HandlerMethod` でない `handler` を渡すケースで、fail-closed 化により 403 が正しい挙動になったため。旧来の「文脈未設定」というアサーションは維持したまま、新たに 403 の確認を追加（弱化ではなく強化）。
- **新規ITの匿名リクエストは `logout`/`init-admin-user` に対しては、パース不能な `Bearer` トークンを使用**（真の意味でのヘッダ完全無しではない）。理由: この2パスは `SecurityConfig` の CSRF 除外リストに正しく載っておらず（後述 #292）、真に匿名だと `CsrfFilter` が本題の `TenantIdInterceptor` に到達する前に 403 を返してしまい、検証したい `@TenantOptional` の挙動を隠してしまうため。パース不能トークンは認証を確立しないので、テナント文脈は未解決のまま `@TenantOptional` の分岐だけを切り出して検証できる（対抗的事前レビューで独立に確認済み）。
- **`/tenant/casts/public` の漏洩確認テストはテナント1自身のシードデータを "餌" に使用**（テナント2データではない）: `#285` の修正によりテナント2データはAPI経由で作成不可能になっており、シードデータにもテナント2の行が一切存在しない（central_tenants に id=2 の行なし、対抗的事前レビューで確認済み）。この環境では「全テナントのデータ」と「テナント1のデータ」が同一集合のため、テナント1データを匿名リクエストから隠せることの確認で本質的に同じ安全性を実証できる。

## 備考 / レビュー観点

- 対抗的事前レビュー中に発見した既存の別バグ（`SecurityConfig` の `init-admin-use` 綴り違いが、フロントエンドの登録API呼び出し・招待メールリンク生成にも伝播しており、テナント登録フローが本番で機能していない可能性）は、本PRのスコープ外として **#292**（優先度 high に修正済み）に集約した。本PRでは一切触れていない。
