### PR TITLE
fix(backend): TenantIdInterceptor のヘッダ兜底を未認証に限定しテナント詐称と桁あふれを根治（#305）

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/shared/TenantContextFailClosedIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/shared/TenantContextFailClosedIT.java
@@ -86,6 +86,19 @@ class TenantContextFailClosedIT extends CrossTenantTestSupport {
   }
 
   @Test
+  @DisplayName("匿名 + X-Tenant-ID が long 桁あふれの GET /tenant/casts/public は 500 でなく 400 になること（#288）")
+  void anonymousOverflowingTenantIdHeaderReturns400() {
+    HttpHeaders headers = anonymous();
+    headers.set("X-Role", "tenant");
+    headers.set("X-Tenant-ID", "99999999999999999999");
+
+    ResponseEntity<String> res =
+        rest.exchange(CASTS_PUBLIC, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
+  @Test
   @DisplayName("テナント文脈を解決できない POST /tenant/login は 403 で拒否されること")
   void anonymousLoginIsForbidden() {
     ResponseEntity<String> res =

--- a/backend/src/integrationTest/java/com/kizuna/storage/FileUploadCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/storage/FileUploadCrossTenantIT.java
@@ -1,0 +1,93 @@
+package com.kizuna.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * 央端（CentralAuth）トークンによる {@code /files/upload} のテナント冒認（#294）を本物の PostgreSQL/Redis/MinIO で固定する統合テスト。
+ *
+ * <p>{@code /files/**} は {@code JwtAuthenticationFilter.issuerMatchesDomain} の issuer
+ * 制約外のため央端トークンでも認証が通る。 修正前は、央端トークンに {@code X-Role:tenant} + {@code X-Tenant-ID} を付けると interceptor
+ * のヘッダ兜底に落ち、指定テナントの prefix にファイルが保存されていた。本テストは詐称ヘッダ付きが 403 で拒否されること（負向）と、 詐称ヘッダ無しの央端アップロードが従来どおり
+ * central 領域へ 200 で保存されること（正向対照）を固定する。
+ *
+ * <p>中央ログイン前提のため {@link com.kizuna.shared.CrossTenantTestSupport}（tenant ログイン）は継承せず、中央ログインを自前で行う。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class FileUploadCrossTenantIT {
+
+  @Autowired private TestRestTemplate rest;
+
+  private String centralLogin() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/central/login",
+            new HttpEntity<>("{\"username\": \"admin\", \"password\": \"pass\"}", headers),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).as("前提: 中央 admin でのログインが成功すること").isEqualTo(HttpStatus.OK);
+    String token = res.getBody().path("token").asText();
+    assertThat(token).isNotBlank();
+    return token;
+  }
+
+  /** 与えられたヘッダに multipart のダミー JPEG を載せたアップロードリクエストを組み立てる。 */
+  private HttpEntity<MultiValueMap<String, Object>> uploadRequest(HttpHeaders headers) {
+    ByteArrayResource image =
+        new ByteArrayResource("dummy-jpeg-bytes".getBytes()) {
+          @Override
+          public String getFilename() {
+            // 拡張子から part の Content-Type が image/jpeg に解決され、許可 MIME を満たす。
+            return "photo.jpg";
+          }
+        };
+    headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+    LinkedMultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+    body.add("file", image);
+    return new HttpEntity<>(body, headers);
+  }
+
+  @Test
+  @DisplayName(
+      "央端トークン + X-Role:tenant + X-Tenant-ID の /files/upload は 403 で拒否されテナントに保存されないこと（#294）")
+  void centralTokenWithSpoofedTenantHeaderIsForbidden() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(centralLogin());
+    headers.set("X-Role", "tenant");
+    headers.set("X-Tenant-ID", "1");
+
+    ResponseEntity<String> res =
+        rest.exchange("/files/upload", HttpMethod.POST, uploadRequest(headers), String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("央端トークン（詐称ヘッダ無し）の /files/upload は従来どおり central 領域へ 200 で保存されること")
+  void centralTokenWithoutSpoofUploadsToCentral() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(centralLogin());
+
+    ResponseEntity<JsonNode> res =
+        rest.exchange("/files/upload", HttpMethod.POST, uploadRequest(headers), JsonNode.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(res.getBody().path("url").asText()).contains("/central/");
+  }
+}

--- a/backend/src/main/java/com/kizuna/shared/tenancy/TenantIdInterceptor.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/TenantIdInterceptor.java
@@ -30,25 +30,49 @@ public class TenantIdInterceptor implements HandlerInterceptor {
       @NonNull HttpServletRequest request,
       @NonNull HttpServletResponse response,
       @NonNull Object handler) {
-    Long jwtTenantId = authenticatedTenantId();
+    Claims claims = authenticatedClaims();
+    Long jwtTenantId = claims == null ? null : claims.get("tenantId", Long.class);
     if (jwtTenantId != null) {
       // 認証済みテナント JWT: claim を正としてテナント文脈を確定する。ヘッダの有無・形式には依存させない
       // （X-Role/X-Tenant-ID を省略・改変してこの検証と分離を素通りされるのを防ぐため）。
       String headerTenantId = request.getHeader(HEADER_TENANT_ID);
-      if (StringUtils.isNumeric(headerTenantId)
-          && !jwtTenantId.equals(Long.parseLong(headerTenantId))) {
-        // X-Tenant-ID が別テナントを指す明確な詐称は拒否する。
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-        return false;
+      if (StringUtils.isNumeric(headerTenantId)) {
+        Long headerValue = tryParseTenantId(headerTenantId);
+        if (headerValue == null) {
+          // 全桁数字だが long 範囲外。素の 500 を避けクリーンに 400 で拒否する（#288）。
+          response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+          return false;
+        }
+        if (!jwtTenantId.equals(headerValue)) {
+          // X-Tenant-ID が別テナントを指す明確な詐称は拒否する。
+          response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+          return false;
+        }
       }
       this.tenantContext.setTenantId(jwtTenantId);
       return true;
     }
-    // 認証前（ログイン等）または tenantId claim を持たないトークン: 従来通りヘッダのみで信用する。
-    if (HEADER_ROLE_TENANT.equals(request.getHeader(HEADER_ROLE))
-        && StringUtils.isNotBlank(request.getHeader(HEADER_TENANT_ID))
+    boolean claimsTenantHeaderPresent =
+        HEADER_ROLE_TENANT.equals(request.getHeader(HEADER_ROLE))
+            && StringUtils.isNotBlank(request.getHeader(HEADER_TENANT_ID));
+    if (claims != null) {
+      // 認証済みだが tenantId claim を持たない（央端 CentralAuth 発行、または tenantId 無しの legacy）。
+      // ヘッダでテナントを名乗る主張は詐称として 403 で拒否する（#294）。詐称ヘッダが無ければ下の
+      // @TenantOptional 判定に委ね、央端の正当な素通り（例: /files/upload の central 保存）を保つ。
+      if (claimsTenantHeaderPresent) {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        return false;
+      }
+    } else if (claimsTenantHeaderPresent
         && StringUtils.isNumeric(request.getHeader(HEADER_TENANT_ID))) {
-      this.tenantContext.setTenantId(Long.parseLong(request.getHeader(HEADER_TENANT_ID)));
+      // 未認証（ログイン前・公開ページ）だけがヘッダのみでテナントを名乗れる。
+      Long headerValue = tryParseTenantId(request.getHeader(HEADER_TENANT_ID));
+      if (headerValue == null) {
+        // 全桁数字だが long 範囲外（#288）。
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        return false;
+      }
+      this.tenantContext.setTenantId(headerValue);
       return true;
     }
     // JWT claim・ヘッダのいずれからもテナント文脈を解決できなかった。文脈が無いまま素通りさせると
@@ -63,15 +87,24 @@ public class TenantIdInterceptor implements HandlerInterceptor {
   }
 
   /**
-   * 認証済みリクエストの JWT に埋め込まれた tenantId claim を返す。未認証、または details に {@link Claims}
-   * を持たない（匿名認証やログイン前など）場合は null を返し、呼び出し側は従来通りヘッダのみで文脈を設定する。
+   * 認証済みリクエストの JWT Claims（JwtAuthenticationFilter が details に載せたもの）を返す。 未認証、または details に {@link
+   * Claims} を持たない（匿名認証やログイン前など）場合は null。
    */
-  private Long authenticatedTenantId() {
+  private Claims authenticatedClaims() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     if (authentication != null && authentication.getDetails() instanceof Claims claims) {
-      return claims.get("tenantId", Long.class);
+      return claims;
     }
     return null;
+  }
+
+  /** 全桁数字の文字列を long に変換する。long 範囲を超える場合は null（呼び出し側が 400 を返す）。 */
+  private static Long tryParseTenantId(String numericValue) {
+    try {
+      return Long.parseLong(numericValue);
+    } catch (NumberFormatException e) {
+      return null;
+    }
   }
 
   @Override

--- a/backend/src/test/java/com/kizuna/shared/tenancy/TenantIdInterceptorTest.java
+++ b/backend/src/test/java/com/kizuna/shared/tenancy/TenantIdInterceptorTest.java
@@ -43,6 +43,16 @@ class TenantIdInterceptorTest {
     SecurityContextHolder.getContext().setAuthentication(authentication);
   }
 
+  /** 認証済みだが tenantId claim を持たない Claims（央端 / legacy）を模擬する。 */
+  private void authenticateWithoutTenantId() {
+    Claims claims = Jwts.claims().issuer("CentralAuth").build();
+    PreAuthenticatedAuthenticationToken authentication =
+        new PreAuthenticatedAuthenticationToken(
+            "user", "token", List.of(new SimpleGrantedAuthority("CENTRAL_USER")));
+    authentication.setDetails(claims);
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
   /** テスト用ハンドラ: {@link TenantOptional} の有無を切り替えて HandlerMethod を組み立てるための土台。 */
   static class Handlers {
     @TenantOptional
@@ -221,6 +231,53 @@ class TenantIdInterceptorTest {
 
     assertThat(result).isFalse();
     assertThat(response.getStatus()).isEqualTo(403);
+    assertThat(tenantContext.isTenant()).isFalse();
+  }
+
+  @Test
+  @DisplayName("認証済みだが tenantId claim が無いトークンが X-Role:tenant で別テナントを名乗ると 403 で拒否すること（#294）")
+  void preHandle_rejectsAuthenticatedTokenWithoutTenantIdClaimSpoofingHeader() {
+    authenticateWithoutTenantId();
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("X-Role", "tenant");
+    request.addHeader("X-Tenant-ID", "2");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, new Object());
+
+    assertThat(result).isFalse();
+    assertThat(response.getStatus()).isEqualTo(403);
+    assertThat(tenantContext.isTenant()).isFalse();
+  }
+
+  @Test
+  @DisplayName("未認証で X-Tenant-ID が long 範囲を超える桁数なら 400 で拒否すること（#288）")
+  void preHandle_rejectsOverflowingTenantIdHeaderWith400() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("X-Role", "tenant");
+    request.addHeader("X-Tenant-ID", "99999999999999999999");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, new Object());
+
+    assertThat(result).isFalse();
+    assertThat(response.getStatus()).isEqualTo(400);
+    assertThat(tenantContext.isTenant()).isFalse();
+  }
+
+  @Test
+  @DisplayName("認証済みテナント JWT でも X-Tenant-ID が long 範囲を超えるなら 400 で拒否すること（#288）")
+  void preHandle_rejectsOverflowingHeaderForAuthenticatedTenant() {
+    authenticateWithTenantId(1L);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("X-Role", "tenant");
+    request.addHeader("X-Tenant-ID", "99999999999999999999");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, new Object());
+
+    assertThat(result).isFalse();
+    assertThat(response.getStatus()).isEqualTo(400);
     assertThat(tenantContext.isTenant()).isFalse();
   }
 


### PR DESCRIPTION
## 概要

`TenantIdInterceptor` のヘッダ兜底（JWT に `tenantId` claim が無い場合に `X-Role` / `X-Tenant-ID` をそのままテナント文脈として信用する分岐）を「真に未認証のリクエスト」に限定する。`X-Role` / `X-Tenant-ID` は Next.js middleware が注入する内部ルーティング情報であり、認証主体の主張として扱わない、という信頼境界を interceptor 内で一度で確定させる umbrella 修正。

Closes #305

## 変更内容

- `fix(backend)`: `authenticatedTenantId()` を `authenticatedClaims()` へ置き換え、リクエストの認証状態（未認証 / 央端 CentralAuth 認証済み / テナント TenantAuth 認証済み）で分岐を三分割する。
  - テナント JWT（`tenantId` claim あり）: 従来通り claim を正としヘッダに依存しない（#285 の動作を維持）。
  - 認証済みだが `tenantId` claim 無し（央端発行、または legacy）: `X-Role: tenant` + `X-Tenant-ID` の詐称ヘッダを **403** で拒否。詐称ヘッダが無ければ下流の `@TenantOptional` 判定に委ね、央端の正当な素通り（例: `/files/upload` の central 保存）を保つ（#294）。
  - 未認証（ログイン前・公開ページ）のみがヘッダでテナントを名乗れる。
  - ヘッダ値のパースを `tryParseTenantId()` へ集約し、`long` 桁あふれを素の 500 でなくクリーンに **400** で返す（#288）。
- `test(backend)`: 央端トークン + ヘッダ詐称の `/files/upload` が 403 になること、詐称なしの央端アップロードが 200 で `/central/` 配下に保存されることを実 MinIO で固定（`FileUploadCrossTenantIT`、#294）。
- `test(backend)`: 未認証の桁あふれ `X-Tenant-ID` が 500 でなく 400 になることを固定（`TenantContextFailClosedIT`、#288）。認証済みテナント経路の桁あふれ 400 は `TenantIdInterceptorTest` に単体で追加。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: ）— 対象外（UI 面なし。ヘッダ信頼境界はブラウザ層より下位で、integrationTest 層で検証。詳細は備考）

`task test` は実 Postgres / Redis / MinIO（`backend/docker-compose.test.yml`）に対して実行。high-risk auth 修正のため backend unit-test の Docker 層はキャッシュヒットを避け `--no-cache` で真実行を強制した。`FileUploadCrossTenantIT`(2)・`TenantContextFailClosedIT`(5)・`TenantIdInterceptorTest`(16) が当日タイムスタンプで実 infra に対し実行・全緑を確認（UP-TO-DATE ではない）。

## 決定ログ

- **判定軸をヘッダ主体でなく「Claims の有無 × tenantId claim の有無」に置いた**。issuer 文字列で直接分岐するより、`JwtAuthenticationFilter` が `Authentication.getDetails()` に載せた `Claims` の有無で認証状態を判定するほうが、匿名認証（`getDetails()` が `Claims` でない）と自然に区別でき、既存の fail-closed 経路と噛み合う。
- **桁あふれは例外送出でなく `response.setStatus(400) + return false`**。interceptor は `@ExceptionHandler` へのルーティングに依存させたくない（handler 到達前に short-circuit するのが目的）ため、その場でステータスを立てて MVC チェーンを止める。
- **`FileUploadController` は変更しない**。同 controller の `isTenantIssuedToken()` による fail-closed ガードは `TenantAuth` legacy トークン経路の唯一の防御であり、interceptor 側の修正と役割が異なるため残す。central トークンが詐称ヘッダ無しで通った場合も、controller が issuer を見て `central` prefix に保存する挙動は正当なので維持する。
- **回帰固定は MenuCrossTenantIT 型**（repository 直挿し不要な本件では実 infra への実 HTTP 経路 + ステータス/保存 prefix 断言）で、4 変種すべてに red→green を通した。

## 備考 / レビュー観点

- **リスク層別: high-risk（認証・テナント分離）**。push 前に計画を知らない fresh subagent による対抗的事前レビューを実施済み: header 大小文字・空白・重複、`StringUtils.isNumeric` と `Long.parseLong` の乖離、三分岐の落穂、#294 の保存 prefix 時序、#288 溢出双路径、`preHandle` が true を返しつつ文脈未設定のときの下流 fail-closed——7 候補すべて file:line 証拠付きで駁回、可利用な欠陥なし。
- 意図的な非対称（安全側）: 央端トークン + `X-Role: tenant` + 非数字 `X-Tenant-ID` は 403、空値は 200（central 保存）。いずれもテナント文脈を漏らさず、fail-open しない。
- `.feature` を意図的に置いていない（ヘッダ信頼境界はブラウザ層より下位で、middleware 注入前提のヘッダを e2e から再現する意味が薄い）。検証は integrationTest 層に集約。
