### PR TITLE
chore(dev): dev-loop の worktree 起手から .env コピーを撤去しスタック要 run はユーザー配置に切替

### DIFF
--- a/.claude/agents/kizuna-implementer.md
+++ b/.claude/agents/kizuna-implementer.md
@@ -9,7 +9,7 @@ skills:
 
 You are the implementer in Kizuna's dev-loop (plan → **code** → QA → PR → CI watch; loop spec: `.claude/skills/dev-loop/SKILL.md`). You are a senior engineer executing a plan that was already argued over and settled: disciplined, literal about scope, suspicious of your own cleverness. Your judgement goes into HOW each task is coded — never into WHAT ships. You never push, never merge, and never leave the worktree you were given.
 
-Your prompt gives an **absolute worktree path** and an **absolute plan path**. Before the first change, verify `pwd` is the worktree and `git rev-parse --abbrev-ref HEAD` is the plan's branch (the orchestrator created it; `.env` is in place). Never touch the main checkout.
+Your prompt gives an **absolute worktree path** and an **absolute plan path**. Before the first change, verify `pwd` is the worktree and `git rev-parse --abbrev-ref HEAD` is the plan's branch (the orchestrator created it; `.env` is present only when the run needs the stack — it is deny-ruled for agents, so the user places it). Never touch the main checkout.
 
 ## Workflow
 

--- a/.claude/skills/dev-loop/SKILL.md
+++ b/.claude/skills/dev-loop/SKILL.md
@@ -42,10 +42,11 @@ From the main checkout:
 
 ```bash
 git worktree add .worktrees/<branch> -b <branch> master
-cp infrastructure/development/.env .worktrees/<branch>/infrastructure/development/.env
 ```
 
 The worktree lives in `.worktrees/` inside the main checkout (git-ignored, so the main checkout stays clean); pass its **absolute** path to the subagent.
+
+**`.env` is deny-ruled for agents (read AND write — even `cp` is blocked), so the orchestrator never copies it.** Only when the plan needs the stack (`task e2e` / `task up`): ask the user, right after creating the worktree, to run `! cp infrastructure/development/.env .worktrees/<branch>/infrastructure/development/.env` themselves — compose's `env_file: .env` hard-requires the file, so without it the stack cannot start. Runs with no stack need skip this entirely.
 
 Spawn `kizuna-implementer` with the **absolute worktree path**, the **absolute plan path**, and — running it on each task's assigned **実行モデル** (Agent tool `model` override) — the exact `Co-Authored-By:` trailer for that model. Consecutive same-model tasks may share one spawn; a model change starts a fresh spawn, which reads the accumulated commits + plan as its context. Done when every task is one commit, with each gate's exit code and any deviations reported.
 


### PR DESCRIPTION
## 概要

#310 / #311 の dev-loop run の retro 吸収項。dev-loop skill の worktree 起手式にある `cp infrastructure/development/.env` は、`.env` の deny 規則（読み書きとも禁止 — `cp` も読取としてブロックされる）と矛盾しており、両 run で実際に拒否された。スタックが必要な run のみユーザーに `cp` を依頼する方式へ記述を改める。

Refs #310

## 変更内容

- `.claude/skills/dev-loop/SKILL.md`: Stage 3 の起手コードブロックから `cp .env` 行を削除し、「`.env` はエージェント deny 対象。スタック要 run（`task e2e` / `task up`）のみ、worktree 作成直後にユーザーへ `!` プレフィックスでの `cp` 実行を依頼する（compose の `env_file: .env` はファイル必須のため、無いとスタックは起動不能）」を明記
- `.claude/agents/kizuna-implementer.md`: 冒頭検証の括注「`.env` is in place」を「スタック要 run のときのみユーザーが配置する」に修正（現実との整合）

## 検証

- 対象外（コード変更なし）: 変更は `.claude/` 配下の AI 規訓ドキュメント 2 ファイルのみ
- [ ] `task lint` exit 0
- [ ] `task test` exit 0
- [ ] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: なし）
- `task lint-repo` exit 0（actionlint / agents skills 参照検証 / pre-pr-gate 回帰 19 件 — kizuna-implementer.md の frontmatter 変更なしのため skills 参照は不変）

## 決定ログ

- 「Taskfile に .env 配置タスクを足す」案は見送り: task 経由でも実体はエージェント発の `.env` 読取であり、deny の意図（エージェントのコンテキストに `.env` の値を載せない）を迂回することになるため。ユーザー自身の `!` 実行が意図に最も忠実。
- implementer の「主検出を触らない・pwd/branch を先に確認する」規定（12 行目）は既存のまま — #311 run で一度違反されたが同じ規定の自己点検で自愈しており、規則追加ではなく括注の事実修正のみ行った。

## 備考 / レビュー観点

- #310（PR #314）/ #311（PR #315）の run 中、この `cp` が deny されたのが発端（両 run はスタック不要だったため実害なし）。次にスタックが必要になるのは #277 run（e2e あり）で、本修正の最初の消費者になる。
