### PR TITLE
fix: init-admin-user のパス綴り違いを修正し招待メールリンクをフロントエンド登録ページへ修正

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/auth/InitAdminUserCsrfIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/auth/InitAdminUserCsrfIT.java
@@ -1,0 +1,49 @@
+package com.kizuna.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * {@code POST /tenant/init-admin-user} が CSRF 除外の対象になっていることを、本物の PostgreSQL/Redis で検証する統合テスト（#292）。
+ *
+ * <p>{@code SecurityConfig} の CSRF 除外パスは以前 {@code /tenant/init-admin-use}（綴り違い）を指しており、正しいパス {@code
+ * /tenant/init-admin-user} は除外されていなかった。既定の {@code XorCsrfTokenRequestAttributeHandler} はトークン無しの
+ * POST を拒否するため、綴り違いのままだと {@code CsrfFilter} が interceptor より先に 403 を返す。
+ *
+ * <p>{@code TenantContextFailClosedIT} も同じエンドポイントを叩くが、あちらは Bearer ヘッダ付き（Bearer の存在による CSRF
+ * 免除）なので、パス指定の除外が正しいかは検証できない。本テストは Authorization も CSRF トークンも一切持たない「完全匿名」の POST を送り、パス指定の CSRF
+ * 除外そのものが効いていることを固定する。 無効な登録トークンにより業務エラーにはなるが、CSRF 由来の 403（fail-closed）ではないことを確認する。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class InitAdminUserCsrfIT {
+
+  @Autowired private TestRestTemplate rest;
+
+  @Test
+  @DisplayName("CSRF トークンも Authorization も無い POST /tenant/init-admin-user が CSRF 由来の 403 にならないこと")
+  void initAdminUserIsCsrfExemptOnCorrectPath() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    ResponseEntity<String> res =
+        rest.postForEntity(
+            "/tenant/init-admin-user",
+            new HttpEntity<>(
+                "{\"token\": \"invalid-registration-token-invalid-registration-token\", "
+                    + "\"email\": \"newadmin@example.com\", \"password\": \"password123\"}",
+                headers),
+            String.class);
+
+    assertThat(res.getStatusCode()).isNotEqualTo(HttpStatus.FORBIDDEN);
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/AuthPaths.java
+++ b/backend/src/main/java/com/kizuna/auth/AuthPaths.java
@@ -1,0 +1,21 @@
+package com.kizuna.auth;
+
+/**
+ * auth モジュールが公開する API パス定数。
+ *
+ * <p>{@code com.kizuna.auth} ベースパッケージ直下に置くことで、Spring Modulith の既定規則により auth モジュールの公開 API となり、CSRF
+ * 除外設定・招待メールリンク生成など他モジュールからも同一のパスを参照できる（綴り違いの再発を防ぐ）。
+ */
+public final class AuthPaths {
+
+  private AuthPaths() {}
+
+  /** 管理者ユーザー初期化エンドポイントの、{@code AuthController} クラスパス（{@code /tenant}）配下の相対パス。 */
+  public static final String INIT_ADMIN_USER = "/init-admin-user";
+
+  /**
+   * 管理者ユーザー初期化エンドポイントの絶対パス（CSRF 除外・招待メールリンク生成が参照）。 先頭の {@code /tenant} は {@code AuthController}
+   * のクラスレベル {@code @RequestMapping} と一致させること。
+   */
+  public static final String INIT_ADMIN_USER_PATH = "/tenant" + INIT_ADMIN_USER;
+}

--- a/backend/src/main/java/com/kizuna/auth/api/store/AuthController.java
+++ b/backend/src/main/java/com/kizuna/auth/api/store/AuthController.java
@@ -1,5 +1,6 @@
 package com.kizuna.auth.api.store;
 
+import com.kizuna.auth.AuthPaths;
 import com.kizuna.auth.api.dto.LoginRequest;
 import com.kizuna.auth.api.dto.PasswordChangeRequest;
 import com.kizuna.auth.api.dto.TenantRegisterRequest;
@@ -58,7 +59,7 @@ public class AuthController {
     return ResponseEntity.noContent().build();
   }
 
-  @PostMapping("/init-admin-user")
+  @PostMapping(AuthPaths.INIT_ADMIN_USER)
   @PermitAll
   @TenantOptional
   public ResponseEntity<TenantRegisterResponse> initializeAdminUser(

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/SecurityConfig.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.kizuna.auth.infrastructure;
 
+import com.kizuna.auth.AuthPaths;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
@@ -29,7 +30,7 @@ public class SecurityConfig {
   private static final RequestMatcher[] CSRF_IGNORED_MATCHERS = {
     PathPatternRequestMatcher.withDefaults().matcher("/central/login"),
     PathPatternRequestMatcher.withDefaults().matcher("/tenant/login"),
-    PathPatternRequestMatcher.withDefaults().matcher("/tenant/init-admin-use"),
+    PathPatternRequestMatcher.withDefaults().matcher(AuthPaths.INIT_ADMIN_USER_PATH),
     PathPatternRequestMatcher.withDefaults().matcher("/files/upload"),
     request -> {
       String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);

--- a/backend/src/main/java/com/kizuna/notification/application/TenantCreatedListener.java
+++ b/backend/src/main/java/com/kizuna/notification/application/TenantCreatedListener.java
@@ -1,6 +1,5 @@
 package com.kizuna.notification.application;
 
-import com.kizuna.auth.AuthPaths;
 import com.kizuna.shared.config.AppProperties;
 import com.kizuna.tenant.domain.event.TenantCreatedEvent;
 import lombok.RequiredArgsConstructor;
@@ -21,8 +20,7 @@ public class TenantCreatedListener {
     String subject = "[きずな] テナント登録のご案内";
     String link =
         String.format(
-            "%s://%s%s?token=%s",
-            appProperties.getScheme(), ev.domain(), AuthPaths.INIT_ADMIN_USER_PATH, ev.token());
+            "%s://%s/register?token=%s", appProperties.getScheme(), ev.domain(), ev.token());
     String body =
         String.format(
             "きずなへようこそ, %s，\n\n登録を完了するには次のリンクをクリックしてください： %s \n\nこのリンクは7日間有効です。", ev.name(), link);

--- a/backend/src/main/java/com/kizuna/notification/application/TenantCreatedListener.java
+++ b/backend/src/main/java/com/kizuna/notification/application/TenantCreatedListener.java
@@ -1,5 +1,6 @@
 package com.kizuna.notification.application;
 
+import com.kizuna.auth.AuthPaths;
 import com.kizuna.shared.config.AppProperties;
 import com.kizuna.tenant.domain.event.TenantCreatedEvent;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,8 @@ public class TenantCreatedListener {
     String subject = "[きずな] テナント登録のご案内";
     String link =
         String.format(
-            "%s://%s/init-admin-use?token=%s", appProperties.getScheme(), ev.domain(), ev.token());
+            "%s://%s%s?token=%s",
+            appProperties.getScheme(), ev.domain(), AuthPaths.INIT_ADMIN_USER_PATH, ev.token());
     String body =
         String.format(
             "きずなへようこそ, %s，\n\n登録を完了するには次のリンクをクリックしてください： %s \n\nこのリンクは7日間有効です。", ev.name(), link);

--- a/backend/src/test/java/com/kizuna/notification/application/TenantCreatedListenerTest.java
+++ b/backend/src/test/java/com/kizuna/notification/application/TenantCreatedListenerTest.java
@@ -37,7 +37,7 @@ class TenantCreatedListenerTest {
         .send(
             eq("owner@example.com"),
             eq("[きずな] テナント登録のご案内"),
-            contains("https://store1.example.com/tenant/init-admin-user?token=tok-123"));
+            contains("https://store1.example.com/register?token=tok-123"));
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/notification/application/TenantCreatedListenerTest.java
+++ b/backend/src/test/java/com/kizuna/notification/application/TenantCreatedListenerTest.java
@@ -37,7 +37,7 @@ class TenantCreatedListenerTest {
         .send(
             eq("owner@example.com"),
             eq("[きずな] テナント登録のご案内"),
-            contains("https://store1.example.com/init-admin-use?token=tok-123"));
+            contains("https://store1.example.com/tenant/init-admin-user?token=tok-123"));
   }
 
   @Test

--- a/frontend/src/entities/user/__tests__/store-auth-api.test.ts
+++ b/frontend/src/entities/user/__tests__/store-auth-api.test.ts
@@ -7,7 +7,7 @@ jest.mock('@/shared/api/client', () => ({
     put: jest.fn(async (url: string) => ({ data: { ok: true, url } })),
     post: jest.fn(async (url: string, _data?: any) => ({
       data:
-        url === '/tenant/init-admin-use'
+        url === '/tenant/init-admin-user'
           ? {
               tenant_domain: 'tenant.example.com',
               login_url: 'https://tenant.example.com/login',
@@ -21,7 +21,7 @@ jest.mock('@/shared/api/client', () => ({
 }));
 
 describe('tenant api', () => {
-  it('register returns data from /tenant/init-admin-use', async () => {
+  it('register returns data from /tenant/init-admin-user', async () => {
     const res = await storeAuthApi.register({} as any);
     expect(res).toEqual({
       tenant_domain: 'tenant.example.com',

--- a/frontend/src/entities/user/api/store.ts
+++ b/frontend/src/entities/user/api/store.ts
@@ -11,7 +11,7 @@ import {
 
 export const storeAuthApi = {
   register: async (data: RegisterRequest): Promise<RegisterResponse> => {
-    const response = await apiClient.post('/tenant/init-admin-use', data);
+    const response = await apiClient.post('/tenant/init-admin-user', data);
     return response.data;
   },
   login: async (data: LoginRequest): Promise<LoginResponse> => {


### PR DESCRIPTION
## 概要

`init-admin-use`（`r` 抜け）という綴り違いが CSRF 除外設定・招待メールリンク・フロントエンドの API 呼び出しに伝播しており、テナント管理者登録フローが実質的に機能していなかった問題を修正する。あわせて招待メールリンクが本来指すべき対象（フロントエンドの登録ページ）を指していなかった、より根本的な設計漏れも修正する。

Closes #292

## 変更内容

- `AuthPaths`（新規、`com.kizuna.auth` ベースパッケージ）: `/tenant/init-admin-user` の経路情報を一元化。`AuthController` の `@PostMapping` と `SecurityConfig` の CSRF 除外マッチャーが参照する
- `TenantCreatedListener`: 招待メールリンクをバックエンドAPIパス（誤: POSTのみ受け付ける、ブラウザで開くと 405）からフロントエンドの登録ページ `/register?token=...`（`RegisterForm` が token を読んで正しい API を叩く）に修正
- `frontend/src/entities/user/api/store.ts`: `storeAuthApi.register` の呼び出し先の綴りを修正
- `InitAdminUserCsrfIT`（新規）: `/tenant/init-admin-user` への CSRF 除外が正しいパスに適用されることを実HTTP/DBで固定

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: 対象外 — UIの見た目の変更はなく、URL文字列の修正のみ）

## 決定ログ

- **`AuthPaths` の配置場所**: `com.kizuna.auth` モジュールに `package-info.java` が一切無く、既存クラスは全て `api.store`/`infrastructure` 等のサブパッケージにある。Spring Modulith のデフォルト規則では、ベースパッケージ直下（サブパッケージに入っていない場所）は `@NamedInterface` 無しでもモジュールの公開 API とみなされるため、`AuthPaths` をそこに新設した。`ModularityTests` で実証済み。
- **`@PostMapping` はコンパイル時定数が必要**なため、`AuthPaths` は相対セグメント（`AuthController` 用）と絶対パス（`SecurityConfig` 用）の2定数に分割した。
- **招待メールリンクの修正はスコープを広げた判断**: 当初計画は「綴りをバックエンドAPIパスに揃える」のみだったが、実装中に「バックエンドAPIパスはPOST専用で、メールのリンクをブラウザで開くと405になる」ことが判明。`frontend/src/features/tenant-register/ui/RegisterForm.tsx` が既に token 読み取り→API呼び出しの完全な実装を持っていたため、リンク先をフロントエンドの `/register` ページに修正した。結果として `notification → auth` のモジュール依存も消滅（メールリンク生成がバックエンドAPIパスの定数を参照しなくなったため）。
- **`/register` は定数化しなかった**: `notification` モジュール内でこの URL を組み立てるのはこの1箇所のみで、バックエンドからフロントルートを参照する既存パターンも無いため、リテラルのままとした（重複2回以上で抽象化、の原則）。

## 備考 / レビュー観点

- `InitAdminUserCsrfIT` は無効な登録トークンで `ServiceException`（400系）を期待していたが、実装は `IllegalArgumentException` で汎用ハンドラ経由の 500 を返す。CSRF 起因の 403 ではないことのみをアサーションの主眼としているため、既存の `TenantContextFailClosedIT` と同じ `isNotEqualTo(FORBIDDEN)` で固定した（トークン検証エラーのステータスコード自体の適切さは本PRのスコープ外）
- `TenantContextFailClosedIT` の javadoc に「init-admin-user は CSRF 免除対象外」という記述が残っており、今回の修正で陳腐化した（アサーション自体は変更不要で緑のまま）。外科的原則によりファイルは触れていない。コメント整理は別途小さなフォローアップ候補
- `frontend/DESIGN.md` に prettier 未適合の既存ドリフトがあるのを確認したが、`frontend/.dockerignore` の `*.md` により Docker lint ステージ（権威ゲート）には一切見えず、CIも本PRも無関係。本PRでは未修正（スコープ外）
