### PR TITLE
feat(auth): プラットフォーム身分基盤（expand）— 統一ログイン API とロール×店舗集合授権を新設

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,10 @@ _Avoid_: Branch
 店舗の従業員アカウント。email でログインし、データはテナント単位で分離される。
 _Avoid_: TenantUser（旧名）
 
+**PlatformUser（プラットフォームユーザー）**:
+プラットフォーム共通アカウントとしての「プラットフォーム身分」。email でログインし、授権は「ロール×店舗集合」（店舗集合は「全店舗」「個別店舗」の 2 種のみ）で表す。プラットフォーム化転換（#320/#321）の expand 段階では CentralUser / StoreUser と並存し、旧二本立ての撤去は contract チケットで行う。
+_Avoid_: PlatformAccount、「テナントユーザー」系の呼称
+
 **AuthSession（認証セッション）**:
 発行済みの 1 枚の JWT が表す認証状態。ログアウトとパスワード変更はいずれも唯一の無効化経路（token ブラックリスト）を通じて現在のセッションを失効させる。
 _Avoid_: Token の裸使用（token は担体、session は概念）
@@ -37,6 +41,10 @@ _Avoid_: Token の裸使用（token は担体、session は概念）
 
 **Customer（顧客）**:
 店舗の顧客。CRM の管理対象。単一の店舗に帰属する。
+
+**Member（会員）**:
+プラットフォーム層の会員身分。Customer（店舗 CRM 台帳・店舗層）とは別概念であり、Member は複数店舗の Customer 台帳と紐づき得る。非会員の顧客は存在し続ける（Customer だけがあり Member がない状態）。集約の実装は後続チケット（本項は用語の予約）。
+_Avoid_: Member と Customer の混用、「会員」を店舗台帳の意味で使うこと
 
 **Order（注文）**:
 顧客の店舗における 1 回の予約／受注記録。Customer、Cast、および接客担当（StoreUser）に紐づく。

--- a/backend/src/integrationTest/java/com/kizuna/auth/PlatformAuthIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/auth/PlatformAuthIT.java
@@ -1,0 +1,210 @@
+package com.kizuna.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.kizuna.user.domain.PlatformRole;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import com.kizuna.user.domain.StoreScopeType;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * 統一（プラットフォーム）認証境界の統合テスト（#322）。本物の PostgreSQL/Redis に対して検証する。
+ *
+ * <p>様式は {@link InitAdminUserCsrfIT}（完全匿名 POST による CSRF 免除の固定）と {@link
+ * com.kizuna.menu.MenuCrossTenantIT}（リポジトリ直挿 + 実データ断言）に倣う。プラットフォームトークンと 既存 central/tenant
+ * トークンの相互拒否、および三軌の共存を HTTP 境界で固定する。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PlatformAuthIT {
+
+  private static final String SEED_EMAIL = "admin@kizuna.test";
+  private static final String SEED_PASSWORD = "pass";
+  private static final String SEED_DISPLAY_NAME = "HQ管理者";
+
+  private static final String SPECIFIC_EMAIL = "manager@kizuna.test";
+  private static final String SPECIFIC_PASSWORD = "pass";
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private PlatformUserRepository platformUserRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  private static HttpHeaders jsonHeaders() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+
+  private ResponseEntity<JsonNode> platformLogin(String email, String password) {
+    return rest.postForEntity(
+        "/platform/login",
+        new HttpEntity<>(
+            String.format("{\"email\": \"%s\", \"password\": \"%s\"}", email, password),
+            jsonHeaders()),
+        JsonNode.class);
+  }
+
+  private String platformToken(String email, String password) {
+    ResponseEntity<JsonNode> res = platformLogin(email, password);
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    String token = res.getBody().path("token").asText();
+    assertThat(token).isNotBlank();
+    return token;
+  }
+
+  private String centralToken() {
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/central/login",
+            new HttpEntity<>("{\"username\": \"admin\", \"password\": \"pass\"}", jsonHeaders()),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    return res.getBody().path("token").asText();
+  }
+
+  private ResponseEntity<JsonNode> getPlatformMe(String token) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(token);
+    return rest.exchange("/platform/me", HttpMethod.GET, new HttpEntity<>(headers), JsonNode.class);
+  }
+
+  @Test
+  @DisplayName("匿名 POST /platform/login がシード資格情報で 200 + 非空トークンを返す（CSRF 免除 + シード投入の同時証明）")
+  void anonymousLoginWithSeedCredentialsSucceeds() {
+    ResponseEntity<JsonNode> res = platformLogin(SEED_EMAIL, SEED_PASSWORD);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(res.getBody().path("token").asText()).isNotBlank();
+  }
+
+  @Test
+  @DisplayName("誤パスワードは 401（403 でないこと = CSRF 免除の回帰ガード）")
+  void wrongPasswordReturns401NotForbidden() {
+    ResponseEntity<JsonNode> res = platformLogin(SEED_EMAIL, "wrong-password");
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  @DisplayName("GET /platform/me がシード HQ 管理者のロール・店舗集合を返す（ALL_STORES は store_ids 空）")
+  void meReturnsSeedHqAdminRoleAndScope() {
+    ResponseEntity<JsonNode> res = getPlatformMe(platformToken(SEED_EMAIL, SEED_PASSWORD));
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    JsonNode body = res.getBody();
+    assertThat(body.path("email").asText()).isEqualTo(SEED_EMAIL);
+    assertThat(body.path("display_name").asText()).isEqualTo(SEED_DISPLAY_NAME);
+    assertThat(body.path("role").asText()).isEqualTo("HQ_ADMIN");
+    assertThat(body.path("store_scope_type").asText()).isEqualTo("ALL_STORES");
+    assertThat(body.path("store_ids")).isEmpty();
+  }
+
+  @Test
+  @DisplayName("SPECIFIC_STORES ユーザーはログイン後 me が store_ids=[1] を返す（リポジトリ直挿の実データ断言）")
+  void specificStoresUserSeesOwnStoreIds() {
+    platformUserRepository
+        .findByEmail(SPECIFIC_EMAIL)
+        .orElseGet(
+            () ->
+                platformUserRepository.save(
+                    PlatformUser.builder()
+                        .email(SPECIFIC_EMAIL)
+                        .password(passwordEncoder.encode(SPECIFIC_PASSWORD))
+                        .displayName("個別店舗担当")
+                        .enabled(true)
+                        .role(PlatformRole.STORE_MANAGER)
+                        .storeScopeType(StoreScopeType.SPECIFIC_STORES)
+                        .storeIds(Set.of(1L))
+                        .build()));
+
+    ResponseEntity<JsonNode> res = getPlatformMe(platformToken(SPECIFIC_EMAIL, SPECIFIC_PASSWORD));
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    JsonNode body = res.getBody();
+    assertThat(body.path("store_scope_type").asText()).isEqualTo("SPECIFIC_STORES");
+    assertThat(body.path("store_ids").isArray()).isTrue();
+    assertThat(body.path("store_ids").size()).isEqualTo(1);
+    assertThat(body.path("store_ids").get(0).asLong()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("既存 central / tenant ログインが無変更で 200 を返す（三軌の共存）")
+  void existingCentralAndTenantLoginStillWork() {
+    ResponseEntity<JsonNode> central =
+        rest.postForEntity(
+            "/central/login",
+            new HttpEntity<>("{\"username\": \"admin\", \"password\": \"pass\"}", jsonHeaders()),
+            JsonNode.class);
+    assertThat(central.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(central.getBody().path("token").asText()).isNotBlank();
+
+    HttpHeaders tenantHeaders = jsonHeaders();
+    tenantHeaders.set("X-Role", "tenant");
+    tenantHeaders.set("X-Tenant-ID", "1");
+    ResponseEntity<JsonNode> tenant =
+        rest.postForEntity(
+            "/tenant/login",
+            new HttpEntity<>(
+                "{\"username\": \"admin@store1.kizuna.com\", \"password\": \"pass\"}",
+                tenantHeaders),
+            JsonNode.class);
+    assertThat(tenant.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(tenant.getBody().path("token").asText()).isNotBlank();
+  }
+
+  @Test
+  @DisplayName("central トークンで /platform/me は 403（issuer 相互拒否）")
+  void centralTokenRejectedOnPlatformMe() {
+    ResponseEntity<String> res =
+        rest.exchange(
+            "/platform/me", HttpMethod.GET, new HttpEntity<>(bearer(centralToken())), String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("platform トークンで /central/me は 403（issuer 相互拒否）")
+  void platformTokenRejectedOnCentralMe() {
+    ResponseEntity<String> res =
+        rest.exchange(
+            "/central/me",
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(platformToken(SEED_EMAIL, SEED_PASSWORD))),
+            String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("platform トークンで tenant 系 GET は 403（issuer 相互拒否）")
+  void platformTokenRejectedOnTenantEndpoint() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(platformToken(SEED_EMAIL, SEED_PASSWORD));
+    headers.set("X-Role", "tenant");
+    headers.set("X-Tenant-ID", "1");
+
+    ResponseEntity<String> res =
+        rest.exchange("/tenant/menus/me", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  private static HttpHeaders bearer(String token) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(token);
+    return headers;
+  }
+}

--- a/backend/src/integrationTest/java/com/kizuna/storage/FileUploadCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/storage/FileUploadCrossTenantIT.java
@@ -26,6 +26,10 @@ import org.springframework.util.MultiValueMap;
  * のヘッダ兜底に落ち、指定テナントの prefix にファイルが保存されていた。本テストは詐称ヘッダ付きが 403 で拒否されること（負向）と、 詐称ヘッダ無しの央端アップロードが従来どおり
  * central 領域へ 200 で保存されること（正向対照）を固定する。
  *
+ * <p>あわせてプラットフォーム発行（PlatformAuth）トークンによる同エンドポイントの中央領域アップロードが 403 で拒否されること（#322）も固定する。 PlatformAuth
+ * も {@code tenantId} claim を持たず {@code @TenantOptional} の許可経路に乗るため、低権限のプラットフォーム身分が
+ * 中央共有領域へ書き込めないことを保証する。
+ *
  * <p>中央ログイン前提のため {@link com.kizuna.shared.CrossTenantTestSupport}（tenant ログイン）は継承せず、中央ログインを自前で行う。
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -42,6 +46,20 @@ class FileUploadCrossTenantIT {
             new HttpEntity<>("{\"username\": \"admin\", \"password\": \"pass\"}", headers),
             JsonNode.class);
     assertThat(res.getStatusCode()).as("前提: 中央 admin でのログインが成功すること").isEqualTo(HttpStatus.OK);
+    String token = res.getBody().path("token").asText();
+    assertThat(token).isNotBlank();
+    return token;
+  }
+
+  private String platformLogin() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/platform/login",
+            new HttpEntity<>("{\"email\": \"admin@kizuna.test\", \"password\": \"pass\"}", headers),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).as("前提: プラットフォーム HQ 管理者でのログインが成功すること").isEqualTo(HttpStatus.OK);
     String token = res.getBody().path("token").asText();
     assertThat(token).isNotBlank();
     return token;
@@ -71,6 +89,18 @@ class FileUploadCrossTenantIT {
     headers.setBearerAuth(centralLogin());
     headers.set("X-Role", "tenant");
     headers.set("X-Tenant-ID", "1");
+
+    ResponseEntity<String> res =
+        rest.exchange("/files/upload", HttpMethod.POST, uploadRequest(headers), String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("プラットフォームトークンの /files/upload は 403 で拒否され中央領域に保存されないこと（#322）")
+  void platformTokenUploadIsForbidden() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(platformLogin());
 
     ResponseEntity<String> res =
         rest.exchange("/files/upload", HttpMethod.POST, uploadRequest(headers), String.class);

--- a/backend/src/integrationTest/java/com/kizuna/tenant/SeedSequenceAlignmentIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/tenant/SeedSequenceAlignmentIT.java
@@ -29,14 +29,15 @@ import org.springframework.jdbc.core.JdbcTemplate;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class SeedSequenceAlignmentIT {
 
-  /** 明示 id を播種している autoIncrement 5 表（issue #237 の setval 対象）。 */
+  /** 明示 id を播種している autoIncrement 表（issue #237 の setval 対象、#322 で platform_users を追加）。 */
   private static final List<String> SEEDED_IDENTITY_TABLES =
       List.of(
           "central_users",
           "central_roles",
           "central_permissions",
           "central_tenants",
-          "central_menus");
+          "central_menus",
+          "platform_users");
 
   @Autowired private TestRestTemplate rest;
   @Autowired private JdbcTemplate jdbcTemplate;
@@ -77,7 +78,7 @@ class SeedSequenceAlignmentIT {
   }
 
   @Test
-  @DisplayName("明示 id 播種の autoIncrement 5 表のシーケンスが全て MAX(id) を上回ること")
+  @DisplayName("明示 id 播種の autoIncrement 6 表のシーケンスが全て MAX(id) を上回ること")
   void seededIdentitySequencesAreAligned() {
     for (String table : SEEDED_IDENTITY_TABLES) {
       // 使い捨て DB なので nextval の消費は無害。nextval > MAX(id) は実行順に依存しない述語。

--- a/backend/src/integrationTest/java/com/kizuna/tenant/TenantDeletionCascadeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/tenant/TenantDeletionCascadeIT.java
@@ -1,0 +1,113 @@
+package com.kizuna.tenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.kizuna.tenant.domain.Tenant;
+import com.kizuna.tenant.domain.TenantRepository;
+import com.kizuna.user.domain.PlatformRole;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import com.kizuna.user.domain.StoreScopeType;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * テナント削除が platform_user_stores（プラットフォームユーザーの店舗授権集合）まで ON DELETE CASCADE で従うことを 本物の PostgreSQL
+ * で検証する統合テスト（#322）。
+ *
+ * <p>テナント削除は既存の全テナント参照 FK が CASCADE で従う確立済みセマンティクスであり、店舗授権行も店舗と共に消えるのが整合的。 修正前は
+ * platform_user_stores→central_tenants の FK が既定の NO ACTION だったため、SPECIFIC_STORES ユーザーが
+ * 授権している店舗を削除すると FK 違反でテナント削除自体が失敗していた（本 IT はその退行のガード）。
+ *
+ * <p>様式は {@link SeedSequenceAlignmentIT}（中央ログイン + JdbcTemplate による実 DB 断言）に倣う。使い捨て tmpfs DB のためシード
+ * tenant 1 は決して削除せず、第二テナントを直挿して検証する。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class TenantDeletionCascadeIT {
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private JdbcTemplate jdbcTemplate;
+  @Autowired private TenantRepository tenantRepository;
+  @Autowired private PlatformUserRepository platformUserRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  private String centralLogin() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/central/login",
+            new HttpEntity<>("{\"username\": \"admin\", \"password\": \"pass\"}", headers),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).as("前提: 中央 admin でのログインが成功すること").isEqualTo(HttpStatus.OK);
+    String token = res.getBody().path("token").asText();
+    assertThat(token).isNotBlank();
+    return token;
+  }
+
+  @Test
+  @DisplayName("テナント削除で SPECIFIC_STORES ユーザーの店舗授権行が CASCADE 消去され、ユーザー本体は残ること")
+  void deletingTenantCascadesStoreGrantButKeepsPlatformUser() {
+    // 第二テナントを直挿（シード tenant 1 は他 IT が依存するため決して削除しない）。
+    Tenant tenant =
+        tenantRepository.save(
+            new Tenant(
+                "削除カスケード検証テナント", "tenant-delete-it-" + UUID.randomUUID() + ".kizuna.test", null));
+    long storeId = tenant.getId();
+
+    // その店舗のみを授権集合に持つ SPECIFIC_STORES ユーザーを直挿（ログインは行わないため password はエンコード済みダミー）。
+    PlatformUser user =
+        platformUserRepository.save(
+            PlatformUser.builder()
+                .email("cascade-it-" + UUID.randomUUID() + "@kizuna.test")
+                .password(passwordEncoder.encode("pass"))
+                .displayName("店舗授権カスケード検証")
+                .enabled(true)
+                .role(PlatformRole.STORE_MANAGER)
+                .storeScopeType(StoreScopeType.SPECIFIC_STORES)
+                .storeIds(Set.of(storeId))
+                .build());
+    long userId = user.getId();
+
+    // 前提: 削除前は授権行が 1 件存在する（空振りで緑にならないことを固定）。
+    assertThat(countStoreGrants(storeId)).as("削除前は店舗授権行が存在すること").isEqualTo(1L);
+
+    // 実削除フロー: 中央 admin トークンで DELETE /central/tenant/{id}。
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(centralLogin());
+    ResponseEntity<Void> res =
+        rest.exchange(
+            "/central/tenant/" + storeId, HttpMethod.DELETE, new HttpEntity<>(headers), Void.class);
+
+    // FK が ON DELETE CASCADE でなければテナント削除は FK 違反で失敗する（本修正前の退行）。
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    // 店舗授権行は店舗と共に消える。
+    assertThat(countStoreGrants(storeId)).as("削除後は店舗授権行が CASCADE 消去されること").isZero();
+    // ユーザー本体は残る（授権集合が空になるだけ = authorizes() 全 false の fail-closed）。
+    assertThat(countPlatformUser(userId)).as("プラットフォームユーザー本体は残存すること").isEqualTo(1L);
+  }
+
+  private long countStoreGrants(long storeId) {
+    return jdbcTemplate.queryForObject(
+        "SELECT count(*) FROM platform_user_stores WHERE store_id = ?", Long.class, storeId);
+  }
+
+  private long countPlatformUser(long userId) {
+    return jdbcTemplate.queryForObject(
+        "SELECT count(*) FROM platform_users WHERE id = ?", Long.class, userId);
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/api/dto/PlatformLoginRequest.java
+++ b/backend/src/main/java/com/kizuna/auth/api/dto/PlatformLoginRequest.java
@@ -1,0 +1,20 @@
+package com.kizuna.auth.api.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PlatformLoginRequest {
+
+  @NotBlank(message = "email is required")
+  @Email(message = "email format is invalid")
+  private String email;
+
+  @NotBlank(message = "password is required")
+  private String password;
+}

--- a/backend/src/main/java/com/kizuna/auth/api/dto/PlatformMeResponse.java
+++ b/backend/src/main/java/com/kizuna/auth/api/dto/PlatformMeResponse.java
@@ -1,0 +1,10 @@
+package com.kizuna.auth.api.dto;
+
+import java.util.List;
+
+/**
+ * GET /platform/me の応答。JSON キーは Jackson 設定により snake_case（display_name / store_scope_type /
+ * store_ids）。
+ */
+public record PlatformMeResponse(
+    String email, String displayName, String role, String storeScopeType, List<Long> storeIds) {}

--- a/backend/src/main/java/com/kizuna/auth/api/platform/PlatformAuthController.java
+++ b/backend/src/main/java/com/kizuna/auth/api/platform/PlatformAuthController.java
@@ -1,0 +1,52 @@
+package com.kizuna.auth.api.platform;
+
+import com.kizuna.auth.api.dto.PlatformLoginRequest;
+import com.kizuna.auth.api.dto.PlatformMeResponse;
+import com.kizuna.auth.api.dto.Token;
+import com.kizuna.auth.application.PlatformAuthService;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import jakarta.annotation.security.PermitAll;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 統一（プラットフォーム）認証のコントローラ。 */
+@RestController
+@RequestMapping("/platform")
+@RequiredArgsConstructor
+public class PlatformAuthController {
+
+  private final PlatformAuthService authService;
+  private final PlatformUserRepository userRepository;
+
+  @PostMapping("/login")
+  @PermitAll
+  public ResponseEntity<Token> login(@Valid @RequestBody PlatformLoginRequest req) {
+    return ResponseEntity.ok(authService.login(req.getEmail(), req.getPassword()));
+  }
+
+  @GetMapping("/me")
+  @PreAuthorize("isAuthenticated()")
+  public ResponseEntity<PlatformMeResponse> me(Principal principal) {
+    if (principal == null || principal.getName() == null) {
+      return ResponseEntity.status(401).build();
+    }
+    PlatformUser user = userRepository.findByEmail(principal.getName()).orElse(null);
+    if (user == null) return ResponseEntity.status(404).build();
+    return ResponseEntity.ok(
+        new PlatformMeResponse(
+            user.getEmail(),
+            user.getDisplayName(),
+            user.getRole().name(),
+            user.getStoreScopeType().name(),
+            user.getStoreIds().stream().sorted().toList()));
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/application/PlatformAuthService.java
+++ b/backend/src/main/java/com/kizuna/auth/application/PlatformAuthService.java
@@ -1,0 +1,54 @@
+package com.kizuna.auth.application;
+
+import com.kizuna.auth.api.dto.Token;
+import com.kizuna.auth.infrastructure.JwtUtil;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 統一（プラットフォーム）ログイン。既存の central/tenant 二軌のコードパスに触れないため AuthenticationManager を経由せず、findByEmail +
+ * パスワード照合 + enabled 判定を自前で行う。 メール不存在・パスワード不一致は同一メッセージの {@link
+ * BadCredentialsException}（ユーザー列挙防止）、無効化ユーザーは {@link DisabledException}。いずれも {@code
+ * AuthenticationException} 系のため 401 で応答される。
+ */
+@Service
+@RequiredArgsConstructor
+public class PlatformAuthService {
+
+  private static final String INVALID_CREDENTIALS_MESSAGE = "メールアドレスまたはパスワードが正しくありません";
+
+  private final PlatformUserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final JwtUtil jwtUtil;
+
+  @Transactional(readOnly = true)
+  public Token login(String email, String password) {
+    PlatformUser user =
+        userRepository
+            .findByEmail(email)
+            .orElseThrow(() -> new BadCredentialsException(INVALID_CREDENTIALS_MESSAGE));
+    if (!passwordEncoder.matches(password, user.getPassword())) {
+      throw new BadCredentialsException(INVALID_CREDENTIALS_MESSAGE);
+    }
+    if (!user.getEnabled()) {
+      throw new DisabledException("アカウントが無効化されています");
+    }
+
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("authorities", List.of("ROLE_" + user.getRole().name()));
+    claims.put("role", user.getRole().name());
+    claims.put("storeScopeType", user.getStoreScopeType().name());
+    claims.put("storeIds", new ArrayList<>(user.getStoreIds()));
+    return jwtUtil.generateToken(user.getEmail(), JwtUtil.ISSUER_PLATFORM, claims);
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/application/PlatformAuthService.java
+++ b/backend/src/main/java/com/kizuna/auth/application/PlatformAuthService.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -17,12 +16,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 統一（プラットフォーム）ログイン。既存の central/tenant 二軌のコードパスに触れないため AuthenticationManager を経由せず、findByEmail +
- * パスワード照合 + enabled 判定を自前で行う。 メール不存在・パスワード不一致は同一メッセージの {@link
- * BadCredentialsException}（ユーザー列挙防止）、無効化ユーザーは {@link DisabledException}。いずれも {@code
+ * enabled 判定 + パスワード照合を自前で行う。判定順は DaoAuthenticationProvider に倣い enabled を先行させ、無効化ユーザーはパスワードの正誤に関わらず
+ * {@link DisabledException} を投げる（無効化アカウントでのパスワード正誤オラクルを塞ぐ）。 メール不存在時は既知メール（誤パスワード）との応答時間差を無くすため、ダミーの
+ * bcrypt 照合を 1 回行ってからパスワード不一致と同一メッセージの {@link BadCredentialsException} を投げる（列挙耐性: メッセージ均一 +
+ * タイミング均一。 DaoAuthenticationProvider.mitigateAgainstTimingAttack と同趣旨）。いずれの例外も {@code
  * AuthenticationException} 系のため 401 で応答される。
  */
 @Service
-@RequiredArgsConstructor
 public class PlatformAuthService {
 
   private static final String INVALID_CREDENTIALS_MESSAGE = "メールアドレスまたはパスワードが正しくありません";
@@ -31,17 +31,30 @@ public class PlatformAuthService {
   private final PasswordEncoder passwordEncoder;
   private final JwtUtil jwtUtil;
 
+  /** メール不存在時のタイミング均一化に用いるダミー bcrypt ハッシュ（秘密値ではない固定文字列を構築時に符号化）。 */
+  private final String userNotFoundEncodedPassword;
+
+  public PlatformAuthService(
+      PlatformUserRepository userRepository, PasswordEncoder passwordEncoder, JwtUtil jwtUtil) {
+    this.userRepository = userRepository;
+    this.passwordEncoder = passwordEncoder;
+    this.jwtUtil = jwtUtil;
+    this.userNotFoundEncodedPassword = passwordEncoder.encode("userNotFoundPassword");
+  }
+
   @Transactional(readOnly = true)
   public Token login(String email, String password) {
-    PlatformUser user =
-        userRepository
-            .findByEmail(email)
-            .orElseThrow(() -> new BadCredentialsException(INVALID_CREDENTIALS_MESSAGE));
-    if (!passwordEncoder.matches(password, user.getPassword())) {
+    PlatformUser user = userRepository.findByEmail(email).orElse(null);
+    if (user == null) {
+      // メール不存在でも既知メール（誤パスワード）と同等の時間を要するようダミー照合を実行する。
+      passwordEncoder.matches(password, userNotFoundEncodedPassword);
       throw new BadCredentialsException(INVALID_CREDENTIALS_MESSAGE);
     }
     if (!user.getEnabled()) {
       throw new DisabledException("アカウントが無効化されています");
+    }
+    if (!passwordEncoder.matches(password, user.getPassword())) {
+      throw new BadCredentialsException(INVALID_CREDENTIALS_MESSAGE);
     }
 
     Map<String, Object> claims = new HashMap<>();

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/JwtAuthenticationFilter.java
@@ -82,6 +82,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     if (path.equals("/tenant") || path.startsWith("/tenant/")) {
       return JwtUtil.ISSUER_TENANT.equals(issuer);
     }
+    if (path.equals("/platform") || path.startsWith("/platform/")) {
+      return JwtUtil.ISSUER_PLATFORM.equals(issuer);
+    }
     return true;
   }
 }

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/JwtUtil.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/JwtUtil.java
@@ -23,6 +23,9 @@ public class JwtUtil {
   /** テナントドメインのトークン発行者 */
   public static final String ISSUER_TENANT = "TenantAuth";
 
+  /** プラットフォームドメインのトークン発行者 */
+  public static final String ISSUER_PLATFORM = "PlatformAuth";
+
   private final AppProperties appProperties;
 
   public Token generateToken(

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/SecurityConfig.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
   private static final RequestMatcher[] CSRF_IGNORED_MATCHERS = {
     PathPatternRequestMatcher.withDefaults().matcher("/central/login"),
     PathPatternRequestMatcher.withDefaults().matcher("/tenant/login"),
+    PathPatternRequestMatcher.withDefaults().matcher("/platform/login"),
     PathPatternRequestMatcher.withDefaults().matcher(AuthPaths.INIT_ADMIN_USER_PATH),
     PathPatternRequestMatcher.withDefaults().matcher("/files/upload"),
     request -> {

--- a/backend/src/main/java/com/kizuna/storage/api/store/FileUploadController.java
+++ b/backend/src/main/java/com/kizuna/storage/api/store/FileUploadController.java
@@ -23,9 +23,10 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class FileUploadController {
 
-  // JwtUtil.ISSUER_TENANT と一致させること。storage → auth.infrastructure は Modulith 上不可視のため
-  // 定数を直接参照せずローカルに複製している（発行者名はトークンの署名対象で実質不変）。
+  // JwtUtil.ISSUER_TENANT / ISSUER_PLATFORM と一致させること。storage → auth.infrastructure は Modulith 上
+  // 不可視のため定数を直接参照せずローカルに複製している（発行者名はトークンの署名対象で実質不変）。
   private static final String TENANT_ISSUER = "TenantAuth";
+  private static final String PLATFORM_ISSUER = "PlatformAuth";
 
   private final FileStorageService fileStorageService;
   private final TenantContext tenantContext;
@@ -53,24 +54,30 @@ public class FileUploadController {
   /**
    * 保存先プレフィクスを決める。テナント文脈があればそのテナント配下、無ければ中央領域（central）へ保存する。
    *
-   * <p>ただしテナント発行（TenantAuth）のトークンでテナント文脈を解決できない場合は、テナントの資産を中央共有領域へ誤って 保存しないよう 403 で拒否する。tenantId
-   * claim を持たないレガシートークンが {@code @TenantOptional} の許可経路に乗って 中央プレフィクスに落ちるのを防ぐ（#287 の fail-closed
-   * をこのエンドポイントにも適用）。中央発行（CentralAuth）は テナント文脈を持たないのが正当なため従来どおり central へ保存する。
+   * <p>ただしテナント発行（TenantAuth）のトークンでテナント文脈を解決できない場合、およびプラットフォーム発行（PlatformAuth）の トークンの場合は 403
+   * で拒否する。いずれも {@code tenantId} claim を持たず {@code @TenantOptional} の許可経路に乗るため、
+   * テナント／プラットフォームの資産を中央共有領域へ誤って 保存しないよう fail-closed で弾く（#287 / #322）。中央発行（CentralAuth）は
+   * テナント文脈を持たないのが正当なため従来どおり central へ保存する。
    */
   private String resolveStoragePrefix() {
     if (tenantContext.isTenant()) {
       return String.valueOf(tenantContext.getTenantId());
     }
-    if (isTenantIssuedToken()) {
+    String issuer = tokenIssuer();
+    if (TENANT_ISSUER.equals(issuer)) {
       throw new AccessDeniedException("テナント文脈を解決できないため、アップロードを拒否しました");
+    }
+    if (PLATFORM_ISSUER.equals(issuer)) {
+      throw new AccessDeniedException("プラットフォームトークンでは中央領域へのアップロードを許可していません");
     }
     return "central";
   }
 
-  private boolean isTenantIssuedToken() {
+  private String tokenIssuer() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    return authentication != null
-        && authentication.getDetails() instanceof Claims claims
-        && TENANT_ISSUER.equals(claims.getIssuer());
+    if (authentication != null && authentication.getDetails() instanceof Claims claims) {
+      return claims.getIssuer();
+    }
+    return null;
   }
 }

--- a/backend/src/main/java/com/kizuna/user/domain/InvalidStoreScopeException.java
+++ b/backend/src/main/java/com/kizuna/user/domain/InvalidStoreScopeException.java
@@ -1,0 +1,11 @@
+package com.kizuna.user.domain;
+
+import com.kizuna.shared.exception.ServiceException;
+
+/** 店舗集合の不変条件（種別と店舗集合の整合）に違反したことを表すドメイン例外。ServiceException 継承により HTTP 400 で応答される。 */
+public class InvalidStoreScopeException extends ServiceException {
+
+  public InvalidStoreScopeException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/com/kizuna/user/domain/PlatformRole.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PlatformRole.java
@@ -1,0 +1,10 @@
+package com.kizuna.user.domain;
+
+/** プラットフォームユーザーのロール。授権は「ロール×店舗集合」で表す（1 ユーザー = 1 ロール）。 エリアマネージャ等の追加値は後続チケットで拡張する（#320/#321）。 */
+public enum PlatformRole {
+  HQ_ADMIN,
+  STORE_MANAGER,
+  STORE_STAFF,
+  CAST,
+  MEMBER
+}

--- a/backend/src/main/java/com/kizuna/user/domain/PlatformUser.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PlatformUser.java
@@ -1,0 +1,87 @@
+package com.kizuna.user.domain;
+
+import com.kizuna.shared.persistence.BaseEntity;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * プラットフォーム共通ユーザー集約。email でログインし、授権は「ロール×店舗集合」で表す（1 ユーザー = 1 ロール + 1 店舗集合）。
+ *
+ * <p>店舗集合の不変条件は構築時に検証する: {@code SPECIFIC_STORES} は店舗集合が非空、{@code ALL_STORES} は店舗集合が空。 違反は {@link
+ * InvalidStoreScopeException}。
+ */
+@Entity
+@Table(name = "platform_users")
+@Getter
+@NoArgsConstructor
+public class PlatformUser extends BaseEntity {
+
+  @Column(nullable = false, unique = true, length = 255)
+  private String email;
+
+  @Column(nullable = false)
+  private String password;
+
+  @Column(name = "display_name", nullable = false, length = 150)
+  private String displayName;
+
+  @Column(nullable = false)
+  private Boolean enabled = true;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 30)
+  private PlatformRole role;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "store_scope_type", nullable = false, length = 20)
+  private StoreScopeType storeScopeType;
+
+  @ElementCollection(fetch = FetchType.EAGER)
+  @CollectionTable(
+      name = "platform_user_stores",
+      joinColumns = @JoinColumn(name = "platform_user_id"))
+  @Column(name = "store_id")
+  private Set<Long> storeIds = new HashSet<>();
+
+  @Builder
+  public PlatformUser(
+      String email,
+      String password,
+      String displayName,
+      boolean enabled,
+      PlatformRole role,
+      StoreScopeType storeScopeType,
+      Set<Long> storeIds) {
+    Set<Long> stores = storeIds == null ? Set.of() : storeIds;
+    if (storeScopeType == StoreScopeType.SPECIFIC_STORES && stores.isEmpty()) {
+      throw new InvalidStoreScopeException("SPECIFIC_STORES の授権には少なくとも 1 つの店舗が必要です");
+    }
+    if (storeScopeType == StoreScopeType.ALL_STORES && !stores.isEmpty()) {
+      throw new InvalidStoreScopeException("ALL_STORES の授権に個別店舗を指定できません");
+    }
+    this.email = email;
+    this.password = password;
+    this.displayName = displayName;
+    this.enabled = enabled;
+    this.role = role;
+    this.storeScopeType = storeScopeType;
+    this.storeIds = new HashSet<>(stores);
+  }
+
+  /** 指定店舗を授権するか。ALL_STORES は常に true、SPECIFIC_STORES は店舗集合のメンバーのみ true。 */
+  public boolean authorizes(Long storeId) {
+    return storeScopeType == StoreScopeType.ALL_STORES || storeIds.contains(storeId);
+  }
+}

--- a/backend/src/main/java/com/kizuna/user/domain/PlatformUserRepository.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PlatformUserRepository.java
@@ -1,0 +1,8 @@
+package com.kizuna.user.domain;
+
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+
+public interface PlatformUserRepository extends CrudRepository<PlatformUser, Long> {
+  Optional<PlatformUser> findByEmail(String email);
+}

--- a/backend/src/main/java/com/kizuna/user/domain/StoreScopeType.java
+++ b/backend/src/main/java/com/kizuna/user/domain/StoreScopeType.java
@@ -1,0 +1,7 @@
+package com.kizuna.user.domain;
+
+/** 授権の店舗集合種別。「全店舗」「個別店舗」の 2 種のみ（受け入れ基準 3）。 */
+public enum StoreScopeType {
+  ALL_STORES,
+  SPECIFIC_STORES
+}

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -8,3 +8,6 @@ databaseChangeLog:
   - include:
       file: releases/v0.3.0/master.yaml
       relativeToChangelogFile: true
+  - include:
+      file: releases/v0.4.0/master.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.4.0/central/01-platform-users-schema.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.4.0/central/01-platform-users-schema.yaml
@@ -1,0 +1,93 @@
+databaseChangeLog:
+  - changeSet:
+      id: central-009-platform-users-schema
+      author: kanghouchao
+      changes:
+        - createTable:
+            tableName: platform_users
+            remarks: プラットフォーム共通ユーザー（ロール×店舗集合の授権）
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_platform_users
+              - column:
+                  name: email
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uq_platform_users_email
+              - column:
+                  name: password
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: display_name
+                  type: VARCHAR(150)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: enabled
+                  type: BOOLEAN
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: role
+                  type: VARCHAR(30)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: store_scope_type
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+        - createTable:
+            tableName: platform_user_stores
+            remarks: プラットフォームユーザーの授権店舗集合（SPECIFIC_STORES 時のみ行を持つ）
+            columns:
+              - column:
+                  name: platform_user_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: store_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: platform_user_stores
+            columnNames: platform_user_id,store_id
+            constraintName: pk_platform_user_stores
+        - addForeignKeyConstraint:
+            constraintName: fk_platform_user_stores_user
+            baseTableName: platform_user_stores
+            baseColumnNames: platform_user_id
+            referencedTableName: platform_users
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            constraintName: fk_platform_user_stores_store
+            baseTableName: platform_user_stores
+            baseColumnNames: store_id
+            referencedTableName: central_tenants
+            referencedColumnNames: id

--- a/backend/src/main/resources/db/changelog/releases/v0.4.0/central/02-platform-users-seed.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.4.0/central/02-platform-users-seed.yaml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  - changeSet:
+      id: central-010-platform-users-seed
+      author: kanghouchao
+      changes:
+        # HQ 管理者シード。password は既存の central_users シードと同一の bcrypt ハッシュ（平文 pass）を再利用する
+        # （新しい秘密情報リテラルを導入しない）。ALL_STORES 授権のため platform_user_stores 行は持たない。
+        - insert:
+            tableName: platform_users
+            columns:
+              - column: { name: id, valueNumeric: 1 }
+              - column: { name: email, value: admin@kizuna.test }
+              - column: { name: password, value: "$2a$10$vE/ReAxs2rLV.FEJSDUK4.EpsPrbllLD2uOgtPaEUh1koMTovAaue" }
+              - column: { name: display_name, value: "HQ管理者" }
+              - column: { name: enabled, valueBoolean: true }
+              - column: { name: role, value: HQ_ADMIN }
+              - column: { name: store_scope_type, value: ALL_STORES }
+  - changeSet:
+      id: central-011-platform-users-seed-sequence-sync
+      author: kanghouchao
+      changes:
+        # 明示 id で挿入した autoIncrement 表は IDENTITY シーケンスが未進行のため、初回の @GeneratedValue 採番が
+        # seed id と衝突する（issue #237）。シーケンスを MAX(id) へ整合させる。
+        - sql:
+            sql: SELECT setval(pg_get_serial_sequence('platform_users','id'), (SELECT MAX(id) FROM platform_users))

--- a/backend/src/main/resources/db/changelog/releases/v0.4.0/central/03-platform-user-stores-fk-cascade.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.4.0/central/03-platform-user-stores-fk-cascade.yaml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+  - changeSet:
+      id: central-012-platform-user-stores-store-fk-cascade
+      author: kanghouchao
+      changes:
+        # テナント削除は既存全テーブルが CASCADE で従う確立済みセマンティクスであり、店舗授権行も店舗と共に消えるのが整合的。
+        # SPECIFIC_STORES ユーザーの残存空集合は authorizes() が全 false になる fail-closed 挙動。
+        # 01-platform-users-schema の初期 FK（onDelete 未指定 = NO ACTION）を落とし、ON DELETE CASCADE で貼り直す。
+        # 既適用の changeSet は checksum 不整合を招くため編集せず、新規 changeSet で是正する。
+        - dropForeignKeyConstraint:
+            baseTableName: platform_user_stores
+            constraintName: fk_platform_user_stores_store
+        - addForeignKeyConstraint:
+            constraintName: fk_platform_user_stores_store
+            baseTableName: platform_user_stores
+            baseColumnNames: store_id
+            referencedTableName: central_tenants
+            referencedColumnNames: id
+            onDelete: CASCADE

--- a/backend/src/main/resources/db/changelog/releases/v0.4.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.4.0/master.yaml
@@ -1,0 +1,7 @@
+databaseChangeLog:
+  - include:
+      file: central/01-platform-users-schema.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: central/02-platform-users-seed.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.4.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.4.0/master.yaml
@@ -5,3 +5,6 @@ databaseChangeLog:
   - include:
       file: central/02-platform-users-seed.yaml
       relativeToChangelogFile: true
+  - include:
+      file: central/03-platform-user-stores-fk-cascade.yaml
+      relativeToChangelogFile: true

--- a/backend/src/test/java/com/kizuna/auth/application/PlatformAuthServiceTest.java
+++ b/backend/src/test/java/com/kizuna/auth/application/PlatformAuthServiceTest.java
@@ -1,0 +1,136 @@
+package com.kizuna.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.kizuna.auth.api.dto.Token;
+import com.kizuna.auth.infrastructure.JwtUtil;
+import com.kizuna.user.domain.PlatformRole;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import com.kizuna.user.domain.StoreScopeType;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class PlatformAuthServiceTest {
+
+  @Mock private PlatformUserRepository userRepository;
+  @Mock private PasswordEncoder passwordEncoder;
+  @Mock private JwtUtil jwtUtil;
+
+  @Captor private ArgumentCaptor<Map<String, Object>> claimsCaptor;
+
+  @InjectMocks private PlatformAuthService authService;
+
+  private PlatformUser hqAdmin() {
+    return PlatformUser.builder()
+        .email("admin@kizuna.test")
+        .password("stored-hash")
+        .displayName("HQ管理者")
+        .enabled(true)
+        .role(PlatformRole.HQ_ADMIN)
+        .storeScopeType(StoreScopeType.ALL_STORES)
+        .storeIds(Set.of())
+        .build();
+  }
+
+  @Test
+  void login_success_issuesPlatformTokenWithRoleAndScopeClaims() {
+    when(userRepository.findByEmail("admin@kizuna.test")).thenReturn(Optional.of(hqAdmin()));
+    when(passwordEncoder.matches("pass", "stored-hash")).thenReturn(true);
+    Token mockToken = new Token("platform_token", 12345L);
+    when(jwtUtil.generateToken(eq("admin@kizuna.test"), eq(JwtUtil.ISSUER_PLATFORM), any()))
+        .thenReturn(mockToken);
+
+    Token res = authService.login("admin@kizuna.test", "pass");
+
+    assertThat(res.token()).isEqualTo("platform_token");
+    org.mockito.Mockito.verify(jwtUtil)
+        .generateToken(
+            eq("admin@kizuna.test"), eq(JwtUtil.ISSUER_PLATFORM), claimsCaptor.capture());
+    Map<String, Object> claims = claimsCaptor.getValue();
+    assertThat(claims.get("authorities")).isEqualTo(List.of("ROLE_HQ_ADMIN"));
+    assertThat(claims.get("role")).isEqualTo("HQ_ADMIN");
+    assertThat(claims.get("storeScopeType")).isEqualTo("ALL_STORES");
+    assertThat(claims.get("storeIds")).isEqualTo(List.of());
+  }
+
+  @Test
+  void login_success_specificStores_carriesStoreIdsClaim() {
+    PlatformUser manager =
+        PlatformUser.builder()
+            .email("mgr@kizuna.test")
+            .password("stored-hash")
+            .displayName("店長")
+            .enabled(true)
+            .role(PlatformRole.STORE_MANAGER)
+            .storeScopeType(StoreScopeType.SPECIFIC_STORES)
+            .storeIds(Set.of(1L))
+            .build();
+    when(userRepository.findByEmail("mgr@kizuna.test")).thenReturn(Optional.of(manager));
+    when(passwordEncoder.matches("pass", "stored-hash")).thenReturn(true);
+    when(jwtUtil.generateToken(eq("mgr@kizuna.test"), eq(JwtUtil.ISSUER_PLATFORM), any()))
+        .thenReturn(new Token("t", 1L));
+
+    authService.login("mgr@kizuna.test", "pass");
+
+    org.mockito.Mockito.verify(jwtUtil)
+        .generateToken(eq("mgr@kizuna.test"), eq(JwtUtil.ISSUER_PLATFORM), claimsCaptor.capture());
+    Map<String, Object> claims = claimsCaptor.getValue();
+    assertThat(claims.get("role")).isEqualTo("STORE_MANAGER");
+    assertThat(claims.get("storeScopeType")).isEqualTo("SPECIFIC_STORES");
+    assertThat(claims.get("storeIds")).isEqualTo(List.of(1L));
+  }
+
+  @Test
+  void login_emailNotFound_throwsBadCredentials() {
+    when(userRepository.findByEmail("missing@kizuna.test")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> authService.login("missing@kizuna.test", "pass"))
+        .isInstanceOf(BadCredentialsException.class);
+  }
+
+  @Test
+  void login_wrongPassword_throwsBadCredentials() {
+    when(userRepository.findByEmail("admin@kizuna.test")).thenReturn(Optional.of(hqAdmin()));
+    when(passwordEncoder.matches("wrong", "stored-hash")).thenReturn(false);
+
+    assertThatThrownBy(() -> authService.login("admin@kizuna.test", "wrong"))
+        .isInstanceOf(BadCredentialsException.class);
+  }
+
+  @Test
+  void login_disabledUser_throwsDisabled() {
+    PlatformUser disabled =
+        PlatformUser.builder()
+            .email("admin@kizuna.test")
+            .password("stored-hash")
+            .displayName("HQ管理者")
+            .enabled(false)
+            .role(PlatformRole.HQ_ADMIN)
+            .storeScopeType(StoreScopeType.ALL_STORES)
+            .storeIds(Set.of())
+            .build();
+    when(userRepository.findByEmail("admin@kizuna.test")).thenReturn(Optional.of(disabled));
+    when(passwordEncoder.matches("pass", "stored-hash")).thenReturn(true);
+
+    assertThatThrownBy(() -> authService.login("admin@kizuna.test", "pass"))
+        .isInstanceOf(DisabledException.class);
+  }
+}

--- a/backend/src/test/java/com/kizuna/auth/application/PlatformAuthServiceTest.java
+++ b/backend/src/test/java/com/kizuna/auth/application/PlatformAuthServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.kizuna.auth.api.dto.Token;
@@ -61,7 +62,7 @@ class PlatformAuthServiceTest {
     Token res = authService.login("admin@kizuna.test", "pass");
 
     assertThat(res.token()).isEqualTo("platform_token");
-    org.mockito.Mockito.verify(jwtUtil)
+    verify(jwtUtil)
         .generateToken(
             eq("admin@kizuna.test"), eq(JwtUtil.ISSUER_PLATFORM), claimsCaptor.capture());
     Map<String, Object> claims = claimsCaptor.getValue();
@@ -90,7 +91,7 @@ class PlatformAuthServiceTest {
 
     authService.login("mgr@kizuna.test", "pass");
 
-    org.mockito.Mockito.verify(jwtUtil)
+    verify(jwtUtil)
         .generateToken(eq("mgr@kizuna.test"), eq(JwtUtil.ISSUER_PLATFORM), claimsCaptor.capture());
     Map<String, Object> claims = claimsCaptor.getValue();
     assertThat(claims.get("role")).isEqualTo("STORE_MANAGER");
@@ -107,7 +108,7 @@ class PlatformAuthServiceTest {
         .hasMessage("メールアドレスまたはパスワードが正しくありません");
 
     // 列挙耐性: メール不存在でもダミー bcrypt 照合を 1 回行い、既知メール（誤パスワード）との応答時間差を作らない。
-    org.mockito.Mockito.verify(passwordEncoder).matches(eq("pass"), any());
+    verify(passwordEncoder).matches(eq("pass"), any());
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/auth/application/PlatformAuthServiceTest.java
+++ b/backend/src/test/java/com/kizuna/auth/application/PlatformAuthServiceTest.java
@@ -103,7 +103,11 @@ class PlatformAuthServiceTest {
     when(userRepository.findByEmail("missing@kizuna.test")).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> authService.login("missing@kizuna.test", "pass"))
-        .isInstanceOf(BadCredentialsException.class);
+        .isInstanceOf(BadCredentialsException.class)
+        .hasMessage("メールアドレスまたはパスワードが正しくありません");
+
+    // 列挙耐性: メール不存在でもダミー bcrypt 照合を 1 回行い、既知メール（誤パスワード）との応答時間差を作らない。
+    org.mockito.Mockito.verify(passwordEncoder).matches(eq("pass"), any());
   }
 
   @Test
@@ -112,25 +116,37 @@ class PlatformAuthServiceTest {
     when(passwordEncoder.matches("wrong", "stored-hash")).thenReturn(false);
 
     assertThatThrownBy(() -> authService.login("admin@kizuna.test", "wrong"))
-        .isInstanceOf(BadCredentialsException.class);
+        .isInstanceOf(BadCredentialsException.class)
+        .hasMessage("メールアドレスまたはパスワードが正しくありません");
   }
 
   @Test
-  void login_disabledUser_throwsDisabled() {
-    PlatformUser disabled =
-        PlatformUser.builder()
-            .email("admin@kizuna.test")
-            .password("stored-hash")
-            .displayName("HQ管理者")
-            .enabled(false)
-            .role(PlatformRole.HQ_ADMIN)
-            .storeScopeType(StoreScopeType.ALL_STORES)
-            .storeIds(Set.of())
-            .build();
-    when(userRepository.findByEmail("admin@kizuna.test")).thenReturn(Optional.of(disabled));
-    when(passwordEncoder.matches("pass", "stored-hash")).thenReturn(true);
+  void login_disabledUser_correctPassword_throwsDisabled() {
+    when(userRepository.findByEmail("admin@kizuna.test")).thenReturn(Optional.of(disabledUser()));
 
+    // enabled 判定がパスワード照合より先行するため、正しいパスワードでも DisabledException になる。
     assertThatThrownBy(() -> authService.login("admin@kizuna.test", "pass"))
         .isInstanceOf(DisabledException.class);
+  }
+
+  @Test
+  void login_disabledUser_wrongPassword_throwsDisabled() {
+    when(userRepository.findByEmail("admin@kizuna.test")).thenReturn(Optional.of(disabledUser()));
+
+    // 誤パスワードでも enabled 判定が先行するため DisabledException（無効化アカウントでのパスワード正誤オラクルを塞ぐ）。
+    assertThatThrownBy(() -> authService.login("admin@kizuna.test", "wrong"))
+        .isInstanceOf(DisabledException.class);
+  }
+
+  private PlatformUser disabledUser() {
+    return PlatformUser.builder()
+        .email("admin@kizuna.test")
+        .password("stored-hash")
+        .displayName("HQ管理者")
+        .enabled(false)
+        .role(PlatformRole.HQ_ADMIN)
+        .storeScopeType(StoreScopeType.ALL_STORES)
+        .storeIds(Set.of())
+        .build();
   }
 }

--- a/backend/src/test/java/com/kizuna/auth/infrastructure/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/kizuna/auth/infrastructure/JwtAuthenticationFilterTest.java
@@ -72,6 +72,37 @@ class JwtAuthenticationFilterTest {
   }
 
   @Test
+  @DisplayName("PlatformAuth 発行のトークンは /platform 配下で認証されること")
+  void platformTokenOnPlatformPath() throws Exception {
+    when(tokenBlacklistService.isBlacklisted("token")).thenReturn(false);
+    assertThat(authenticated("/platform/me", "PlatformAuth")).isTrue();
+  }
+
+  @Test
+  @DisplayName("PlatformAuth 発行のトークンは /central 配下で認証されないこと")
+  void platformTokenOnCentralPath() throws Exception {
+    assertThat(authenticated("/central/configs", "PlatformAuth")).isFalse();
+  }
+
+  @Test
+  @DisplayName("PlatformAuth 発行のトークンは /tenant 配下で認証されないこと")
+  void platformTokenOnTenantPath() throws Exception {
+    assertThat(authenticated("/tenant/orders", "PlatformAuth")).isFalse();
+  }
+
+  @Test
+  @DisplayName("CentralAuth 発行のトークンは /platform 配下で認証されないこと")
+  void centralTokenOnPlatformPath() throws Exception {
+    assertThat(authenticated("/platform/me", "CentralAuth")).isFalse();
+  }
+
+  @Test
+  @DisplayName("TenantAuth 発行のトークンは /platform 配下で認証されないこと")
+  void tenantTokenOnPlatformPath() throws Exception {
+    assertThat(authenticated("/platform/me", "TenantAuth")).isFalse();
+  }
+
+  @Test
   @DisplayName("ドメイン外のパスでは issuer を制限しないこと")
   void anyIssuerOnDomainFreePath() throws Exception {
     when(tokenBlacklistService.isBlacklisted("token")).thenReturn(false);

--- a/backend/src/test/java/com/kizuna/storage/api/store/FileUploadControllerTest.java
+++ b/backend/src/test/java/com/kizuna/storage/api/store/FileUploadControllerTest.java
@@ -33,6 +33,7 @@ class FileUploadControllerTest {
 
   private static final String ISSUER_TENANT = "TenantAuth";
   private static final String ISSUER_CENTRAL = "CentralAuth";
+  private static final String ISSUER_PLATFORM = "PlatformAuth";
 
   @Mock private FileStorageService fileStorageService;
   @Mock private MultipartFile file;
@@ -69,6 +70,19 @@ class FileUploadControllerTest {
   void upload_rejectsTenantIssuedTokenWithoutTenantContext() {
     // tenantId claim を持たない = テナント文脈は未解決のまま
     authenticateWithIssuer(ISSUER_TENANT);
+
+    assertThatThrownBy(() -> controller.upload(file, "public"))
+        .isInstanceOf(AccessDeniedException.class);
+
+    verify(fileStorageService, never()).store(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("プラットフォーム発行トークンはテナント文脈が無くても central に保存せず拒否すること（#322）")
+  void upload_rejectsPlatformIssuedToken() {
+    // PlatformAuth は tenantId claim を持たず @TenantOptional の許可経路に乗るため、
+    // 中央プレフィクスへ落ちないよう fail-closed で拒否する。
+    authenticateWithIssuer(ISSUER_PLATFORM);
 
     assertThatThrownBy(() -> controller.upload(file, "public"))
         .isInstanceOf(AccessDeniedException.class);

--- a/backend/src/test/java/com/kizuna/user/domain/PlatformUserTest.java
+++ b/backend/src/test/java/com/kizuna/user/domain/PlatformUserTest.java
@@ -1,0 +1,68 @@
+package com.kizuna.user.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PlatformUserTest {
+
+  private PlatformUser.PlatformUserBuilder seedBuilder() {
+    return PlatformUser.builder()
+        .email("user@kizuna.test")
+        .password("hash")
+        .displayName("表示名")
+        .enabled(true)
+        .role(PlatformRole.HQ_ADMIN);
+  }
+
+  @Test
+  @DisplayName("SPECIFIC_STORES で店舗集合が空だと不変条件違反で例外")
+  void specificStoresWithEmptyStoreIdsThrows() {
+    assertThatThrownBy(
+            () ->
+                seedBuilder()
+                    .storeScopeType(StoreScopeType.SPECIFIC_STORES)
+                    .storeIds(Set.of())
+                    .build())
+        .isInstanceOf(InvalidStoreScopeException.class);
+  }
+
+  @Test
+  @DisplayName("ALL_STORES で店舗集合が非空だと不変条件違反で例外")
+  void allStoresWithNonEmptyStoreIdsThrows() {
+    assertThatThrownBy(
+            () ->
+                seedBuilder()
+                    .storeScopeType(StoreScopeType.ALL_STORES)
+                    .storeIds(Set.of(1L))
+                    .build())
+        .isInstanceOf(InvalidStoreScopeException.class);
+  }
+
+  @Test
+  @DisplayName("ALL_STORES は任意の店舗 id を授権する")
+  void allStoresAuthorizesAnyStore() {
+    PlatformUser user =
+        seedBuilder().storeScopeType(StoreScopeType.ALL_STORES).storeIds(Set.of()).build();
+
+    assertThat(user.authorizes(1L)).isTrue();
+    assertThat(user.authorizes(999L)).isTrue();
+  }
+
+  @Test
+  @DisplayName("SPECIFIC_STORES はメンバー店舗のみを授権する")
+  void specificStoresAuthorizesOnlyMembers() {
+    PlatformUser user =
+        seedBuilder()
+            .storeScopeType(StoreScopeType.SPECIFIC_STORES)
+            .storeIds(Set.of(1L, 2L))
+            .build();
+
+    assertThat(user.authorizes(1L)).isTrue();
+    assertThat(user.authorizes(2L)).isTrue();
+    assertThat(user.authorizes(3L)).isFalse();
+  }
+}


### PR DESCRIPTION
## 概要

プラットフォーム化転換（#320/#321）の起点チケット。プラットフォームユーザー集約（email＋パスワード・表示名・有効フラグ、授権＝ロール×店舗集合）と統一ログイン API（`POST /platform/login`・`GET /platform/me`）を expand 方式で新設する。既存の central/store 二本立て認証は無変更のまま並存し、撤去は contract チケット（#326）で行う。

Closes #322

## 変更内容

- **user/domain**: `PlatformUser` 集約（リッチモデル・構築時不変条件: `SPECIFIC_STORES`→店舗集合非空 / `ALL_STORES`→空）、`PlatformRole`（HQ_ADMIN / STORE_MANAGER / STORE_STAFF / CAST / MEMBER）、`StoreScopeType`（**「全店舗」「個別店舗」の 2 値のみ** — エリアは実体化しない）、授権判定 `authorizes(storeId)`、`PlatformUserRepository`
- **Liquibase v0.4.0**: `platform_users`・`platform_user_stores`（複合 PK、FK → platform_users ON DELETE CASCADE / FK → central_tenants）、HQ 管理者シード（既存シードと同一の bcrypt ハッシュを再利用、新規秘密リテラルなし）、setval シーケンス整合（#237 型対策）
- **auth**: `ISSUER_PLATFORM` 追加、`issuerMatchesDomain` に `/platform` 分岐（三軌トークンの相互拒否）、CSRF 免除に `/platform/login`、`PlatformAuthService`（AuthenticationManager 非経由・enabled 先行判定・未知メールへのダミー bcrypt 照合）、`PlatformAuthController`（login / me）
- **storage**: `FileUploadController` の保存先解決を PlatformAuth トークンにも fail-closed 化（敵対的プレレビュー指摘の是正。CentralAuth・null/未知 issuer の挙動は不変）
- **テスト**: ドメイン単体 `PlatformUserTest`(4)、`PlatformAuthServiceTest`(6)、`JwtAuthenticationFilterTest` に platform×path 行列 +5(計10)、`PlatformAuthIT`(8: CSRF 免除・401≠403・me のロール×店舗集合・SPECIFIC_STORES の repository 直挿実データ断言・三軌共存・issuer 相互拒否 3 方向)、`FileUploadCrossTenantIT` +1(platform トークン 403)、`FileUploadControllerTest` +1、`SeedSequenceAlignmentIT` の列挙に platform_users 追加
- **CONTEXT.md 用語集**: PlatformUser（プラットフォーム身分）と Member（会員）/ Customer（顧客）の区別を追記

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 中央管理画面ログイン › シード管理者で中央管理画面にログインできる / テナント管理画面ログイン › シード管理者でテナント管理画面にログインできる / 年齢確認ゲート › 拒否では入場できず承認で入場できる / 公開キャスト詳細のクロステナント越権 404 › 自店舗のキャスト詳細は表示でき、店舗に属さない ID は 404 になる / 公開サイト表示 › 公開サイトの主要ページがすべて表示される / 公開出勤表 › 本日の確定シフトだけが公開出勤表に表示される / 店舗設定の保存 › 模版テキストを保存すると再読込後も反映されている / 模版切替 › template_key を変更すると公開サイトの見た目が切り替わる — 8/8 passed。既存プールの回帰であり新規 .feature なし。中央・テナント両ログインが v0.4.0 マイグレーション適用済みの実スタックで成立＝並存の実証）

### 視覚確認（UI 変更時）

対象外（バックエンドのみ、UI 変更なし）

## 決定ログ

- **集約は user モジュールへ配置（新 Modulith モジュールを立てない）**: `auth` → `user/domain` の `@NamedInterface` 参照が既存で、#326 contract は旧 2 集約を同モジュール内で削除するだけになる。Modulith docs に構造 diff なし（`ModularityTests` green）。
- **プラットフォームログインは AuthenticationManager 非経由**: `CustomUserDetailsService` が `TenantContext` で central/store に二分岐しており、これに触れないことで旧二軌の挙動不変を構造的に保証。`findByEmail`＋BCrypt 照合の自前実装とし、`DaoAuthenticationProvider` に合わせて enabled 先行判定・未知メールへのダミー bcrypt 照合（タイミング均一化）を実装。
- **トークン分離は既存の issuer 方式を踏襲**: `ISSUER_PLATFORM` 新設＋パス接頭辞照合。既存 3 ファイル（JwtUtil / JwtAuthenticationFilter / SecurityConfig）への変更は加算のみ 3/3/1 行で、既存行の削除・変更ゼロ。
- **授権スコープは 2 種のみ**（#321 裁定 2）: エリア単位はエリアマネージャ実装と同時に後続。1 ユーザー＝1 ロール×1 店舗集合（spec に複数授権の要求なし）。
- **CAST / MEMBER ロールも enum に先行定義**: 後続チケットが値追加なしで身分を発行できるように。本 PR に発行経路はなく、シードは HQ_ADMIN のみ。
- **見送った代替案**: PlatformPrincipal 型の導入（#323 集合作用域機構の責務）／ `/platform/logout`（#324 の UI 導入時に追加）／ email の小文字正規化（既存 StoreUser と同挙動を維持し、裁定は #324/#325 へ）。

## 備考 / レビュー観点

- **重点**: `JwtAuthenticationFilter` の `/platform` 分岐と `SecurityConfig` の CSRF 免除 1 行 — 旧二軌への影響はこの加算のみ。相互拒否はフィルタ単体行列＋IT の 403 三方向で固定済み。
- `FileUploadController` は三前綴（/central・/tenant・/platform）外に立つ唯一のコントローラであり、PlatformAuth の fail-closed 追加で issuer 素通り面を全閉した（プレレビュー指摘の是正コミット）。
- email の大小文字は既存 StoreUser と同じく区別する挙動のまま（プラットフォーム唯一のログインキーになるため、正規化の要否は #324/#325 で裁定）。
- 切り出した別 issue: なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
