### PR TITLE
fix(infra): dev compose の backend に UPLOAD_S3_* 既定値を追加し陳腐化した .env でも起動可能にする

### DIFF
--- a/infrastructure/development/docker-compose.yml
+++ b/infrastructure/development/docker-compose.yml
@@ -43,6 +43,11 @@ services:
     container_name: backend
     networks:
       - network
+    environment:
+      UPLOAD_S3_ENDPOINT: ${UPLOAD_S3_ENDPOINT:-http://storage:9000}
+      UPLOAD_S3_BUCKET: ${UPLOAD_S3_BUCKET:-uploads}
+      UPLOAD_S3_ACCESS_KEY: ${UPLOAD_S3_ACCESS_KEY:-minioadmin}
+      UPLOAD_S3_SECRET_KEY: ${UPLOAD_S3_SECRET_KEY:-changeme}
     env_file:
       - .env
     depends_on:

--- a/infrastructure/docker-compose.example.yml
+++ b/infrastructure/docker-compose.example.yml
@@ -43,6 +43,11 @@ services:
     container_name: backend
     networks:
       - network
+    environment:
+      UPLOAD_S3_ENDPOINT: ${UPLOAD_S3_ENDPOINT:-http://storage:9000}
+      UPLOAD_S3_BUCKET: ${UPLOAD_S3_BUCKET:-uploads}
+      UPLOAD_S3_ACCESS_KEY: ${UPLOAD_S3_ACCESS_KEY:-minioadmin}
+      UPLOAD_S3_SECRET_KEY: ${UPLOAD_S3_SECRET_KEY:-changeme}
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
## 概要

storage モジュール（MinIO）導入前にコピーした `infrastructure/development/.env` のまま `task up` すると、`UPLOAD_S3_ENDPOINT` 未設定 → Spring が既定 `http://localhost:9000` にフォールバック → backend unhealthy でスタック全体が起動不能になる。backend サービスに storage サービスと同型の `${VAR:-default}` 既定値を与え、陳腐化した `.env` でも起動できるようにする。

Closes #311

## 変更内容

- `infrastructure/docker-compose.example.yml` / `infrastructure/development/docker-compose.yml` の backend サービスに `environment:` ブロックを追加（各 +5 行、両ファイル完全同一）:
  - `UPLOAD_S3_ENDPOINT: ${UPLOAD_S3_ENDPOINT:-http://storage:9000}`
  - `UPLOAD_S3_BUCKET: ${UPLOAD_S3_BUCKET:-uploads}`
  - `UPLOAD_S3_ACCESS_KEY: ${UPLOAD_S3_ACCESS_KEY:-minioadmin}`
  - `UPLOAD_S3_SECRET_KEY: ${UPLOAD_S3_SECRET_KEY:-changeme}`
- release 用 compose は**意図的に対象外**（issue 記載どおり release は `.env` 整備が前提。かつ release 側は凭証を `:?` 必須化する fail-loud 方向の検討があり、`:-` 既定値の追加はそれと逆行するため）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: なし — 実行には worktree への実 `.env` 配置が必要だが、`.env` はエージェント読み書き禁止のため未実行。挙動検証は下記フィクスチャで代替）

`task lint` / `task test` / `task build` は本ブランチの worktree で実行し、いずれも exit 0（`task lint` には actionlint / agents skills 参照検証 / pre-pr-gate 回帰 19 件を含む `lint-repo` を含む）。

挙動の赤緑実証（スクラッチパッド上のフィクスチャ + `docker compose config` レンダリング検査、実 `.env` は未読未書き。implementer 実行 + verifier 独立再実行の二重確認、判定はすべて exit code）:

- 修正前 RED: 陳腐化 `.env`（`UPLOAD_S3_*` / `MINIO_ROOT_*` 欠落）で backend の実効 environment に `UPLOAD_S3_*` が 4 キーとも不在
- 修正後 GREEN #1（陳腐化 `.env`）: 4 キーとも既定値（`http://storage:9000` / `uploads` / `minioadmin` / `changeme`）
- 修正後 GREEN #2（完全な `.env` + 既定値と異なる distinct 値）: 4 キーとも明示値が反映（既定値が明示設定を上書きしない）
- 修正後 GREEN #3（部分陳腐化: `UPLOAD_S3_BUCKET=custom-bucket` のみ設定）: BUCKET は明示値、他 3 キーは既定値（混在解決）
- `docker-compose.example.yml` 側も同一フィクスチャで同一結果、`git diff master -- infrastructure/release/` は空（release 無変更）

### 視覚確認（UI 変更時）

なし（インフラ設定のみ）。

## 決定ログ

- **`${VAR:-default}` 形式**（GitGuardian 規約）。插值はプロジェクトディレクトリ `.env` + shell 環境から解決されるため、`.env` に値があればそれが勝ち、無ければ既定値が入る。`environment:` は `env_file:` より優先されるが、插值経由で同値になるため整備済み `.env` の挙動は不変（フィクスチャ #2 で実証）。
- **ENDPOINT だけでなく 4 キーを揃えた**: application.yml の既定と storage サービスの既定は元々一致しており致命なのは ENDPOINT のみだが、backend が消費する S3 変数の契約を compose 上で可視化し、「`environment:` 插值は shell 環境も読む（`env_file:` は読まない）」という既知トラップの解消も backend に及ぶため。
- **実スタック起動での再現は run 内では実施しない**: 陳腐化 `.env` の実配置が必要だが `.env` はエージェント書換禁止。環境変数がコンテナに渡れば Spring が `storage:9000` を使う因果は #279 run で実測済みの事実を根拠とし、compose レンダリング層の赤緑で固定した。

## 備考 / レビュー観点

- マージ後、storage 導入前の `.env` のままの開発環境でも次の `task up` がそのまま通るようになる（`.env` の補完はもはや必須でない。ただし `.env.example` への追随は引き続き推奨）。
- インデント・記法は同ファイル内 storage サービスの `MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}` と同型。
