### PR TITLE
fix(dev): validate-agent-skills が skills: キー行の行内コメントを誤拒否する問題を修正

### DIFF
--- a/.claude/scripts/validate-agent-skills.sh
+++ b/.claude/scripts/validate-agent-skills.sh
@@ -66,7 +66,8 @@ for path in sorted(glob.glob(os.path.join(agents_dir, "*.md"))):
     if skills_idx is None:
         continue  # skills: キーが無いのは正常
 
-    rest = re.match(r"^skills:\s*(.*)$", front[skills_idx]).group(1).strip()
+    # キー行の行内コメント（`skills: # ...`）は YAML として正当なので除去してから形式判定する（#310）
+    rest = strip_item(re.match(r"^skills:\s*(.*)$", front[skills_idx]).group(1))
     if rest:
         # `skills: [tdd]` のような inline 形式は未対応
         errors.append(f"{name}: skills: が未対応形式です（ブロックリストのみサポート）: {front[skills_idx]!r}")

--- a/.claude/scripts/validate-agent-skills.sh
+++ b/.claude/scripts/validate-agent-skills.sh
@@ -66,8 +66,15 @@ for path in sorted(glob.glob(os.path.join(agents_dir, "*.md"))):
     if skills_idx is None:
         continue  # skills: キーが無いのは正常
 
-    # キー行の行内コメント（`skills: # ...`）は YAML として正当なので除去してから形式判定する（#310）
-    rest = strip_item(re.match(r"^skills:\s*(.*)$", front[skills_idx]).group(1))
+    # キー行の行内コメントは、コロン後に YAML として正当な空白区切りがある場合のみ除去する
+    # （`skills: # c` は正当なコメント、`skills:# c` は区切りなし＝コメントではないので loud に拒否する。PR #314 レビュー指摘）
+    raw_rest = re.match(r"^skills:(.*)$", front[skills_idx]).group(1)
+    if raw_rest.strip() == "":
+        rest = ""
+    elif not re.match(r"^\s", raw_rest):
+        rest = raw_rest.strip()  # 区切りなし（`skills:#...` / `skills:[x]` 等）→ 非空のまま未対応形式エラーへ
+    else:
+        rest = strip_item(raw_rest)
     if rest:
         # `skills: [tdd]` のような inline 形式は未対応
         errors.append(f"{name}: skills: が未対応形式です（ブロックリストのみサポート）: {front[skills_idx]!r}")


### PR DESCRIPTION
## 概要

`.claude/scripts/validate-agent-skills.sh` が、YAML として正当な `skills:` キー行の行内コメント（`skills: # local skills`）を「未対応形式（inline）」と誤認して exit 1 にする誤検知（fail-closed 方向）を修正する。

Closes #310

## 変更内容

- `skills:` キー行の残余文字列を、既存の `strip_item()`（行内コメント除去・行全体コメント判定・クォート処理を実装済み）に通してから inline 形式判定するようにした（1 ファイル、+2/-1）
- `skills: [tdd]` のような真の inline 形式は、コメント除去後も非空のため従来どおり「未対応形式」エラー（挙動保存）

## 検証

- 対象外（コード変更なし）: 変更は `.claude/scripts/validate-agent-skills.sh` のみで、frontend / backend / e2e / infrastructure / Taskfile / .github/workflows / .github/scripts に触れない
- [ ] `task lint` exit 0
- [ ] `task test` exit 0
- [ ] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: なし — Web アプリの挙動変更なし）

上記に代えて、本スクリプトを実際に覆うゲートと一時 fixture 方式（issue #310 のスコープどおり）で赤緑を実証した。判定はすべて exit code:

- `task lint-repo` exit 0（actionlint / 本スクリプトの実リポジトリ実行 / pre-pr-gate 回帰テスト PASS=19 FAIL=0）
- 修正前 RED: `skills: # local skills` + 有効ブロックリスト → exit 1（バグ再現を実証）
- 修正後 GREEN: 同 fixture → exit 0
- 回帰 6 ケース（真 inline / 裸名解決 OK・NG / 名前空間 skip / null item / 解釈不能行）: 修正前後で exit code 完全一致
- 追加境界 3 ケース（クォート付き inline `skills: "x"` / コロン後空白のみ / `foo#bar` の空白なし `#`＝名前の一部）: 修正前後で exit code 完全一致
- 実証は implementer の実行に加え、verifier が独立に fixture を再構築して再実行（二重確認）

### 視覚確認（UI 変更時）

なし（CLI スクリプトのみ）。

## 決定ログ

- 修正は既存 `strip_item()` の再利用に限定した。キー行専用の除去ロジックを別途書く案は、ブロック項目側とコメント解釈が割れるリスクがあるため見送り。
- 回帰テストの入库は issue のスコープどおり見送り（一時 fixture 方式で実証）。本スクリプトの修正がさらに続くようなら、`pre-pr-gate.test.sh` と同型の常設テスト化を別 issue で検討する。
- `skills: [x] # c` は `strip_item` で `[x]` に縮んだうえで未対応形式エラーになる — コメント除去が inline 検出を弱めないことを fixture で固定した。

## 備考 / レビュー観点

- PR #309 で修正した同スクリプトの 3 変種（ブロック内コメント/空行・行内コメント・null 項目）の続き。本 PR で codex レビュー指摘 4 件すべてが解消する。
- 現行 `.claude/agents/*.md` にキー行コメント形式は未使用のため、実リポジトリの検証結果は修正前後で不変（実害発生前の予防修正）。
