### PR TITLE
chore(ci): lint ゲートの盲点を一括解消（actionlint 導入 / md ゲート復帰 / .claude 検証 / pre-pr-gate 厳密化）

### DIFF
--- a/.claude/hooks/pre-pr-gate.sh
+++ b/.claude/hooks/pre-pr-gate.sh
@@ -16,7 +16,7 @@ esac
 # 判定は python3（JSON + shlex）。1 行を返す: ALLOW / REJECT<TAB>理由 / CHECK<TAB>title<TAB>body-file
 # heredoc がプログラム本体を占有するため、payload は環境変数で渡す（stdin は使えない）
 result=$(PRE_PR_GATE_PAYLOAD="$payload" python3 - <<'PY'
-import json, os, shlex, sys
+import json, os, re, shlex, sys
 
 try:
     data = json.loads(os.environ.get("PRE_PR_GATE_PAYLOAD") or "{}")
@@ -28,16 +28,44 @@ try:
 except ValueError:
     print("REJECT\tコマンドを解析できない — gh pr create は --title \"...\" --body-file <絶対パス> の単純形式のみ許可")
     sys.exit(0)
-# トークン列 gh → pr → create の順序一致で検出（隣接不要 — `gh -R <repo> pr create`
-# のようなグローバルフラグ挟み込みも対象）。引用文字列内の言及は 1 トークンなので素通し。
-want = ["gh", "pr", "create"]
-idx = 0
-for t in toks:
-    if t == want[idx]:
-        idx += 1
-        if idx == len(want):
-            break
-if idx < len(want):
+# `gh` トークンから厳密照合する（隣接不要 — `gh -R <repo> pr create` のような
+# グローバルフラグ挟み込みは対象、`gh pr list --search create` のような別 subcommand は非対象）。
+# 規則: `gh` の後、フラグトークン（`-` 始まり）とその値のみを挟んで、次の非フラグトークンが
+# `pr`、さらに同条件で次の非フラグトークンが `create` であれば検出。`=` を含まないフラグは
+# 直後 1 トークンを値として消費し得るが、その値が次に期待する語なら語を優先する。
+# どの `gh` からも成立しなければ ALLOW（引用文字列内の言及は 1 トークンなので `gh` に一致しない）。
+def is_gh_pr_create(tokens):
+    want = ["pr", "create"]
+    n = len(tokens)
+    i = 0
+    while i < n:
+        if tokens[i] != "gh":
+            i += 1
+            continue
+        j = i + 1
+        wi = 0
+        matched = True
+        while wi < len(want) and j < n:
+            t = tokens[j]
+            if t.startswith("-"):
+                # フラグ。= 無しかつ直後が期待語でなければ、直後 1 トークンを値として消費。
+                if "=" not in t and j + 1 < n and tokens[j + 1] != want[wi]:
+                    j += 2
+                else:
+                    j += 1
+                continue
+            if t == want[wi]:
+                wi += 1
+                j += 1
+            else:
+                matched = False
+                break
+        if matched and wi == len(want):
+            return True
+        i += 1  # この `gh` からは不成立 — 次の `gh` 出現から再試行
+    return False
+
+if not is_gh_pr_create(toks):
     print("ALLOW"); sys.exit(0)
 title = body = None
 for i, t in enumerate(toks):
@@ -49,9 +77,14 @@ for i, t in enumerate(toks):
         body = toks[i + 1]
     elif t.startswith("--body-file="):
         body = t[len("--body-file="):]
-    elif t.split("=")[0] in ("--body", "-b", "--fill", "--fill-first", "--fill-verbose", "--web", "-w"):
-        # = 形式のブールフラグ（--web=true 等）も割った先頭で拒否判定する
+    elif t.split("=")[0] in ("--body", "-b", "--fill", "--fill-first", "--fill-verbose", "--web", "-w", "-f"):
+        # = 形式のブールフラグ（--web=true 等）も割った先頭で拒否判定する。-f は --fill の短縮形。
         print(f"REJECT\t{t} は不可 — --title \"...\" --body-file <絶対パス> の形式のみ許可")
+        sys.exit(0)
+    elif re.match(r"^-[A-Za-z]{2,}$", t) and any(c in t for c in ("b", "f", "w")):
+        # 連結ブール短縮（-dw 等）: b/f/w のいずれかを含めば --body/--fill/--web 相当として拒否。
+        # -d 単独や --draft は {2,} または `--` 始まりで対象外（現行どおり許可）。
+        print(f"REJECT\t{t} は不可（連結短縮フラグに --body/--fill/--web 相当を含む）— --title \"...\" --body-file <絶対パス> の形式のみ許可")
         sys.exit(0)
 if not title or not body:
     print("REJECT\t--title と --body-file が必須（長形式のみ・スペース区切りと = 形式どちらでも可。-t/-F 等の短縮形は不可）")

--- a/.claude/hooks/tests/pre-pr-gate.test.sh
+++ b/.claude/hooks/tests/pre-pr-gate.test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# pre-pr-gate.sh の回帰テスト（#261）。
+# 方式: 一時ディレクトリに hook 実物と check-pr.sh スタブを配置して密閉し、
+#       hook JSON payload（{"tool_input":{"command":"..."}}）を stdin で流して
+#       exit code（許可=0 / 拒否=2）と、CHECK 経路はスタブ到達を断言する。
+# テスト対象 hook は第 1 引数または $PRE_PR_GATE_HOOK で差し替え可（既定=リポジトリ実物）。
+set -u
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+hook_src=${1:-${PRE_PR_GATE_HOOK:-"$script_dir/../pre-pr-gate.sh"}}
+
+if [ ! -f "$hook_src" ]; then
+  echo "FATAL: テスト対象の hook が見つからない: $hook_src" >&2
+  exit 1
+fi
+
+# 密閉テスト木: hook 実物のコピー + check-pr.sh スタブ（引数を記録して exit 0）。
+# hook は check-pr.sh を自身の位置からの相対（../skills/create-pr/）で解決するため、
+# この配置でスタブへ確実に到達する。
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/.claude/hooks" "$work/.claude/skills/create-pr"
+cp "$hook_src" "$work/.claude/hooks/pre-pr-gate.sh"
+chmod +x "$work/.claude/hooks/pre-pr-gate.sh"
+hook="$work/.claude/hooks/pre-pr-gate.sh"
+
+stub_log="$work/stub-args.log"
+cat > "$work/.claude/skills/create-pr/check-pr.sh" <<STUB
+#!/bin/bash
+# check-pr.sh スタブ — 受け取った引数を記録して合格（exit 0）を返す
+printf '%s\n' "\$@" > "$stub_log"
+exit 0
+STUB
+chmod +x "$work/.claude/skills/create-pr/check-pr.sh"
+
+pass=0
+fail=0
+
+# コマンド文字列を安全に JSON payload へ埋め込む
+make_payload() {
+  PAYLOAD_CMD="$1" python3 -c 'import json,os; print(json.dumps({"tool_input":{"command":os.environ["PAYLOAD_CMD"]}}))'
+}
+
+# run <期待exit> <説明> <コマンド> — exit code のみ断言（許可/拒否ケース）
+run() {
+  local want=$1 desc=$2 cmd=$3 got
+  make_payload "$cmd" | "$hook" >/dev/null 2>&1
+  got=$?
+  if [ "$got" -eq "$want" ]; then
+    printf 'PASS [exit %s]        %s\n' "$got" "$desc"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL [exit %s want %s] %s\n' "$got" "$want" "$desc"
+    fail=$((fail + 1))
+  fi
+}
+
+# check <説明> <コマンド> — CHECK 経路: hook exit 0 かつスタブ到達を断言
+check() {
+  local desc=$1 cmd=$2 got reached
+  rm -f "$stub_log"
+  make_payload "$cmd" | "$hook" >/dev/null 2>&1
+  got=$?
+  [ -f "$stub_log" ] && reached=到達 || reached=未到達
+  if [ "$got" -eq 0 ] && [ "$reached" = 到達 ]; then
+    printf 'PASS [exit 0 スタブ到達]  %s\n' "$desc"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL [exit %s スタブ%s] %s\n' "$got" "$reached" "$desc"
+    fail=$((fail + 1))
+  fi
+}
+
+echo "== 許可（exit 0）=="
+run 0 '許可: git status'                        'git status'
+run 0 '許可: gh issue create --title x'         'gh issue create --title x'
+run 0 '許可: gh pr list --search create'        'gh pr list --search create'
+run 0 '許可: gh pr view 123'                    'gh pr view 123'
+run 0 '許可: gh pr checks 42'                   'gh pr checks 42'
+run 0 '許可: gh pr edit 5 --title x'            'gh pr edit 5 --title x'
+run 0 '許可: echo "gh pr create"（引用内言及）' 'echo "gh pr create"'
+
+echo "== 拒否（exit 2）=="
+run 2 '拒否: gh pr create（title/body 欠如）'          'gh pr create'
+run 2 '拒否: gh pr create --title x --body y'          'gh pr create --title x --body y'
+run 2 '拒否: gh pr create --fill'                      'gh pr create --fill'
+run 2 '拒否: gh pr create -f（--fill 短縮）'           'gh pr create -f'
+run 2 '拒否: gh pr create --title x --body-file /a -w' 'gh pr create --title x --body-file /a -w'
+run 2 '拒否: gh pr create --title x --body-file /a -dw' 'gh pr create --title x --body-file /a -dw'
+run 2 '拒否: gh pr create --title x --body-file rel/path（相対）' 'gh pr create --title x --body-file rel/path'
+run 2 '拒否: gh pr create --title x --body-file=/a --web=true'   'gh pr create --title x --body-file=/a --web=true'
+run 2 '拒否: gh -R o/r pr create -f（グローバルフラグ越し）'      'gh -R o/r pr create -f'
+
+echo "== CHECK 到達（exit 0 + スタブ到達）=="
+check 'CHECK: gh pr create --title "t" --body-file /abs'          'gh pr create --title "t" --body-file /abs'
+check 'CHECK: gh -R o/r pr create --title t --body-file /abs'     'gh -R o/r pr create --title t --body-file /abs'
+check 'CHECK: cd /x && gh pr create --title t --body-file /abs'   'cd /x && gh pr create --title t --body-file /abs'
+
+echo "----------------------------------------"
+printf '合計: PASS=%s FAIL=%s\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/scripts/validate-agent-skills.sh
+++ b/.claude/scripts/validate-agent-skills.sh
@@ -72,16 +72,26 @@ for path in sorted(glob.glob(os.path.join(agents_dir, "*.md"))):
         errors.append(f"{name}: skills: が未対応形式です（ブロックリストのみサポート）: {front[skills_idx]!r}")
         continue
 
-    # 後続のブロックリスト項目（`  - name`）を収集（空行・コメント行はブロック終端とみなさずスキップ）
+    # 後続のブロックリスト項目（`  - name`）を収集する。
+    # ・空行/コメント行はスキップ（ブロック終端にしない）。
+    # ・非インデント行（次のトップレベルキー）のときだけブロック終端とする。
+    # ・`-` のみの行（YAML null item）や、項目にもコメントにも一致しないインデント行は、
+    #   黙って走査を打ち切らずエラーとして記録したうえで走査を継続する（#290）。
     entries = []
     for line in front[skills_idx + 1:]:
         if not line.strip() or re.match(r"^\s*#", line):
             continue
-        m = re.match(r"^\s+-\s*(.+)$", line)
-        if not m:
+        if re.match(r"^\S", line):
             break
-        raw_entry = m.group(1)
-        entries.append((raw_entry, strip_item(raw_entry)))
+        m = re.match(r"^\s+-\s*(.+)$", line)
+        if m:
+            raw_entry = m.group(1)
+            entries.append((raw_entry, strip_item(raw_entry)))
+            continue
+        if re.match(r"^\s+-\s*$", line):
+            errors.append(f"{name}: skills エントリが不正です（null item）: {line!r}")
+            continue
+        errors.append(f"{name}: skills ブロック内の行を解釈できません: {line!r}")
 
     for raw_entry, entry in entries:
         if not entry:

--- a/.claude/scripts/validate-agent-skills.sh
+++ b/.claude/scripts/validate-agent-skills.sh
@@ -63,9 +63,11 @@ for path in sorted(glob.glob(os.path.join(agents_dir, "*.md"))):
         errors.append(f"{name}: skills: が未対応形式です（ブロックリストのみサポート）: {front[skills_idx]!r}")
         continue
 
-    # 後続のブロックリスト項目（`  - name`）を収集
+    # 後続のブロックリスト項目（`  - name`）を収集（空行・コメント行はブロック終端とみなさずスキップ）
     entries = []
     for line in front[skills_idx + 1:]:
+        if not line.strip() or re.match(r"^\s*#", line):
+            continue
         m = re.match(r"^\s+-\s*(.+)$", line)
         if not m:
             break

--- a/.claude/scripts/validate-agent-skills.sh
+++ b/.claude/scripts/validate-agent-skills.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# .claude/agents/*.md の frontmatter skills: エントリが実在の skill に解決できるか検証する（#290）。
+# 裸名（`:` を含まない）→ .claude/skills/<name>/SKILL.md が無ければエラー（exit 1）。
+# 名前空間付き（`plugin:skill` 形式）→ CI ではプラグイン導入状態を検証できないため skip（情報表示のみ）。
+# skills: キーが無いファイルは正常。ブロックリスト以外の形（inline [...] 等）は「未対応形式」としてエラー。
+set -u
+
+# リポジトリルートは自身の位置から解決する（cwd がルートでも .claude/scripts でも動く）
+script_dir=$(cd "$(dirname "$0")" && pwd)
+repo_root=$(cd "$script_dir/../.." && pwd)
+agents_dir="$repo_root/.claude/agents"
+skills_dir="$repo_root/.claude/skills"
+
+if [ ! -d "$agents_dir" ]; then
+  echo "FATAL: agents ディレクトリが見つからない: $agents_dir" >&2
+  exit 1
+fi
+
+AGENTS_DIR="$agents_dir" SKILLS_DIR="$skills_dir" python3 - <<'PY'
+import os, re, sys, glob
+
+agents_dir = os.environ["AGENTS_DIR"]
+skills_dir = os.environ["SKILLS_DIR"]
+
+errors = []
+infos = []
+
+def strip_item(raw):
+    s = raw.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ("'", '"'):
+        s = s[1:-1]
+    return s
+
+for path in sorted(glob.glob(os.path.join(agents_dir, "*.md"))):
+    name = os.path.basename(path)
+    with open(path, encoding="utf-8") as f:
+        lines = f.read().splitlines()
+
+    # frontmatter は先頭の `---` ペアの間
+    if not lines or lines[0].strip() != "---":
+        continue
+    end = None
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            end = idx
+            break
+    if end is None:
+        continue
+    front = lines[1:end]
+
+    # トップレベル `skills:` キーを探す（フロントマターは無インデント）
+    skills_idx = None
+    for idx, line in enumerate(front):
+        if re.match(r"^skills:\s*(.*)$", line):
+            skills_idx = idx
+            break
+    if skills_idx is None:
+        continue  # skills: キーが無いのは正常
+
+    rest = re.match(r"^skills:\s*(.*)$", front[skills_idx]).group(1).strip()
+    if rest:
+        # `skills: [tdd]` のような inline 形式は未対応
+        errors.append(f"{name}: skills: が未対応形式です（ブロックリストのみサポート）: {front[skills_idx]!r}")
+        continue
+
+    # 後続のブロックリスト項目（`  - name`）を収集
+    entries = []
+    for line in front[skills_idx + 1:]:
+        m = re.match(r"^\s+-\s*(.+)$", line)
+        if not m:
+            break
+        entries.append(strip_item(m.group(1)))
+
+    for entry in entries:
+        if ":" in entry:
+            infos.append(f"{name}: {entry} は名前空間付き参照のため skip（CI ではプラグイン導入状態を検証不可）")
+            continue
+        skill_file = os.path.join(skills_dir, entry, "SKILL.md")
+        if not os.path.isfile(skill_file):
+            errors.append(f"{name}: skills 参照 '{entry}' が {skill_file} に解決できない")
+
+for info in infos:
+    print(f"INFO: {info}")
+
+if errors:
+    for err in errors:
+        print(f"NG: {err}", file=sys.stderr)
+    sys.exit(1)
+
+print("OK: すべての agents skills 参照が解決できた")
+sys.exit(0)
+PY

--- a/.claude/scripts/validate-agent-skills.sh
+++ b/.claude/scripts/validate-agent-skills.sh
@@ -27,8 +27,17 @@ infos = []
 
 def strip_item(raw):
     s = raw.strip()
-    if len(s) >= 2 and s[0] == s[-1] and s[0] in ("'", '"'):
-        s = s[1:-1]
+    # クォート付き（`"x" # c` 等）: 内側の値を取り出す。閉じクォート後の行内コメントは許容する
+    m = re.match(r"^(['\"])(.*?)\1\s*(?:#.*)?$", s)
+    if m:
+        return m.group(2)
+    # 非クォート: 行全体がコメントなら空エントリ扱い
+    if s.startswith("#"):
+        return ""
+    # 空白+# 以降は行内コメントとして除去する（`foo#bar` のように空白を伴わない # は名前の一部）
+    m = re.search(r"\s+#", s)
+    if m:
+        return s[: m.start()]
     return s
 
 for path in sorted(glob.glob(os.path.join(agents_dir, "*.md"))):
@@ -71,9 +80,13 @@ for path in sorted(glob.glob(os.path.join(agents_dir, "*.md"))):
         m = re.match(r"^\s+-\s*(.+)$", line)
         if not m:
             break
-        entries.append(strip_item(m.group(1)))
+        raw_entry = m.group(1)
+        entries.append((raw_entry, strip_item(raw_entry)))
 
-    for entry in entries:
+    for raw_entry, entry in entries:
+        if not entry:
+            errors.append(f"{name}: skills エントリが不正です（空、またはコメントのみ）: {raw_entry!r}")
+            continue
         if ":" in entry:
             infos.append(f"{name}: {entry} は名前空間付き参照のため skip（CI ではプラグイン導入状態を検証不可）")
             continue

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -46,11 +46,15 @@ jobs:
             network=host
 
       - name: Set up Task
-        if: steps.diff.outputs.docs_only != 'true'
         uses: arduino/setup-task@v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # リポジトリ横断 lint（workflows / .claude）は軽量なため docs-only でも常時実行する。
+      # これにより .claude のみの変更（docs-only 扱い）でも壊れを CI で検知できる（#290/#301）。
+      - name: Repo lint
+        run: task lint-repo
 
       - name: Lint
         if: steps.diff.outputs.docs_only != 'true'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,6 +37,8 @@ tasks:
           echo "🧹 {{.service}} の Lint を実行中..."
           task -d "{{.service}}" lint
         else
+          echo "🧹 Repo lint..."
+          task lint-repo
           echo "🧹 すべてのサービスの Lint を実行中..."
           echo "🧹 Frontend lint..."
           task -d frontend lint
@@ -44,6 +46,16 @@ tasks:
           task -d backend lint
           echo "✅ Lint 完了"
         fi
+
+  lint-repo:
+    desc: リポジトリ横断の Lint（GitHub Actions workflows / .claude 設定）
+    cmds:
+      - echo "🧹 Workflows lint (actionlint)..."
+      - docker run --rm -v "$(pwd):/repo" -w /repo rhysd/actionlint:1.7.12
+      - echo "🧹 .claude/agents の skills 参照検証..."
+      - .claude/scripts/validate-agent-skills.sh
+      - echo "🧹 pre-pr-gate hook 回帰テスト..."
+      - .claude/hooks/tests/pre-pr-gate.test.sh
 
   test:
     desc: すべてのサービスのテストを実行（frontend + backend unit + integration、後方互換）

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -47,9 +47,6 @@ artifacts/
 Dockerfile*
 .dockerignore
 
-# Documentation
-*.md
-
 # Temporary files
 *.tmp
 *.temp

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -4,10 +4,10 @@ Design rules for all UI work. Structure follows the DESIGN.md convention (design
 
 ## Scope: two visual worlds
 
-| World | Source of truth | Where styles live |
-|---|---|---|
+| World                                                                                 | Source of truth                                                                                                                      | Where styles live                                                                           |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
 | **Admin UI** (central + tenant management screens: dashboards, lists, settings forms) | Figma file `5r40p5muNqFxwZLa5itKB8` (page 総合ダッシュボード). Screens not yet designed in Figma are extrapolated from these tokens. | Tailwind semantic classes (default v4 palette — the Figma design uses exactly these values) |
-| **Public storefront** (`_pages/store-site/templates/**`) | Template code itself; per-template `theme.css` tokens | `templates/<key>/theme.css` CSS custom properties + shared `_sections/` components |
+| **Public storefront** (`_pages/store-site/templates/**`)                              | Template code itself; per-template `theme.css` tokens                                                                                | `templates/<key>/theme.css` CSS custom properties + shared `_sections/` components          |
 
 Never mix the two vocabularies: no gold-serif storefront styling in admin screens, no admin blue/gray cards in storefront templates.
 
@@ -15,41 +15,41 @@ Never mix the two vocabularies: no gold-serif storefront styling in admin screen
 
 ### Admin UI (Tailwind semantic classes only — never raw hex)
 
-| Token | Tailwind | Usage rules |
-|---|---|---|
-| Page background | `bg-gray-50` | App shell behind cards |
-| Surface | `bg-white` | Cards, sidebar, header |
-| Border | `border-gray-200` | Card and input borders |
-| Text primary | `text-gray-900` | Headings, key figures |
-| Text secondary | `text-gray-600` | Labels, body |
-| Text muted | `text-gray-500` | Hints, "vs 先月"-style annotations |
-| **Primary** | `blue-600` (`text-blue-600`, `bg-blue-600`) | CTAs, links, active states, progress fill. **Primary is blue, not indigo** — new screens use blue-600; existing indigo-600 usages are migrated opportunistically in PRs that already touch them (no dedicated recolor PRs) |
-| Primary tint | `bg-blue-50` | Active nav background, rank chips |
-| Success | `green-600` text / `bg-green-100 text-green-800` pill | Positive trends; 確定 status |
-| Warning | `bg-yellow-100 text-yellow-800` pill | 保留 status |
-| Danger | `red-600` | Destructive actions, errors |
-| Icon chips | `bg-blue-500` / `bg-green-500` / `bg-orange-500` / `bg-purple-500` | Stat-card icons; one hue per metric, white icon |
+| Token           | Tailwind                                                           | Usage rules                                                                                                                                                                                                                |
+| --------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Page background | `bg-gray-50`                                                       | App shell behind cards                                                                                                                                                                                                     |
+| Surface         | `bg-white`                                                         | Cards, sidebar, header                                                                                                                                                                                                     |
+| Border          | `border-gray-200`                                                  | Card and input borders                                                                                                                                                                                                     |
+| Text primary    | `text-gray-900`                                                    | Headings, key figures                                                                                                                                                                                                      |
+| Text secondary  | `text-gray-600`                                                    | Labels, body                                                                                                                                                                                                               |
+| Text muted      | `text-gray-500`                                                    | Hints, "vs 先月"-style annotations                                                                                                                                                                                         |
+| **Primary**     | `blue-600` (`text-blue-600`, `bg-blue-600`)                        | CTAs, links, active states, progress fill. **Primary is blue, not indigo** — new screens use blue-600; existing indigo-600 usages are migrated opportunistically in PRs that already touch them (no dedicated recolor PRs) |
+| Primary tint    | `bg-blue-50`                                                       | Active nav background, rank chips                                                                                                                                                                                          |
+| Success         | `green-600` text / `bg-green-100 text-green-800` pill              | Positive trends; 確定 status                                                                                                                                                                                               |
+| Warning         | `bg-yellow-100 text-yellow-800` pill                               | 保留 status                                                                                                                                                                                                                |
+| Danger          | `red-600`                                                          | Destructive actions, errors                                                                                                                                                                                                |
+| Icon chips      | `bg-blue-500` / `bg-green-500` / `bg-orange-500` / `bg-purple-500` | Stat-card icons; one hue per metric, white icon                                                                                                                                                                            |
 
 ### Public storefront (three templates)
 
 Each template owns a `templates/<key>/theme.css` that defines the same `--storefront-*` token contract on a `.storefront-<key>` class; the shared `_sections/` read only these tokens — never raw hex/rgba (sections use `var()` for solid colors and `color-mix(in srgb, var(--token) N%, transparent)` for opacities). Templates differ only via token values and page layout, never by forking `_sections/`. New color needs = a new `--storefront-*` token added to **all** template theme.css files in the same PR, never inline hex in sections.
 
-| token | default (dark luxury) | modern (dark vivid) | classic (light) |
-|---|---|---|---|
-| `--storefront-bg` | `#080808` | `#0b0b12` | `#faf7f2` |
-| `--storefront-fg` | `#f8f4f0` | `#f2eff4` | `#2a2a28` |
-| `--storefront-accent` | `#c9a84c` gold | `#e64980` rose | `#4e8da6` teal |
-| `--storefront-muted` | `#a89880` | `#8a87a0` | `#7a776e` |
-| `--storefront-neutral` | `#484848` | `#3a3a48` | `#d8d4cc` |
-| `--storefront-subtle` | `#252525` | `#1e1e29` | `#ebe7e1` |
-| `--storefront-danger` | `#8b1a2e` | `#8b1a2e` | `#b0453a` |
-| `--storefront-bg-deep` | `#050505` | `#07070c` | `#efe8dc` |
-| `--storefront-surface-1` | `#0a0a0a` | `#10101a` | `#f4f0e9` |
-| `--storefront-surface-2` | `#0d0d0d` | `#13131e` | `#f0ebe2` |
-| `--storefront-surface-3` | `#0f0f0f` | `#161622` | `#ece6db` |
-| `--storefront-line` | `#2a2a2a` | `#24242f` | `#e2ddd3` |
-| `--storefront-bg-glow` | `#130d08` | `#170d14` | `#fffdf8` |
-| `--storefront-hairline` | `rgba(255,255,255,0.04)` | `rgba(255,255,255,0.05)` | `rgba(0,0,0,0.06)` |
+| token                       | default (dark luxury)       | modern (dark vivid)             | classic (light)             |
+| --------------------------- | --------------------------- | ------------------------------- | --------------------------- |
+| `--storefront-bg`           | `#080808`                   | `#0b0b12`                       | `#faf7f2`                   |
+| `--storefront-fg`           | `#f8f4f0`                   | `#f2eff4`                       | `#2a2a28`                   |
+| `--storefront-accent`       | `#c9a84c` gold              | `#e64980` rose                  | `#4e8da6` teal              |
+| `--storefront-muted`        | `#a89880`                   | `#8a87a0`                       | `#7a776e`                   |
+| `--storefront-neutral`      | `#484848`                   | `#3a3a48`                       | `#d8d4cc`                   |
+| `--storefront-subtle`       | `#252525`                   | `#1e1e29`                       | `#ebe7e1`                   |
+| `--storefront-danger`       | `#8b1a2e`                   | `#8b1a2e`                       | `#b0453a`                   |
+| `--storefront-bg-deep`      | `#050505`                   | `#07070c`                       | `#efe8dc`                   |
+| `--storefront-surface-1`    | `#0a0a0a`                   | `#10101a`                       | `#f4f0e9`                   |
+| `--storefront-surface-2`    | `#0d0d0d`                   | `#13131e`                       | `#f0ebe2`                   |
+| `--storefront-surface-3`    | `#0f0f0f`                   | `#161622`                       | `#ece6db`                   |
+| `--storefront-line`         | `#2a2a2a`                   | `#24242f`                       | `#e2ddd3`                   |
+| `--storefront-bg-glow`      | `#130d08`                   | `#170d14`                       | `#fffdf8`                   |
+| `--storefront-hairline`     | `rgba(255,255,255,0.04)`    | `rgba(255,255,255,0.05)`        | `rgba(0,0,0,0.06)`          |
 | `--storefront-font-display` | `'Noto Serif JP', …, serif` | `'Noto Sans JP', …, sans-serif` | `'Noto Serif JP', …, serif` |
 
 `surface-1/2/3` step away from `bg` toward higher contrast (dark templates lighten, classic sinks). `bg-deep` is the Footer band below `bg`; `line` is a weaker border than `neutral`; `bg-glow` is the AgeVerification radial-gradient center; `hairline` is an ultra-thin rule; `subtle` is the faintest near-background text/border tone (legal fine print, copyright line).


### PR DESCRIPTION
## 概要

lint ゲートの盲点 4 件を一括解消する。GitHub Actions workflow が無検証で全ゲートを通過し得る問題（#301）、`frontend/DESIGN.md` が `.dockerignore` の `*.md` により format ゲートの対象外だった問題（#296）、`.claude/agents` の `skills:` frontmatter 参照が壊れても検知されない問題（#290）、pre-pr-gate hook の誤遮断・短縮形漏れ（#261）。

Closes #301
Closes #296
Closes #290
Closes #261
Refs #264（watch-pr の thread 駆動退出は PR #283 で文書改訂済み — 本 PR の watch 運用で実測検証し、証拠付きで別途クローズする。ファイル変更なし）

## 変更内容

- **#261**: `pre-pr-gate.sh` の `gh pr create` 検出を厳密化 — `gh`→`pr`→`create` の間に挟めるのはフラグトークンとその値のみ（`gh pr list --search create` の誤遮断を解消、`gh -R <repo> pr create` の検出は維持）。deny 集合に `-f` と連結ブール短縮（`-dw` 等、`b`/`f`/`w` を含むもの）を補完。回帰テスト `.claude/hooks/tests/pre-pr-gate.test.sh`（許可 7 / 拒否 9 / CHECK 到達 3 の 19 ケース、check-pr.sh スタブによる密閉ハーネス）を新設。
- **#296**: `frontend/.dockerignore` の `*.md` 除外を撤廃し、`DESIGN.md` を `prettier --write` で適合（機械整形のみ・手編集なし）。既存の `format:check`（glob `.`）がそのまま md を担保する。
- **#290**: `.claude/scripts/validate-agent-skills.sh` を新設 — `.claude/agents/*.md` の `skills:` 裸名エントリが `.claude/skills/<name>/SKILL.md` に解決できなければ exit 1。名前空間付き参照（`plugin:skill`）は CI で導入状態を検証できないため skip（情報表示）。inline 形式は未対応として明示エラー。
- **#301**: ルート Taskfile に `lint-repo` タスクを新設（actionlint **1.7.12 固定**の Docker 実行 + 上記 2 検証）し、`task lint` フル実行の先頭へ接続。CI（lint-and-test.yml）には docs-only 判定に依らない常時実行の `Repo lint` ステップを追加 — 純 `.claude` 変更（docs-only 経路）でも壊れを検知できる。

## 検証

- [x] `task lint` exit 0（lint-repo + frontend + backend）
- [x] `task test` exit 0（frontend jest + backend unit + integration）
- [x] `task build` exit 0（backend + frontend 本番イメージ）
- `task e2e`: 対象外 — アプリ表面に一切触れない（Taskfile / CI workflow / .claude 工具 / md 整形のみ）ため実行せず

赤側（ゲートが本当に検知することの実証、QA で fixture 再現済み）:

- DESIGN.md に drift を再導入 → `task lint service=frontend` 非 0（`*.md` を `.dockerignore` に戻すと再び素通り — 因果を反証法で確認）
- 不正な `${{ }}` 式の workflow fixture → `task lint-repo` 非 0（actionlint が検出）
- 存在しない skill 参照 fixture → `validate-agent-skills.sh` exit 1（ファイル名・エントリ名を列挙）
- 新回帰テストを master の旧 hook に適用 → exit 1（誤遮断 `gh pr list --search create` と `-dw` 漏れの 2 ケースのみ赤 = テストが修正を確かに固定）

## 決定ログ

- **docs-only 境界 regex は変更しない**（lint-and-test.yml と check-pr.sh の同一性規約を維持）。純 `.claude` 変更の検知は、境界拡張（.claude-only PR にフルゲート数分を課す）ではなく、秒級の常時実行 `Repo lint` ステップで実現。code-touched PR では `task lint` 内と二重実行になるが数十秒であり、ローカル/CI パリティを優先して許容。
- actionlint はローカルバイナリでなく **Docker 経由 + バージョン固定（1.7.12）** — 開発機と CI で同一挙動、導入手順ゼロ。
- 名前空間付き skill 参照を fail にしない設計は #290 の受け入れ基準「誤検知ゼロ」による（CI にプラグインは導入されない）。
- pre-pr-gate の検出 walker は緩い部分列一致から「フラグとその値のみ挟める」照合へ置換。複合コマンド（`cd x && gh pr create …`）対応は従来どおり維持。`--draft` / `-d` 単独の扱いは変えない（従来も deny 対象外）。
- **#264 は実装済みと判明**（commit 39fb29e / PR #283 で thread 駆動化済み）— 本 PR にファイル変更は含めず、残る受け入れ基準「実 PR 1 件での実測」を本 PR の watch 運用で満たす。

## 備考 / レビュー観点

- 重点レビュー先: `.claude/hooks/pre-pr-gate.sh` の python heredoc（照合セマンティクス）と `.claude/hooks/tests/pre-pr-gate.test.sh` のケース行列。
- `frontend/DESIGN.md` の差分は prettier の機械整形のみ（`git diff -w --word-diff` で文言変更ゼロを確認済み）。
- 既知の妥協: code-touched PR では lint-repo が CI で二重実行（数十秒）。
