### PR TITLE
feat(order): 集合作用域機構 — fail-closed な集約読みと明示的単店書き(Order トレーサー)を追加(#323)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,10 @@ _Avoid_: PlatformAccount、「テナントユーザー」系の呼称
 発行済みの 1 枚の JWT が表す認証状態。ログアウトとパスワード変更はいずれも唯一の無効化経路（token ブラックリスト）を通じて現在のセッションを失効させる。
 _Avoid_: Token の裸使用（token は担体、session は概念）
 
+**集合作用域（StoreScope / storeSetFilter / @StoreSetScoped）**:
+PlatformUser の授権を表す店舗集合（ALL_STORES または SPECIFIC_STORES の店舗 ID 集合）。読みは Hibernate の第二 filter（`storeSetFilter`）が機構的に濾過する fail-closed 設計（解決不能なら例外）。書きは明示的単一 storeId を受け取り、その storeId が授権集合に含まれるか検証したうえで既存の単店機構（TenantContext + tenantFilter）へ委譲する。
+_Avoid_: 読み・書きを同一機構と混同すること（読みは集合フィルタ、書きは単一 storeId 検証で別経路）
+
 ### 店舗運営
 
 **Cast**:

--- a/backend/docs/modulith/module-shared.adoc
+++ b/backend/docs/modulith/module-shared.adoc
@@ -13,6 +13,7 @@ _Others_
 * `c.k.s.config.JacksonConfig`
 * `c.k.s.config.RedisConfig`
 * `c.k.s.exception.CommonExceptionHandler`
+* `c.k.s.tenancy.StoreSetFilterEnable`
 * `c.k.s.tenancy.TenantContext`
 * `c.k.s.tenancy.TenantFilterEnable`
 * `c.k.s.tenancy.TenantIdInterceptor`

--- a/backend/src/integrationTest/java/com/kizuna/order/PlatformOrderScopeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/PlatformOrderScopeIT.java
@@ -1,0 +1,339 @@
+package com.kizuna.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.kizuna.order.domain.Order;
+import com.kizuna.order.domain.OrderRepository;
+import com.kizuna.order.domain.OrderStatus;
+import com.kizuna.shared.CrossTenantTestSupport;
+import com.kizuna.tenant.domain.Tenant;
+import com.kizuna.tenant.domain.TenantRepository;
+import com.kizuna.user.domain.PlatformRole;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import com.kizuna.user.domain.StoreScopeType;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * 集合作用域（#323）の実データ非漏洩を本物の PostgreSQL で強断言する統合テスト。
+ *
+ * <p>断言は「帰属不一致」型の弱断言ではなく、応答生ボディに授権外店舗の実データ（店舗名・カナリア文字列）が 一切現れないこと（AC2）で行う。読みは storeSetFilter が
+ * session 層で機構的に濾過し、書きは明示的単店 storeId の 授権検証（{@code PlatformOrderService.create}）が担う。先例は {@link
+ * com.kizuna.menu.MenuCrossTenantIT}（リポジトリ直挿 + 実データ断言）と {@link
+ * com.kizuna.auth.PlatformAuthIT}（平台トークン取得 + planted-user）。
+ */
+class PlatformOrderScopeIT extends CrossTenantTestSupport {
+
+  private static final String PASSWORD = "pass";
+
+  /** ALL_STORES/HQ_ADMIN のシードユーザー（v0.4.0 central/02-platform-users-seed.yaml）。 */
+  private static final String SEED_EMAIL = "admin@kizuna.test";
+
+  private static final String SPECIFIC_EMAIL = "scope-manager@kizuna.test";
+  private static final String CAST_EMAIL = "scope-cast@kizuna.test";
+
+  private static final String TENANT_B_DOMAIN = "platform-scope-it.kizuna.test";
+
+  private static final String MARKER_A_STORE_NAME = "店舗A受注マーカー";
+  private static final String MARKER_A_REMARKS = "SCOPE_MARKER_A";
+  private static final String CANARY_B_STORE_NAME = "店舗B機密受注";
+  private static final String CANARY_B_REMARKS = "SCOPE_LEAK_CANARY_B";
+
+  /** マーカー受注が一覧の先頭ページに現れるよう、他 IT の受注より新しい営業日を使う。 */
+  private static final LocalDate MARKER_DATE = LocalDate.of(2999, 1, 1);
+
+  /** tenant/08-initial-data.yaml のシードユーザー（受付担当として使用）。 */
+  private static final String SEED_RECEPTIONIST_ID = "user-1";
+
+  @Autowired private OrderRepository orderRepository;
+  @Autowired private TenantRepository tenantRepository;
+  @Autowired private PlatformUserRepository platformUserRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  /** 保存後に採番された第二テナントの実 id。 */
+  private long tenantBId;
+
+  @BeforeEach
+  void prepareScopeFixture() {
+    Tenant tenantB =
+        tenantRepository
+            .findByDomain(TENANT_B_DOMAIN)
+            .orElseGet(
+                () -> tenantRepository.save(new Tenant("集合作用域IT第二テナント", TENANT_B_DOMAIN, null)));
+    tenantBId = tenantB.getId();
+
+    ensureMarkerOrder(TENANT_A, MARKER_A_STORE_NAME, MARKER_A_REMARKS);
+    ensureMarkerOrder(tenantBId, CANARY_B_STORE_NAME, CANARY_B_REMARKS);
+
+    ensurePlatformUser(
+        SPECIFIC_EMAIL,
+        PlatformRole.STORE_MANAGER,
+        StoreScopeType.SPECIFIC_STORES,
+        Set.of(TENANT_A));
+    ensurePlatformUser(CAST_EMAIL, PlatformRole.CAST, StoreScopeType.ALL_STORES, Set.of());
+  }
+
+  /** リポジトリ直挿（テストスレッドは @TenantScoped を経由せず tenantFilter が無効なので他テナントにも書ける）。 */
+  private void ensureMarkerOrder(long tenantId, String storeName, String remarks) {
+    boolean exists =
+        orderRepository.findAll().stream()
+            .anyMatch(
+                o ->
+                    o.getTenantId() != null
+                        && tenantId == o.getTenantId()
+                        && storeName.equals(o.getStoreName()));
+    if (exists) {
+      return;
+    }
+    Order order =
+        Order.builder()
+            .storeName(storeName)
+            .remarks(remarks)
+            .businessDate(MARKER_DATE)
+            .status(OrderStatus.CREATED)
+            .build();
+    order.setTenantId(tenantId);
+    orderRepository.save(order);
+  }
+
+  private void ensurePlatformUser(
+      String email, PlatformRole role, StoreScopeType scopeType, Set<Long> storeIds) {
+    platformUserRepository
+        .findByEmail(email)
+        .orElseGet(
+            () ->
+                platformUserRepository.save(
+                    PlatformUser.builder()
+                        .email(email)
+                        .password(passwordEncoder.encode(PASSWORD))
+                        .displayName("集合作用域IT " + role.name())
+                        .enabled(true)
+                        .role(role)
+                        .storeScopeType(scopeType)
+                        .storeIds(storeIds)
+                        .build()));
+  }
+
+  private String platformToken(String email, String password) {
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/platform/login",
+            new HttpEntity<>(
+                String.format("{\"email\": \"%s\", \"password\": \"%s\"}", email, password),
+                jsonHeaders()),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).as("前提: 平台ログインが成功すること").isEqualTo(HttpStatus.OK);
+    String t = res.getBody().path("token").asText();
+    assertThat(t).isNotBlank();
+    return t;
+  }
+
+  private static HttpHeaders jsonHeaders() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+
+  private static HttpHeaders bearer(String token) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(token);
+    return headers;
+  }
+
+  private static HttpHeaders bearerJson(String token) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(token);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+
+  private long orderCountForTenant(long tenantId) {
+    return orderRepository.findAll().stream()
+        .filter(o -> o.getTenantId() != null && tenantId == o.getTenantId())
+        .count();
+  }
+
+  private String createCastAs(long tenantId, String name) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/tenant/casts",
+            new HttpEntity<>("{\"name\": \"" + name + "\"}", tenantHeaders(tenantId)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful())
+        .as("前提: tenant %d でのキャスト作成が成功すること", tenantId)
+        .isTrue();
+    return created.getBody().path("id").asText();
+  }
+
+  @Test
+  @DisplayName("SPECIFIC{1} の一覧は授権店舗(store_id=1)のみを返し、正向マーカーを含むこと(AC1)")
+  void specificScopeListReturnsOnlyAuthorizedStores() {
+    ResponseEntity<JsonNode> res =
+        rest.exchange(
+            "/platform/orders?size=500",
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(platformToken(SPECIFIC_EMAIL, PASSWORD))),
+            JsonNode.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    JsonNode content = res.getBody().path("content");
+    assertThat(content).isNotEmpty();
+    content.forEach(
+        node ->
+            assertThat(node.path("store_id").asLong()).as("授権外の店舗が一覧に現れないこと").isEqualTo(TENANT_A));
+
+    boolean hasMarker = false;
+    for (JsonNode node : content) {
+      if (MARKER_A_STORE_NAME.equals(node.path("store_name").asText())) {
+        hasMarker = true;
+        break;
+      }
+    }
+    assertThat(hasMarker).as("授権店舗の正向マーカーが一覧に含まれること").isTrue();
+  }
+
+  @Test
+  @DisplayName("集合外店舗の実データ(店舗B機密受注/カナリア)が応答の生ボディに一切現れないこと(AC2)")
+  void outOfSetRealDataNeverAppearsInResponse() {
+    ResponseEntity<String> res =
+        rest.exchange(
+            "/platform/orders?size=500",
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(platformToken(SPECIFIC_EMAIL, PASSWORD))),
+            String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(res.getBody())
+        .as("授権外店舗の店舗名・カナリア文字列が生ボディに現れないこと")
+        .doesNotContain(CANARY_B_REMARKS)
+        .doesNotContain(CANARY_B_STORE_NAME);
+  }
+
+  @Test
+  @DisplayName("ALL_STORES(seed HQ) の一覧は両店のマーカーが現れ、store_id 集合に {1, B} を含むこと(機構の正側)")
+  void allStoresScopeSeesEveryStore() {
+    ResponseEntity<JsonNode> res =
+        rest.exchange(
+            "/platform/orders?size=500",
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(platformToken(SEED_EMAIL, PASSWORD))),
+            JsonNode.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    JsonNode content = res.getBody().path("content");
+    List<String> storeNames = new ArrayList<>();
+    Set<Long> storeIds = new HashSet<>();
+    content.forEach(
+        node -> {
+          storeNames.add(node.path("store_name").asText());
+          storeIds.add(node.path("store_id").asLong());
+        });
+
+    assertThat(storeNames).contains(MARKER_A_STORE_NAME, CANARY_B_STORE_NAME);
+    assertThat(storeIds).contains(TENANT_A, tenantBId);
+  }
+
+  @Test
+  @DisplayName("store_id 未指定の書きは 400 で拒否されること(AC3 前半)")
+  void writeWithoutStoreIdIsRejected() {
+    String body =
+        String.format(
+            "{\"receptionist_id\": \"%s\", \"business_date\": \"%s\", \"cast_id\": \"dummy-cast\"}",
+            SEED_RECEPTIONIST_ID, LocalDate.now());
+
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/platform/orders",
+            new HttpEntity<>(body, bearerJson(platformToken(SPECIFIC_EMAIL, PASSWORD))),
+            JsonNode.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("授権集合外 store_id の書きは 403 かつ tenant B に永続化されないこと(AC3 後半)")
+  void writeToOutOfSetStoreIsRejected() {
+    long before = orderCountForTenant(tenantBId);
+
+    String body =
+        String.format(
+            "{\"store_id\": %d, \"receptionist_id\": \"%s\", \"business_date\": \"%s\","
+                + " \"cast_id\": \"dummy-cast\"}",
+            tenantBId, SEED_RECEPTIONIST_ID, LocalDate.now());
+
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/platform/orders",
+            new HttpEntity<>(body, bearerJson(platformToken(SPECIFIC_EMAIL, PASSWORD))),
+            JsonNode.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(orderCountForTenant(tenantBId))
+        .as("拒否された書きが tenant B に永続化されていないこと")
+        .isEqualTo(before);
+  }
+
+  @Test
+  @DisplayName("授権店舗への書きはその店舗に受注を作成すること(正向対照: 負向 403 がバリデーション起因でない証明)")
+  void writeToAuthorizedStoreCreatesOrderInThatStore() {
+    String castId = createCastAs(TENANT_A, "集合作用域IT用キャスト");
+
+    String body =
+        String.format(
+            "{\"store_id\": %d, \"receptionist_id\": \"%s\", \"business_date\": \"%s\","
+                + " \"cast_id\": \"%s\"}",
+            TENANT_A, SEED_RECEPTIONIST_ID, LocalDate.now(), castId);
+
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/platform/orders",
+            new HttpEntity<>(body, bearerJson(platformToken(SPECIFIC_EMAIL, PASSWORD))),
+            JsonNode.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    String newId = res.getBody().path("id").asText();
+    assertThat(newId).isNotBlank();
+
+    Order created = orderRepository.findById(newId).orElseThrow();
+    assertThat(created.getTenantId()).as("授権店舗(tenant 1)に永続化されていること").isEqualTo(TENANT_A);
+  }
+
+  @Test
+  @DisplayName("tenant トークンで /platform/orders は 403(issuer 結合の回帰固定)")
+  void tenantTokenIsRejectedOnPlatformOrders() {
+    ResponseEntity<String> res =
+        rest.exchange(
+            "/platform/orders", HttpMethod.GET, new HttpEntity<>(bearer(token)), String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("CAST ロールで /platform/orders は 403(@PreAuthorize の役割線)")
+  void castRoleIsRejectedOnPlatformOrders() {
+    ResponseEntity<String> res =
+        rest.exchange(
+            "/platform/orders",
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(platformToken(CAST_EMAIL, PASSWORD))),
+            String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+}

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderMapper.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderMapper.java
@@ -4,6 +4,7 @@ import com.kizuna.customer.domain.Customer;
 import com.kizuna.order.domain.Order;
 import com.kizuna.order.domain.OrderPatch;
 import com.kizuna.order.domain.OrderView;
+import com.kizuna.order.domain.PlatformOrderView;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -15,6 +16,9 @@ public interface OrderMapper {
 
   /** 読み側 projection をレスポンスDTOに変換します。 */
   OrderResponse toResponse(OrderView view);
+
+  /** 平台横断一覧の projection をレスポンスDTOに変換します（#323 集合作用域）。 */
+  PlatformOrderResponse toPlatformResponse(PlatformOrderView view);
 
   // ==================== CreateRequest -> Entity ====================
 

--- a/backend/src/main/java/com/kizuna/order/api/dto/PlatformOrderCreateRequest.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/PlatformOrderCreateRequest.java
@@ -1,0 +1,14 @@
+package com.kizuna.order.api.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/** 平台からの明示的単店指定の受注作成リクエスト（#323）。店舗（tenant）を storeId で明示する以外は {@link OrderCreateRequest} と同一。 */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class PlatformOrderCreateRequest extends OrderCreateRequest {
+
+  @NotNull(message = "店舗IDは必須です")
+  private Long storeId;
+}

--- a/backend/src/main/java/com/kizuna/order/api/dto/PlatformOrderResponse.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/PlatformOrderResponse.java
@@ -1,0 +1,23 @@
+package com.kizuna.order.api.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** 平台横断受注一覧のレスポンスDTO（#323）。JSON キーはグローバルの snake_case 設定に従う。 */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlatformOrderResponse {
+  private String id;
+  private Long storeId;
+  private String storeName;
+  private LocalDate businessDate;
+  private LocalTime arrivalScheduledStartTime;
+  private LocalTime arrivalScheduledEndTime;
+  private String status;
+}

--- a/backend/src/main/java/com/kizuna/order/api/platform/PlatformOrderController.java
+++ b/backend/src/main/java/com/kizuna/order/api/platform/PlatformOrderController.java
@@ -1,0 +1,30 @@
+package com.kizuna.order.api.platform;
+
+import com.kizuna.order.api.dto.PlatformOrderResponse;
+import com.kizuna.order.application.PlatformOrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 平台（統一）受注 API。授権店舗集合での横断一覧を提供する（#323 集合作用域）。 */
+@RestController
+@RequestMapping("/platform/orders")
+@RequiredArgsConstructor
+public class PlatformOrderController {
+
+  private final PlatformOrderService platformOrderService;
+
+  @GetMapping
+  @PreAuthorize("hasAnyAuthority('ROLE_HQ_ADMIN','ROLE_STORE_MANAGER','ROLE_STORE_STAFF')")
+  public ResponseEntity<Page<PlatformOrderResponse>> list(
+      @PageableDefault(sort = "businessDate", direction = Sort.Direction.DESC) Pageable pageable) {
+    return ResponseEntity.ok(platformOrderService.list(pageable));
+  }
+}

--- a/backend/src/main/java/com/kizuna/order/api/platform/PlatformOrderController.java
+++ b/backend/src/main/java/com/kizuna/order/api/platform/PlatformOrderController.java
@@ -1,15 +1,21 @@
 package com.kizuna.order.api.platform;
 
+import com.kizuna.order.api.dto.OrderResponse;
+import com.kizuna.order.api.dto.PlatformOrderCreateRequest;
 import com.kizuna.order.api.dto.PlatformOrderResponse;
 import com.kizuna.order.application.PlatformOrderService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,5 +32,12 @@ public class PlatformOrderController {
   public ResponseEntity<Page<PlatformOrderResponse>> list(
       @PageableDefault(sort = "businessDate", direction = Sort.Direction.DESC) Pageable pageable) {
     return ResponseEntity.ok(platformOrderService.list(pageable));
+  }
+
+  @PostMapping
+  @PreAuthorize("hasAnyAuthority('ROLE_HQ_ADMIN','ROLE_STORE_MANAGER','ROLE_STORE_STAFF')")
+  public ResponseEntity<OrderResponse> create(
+      @Valid @RequestBody PlatformOrderCreateRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(platformOrderService.create(request));
   }
 }

--- a/backend/src/main/java/com/kizuna/order/application/PlatformOrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/PlatformOrderService.java
@@ -1,12 +1,18 @@
 package com.kizuna.order.application;
 
 import com.kizuna.order.api.dto.OrderMapper;
+import com.kizuna.order.api.dto.OrderResponse;
+import com.kizuna.order.api.dto.PlatformOrderCreateRequest;
 import com.kizuna.order.api.dto.PlatformOrderResponse;
 import com.kizuna.order.domain.OrderRepository;
+import com.kizuna.shared.tenancy.StoreScope;
 import com.kizuna.shared.tenancy.StoreSetScoped;
+import com.kizuna.shared.tenancy.TenantContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class PlatformOrderService {
 
   private final OrderRepository orderRepository;
+  private final OrderService orderService;
+  private final TenantContext tenantContext;
   private final OrderMapper orderMapper;
 
   /** 授権店舗集合での受注横断一覧。濾過は storeSetFilter（@StoreSetScoped）が機構的に行う。 */
@@ -23,5 +31,21 @@ public class PlatformOrderService {
   @Transactional(readOnly = true)
   public Page<PlatformOrderResponse> list(Pageable pageable) {
     return orderRepository.findPlatformViews(pageable).map(orderMapper::toPlatformResponse);
+  }
+
+  /** 明示的単店指定の受注作成。storeId の授権検証後、店側と同一機構（TenantContext+@TenantScoped）で実行する。 */
+  public OrderResponse create(PlatformOrderCreateRequest request) {
+    StoreScope scope =
+        StoreScope.fromAuthentication(SecurityContextHolder.getContext().getAuthentication());
+    if (scope == null || !scope.authorizes(request.getStoreId())) {
+      throw new AccessDeniedException("指定店舗はこのアカウントの授権店舗集合に含まれません");
+    }
+    try {
+      tenantContext.setTenantId(request.getStoreId());
+      return orderService.create(request);
+    } finally {
+      // /platform は TenantIdInterceptor(afterCompletion clear)を通らないため、ここで必ず消す
+      tenantContext.clear();
+    }
   }
 }

--- a/backend/src/main/java/com/kizuna/order/application/PlatformOrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/PlatformOrderService.java
@@ -1,0 +1,27 @@
+package com.kizuna.order.application;
+
+import com.kizuna.order.api.dto.OrderMapper;
+import com.kizuna.order.api.dto.PlatformOrderResponse;
+import com.kizuna.order.domain.OrderRepository;
+import com.kizuna.shared.tenancy.StoreSetScoped;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 平台 principal（授権店舗集合）での受注横断ユースケース（#323 集合作用域）。 */
+@Service
+@RequiredArgsConstructor
+public class PlatformOrderService {
+
+  private final OrderRepository orderRepository;
+  private final OrderMapper orderMapper;
+
+  /** 授権店舗集合での受注横断一覧。濾過は storeSetFilter（@StoreSetScoped）が機構的に行う。 */
+  @StoreSetScoped
+  @Transactional(readOnly = true)
+  public Page<PlatformOrderResponse> list(Pageable pageable) {
+    return orderRepository.findPlatformViews(pageable).map(orderMapper::toPlatformResponse);
+  }
+}

--- a/backend/src/main/java/com/kizuna/order/domain/Order.java
+++ b/backend/src/main/java/com/kizuna/order/domain/Order.java
@@ -20,6 +20,7 @@ import org.hibernate.annotations.Type;
 @Entity
 @Table(name = "t_orders")
 @Filter(name = "tenantFilter", condition = "tenant_id = :tenantId")
+@Filter(name = "storeSetFilter", condition = "tenant_id in (:storeIds)")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
@@ -46,4 +46,21 @@ public interface OrderRepository
 
   @Query(VIEW_SELECT + " where o.id = :id")
   Optional<OrderView> findViewById(@Param("id") String id);
+
+  // 平台横断一覧（#323 集合作用域）。where 句を書かず、濾過は storeSetFilter が session 層で行う（機構の実証）。
+  // 店舗（tenant）表示名の join は張らない。
+  String PLATFORM_VIEW_SELECT =
+      """
+      select o.id as id, o.tenantId as storeId, o.storeName as storeName,
+             o.businessDate as businessDate,
+             o.arrivalScheduledStartTime as arrivalScheduledStartTime,
+             o.arrivalScheduledEndTime as arrivalScheduledEndTime,
+             o.status as status
+      from com.kizuna.order.domain.Order o
+      """;
+
+  @Query(
+      value = PLATFORM_VIEW_SELECT,
+      countQuery = "select count(o) from com.kizuna.order.domain.Order o")
+  Page<PlatformOrderView> findPlatformViews(Pageable pageable);
 }

--- a/backend/src/main/java/com/kizuna/order/domain/PlatformOrderView.java
+++ b/backend/src/main/java/com/kizuna/order/domain/PlatformOrderView.java
@@ -1,0 +1,25 @@
+package com.kizuna.order.domain;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * 平台横断受注一覧の読み側 projection（#323 集合作用域）。 濾過は storeSetFilter が Hibernate session 層で行うため、クエリ側に店舗の where
+ * 句は持たない。
+ */
+public interface PlatformOrderView {
+
+  String getId();
+
+  Long getStoreId();
+
+  String getStoreName();
+
+  LocalDate getBusinessDate();
+
+  LocalTime getArrivalScheduledStartTime();
+
+  LocalTime getArrivalScheduledEndTime();
+
+  OrderStatus getStatus();
+}

--- a/backend/src/main/java/com/kizuna/shared/persistence/TenantScopedEntity.java
+++ b/backend/src/main/java/com/kizuna/shared/persistence/TenantScopedEntity.java
@@ -23,6 +23,10 @@ import org.hibernate.annotations.ParamDef;
     name = "tenantFilter",
     applyToLoadByKey = true,
     parameters = @ParamDef(name = "tenantId", type = Long.class))
+@FilterDef(
+    name = "storeSetFilter",
+    applyToLoadByKey = true,
+    parameters = @ParamDef(name = "storeIds", type = Long.class))
 public abstract class TenantScopedEntity {
 
   @Id @SnowflakeId private String id;

--- a/backend/src/main/java/com/kizuna/shared/tenancy/StoreScope.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/StoreScope.java
@@ -1,0 +1,45 @@
+package com.kizuna.shared.tenancy;
+
+import io.jsonwebtoken.Claims;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.security.core.Authentication;
+
+/**
+ * 認証済み平台トークンの授権店舗集合（#323 集合作用域）。JWT の storeScopeType / storeIds claim から解決する。 解決できない場合は null
+ * を返し、呼び出し側が fail-closed に拒否する。
+ */
+public record StoreScope(boolean allStores, Set<Long> storeIds) {
+
+  public static StoreScope fromAuthentication(Authentication authentication) {
+    if (authentication == null || !(authentication.getDetails() instanceof Claims claims)) {
+      return null;
+    }
+    String scopeType = claims.get("storeScopeType", String.class);
+    if ("ALL_STORES".equals(scopeType)) {
+      return new StoreScope(true, Set.of());
+    }
+    if ("SPECIFIC_STORES".equals(scopeType)) {
+      Object raw = claims.get("storeIds");
+      if (!(raw instanceof List<?> list) || list.isEmpty()) {
+        return null;
+      }
+      Set<Long> ids =
+          list.stream()
+              .filter(Number.class::isInstance)
+              .map(v -> ((Number) v).longValue())
+              .collect(Collectors.toUnmodifiableSet());
+      if (ids.size() != list.size()) {
+        return null;
+      }
+      return new StoreScope(false, ids);
+    }
+    return null;
+  }
+
+  /** 指定店舗がこの授権集合に含まれるか。 */
+  public boolean authorizes(Long storeId) {
+    return storeId != null && (allStores || storeIds.contains(storeId));
+  }
+}

--- a/backend/src/main/java/com/kizuna/shared/tenancy/StoreSetFilterEnable.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/StoreSetFilterEnable.java
@@ -1,0 +1,45 @@
+package com.kizuna.shared.tenancy;
+
+import jakarta.persistence.EntityManager;
+import lombok.AllArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@code @StoreSetScoped} が付いたメソッドで Hibernate の storeSetFilter を有効化する Aspect（#323 集合作用域）。
+ *
+ * <p>認証済み平台トークンの授権店舗集合を {@link StoreScope} で解決し、SPECIFIC_STORES の場合のみ storeSetFilter（{@code
+ * tenant_id in (:storeIds)}）を有効化する。ALL_STORES はフィルタ無効＝全店可視。授権集合を解決できない呼び出しは fail-closed に {@link
+ * AccessDeniedException} で拒否する。{@link TenantFilterEnable} と同型の {@code @Order} 指定（トランザクション advisor
+ * との相対順序）を逐字踏襲する。
+ */
+@Aspect
+@Component
+@Order
+@AllArgsConstructor
+public class StoreSetFilterEnable {
+
+  private final EntityManager entityManager;
+
+  @Around(value = "@annotation(com.kizuna.shared.tenancy.StoreSetScoped)")
+  public Object enableStoreSetFilter(ProceedingJoinPoint pjp) throws Throwable {
+    StoreScope scope =
+        StoreScope.fromAuthentication(SecurityContextHolder.getContext().getAuthentication());
+    if (scope == null) {
+      // fail-closed: 授権集合を解決できない呼び出しは進ませない
+      throw new AccessDeniedException("店舗集合スコープを解決できません");
+    }
+    if (!scope.allStores()) {
+      entityManager
+          .unwrap(org.hibernate.Session.class)
+          .enableFilter("storeSetFilter")
+          .setParameterList("storeIds", scope.storeIds());
+    }
+    return pjp.proceed();
+  }
+}

--- a/backend/src/main/java/com/kizuna/shared/tenancy/StoreSetScoped.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/StoreSetScoped.java
@@ -1,0 +1,16 @@
+package com.kizuna.shared.tenancy;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 集合作用域: 付与されたメソッドで Hibernate の {@code storeSetFilter} を有効化する（#323）。
+ *
+ * <p>認証済み平台トークンの授権店舗集合（{@link StoreScope}）に基づき、SPECIFIC_STORES では {@code tenant_id in (:storeIds)}
+ * で行レベルに濾過し、ALL_STORES ではフィルタ無効＝全店可視とする。授権集合を解決できない呼び出しは fail-closed に拒否される。
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface StoreSetScoped {}

--- a/backend/src/test/java/com/kizuna/TenantIsolationTests.java
+++ b/backend/src/test/java/com/kizuna/TenantIsolationTests.java
@@ -41,10 +41,16 @@ class TenantIsolationTests {
         continue;
       }
       scanned.add(entity.getSimpleName());
-      Filter filter = entity.getAnnotation(Filter.class);
-      if (filter == null
-          || !"tenantFilter".equals(filter.name())
-          || !EXPECTED_CONDITION.equals(filter.condition())) {
+      // @Filter は Hibernate 6 で repeatable のため、tenantFilter を宣言していれば
+      // 他フィルタ（storeSetFilter 等）が並置されていても違反としない。
+      boolean declaresTenantFilter = false;
+      for (Filter filter : entity.getAnnotationsByType(Filter.class)) {
+        if ("tenantFilter".equals(filter.name()) && EXPECTED_CONDITION.equals(filter.condition())) {
+          declaresTenantFilter = true;
+          break;
+        }
+      }
+      if (!declaresTenantFilter) {
         offenders.add(entity.getName());
       }
     }
@@ -60,11 +66,20 @@ class TenantIsolationTests {
   @Test
   @DisplayName("tenantFilter は主キー直接ロード（EntityManager#find 経由の findById 等）にも適用されること")
   void tenantFilterAppliesToLoadByKey() {
-    FilterDef filterDef = TenantScopedEntity.class.getAnnotation(FilterDef.class);
+    // @FilterDef は Hibernate 6 で repeatable のため、tenantFilter の定義を名前で取り出す
+    // （storeSetFilter 等が並置されていても getAnnotation は container を返し null になるため）。
+    FilterDef tenantFilterDef = null;
+    for (FilterDef filterDef : TenantScopedEntity.class.getAnnotationsByType(FilterDef.class)) {
+      if ("tenantFilter".equals(filterDef.name())) {
+        tenantFilterDef = filterDef;
+        break;
+      }
+    }
 
-    assertThat(filterDef).isNotNull();
-    assertThat(filterDef.name()).isEqualTo("tenantFilter");
-    assertThat(filterDef.applyToLoadByKey())
+    assertThat(tenantFilterDef)
+        .as("TenantScopedEntity が tenantFilter の @FilterDef を宣言していること")
+        .isNotNull();
+    assertThat(tenantFilterDef.applyToLoadByKey())
         .as(
             "applyToLoadByKey=false だと Session#find（Spring Data JPA の findById 実装経路）に"
                 + " filter が効かず、他テナントの ID を直接指定した読み取りが素通りする")

--- a/backend/src/test/java/com/kizuna/order/application/PlatformOrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/PlatformOrderServiceTest.java
@@ -1,33 +1,75 @@
 package com.kizuna.order.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.kizuna.order.api.dto.OrderMapper;
+import com.kizuna.order.api.dto.OrderResponse;
+import com.kizuna.order.api.dto.PlatformOrderCreateRequest;
 import com.kizuna.order.api.dto.PlatformOrderResponse;
 import com.kizuna.order.domain.OrderRepository;
 import com.kizuna.order.domain.PlatformOrderView;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.tenancy.TenantContext;
+import io.jsonwebtoken.Claims;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 @ExtendWith(MockitoExtension.class)
 class PlatformOrderServiceTest {
 
   @Mock OrderRepository orderRepository;
+  @Mock OrderService orderService;
   @Mock OrderMapper orderMapper;
 
-  @InjectMocks PlatformOrderService service;
+  // create は実物の TenantContext を注入し、OrderService.create 呼び出し時点の tenantId を捕捉して検証する。
+  private final TenantContext tenantContext = new TenantContext();
+  private PlatformOrderService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new PlatformOrderService(orderRepository, orderService, tenantContext, orderMapper);
+  }
+
+  @AfterEach
+  void clearContext() {
+    SecurityContextHolder.clearContext();
+    tenantContext.clear();
+  }
+
+  private void authenticate(String scopeType, Object storeIds) {
+    Claims claims = mock(Claims.class);
+    lenient().when(claims.get("storeScopeType", String.class)).thenReturn(scopeType);
+    lenient().when(claims.get("storeIds")).thenReturn(storeIds);
+    Authentication auth = mock(Authentication.class);
+    lenient().when(auth.getDetails()).thenReturn(claims);
+    SecurityContextHolder.getContext().setAuthentication(auth);
+  }
+
+  private PlatformOrderCreateRequest requestForStore(long storeId) {
+    PlatformOrderCreateRequest req = new PlatformOrderCreateRequest();
+    req.setStoreId(storeId);
+    return req;
+  }
 
   @Test
   void listMapsPlatformViewsToResponses() {
@@ -44,5 +86,80 @@ class PlatformOrderServiceTest {
     assertThat(result.getContent().get(0).getId()).isEqualTo("o1");
     assertThat(result.getContent().get(0).getStoreId()).isEqualTo(1L);
     verify(orderRepository).findPlatformViews(any(Pageable.class));
+  }
+
+  @Test
+  void createFailsClosedWhenScopeUnresolved() {
+    // 認証コンテキスト未設定 → StoreScope 解決不能
+    assertThatThrownBy(() -> service.create(requestForStore(1L)))
+        .isInstanceOf(AccessDeniedException.class);
+
+    verify(orderService, never()).create(any());
+    assertThat(tenantContext.getTenantId()).isNull();
+  }
+
+  @Test
+  void createRejectsOutOfSetStore() {
+    authenticate("SPECIFIC_STORES", List.of(1));
+
+    assertThatThrownBy(() -> service.create(requestForStore(2L)))
+        .isInstanceOf(AccessDeniedException.class);
+
+    verify(orderService, never()).create(any());
+    assertThat(tenantContext.getTenantId()).isNull();
+  }
+
+  @Test
+  void createSetsTenantContextForAuthorizedStoreAndClearsAfter() {
+    authenticate("SPECIFIC_STORES", List.of(1));
+    PlatformOrderCreateRequest req = requestForStore(1L);
+    OrderResponse res = OrderResponse.builder().id("o1").build();
+
+    AtomicReference<Long> tenantAtCall = new AtomicReference<>();
+    when(orderService.create(req))
+        .thenAnswer(
+            inv -> {
+              tenantAtCall.set(tenantContext.getTenantId());
+              return res;
+            });
+
+    OrderResponse result = service.create(req);
+
+    assertThat(result).isSameAs(res);
+    assertThat(tenantAtCall.get())
+        .as("OrderService.create 呼び出し時点で TenantContext が storeId")
+        .isEqualTo(1L);
+    assertThat(tenantContext.getTenantId()).as("復帰後は finally で clear 済み").isNull();
+  }
+
+  @Test
+  void createAllowsAnyStoreForAllStoresScope() {
+    authenticate("ALL_STORES", null);
+    PlatformOrderCreateRequest req = requestForStore(999L);
+    OrderResponse res = OrderResponse.builder().id("o1").build();
+
+    AtomicReference<Long> tenantAtCall = new AtomicReference<>();
+    when(orderService.create(req))
+        .thenAnswer(
+            inv -> {
+              tenantAtCall.set(tenantContext.getTenantId());
+              return res;
+            });
+
+    service.create(req);
+
+    assertThat(tenantAtCall.get()).isEqualTo(999L);
+    assertThat(tenantContext.getTenantId()).isNull();
+  }
+
+  @Test
+  void createClearsTenantContextEvenWhenOrderServiceThrows() {
+    authenticate("SPECIFIC_STORES", List.of(1));
+    PlatformOrderCreateRequest req = requestForStore(1L);
+
+    when(orderService.create(req)).thenThrow(new ServiceException("boom"));
+
+    assertThatThrownBy(() -> service.create(req)).isInstanceOf(ServiceException.class);
+    assertThat(tenantContext.getTenantId()).as("例外時も finally で clear される").isNull();
   }
 }

--- a/backend/src/test/java/com/kizuna/order/application/PlatformOrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/PlatformOrderServiceTest.java
@@ -1,0 +1,48 @@
+package com.kizuna.order.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.kizuna.order.api.dto.OrderMapper;
+import com.kizuna.order.api.dto.PlatformOrderResponse;
+import com.kizuna.order.domain.OrderRepository;
+import com.kizuna.order.domain.PlatformOrderView;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class PlatformOrderServiceTest {
+
+  @Mock OrderRepository orderRepository;
+  @Mock OrderMapper orderMapper;
+
+  @InjectMocks PlatformOrderService service;
+
+  @Test
+  void listMapsPlatformViewsToResponses() {
+    PlatformOrderView view = mock(PlatformOrderView.class);
+    PlatformOrderResponse res = PlatformOrderResponse.builder().id("o1").storeId(1L).build();
+    Page<PlatformOrderView> page = new PageImpl<>(List.of(view), PageRequest.of(0, 10), 1);
+
+    when(orderRepository.findPlatformViews(any(Pageable.class))).thenReturn(page);
+    when(orderMapper.toPlatformResponse(view)).thenReturn(res);
+
+    Page<PlatformOrderResponse> result = service.list(PageRequest.of(0, 10));
+
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().get(0).getId()).isEqualTo("o1");
+    assertThat(result.getContent().get(0).getStoreId()).isEqualTo(1L);
+    verify(orderRepository).findPlatformViews(any(Pageable.class));
+  }
+}

--- a/backend/src/test/java/com/kizuna/shared/tenancy/StoreScopeTest.java
+++ b/backend/src/test/java/com/kizuna/shared/tenancy/StoreScopeTest.java
@@ -1,0 +1,122 @@
+package com.kizuna.shared.tenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.jsonwebtoken.Claims;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+
+/** {@link StoreScope} の claim 解決と授権判定の単体テスト（#323 集合作用域）。 */
+class StoreScopeTest {
+
+  private Authentication authWith(Claims claims) {
+    Authentication auth = mock(Authentication.class);
+    when(auth.getDetails()).thenReturn(claims);
+    return auth;
+  }
+
+  @Test
+  @DisplayName("ALL_STORES を解決する（allStores=true / storeIds 空）")
+  void resolvesAllStores() {
+    Claims claims = mock(Claims.class);
+    when(claims.get("storeScopeType", String.class)).thenReturn("ALL_STORES");
+
+    StoreScope scope = StoreScope.fromAuthentication(authWith(claims));
+
+    assertThat(scope).isNotNull();
+    assertThat(scope.allStores()).isTrue();
+    assertThat(scope.storeIds()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("SPECIFIC_STORES を解決する（Integer 混在 List を Long へ強制変換）")
+  void resolvesSpecificStoresCoercingIntegersToLong() {
+    Claims claims = mock(Claims.class);
+    when(claims.get("storeScopeType", String.class)).thenReturn("SPECIFIC_STORES");
+    when(claims.get("storeIds")).thenReturn(List.of(1, 2)); // jjwt は数値配列を Integer で返しうる
+
+    StoreScope scope = StoreScope.fromAuthentication(authWith(claims));
+
+    assertThat(scope).isNotNull();
+    assertThat(scope.allStores()).isFalse();
+    assertThat(scope.storeIds()).containsExactlyInAnyOrder(1L, 2L);
+  }
+
+  @Test
+  @DisplayName("authorizes: 含む店舗は true、含まない店舗と null は false")
+  void authorizesRespectsSpecificSet() {
+    StoreScope scope = new StoreScope(false, Set.of(1L));
+
+    assertThat(scope.authorizes(1L)).isTrue();
+    assertThat(scope.authorizes(2L)).isFalse();
+    assertThat(scope.authorizes(null)).isFalse();
+  }
+
+  @Test
+  @DisplayName("authorizes: ALL_STORES は任意店舗で true、ただし null は false")
+  void allStoresAuthorizesAnyNonNullStore() {
+    StoreScope scope = new StoreScope(true, Set.of());
+
+    assertThat(scope.authorizes(1L)).isTrue();
+    assertThat(scope.authorizes(999L)).isTrue();
+    assertThat(scope.authorizes(null)).isFalse();
+  }
+
+  @Test
+  @DisplayName("scopeType claim 欠落は null")
+  void returnsNullWhenScopeTypeMissing() {
+    Claims claims = mock(Claims.class);
+    when(claims.get("storeScopeType", String.class)).thenReturn(null);
+
+    assertThat(StoreScope.fromAuthentication(authWith(claims))).isNull();
+  }
+
+  @Test
+  @DisplayName("未知の scopeType は null")
+  void returnsNullForUnknownScopeType() {
+    Claims claims = mock(Claims.class);
+    when(claims.get("storeScopeType", String.class)).thenReturn("SOMETHING_ELSE");
+
+    assertThat(StoreScope.fromAuthentication(authWith(claims))).isNull();
+  }
+
+  @Test
+  @DisplayName("details が Claims でない場合は null")
+  void returnsNullWhenDetailsNotClaims() {
+    Authentication auth = mock(Authentication.class);
+    when(auth.getDetails()).thenReturn("not-claims");
+
+    assertThat(StoreScope.fromAuthentication(auth)).isNull();
+  }
+
+  @Test
+  @DisplayName("authentication が null の場合は null")
+  void returnsNullWhenAuthenticationNull() {
+    assertThat(StoreScope.fromAuthentication(null)).isNull();
+  }
+
+  @Test
+  @DisplayName("SPECIFIC_STORES で storeIds が空は null")
+  void returnsNullWhenSpecificButStoreIdsEmpty() {
+    Claims claims = mock(Claims.class);
+    when(claims.get("storeScopeType", String.class)).thenReturn("SPECIFIC_STORES");
+    when(claims.get("storeIds")).thenReturn(List.of());
+
+    assertThat(StoreScope.fromAuthentication(authWith(claims))).isNull();
+  }
+
+  @Test
+  @DisplayName("SPECIFIC_STORES で数値でない要素が混入すると null")
+  void returnsNullWhenSpecificContainsNonNumericElement() {
+    Claims claims = mock(Claims.class);
+    when(claims.get("storeScopeType", String.class)).thenReturn("SPECIFIC_STORES");
+    when(claims.get("storeIds")).thenReturn(List.of(1, "x"));
+
+    assertThat(StoreScope.fromAuthentication(authWith(claims))).isNull();
+  }
+}

--- a/backend/src/test/java/com/kizuna/shared/tenancy/StoreSetFilterEnableTest.java
+++ b/backend/src/test/java/com/kizuna/shared/tenancy/StoreSetFilterEnableTest.java
@@ -1,0 +1,97 @@
+package com.kizuna.shared.tenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.jsonwebtoken.Claims;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.Set;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.hibernate.Filter;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class StoreSetFilterEnableTest {
+
+  @Mock private EntityManager entityManager;
+  @Mock private Session session;
+  @Mock private Filter filter;
+  @Mock private ProceedingJoinPoint pjp;
+
+  private StoreSetFilterEnable aspect;
+
+  @BeforeEach
+  void setUp() {
+    aspect = new StoreSetFilterEnable(entityManager);
+  }
+
+  @AfterEach
+  void clearContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void authenticateWith(Claims claims) {
+    Authentication auth = mock(Authentication.class);
+    lenient().when(auth.getDetails()).thenReturn(claims);
+    SecurityContextHolder.getContext().setAuthentication(auth);
+  }
+
+  @Test
+  @DisplayName("授権集合を解決できない呼び出しは fail-closed で AccessDeniedException となり proceed されないこと")
+  void failsClosedWhenScopeUnresolved() throws Throwable {
+    // 認証コンテキスト未設定 → StoreScope 解決不能
+    assertThatThrownBy(() -> aspect.enableStoreSetFilter(pjp))
+        .isInstanceOf(AccessDeniedException.class);
+
+    verify(pjp, never()).proceed();
+  }
+
+  @Test
+  @DisplayName("ALL_STORES はフィルタを有効化せず処理だけ続行すること")
+  void allStoresSkipsFilterAndProceeds() throws Throwable {
+    Claims claims = mock(Claims.class);
+    when(claims.get("storeScopeType", String.class)).thenReturn("ALL_STORES");
+    authenticateWith(claims);
+    when(pjp.proceed()).thenReturn("result");
+
+    Object result = aspect.enableStoreSetFilter(pjp);
+
+    assertThat(result).isEqualTo("result");
+    verify(entityManager, never()).unwrap(Session.class);
+    verify(pjp).proceed();
+  }
+
+  @Test
+  @DisplayName("SPECIFIC_STORES は storeSetFilter を授権集合で有効化してから処理を続行すること")
+  void specificStoresEnablesFilterWithStoreIds() throws Throwable {
+    Claims claims = mock(Claims.class);
+    when(claims.get("storeScopeType", String.class)).thenReturn("SPECIFIC_STORES");
+    when(claims.get("storeIds")).thenReturn(List.of(1, 2));
+    authenticateWith(claims);
+    when(entityManager.unwrap(Session.class)).thenReturn(session);
+    when(session.enableFilter("storeSetFilter")).thenReturn(filter);
+    when(pjp.proceed()).thenReturn("result");
+
+    Object result = aspect.enableStoreSetFilter(pjp);
+
+    assertThat(result).isEqualTo("result");
+    verify(filter).setParameterList("storeIds", Set.of(1L, 2L));
+    verify(pjp).proceed();
+  }
+}


### PR DESCRIPTION
## 概要

プラットフォーム principal(ロール×店舗集合、#322)に対する**集合作用域機構**を導入する。読み=授権店舗集合での集約読みを Hibernate session 層の第二フィルタ(`storeSetFilter`: `tenant_id IN (:storeIds)`)で**機構的に fail-closed** に濾過し、書き=明示的な単一 `store_id` の授権検証(集合外→403、未指定→400)を要求する。Order 集約をトレーサーとして `GET /platform/orders`(集合横断一覧)と `POST /platform/orders`(単店指定作成)を貫通させた。既存の店側 `/tenant/orders`・central 経路は注釈追加のみで無変更。

Closes #323

## 変更内容

- `shared/tenancy`(新規 3 クラス): `StoreScope`(JWT claims `storeScopeType`/`storeIds` から解決する授権集合の値オブジェクト。解決不能は null=fail-closed、jjwt の Integer→Long 強制変換込み)/ `@StoreSetScoped` / `StoreSetFilterEnable`(`TenantFilterEnable` 同型の Aspect。解決不能→`AccessDeniedException`、ALL_STORES→無濾過、SPECIFIC_STORES→`enableFilter("storeSetFilter").setParameterList(...)`)
- `shared/persistence/TenantScopedEntity`: `@FilterDef(storeSetFilter)` を既存 tenantFilter に並置(既存定義は無変更)
- `order/domain/Order`: `@Filter(name="storeSetFilter", condition="tenant_id in (:storeIds)")` を並置(トレーサーは Order のみ。他集約への展開は各ポータルチケットの管轄)
- `order`: `PlatformOrderView`(projection)+ `OrderRepository.findPlatformViews`(**where 句なし**——濾過は session フィルタが機構的に行う)/ `PlatformOrderService`(list=`@StoreSetScoped @Transactional(readOnly)`、create=授権検証→`TenantContext.setTenantId(storeId)`+try/finally clear で既存 `@TenantScoped OrderService.create` を再利用)/ `PlatformOrderController`(`/platform/orders`、`@PreAuthorize` は HQ_ADMIN/STORE_MANAGER/STORE_STAFF のみ)/ DTO `PlatformOrderCreateRequest`(`store_id` @NotNull)・`PlatformOrderResponse`
- 統合テスト `PlatformOrderScopeIT`(8 本): repository 直挿カナリア(`店舗B機密受注`)の**応答生ボディ非含有**断言、SPECIFIC{1} 全行 `store_id==1`、ALL_STORES 正側、書き 400/403(+永続化なしの repository 直読証明)/201 正向対照(tenantId==1)、tenant トークン 403、CAST ロール 403
- 単体テスト: `StoreScopeTest`(10)/ `StoreSetFilterEnableTest`(3)/ `PlatformOrderServiceTest`(6、実物 TenantContext で設定→clear のライフサイクルを固定)
- `TenantIsolationTests`: 反復注釈化(`@Filters`/`@FilterDefs` コンテナ)に伴い `getAnnotationsByType`+名前選別へ読み替え(不変量の意図は不変)
- `CONTEXT.md` 用語集に集合作用域 3 行、`backend/docs/modulith/module-shared.adoc` に `StoreSetFilterEnable` 1 行(無関係ドリフトは merge-base 裏取りのうえ除外)

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0(単体カバレッジゲート+integrationTest 13 スイート全緑。`PlatformOrderScopeIT` 8/8、既存 CrossTenantIT 群・`TenantContextFailClosedIT`・`PlatformAuthIT` 回帰維持)
- [x] `task build` exit 0
- [x] `task e2e` exit 0(実行シナリオ: 年齢確認ゲート／公開キャスト詳細のクロステナント越権 404／中央管理画面ログイン／公開サイト表示／公開出勤表／店舗設定の保存／模版切替／テナント管理画面ログイン——8/8。UI 面なしのため新規 .feature はなし、既存プールの回帰のみ)

### 視覚確認（UI 変更時）

対象外（UI 変更なし）

## 決定ログ

- **読みの fail-closed は session 層の第二フィルタ**: 平台一覧の JPQL には意図的に where を書かず、`@StoreSetScoped` 境界内の全クエリを Hibernate フィルタで濾過する。検証漏れがあっても集合外の行が出ない構造(issue の機構要件)。ALL_STORES はフィルタ無効=全店可視(仕様どおり)。QA は反事実で固定: `allStoresScopeSeesEveryStore` がフィルタ無効時に両店の行が返ることを証明しており、カナリアは SPECIFIC 呼び出し中も DB に実在するため、Aspect が発火しなければ AC1/AC2 が必ず赤くなる。
- **授権判定は JWT claims 準拠**(DB 再読なし): 既存の tenantId claim を正とするモデルと同型。トークン有効期間中の授権変更ステールは既存認証と同一の受容(見直しは #325 の管轄)。
- **書きは TenantContext を検証済み storeId に設定して既存 `OrderService.create` を再利用**: 単店文脈での検証・分離(tenantFilter、跨聚合の existsById)が店側経路と機械的に同一になる。`/platform` は `TenantIdInterceptor`(afterCompletion clear)を通らないため **finally での clear が必須**——単体テストで例外時含め固定。`PlatformOrderService.create` 自身は `@Transactional` を持たない(TenantContext 設定**後**に跨 Bean プロキシ経由で `@TenantScoped` が発火する必要があるため)。
- **トレーサー端点の役割線は HQ_ADMIN / STORE_MANAGER / STORE_STAFF のみ**: CAST/MEMBER は自ポータル(#328/#334-336)で固有ルールを持つため、スタッフ業務 API には入れない。
- **会計金額・人数は追加しない**(裁定 7 は #334/#335 の管轄)。Liquibase 変更なし・フロントエンド変更なし。
- **`TenantIsolationTests` の改修は必須の随伴**: 2 本目の `@Filter`/`@FilterDef` 並置で単一注釈取得(`getAnnotation`)が null になるため。tenantFilter の条件文字列・`applyToLoadByKey=true` の断言強度は維持。

## 備考 / レビュー観点

- high-risk run(テナント分離)として、独立検証(opus)+計画非開示の対抗プレレビュー(opus)を実施済み: **blocking 所見ゼロ**。非阻断所見のうち「`@StoreSetScoped` 拡張時に実体側 `@Filter` 宣言を忘れると fail-open になる将来クラス」と「`totalElements` 濾過の断言未固定」は **#339** に切り出し(消費者=機構を第二集約へ拡張する最初のチケット)。分页サイズ上限なしは既存端点と同水準のため見送り。
- 切面と transaction advisor の相対順序(`@Order` 同値)は既存 `TenantFilterEnable` から継承した暗黙依存(OSIV off のため順序が崩れると静的に漏れる)。今回は同型踏襲であり、IT が実挙動を固定している。
- AC2 のカナリアのうち `remarks` 値は projection に含まれないため断言としては空振り(storeName カナリアが実効断言)。#339 の対応時に整理可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
