### PR TITLE
ci(review): レビューモデルのハードコード既定値を廃止し未指定時は Claude Code 既定へ委譲

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -78,12 +78,12 @@ jobs:
           # --comment: 投稿の必須フラグ。指摘ありは行内コメント(create_inline_comment)、無しは summary を投稿する（#263）
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # allowedTools が無いと投稿系ツールがすべて拒否され、レビューが PR に残らない（#251）
-          # モデルは既定 claude-fable-5（#233〜#267 で稼働実績があり、この CI トークンで実行可能が確認済み）。
-          # リポジトリの Settings → Secrets and variables → Actions → Variables で
-          # リポジトリ変数 CLAUDE_REVIEW_MODEL を設定すれば、この workflow を編集せずレビュー用モデルを差し替えられる。
+          # モデルは未指定なら Claude Code の既定モデルに委ねる（ハードコードしない）。
+          # リポジトリ変数 CLAUDE_REVIEW_MODEL（Settings → Secrets and variables → Actions → Variables）を
+          # 設定した場合のみ --model で上書きする。値は完全な model ID 必須（例: claude-fable-5。
+          # fable-5 のような接頭辞欠落 ID は SDK が is_error で拒否し、下の guard が job を赤にする）。
           claude_args: |
-            --model ${{ vars.CLAUDE_REVIEW_MODEL || 'claude-fable-5' }}
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)" ${{ vars.CLAUDE_REVIEW_MODEL && format('--model {0}', vars.CLAUDE_REVIEW_MODEL) || '' }}
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## 概要

claude-review のモデル指定からハードコード既定値（`|| 'claude-fable-5'`）を廃止する。リポジトリ変数 `CLAUDE_REVIEW_MODEL` を設定した場合のみ `--model` を付与し、未設定時はフラグ自体を渡さず Claude Code の既定モデルに委ねる。あわせてリポジトリ変数は削除済み（既定挙動へ移行）。

Refs #299

## 変更内容

- `claude_args` の `--model ${{ vars.CLAUDE_REVIEW_MODEL || 'claude-fable-5' }}` を条件付与式 `${{ vars.CLAUDE_REVIEW_MODEL && format('--model {0}', vars.CLAUDE_REVIEW_MODEL) || '' }}` に変更（GHA 式では未設定変数は空文字＝falsy）
- 未設定時に `claude_args` の先頭へ空行が入らないよう、式を `--allowedTools` と同一行の末尾に配置（行末空白は trim で消える）
- モデル指定コメントを更新：値は完全な model ID 必須（`fable-5` のような接頭辞欠落 ID は SDK が is_error で拒否し、#300 の guard が job を赤にする）
- リポジトリ変数 `CLAUDE_REVIEW_MODEL` は削除済み（gh variable delete 実施済み。マージ後の次 PR から既定モデルでレビューが走る）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: なし — workflow のみの変更で UI/API に触れないため対象外）

補足：`task test` 初回実行は `FileStorageService` の bean 二義性（`localFileStorageServiceImpl` / `s3FileStorage`）で統合テストが全滅したが、原因は 995ea5e で削除済みのソースの陳旧クラスファイルが `backend/build/classes` に残存していたこと（本 PR と無関係のローカル環境事象）。`./gradlew clean` 後の再実行で全ゲート exit 0。

## 決定ログ

- **条件付与 vs 空文字 `--model`**：`--model ''` を渡すと SDK 側の挙動が未定義のため、変数未設定時はフラグ自体を出さない条件式を採用した。
- **同一行末尾への配置**：複数行 `claude_args` の先頭空行を action がどう解釈するかに依存しないよう、既存の `--allowedTools` 行の末尾に置いた（未設定時は行末空白のみが残り、trim で消える）。
- **変数も削除**：workflow の回退値だけ消して変数を残すと実効モデルは変わらず「既定値に委ねる」という目的を満たさないため、変数本体も削除した。将来モデルを固定したくなったら変数を再設定するだけでよい（workflow 編集不要、これが #300 の変数化の本来の用途）。
- **本 PR では実効確認ができない**：review workflow 自体を変更する PR は claude-code-action が workflow 検証で自審 skip する（execution_file 無し→guard は仕様として通す）。実効確認はマージ後の次の通常 PR で行う。

## 備考 / レビュー観点

- マージ後の最初の通常 PR で、レビューが実際に走るか（guard が緑か）と実効モデルを確認する。不正な状態になった場合も #300 の guard がエラー文言付きで job を赤にするため沈黙はしない。
- 既定モデルは Claude Code CLI／サブスクリプションの既定に従う（バージョンやプランで変わり得るため、ここには固定名を書かない）。
