### PR TITLE
fix: 授権状態の並行上書きを全実体 @Version 楽観ロックと staff API バージョン往復で防ぐ (#400)

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -127,10 +127,11 @@ class PlatformStaffManagementIT extends CrossTenantTestSupport {
         email, PASSWORD, bundleIdsJson, scopeType, storeIds);
   }
 
-  private static String updateBody(String bundleIdsJson, String scopeType, String storeIds) {
+  private static String updateBody(
+      String bundleIdsJson, String scopeType, String storeIds, long version) {
     return String.format(
-        "{\"bundle_ids\":%s,\"store_scope_type\":\"%s\",\"store_ids\":%s}",
-        bundleIdsJson, scopeType, storeIds);
+        "{\"bundle_ids\":%s,\"store_scope_type\":\"%s\",\"store_ids\":%s,\"version\":%d}",
+        bundleIdsJson, scopeType, storeIds, version);
   }
 
   /** 束名を JSON の id 配列へ解決する（例: ["店長"] → "[3]"）。 */
@@ -227,6 +228,7 @@ class PlatformStaffManagementIT extends CrossTenantTestSupport {
             JsonNode.class);
     assertThat(created.getStatusCode()).isEqualTo(HttpStatus.OK);
     long staffId = created.getBody().path("id").asLong();
+    long version = created.getBody().path("version").asLong();
 
     ResponseEntity<String> before =
         rest.exchange(
@@ -244,7 +246,7 @@ class PlatformStaffManagementIT extends CrossTenantTestSupport {
             "/platform/staff/" + staffId,
             HttpMethod.PUT,
             new HttpEntity<>(
-                updateBody(bundlesJson("店長"), "SPECIFIC_STORES", "[" + storeBId + "]"),
+                updateBody(bundlesJson("店長"), "SPECIFIC_STORES", "[" + storeBId + "]", version),
                 bearerJson(hq)),
             JsonNode.class);
     assertThat(updated.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -409,6 +411,7 @@ class PlatformStaffManagementIT extends CrossTenantTestSupport {
             JsonNode.class);
     assertThat(created.getStatusCode()).isEqualTo(HttpStatus.OK);
     long staffId = created.getBody().path("id").asLong();
+    long version = created.getBody().path("version").asLong();
 
     // 停止（enabled=false）。授権内容は同値のまま。
     ResponseEntity<JsonNode> stopped =
@@ -418,7 +421,10 @@ class PlatformStaffManagementIT extends CrossTenantTestSupport {
             new HttpEntity<>(
                 "{\"bundle_ids\":"
                     + bundlesJson("店舗スタッフ")
-                    + ",\"store_scope_type\":\"ALL_STORES\",\"store_ids\":[],\"enabled\":false}",
+                    + ",\"store_scope_type\":\"ALL_STORES\",\"store_ids\":[],\"enabled\":false,"
+                    + "\"version\":"
+                    + version
+                    + "}",
                 bearerJson(hq)),
             JsonNode.class);
     assertThat(stopped.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -493,6 +499,160 @@ class PlatformStaffManagementIT extends CrossTenantTestSupport {
         .as("履歴快照に精算範囲が残ること")
         .contains("settlement_scope_type")
         .contains("SPECIFIC_STORES");
+  }
+
+  /** 付与履歴の行数を返す（陳腐更新の拒否で履歴が増えないことの断言に使う）。 */
+  private int grantHistorySize(String token, long staffId) {
+    ResponseEntity<JsonNode> res =
+        rest.exchange(
+            "/platform/staff/" + staffId + "/grant-history",
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(token)),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    return res.getBody().size();
+  }
+
+  /** スタッフ一覧から email 一致の 1 件を返す（見つからなければ失敗）。 */
+  private JsonNode findStaffByEmail(String token, String email) {
+    ResponseEntity<JsonNode> res =
+        rest.exchange(
+            "/platform/staff", HttpMethod.GET, new HttpEntity<>(bearer(token)), JsonNode.class);
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    for (JsonNode node : res.getBody()) {
+      if (email.equals(node.path("email").asText())) {
+        return node;
+      }
+    }
+    throw new AssertionError("スタッフ一覧に " + email + " が見つかりません");
+  }
+
+  @Test
+  @DisplayName("同一 version の二連 PUT は 2 発目が 409 になり、授権・enabled が巻き戻らず付与履歴も増えないこと(#400 AC1)")
+  void staleUpdateWithSameVersionIsRejectedWithoutRollback() {
+    String hq = platformToken(SEED_EMAIL, PASSWORD);
+    String email = "staff-it-stale@kizuna.test";
+
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/platform/staff",
+            new HttpEntity<>(
+                createBody(email, bundlesJson("店長"), "SPECIFIC_STORES", "[" + storeAId + "]"),
+                bearerJson(hq)),
+            JsonNode.class);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.OK);
+    long staffId = created.getBody().path("id").asLong();
+    long initialVersion = created.getBody().path("version").asLong();
+
+    // 1 発目: 返却された version での更新は成功し、応答は増加した version を返す。
+    ResponseEntity<JsonNode> first =
+        rest.exchange(
+            "/platform/staff/" + staffId,
+            HttpMethod.PUT,
+            new HttpEntity<>(
+                updateBody(
+                    bundlesJson("店長"), "SPECIFIC_STORES", "[" + storeBId + "]", initialVersion),
+                bearerJson(hq)),
+            JsonNode.class);
+    assertThat(first.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(first.getBody().path("version").asLong())
+        .as("更新成功の応答は増加した version を返すこと")
+        .isGreaterThan(initialVersion);
+
+    int historyCountAfterFirst = grantHistorySize(hq, staffId);
+
+    // 2 発目: 同じ（陳腐化した）version で店舗集合を A へ戻し停止も試みる上書きは 409。
+    ResponseEntity<JsonNode> second =
+        rest.exchange(
+            "/platform/staff/" + staffId,
+            HttpMethod.PUT,
+            new HttpEntity<>(
+                "{\"bundle_ids\":"
+                    + bundlesJson("店長")
+                    + ",\"store_scope_type\":\"SPECIFIC_STORES\",\"store_ids\":["
+                    + storeAId
+                    + "],\"enabled\":false,\"version\":"
+                    + initialVersion
+                    + "}",
+                bearerJson(hq)),
+            JsonNode.class);
+    assertThat(second.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+
+    // 授権・enabled は 1 発目の内容のまま巻き戻らない。
+    JsonNode target = findStaffByEmail(hq, email);
+    assertThat(target.path("enabled").asBoolean()).as("陳腐更新で停止へ巻き戻らないこと").isTrue();
+    assertThat(target.path("store_ids")).hasSize(1);
+    assertThat(target.path("store_ids").get(0).asLong())
+        .as("店舗集合は 1 発目の B のまま残ること")
+        .isEqualTo(storeBId);
+
+    // 付与履歴の行も増えない。
+    assertThat(grantHistorySize(hq, staffId))
+        .as("拒否された陳腐更新で付与履歴が増えないこと")
+        .isEqualTo(historyCountAfterFirst);
+  }
+
+  @Test
+  @DisplayName("陳腐 version による停止解除は 409 で拒否され、停止済みアカウントが静黙復活しないこと(#400 AC2)")
+  void staleResumeIsRejectedAndUserStaysStopped() {
+    String hq = platformToken(SEED_EMAIL, PASSWORD);
+    String email = "staff-it-stale-resume@kizuna.test";
+
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/platform/staff",
+            new HttpEntity<>(
+                createBody(email, bundlesJson("店舗スタッフ"), "ALL_STORES", "[]"), bearerJson(hq)),
+            JsonNode.class);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.OK);
+    long staffId = created.getBody().path("id").asLong();
+    long preStopVersion = created.getBody().path("version").asLong();
+
+    // 現行 version で停止する（成功）。
+    ResponseEntity<JsonNode> stopped =
+        rest.exchange(
+            "/platform/staff/" + staffId,
+            HttpMethod.PUT,
+            new HttpEntity<>(
+                "{\"bundle_ids\":"
+                    + bundlesJson("店舗スタッフ")
+                    + ",\"store_scope_type\":\"ALL_STORES\",\"store_ids\":[],\"enabled\":false,"
+                    + "\"version\":"
+                    + preStopVersion
+                    + "}",
+                bearerJson(hq)),
+            JsonNode.class);
+    assertThat(stopped.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(stopped.getBody().path("enabled").asBoolean()).isFalse();
+
+    // 停止前の陳腐 version による再開（enabled=true）の試みは 409。
+    ResponseEntity<JsonNode> resumeAttempt =
+        rest.exchange(
+            "/platform/staff/" + staffId,
+            HttpMethod.PUT,
+            new HttpEntity<>(
+                "{\"bundle_ids\":"
+                    + bundlesJson("店舗スタッフ")
+                    + ",\"store_scope_type\":\"ALL_STORES\",\"store_ids\":[],\"enabled\":true,"
+                    + "\"version\":"
+                    + preStopVersion
+                    + "}",
+                bearerJson(hq)),
+            JsonNode.class);
+    assertThat(resumeAttempt.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+
+    // 停止のまま: 一覧でも enabled=false、ログインも不可。
+    assertThat(findStaffByEmail(hq, email).path("enabled").asBoolean())
+        .as("陳腐 version の停止解除で停止済みアカウントが復活しないこと")
+        .isFalse();
+    ResponseEntity<JsonNode> login =
+        rest.postForEntity(
+            "/platform/login",
+            new HttpEntity<>(
+                String.format("{\"email\": \"%s\", \"password\": \"%s\"}", email, PASSWORD),
+                jsonHeaders()),
+            JsonNode.class);
+    assertThat(login.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
   }
 
   @Test

--- a/backend/src/main/java/com/kizuna/menu/domain/CentralMenu.java
+++ b/backend/src/main/java/com/kizuna/menu/domain/CentralMenu.java
@@ -11,6 +11,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,4 +57,9 @@ public class CentralMenu implements MenuNode {
   @UpdateTimestamp
   @Column(name = "updated_at")
   private LocalDateTime updatedAt;
+
+  /** 楽観ロック用バージョン（全実体共通 — #400）。 */
+  @Version
+  @Column(nullable = false)
+  private Long version;
 }

--- a/backend/src/main/java/com/kizuna/menu/domain/CentralMenu.java
+++ b/backend/src/main/java/com/kizuna/menu/domain/CentralMenu.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
@@ -59,6 +60,7 @@ public class CentralMenu implements MenuNode {
   private LocalDateTime updatedAt;
 
   /** 楽観ロック用バージョン（全実体共通 — #400）。 */
+  @Setter(AccessLevel.NONE) // 新規 public setter 禁止規約: バージョンは JPA が管理し外部から設定させない（#400）
   @Version
   @Column(nullable = false)
   private Long version;

--- a/backend/src/main/java/com/kizuna/menu/domain/StoreMenu.java
+++ b/backend/src/main/java/com/kizuna/menu/domain/StoreMenu.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
@@ -62,6 +63,7 @@ public class StoreMenu implements MenuNode {
   private LocalDateTime updatedAt;
 
   /** 楽観ロック用バージョン（全実体共通 — #400）。 */
+  @Setter(AccessLevel.NONE) // 新規 public setter 禁止規約: バージョンは JPA が管理し外部から設定させない（#400）
   @Version
   @Column(nullable = false)
   private Long version;

--- a/backend/src/main/java/com/kizuna/menu/domain/StoreMenu.java
+++ b/backend/src/main/java/com/kizuna/menu/domain/StoreMenu.java
@@ -10,6 +10,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,4 +60,9 @@ public class StoreMenu implements MenuNode {
   @UpdateTimestamp
   @Column(name = "updated_at")
   private LocalDateTime updatedAt;
+
+  /** 楽観ロック用バージョン（全実体共通 — #400）。 */
+  @Version
+  @Column(nullable = false)
+  private Long version;
 }

--- a/backend/src/main/java/com/kizuna/shared/exception/CommonExceptionHandler.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/CommonExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -53,6 +54,23 @@ public class CommonExceptionHandler {
     Map<String, Object> body = new HashMap<>();
     body.put("error", ex.getMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+  }
+
+  @ExceptionHandler(ConflictException.class)
+  public ResponseEntity<Map<String, Object>> handle(ConflictException ex) {
+    log.warn(ex.getMessage());
+    Map<String, Object> body = new HashMap<>();
+    body.put("error", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+  }
+
+  /** JPA @Version の楽観ロック競合（並行トランザクションの敗者）を 500 でなく 409 へ映射する（#400）。 */
+  @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+  public ResponseEntity<Map<String, Object>> handle(ObjectOptimisticLockingFailureException ex) {
+    log.warn(ex.getMessage());
+    Map<String, Object> body = new HashMap<>();
+    body.put("error", "他の操作と競合しました。最新の状態を取得してやり直してください");
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
   }
 
   @ExceptionHandler(NoResourceFoundException.class)

--- a/backend/src/main/java/com/kizuna/shared/exception/ConflictException.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/ConflictException.java
@@ -1,0 +1,13 @@
+package com.kizuna.shared.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/** 並行更新の競合（楽観ロック・バージョン不一致）を表す例外基底。HTTP 409 で応答される（#400）。 */
+@ResponseStatus(HttpStatus.CONFLICT)
+public class ConflictException extends RuntimeException {
+
+  public ConflictException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/com/kizuna/shared/persistence/BaseEntity.java
+++ b/backend/src/main/java/com/kizuna/shared/persistence/BaseEntity.java
@@ -9,6 +9,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Version;
 import java.time.OffsetDateTime;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -30,6 +31,7 @@ public abstract class BaseEntity {
   private OffsetDateTime updatedAt;
 
   /** 楽観ロック用バージョン（全実体共通 — #400）。 */
+  @Setter(AccessLevel.NONE) // 新規 public setter 禁止規約: バージョンは JPA が管理し外部から設定させない（#400）
   @Version
   @Column(nullable = false)
   private Long version;

--- a/backend/src/main/java/com/kizuna/shared/persistence/BaseEntity.java
+++ b/backend/src/main/java/com/kizuna/shared/persistence/BaseEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Version;
 import java.time.OffsetDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,6 +28,11 @@ public abstract class BaseEntity {
 
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
+
+  /** 楽観ロック用バージョン（全実体共通 — #400）。 */
+  @Version
+  @Column(nullable = false)
+  private Long version;
 
   @PrePersist
   protected void onCreate() {

--- a/backend/src/main/java/com/kizuna/shared/persistence/TenantScopedEntity.java
+++ b/backend/src/main/java/com/kizuna/shared/persistence/TenantScopedEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Version;
 import java.time.OffsetDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -39,6 +40,11 @@ public abstract class TenantScopedEntity {
 
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
+
+  /** 楽観ロック用バージョン（全実体共通 — #400）。 */
+  @Version
+  @Column(nullable = false)
+  private Long version;
 
   @PrePersist
   protected void onCreate() {

--- a/backend/src/main/java/com/kizuna/shared/persistence/TenantScopedEntity.java
+++ b/backend/src/main/java/com/kizuna/shared/persistence/TenantScopedEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Version;
 import java.time.OffsetDateTime;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -42,6 +43,7 @@ public abstract class TenantScopedEntity {
   private OffsetDateTime updatedAt;
 
   /** 楽観ロック用バージョン（全実体共通 — #400）。 */
+  @Setter(AccessLevel.NONE) // 新規 public setter 禁止規約: バージョンは JPA が管理し外部から設定させない（#400）
   @Version
   @Column(nullable = false)
   private Long version;

--- a/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfile.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfile.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -96,6 +97,11 @@ public class StoreProfile {
 
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
+
+  /** 楽観ロック用バージョン（全実体共通 — #400）。 */
+  @Version
+  @Column(nullable = false)
+  private Long version;
 
   @PrePersist
   protected void onCreate() {

--- a/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfile.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfile.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -99,6 +100,7 @@ public class StoreProfile {
   private OffsetDateTime updatedAt;
 
   /** 楽観ロック用バージョン（全実体共通 — #400）。 */
+  @Setter(AccessLevel.NONE) // 新規 public setter 禁止規約: バージョンは JPA が管理し外部から設定させない（#400）
   @Version
   @Column(nullable = false)
   private Long version;

--- a/backend/src/main/java/com/kizuna/user/api/dto/PlatformStaffResponse.java
+++ b/backend/src/main/java/com/kizuna/user/api/dto/PlatformStaffResponse.java
@@ -7,7 +7,8 @@ import java.util.Set;
 /**
  * スタッフ（能力束×店舗集合×精算範囲）の応答。JSON キーは Jackson 設定により snake_case（display_name / store_scope_type /
  * store_ids / settlement_scope_type / settlement_store_ids）。店舗名は解決せず id のみ返す（フロントは GET
- * /platform/stores の id→name テーブルで解決する）。束は選択 UI と一覧表示のため id と名称を返す。
+ * /platform/stores の id→name テーブルで解決する）。束は選択 UI と一覧表示のため id と名称を返す。version は楽観ロックの往復用
+ * （編集リクエストがそのまま返送し、不一致は 409 — #400）。
  */
 public record PlatformStaffResponse(
     Long id,
@@ -18,7 +19,8 @@ public record PlatformStaffResponse(
     StoreScopeType storeScopeType,
     Set<Long> storeIds,
     StoreScopeType settlementScopeType,
-    Set<Long> settlementStoreIds) {
+    Set<Long> settlementStoreIds,
+    long version) {
 
   /** 能力束への参照（id と名称）。 */
   public record BundleRef(Long id, String name) {}

--- a/backend/src/main/java/com/kizuna/user/api/dto/PlatformStaffUpdateRequest.java
+++ b/backend/src/main/java/com/kizuna/user/api/dto/PlatformStaffUpdateRequest.java
@@ -32,4 +32,8 @@ public class PlatformStaffUpdateRequest {
 
   /** 停止・再開。null は現状維持。false=停止（行は残り、過去の実行主体記録を保持）、true=再開。 */
   private Boolean enabled;
+
+  /** 楽観ロック用バージョン（応答の version をそのまま往復する。不一致は 409 — #400）。 */
+  @NotNull(message = "version is required")
+  private Long version;
 }

--- a/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
+++ b/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
@@ -17,6 +17,7 @@ import com.kizuna.user.domain.GrantHistoryRepository;
 import com.kizuna.user.domain.InvalidStoreScopeException;
 import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
+import com.kizuna.user.domain.StaleStaffUpdateException;
 import com.kizuna.user.domain.UserType;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -130,6 +131,11 @@ public class PlatformStaffService {
         .filter(user -> user.getUserType() == UserType.STAFF)
         .map(
             user -> {
+              // 陳腐化した編集フォームの提出は JPA の @Version では捕まらない（再読込後の正当な更新に見える）
+              // ため、応答で往復させた version を明示比対して 409 で拒否する（#400）。
+              if (!user.getVersion().equals(req.getVersion())) {
+                throw new StaleStaffUpdateException("他の管理者が更新しました。最新の内容を確認してください");
+              }
               user.reassignGrants(
                   req.getBundleIds(),
                   req.getStoreScopeType(),
@@ -239,6 +245,7 @@ public class PlatformStaffService {
         user.getStoreScopeType(),
         new HashSet<>(user.getStoreIds()),
         user.getSettlementScopeType(),
-        new HashSet<>(user.getSettlementStoreIds()));
+        new HashSet<>(user.getSettlementStoreIds()),
+        user.getVersion());
   }
 }

--- a/backend/src/main/java/com/kizuna/user/domain/StaleStaffUpdateException.java
+++ b/backend/src/main/java/com/kizuna/user/domain/StaleStaffUpdateException.java
@@ -1,0 +1,11 @@
+package com.kizuna.user.domain;
+
+import com.kizuna.shared.exception.ConflictException;
+
+/** スタッフ授権編集の version 不一致（陳腐化した編集フォームの提出）を表すドメイン例外。ConflictException 継承により HTTP 409 で応答される（#400）。 */
+public class StaleStaffUpdateException extends ConflictException {
+
+  public StaleStaffUpdateException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -35,3 +35,6 @@ databaseChangeLog:
   - include:
       file: releases/v0.12.0/master.yaml
       relativeToChangelogFile: true
+  - include:
+      file: releases/v0.13.0/master.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.13.0/central/01-optimistic-lock-version.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.13.0/central/01-optimistic-lock-version.yaml
@@ -1,0 +1,69 @@
+databaseChangeLog:
+  - changeSet:
+      id: central-v0130-001-optimistic-lock-version
+      author: kanghouchao
+      # 全実体への @Version 楽観ロック導入（#400）。中央側 6 表へ version 列を追加し、既存行は 0 で初期化する。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - addColumn:
+            tableName: central_configs
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン（既存行は 0 で初期化）
+        - addColumn:
+            tableName: central_tenants
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン（既存行は 0 で初期化）
+        - addColumn:
+            tableName: central_menus
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン（既存行は 0 で初期化）
+        - addColumn:
+            tableName: platform_capability_bundles
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン（既存行は 0 で初期化）
+        - addColumn:
+            tableName: platform_grant_history
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン（既存行は 0 で初期化）
+        - addColumn:
+            tableName: platform_users
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン（既存行は 0 で初期化）

--- a/backend/src/main/resources/db/changelog/releases/v0.13.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.13.0/master.yaml
@@ -1,0 +1,7 @@
+databaseChangeLog:
+  - include:
+      file: central/01-optimistic-lock-version.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: tenant/01-optimistic-lock-version.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.13.0/tenant/01-optimistic-lock-version.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.13.0/tenant/01-optimistic-lock-version.yaml
@@ -1,0 +1,89 @@
+databaseChangeLog:
+  - changeSet:
+      id: tenant-v0130-001-optimistic-lock-version
+      author: kanghouchao
+      # 全実体への @Version 楽観ロック導入（#400）。テナント側 8 表へ version 列を追加し、既存行は 0 で初期化する。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - addColumn:
+            tableName: t_cast_field_definitions
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン（既存行は 0 で初期化）
+        - addColumn:
+            tableName: t_cast_invitations
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン（既存行は 0 で初期化）
+        - addColumn:
+            tableName: t_casts
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン（既存行は 0 で初期化）
+        - addColumn:
+            tableName: t_customers
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン（既存行は 0 で初期化）
+        - addColumn:
+            tableName: t_menus
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン（既存行は 0 で初期化）
+        - addColumn:
+            tableName: t_orders
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン（既存行は 0 で初期化）
+        - addColumn:
+            tableName: t_shifts
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン（既存行は 0 で初期化）
+        - addColumn:
+            tableName: t_tenant_configs
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン（既存行は 0 で初期化）

--- a/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kizuna.shared.exception.ConflictException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.api.dto.PlatformStaffCreateRequest;
 import com.kizuna.user.api.dto.PlatformStaffResponse;
@@ -24,6 +25,7 @@ import com.kizuna.user.domain.GrantHistoryRepository;
 import com.kizuna.user.domain.InvalidStoreScopeException;
 import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
+import com.kizuna.user.domain.StaleStaffUpdateException;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
 import java.util.List;
@@ -85,6 +87,8 @@ class PlatformStaffServiceTest {
             .storeIds(storeIds)
             .build();
     user.setId(id);
+    // 永続化済みエンティティを模す（DB の version 列は 0 で初期化される — #400）。
+    user.setVersion(0L);
     return user;
   }
 
@@ -125,6 +129,8 @@ class PlatformStaffServiceTest {
     req.setBundleIds(bundleIds);
     req.setStoreScopeType(scopeType);
     req.setStoreIds(storeIds);
+    // staff() ヘルパの現行 version と一致させる（版の往復 — #400）。
+    req.setVersion(0L);
     return req;
   }
 
@@ -171,6 +177,7 @@ class PlatformStaffServiceTest {
             invocation -> {
               PlatformUser saved = invocation.getArgument(0);
               saved.setId(9L);
+              saved.setVersion(0L);
               return saved;
             });
 
@@ -190,6 +197,7 @@ class PlatformStaffServiceTest {
     assertThat(res.bundles())
         .containsExactly(new PlatformStaffResponse.BundleRef(MANAGER_BUNDLE, "店長"));
     assertThat(res.enabled()).isTrue();
+    assertThat(res.version()).as("作成応答も version を持つこと(#400)").isZero();
   }
 
   @Test
@@ -207,7 +215,13 @@ class PlatformStaffServiceTest {
         .thenReturn(List.of(bundle(MANAGER_BUNDLE, "店長")));
     when(repository.findByEmail("acct@kizuna.test")).thenReturn(Optional.empty());
     when(encoder.encode("rawpass")).thenReturn("ENCODED");
-    when(repository.saveAndFlush(userCaptor.capture())).thenAnswer(i -> i.getArgument(0));
+    when(repository.saveAndFlush(userCaptor.capture()))
+        .thenAnswer(
+            i -> {
+              PlatformUser saved = i.getArgument(0);
+              saved.setVersion(0L);
+              return saved;
+            });
 
     PlatformStaffResponse res = service.create(req, ACTOR);
 
@@ -309,7 +323,13 @@ class PlatformStaffServiceTest {
     when(capabilityBundleRepository.findAllById(Set.of(MANAGER_BUNDLE)))
         .thenReturn(List.of(bundle(MANAGER_BUNDLE, "店長")));
     when(repository.findById(3L)).thenReturn(Optional.of(existing));
-    when(repository.saveAndFlush(existing)).thenReturn(existing);
+    // saveAndFlush は flush 時に version を増加させる（実挙動の模倣 — #400）。
+    when(repository.saveAndFlush(existing))
+        .thenAnswer(
+            i -> {
+              existing.setVersion(existing.getVersion() + 1);
+              return existing;
+            });
 
     Optional<PlatformStaffResponse> res =
         service.update(
@@ -324,6 +344,31 @@ class PlatformStaffServiceTest {
     assertThat(res.get().id()).isEqualTo(3L);
     assertThat(res.get().bundles())
         .containsExactly(new PlatformStaffResponse.BundleRef(MANAGER_BUNDLE, "店長"));
+    assertThat(res.get().version()).as("応答は保存後の増加した version を返すこと(#400)").isEqualTo(1L);
+  }
+
+  @Test
+  void update_staleVersion_throwsConflictWithoutSavingOrRecordingHistory() {
+    // 陳腐化した編集フォームの提出（version 不一致）は reassign 前に 409 系例外で拒否する（#400）。
+    PlatformUser existing =
+        staff(3L, "target@kizuna.test", Set.of(HQ_BUNDLE), StoreScopeType.ALL_STORES, Set.of());
+    existing.setVersion(5L);
+    when(capabilityBundleRepository.findAllById(Set.of(MANAGER_BUNDLE)))
+        .thenReturn(List.of(bundle(MANAGER_BUNDLE, "店長")));
+    when(repository.findById(3L)).thenReturn(Optional.of(existing));
+    PlatformStaffUpdateRequest req =
+        updateRequest(Set.of(MANAGER_BUNDLE), StoreScopeType.SPECIFIC_STORES, Set.of(1L));
+    req.setVersion(4L);
+
+    assertThatThrownBy(() -> service.update(3L, req, ACTOR))
+        .isInstanceOf(StaleStaffUpdateException.class)
+        .isInstanceOf(ConflictException.class)
+        .hasMessage("他の管理者が更新しました。最新の内容を確認してください");
+
+    // 授権は再割当されず、保存も付与履歴の記録も行われない。
+    assertThat(existing.getBundleIds()).containsExactly(HQ_BUNDLE);
+    verify(repository, never()).saveAndFlush(any());
+    verifyNoInteractions(grantHistoryRepository);
   }
 
   @Test
@@ -433,6 +478,7 @@ class PlatformStaffServiceTest {
             invocation -> {
               PlatformUser saved = invocation.getArgument(0);
               saved.setId(9L);
+              saved.setVersion(0L);
               return saved;
             });
 

--- a/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
@@ -41,6 +41,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class PlatformStaffServiceTest {
@@ -88,7 +89,7 @@ class PlatformStaffServiceTest {
             .build();
     user.setId(id);
     // 永続化済みエンティティを模す（DB の version 列は 0 で初期化される — #400）。
-    user.setVersion(0L);
+    ReflectionTestUtils.setField(user, "version", 0L);
     return user;
   }
 
@@ -177,7 +178,7 @@ class PlatformStaffServiceTest {
             invocation -> {
               PlatformUser saved = invocation.getArgument(0);
               saved.setId(9L);
-              saved.setVersion(0L);
+              ReflectionTestUtils.setField(saved, "version", 0L);
               return saved;
             });
 
@@ -219,7 +220,7 @@ class PlatformStaffServiceTest {
         .thenAnswer(
             i -> {
               PlatformUser saved = i.getArgument(0);
-              saved.setVersion(0L);
+              ReflectionTestUtils.setField(saved, "version", 0L);
               return saved;
             });
 
@@ -327,7 +328,7 @@ class PlatformStaffServiceTest {
     when(repository.saveAndFlush(existing))
         .thenAnswer(
             i -> {
-              existing.setVersion(existing.getVersion() + 1);
+              ReflectionTestUtils.setField(existing, "version", existing.getVersion() + 1);
               return existing;
             });
 
@@ -352,7 +353,7 @@ class PlatformStaffServiceTest {
     // 陳腐化した編集フォームの提出（version 不一致）は reassign 前に 409 系例外で拒否する（#400）。
     PlatformUser existing =
         staff(3L, "target@kizuna.test", Set.of(HQ_BUNDLE), StoreScopeType.ALL_STORES, Set.of());
-    existing.setVersion(5L);
+    ReflectionTestUtils.setField(existing, "version", 5L);
     when(capabilityBundleRepository.findAllById(Set.of(MANAGER_BUNDLE)))
         .thenReturn(List.of(bundle(MANAGER_BUNDLE, "店長")));
     when(repository.findById(3L)).thenReturn(Optional.of(existing));
@@ -478,7 +479,7 @@ class PlatformStaffServiceTest {
             invocation -> {
               PlatformUser saved = invocation.getArgument(0);
               saved.setId(9L);
-              saved.setVersion(0L);
+              ReflectionTestUtils.setField(saved, "version", 0L);
               return saved;
             });
 

--- a/frontend/src/_pages/central-staff/ui/StaffPage.tsx
+++ b/frontend/src/_pages/central-staff/ui/StaffPage.tsx
@@ -31,7 +31,10 @@ export default function StaffPage() {
     '店舗一覧の取得に失敗しました'
   );
   const [createOpen, setCreateOpen] = useState(false);
-  const [editing, setEditing] = useState<PlatformStaffResponse | null>(null);
+  // 編集対象は id で保持し、staff オブジェクトは現在の一覧から導出する。
+  // これにより refetch がそのままドロワー内容の最新化になる（409 リフレッシュ — #400）。
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const editingStaff = staff.find(member => member.id === editingId) ?? null;
 
   return (
     <div className="space-y-6">
@@ -82,7 +85,7 @@ export default function StaffPage() {
                 <tr
                   key={member.id}
                   className="cursor-pointer hover:bg-gray-50"
-                  onClick={() => setEditing(member)}
+                  onClick={() => setEditingId(member.id)}
                 >
                   <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                     {member.display_name}
@@ -108,7 +111,7 @@ export default function StaffPage() {
                     <button
                       onClick={e => {
                         e.stopPropagation();
-                        setEditing(member);
+                        setEditingId(member.id);
                       }}
                       className="rounded text-blue-600 hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
                     >
@@ -128,9 +131,9 @@ export default function StaffPage() {
         onCreated={refetch}
       />
       <StaffEditDrawer
-        open={editing !== null}
-        staff={editing}
-        onClose={() => setEditing(null)}
+        open={editingId !== null}
+        staff={editingStaff}
+        onClose={() => setEditingId(null)}
         onUpdated={refetch}
       />
     </div>

--- a/frontend/src/entities/user/__tests__/platform-staff-api.test.ts
+++ b/frontend/src/entities/user/__tests__/platform-staff-api.test.ts
@@ -1,4 +1,5 @@
 import { platformStaffApi } from '@/entities/user';
+import { apiClient } from '@/shared/api';
 
 jest.mock('@/shared/api/client', () => ({
   __esModule: true,
@@ -25,14 +26,20 @@ describe('platformStaffApi', () => {
     });
     expect(res).toEqual({ ok: true, url: '/platform/staff' });
   });
-  it('update は /platform/staff/:id を PUT する', async () => {
+  it('update は /platform/staff/:id を PUT し version を往復する', async () => {
     const res = await platformStaffApi.update(1, {
       bundle_ids: [1, 2],
       store_scope_type: 'ALL_STORES',
       store_ids: [],
       enabled: false,
+      version: 7,
     });
     expect(res).toEqual({ ok: true, url: '/platform/staff/1' });
+    // 楽観ロックの往復契約: 更新ボディに version が含まれること（#400）
+    expect(apiClient.put).toHaveBeenCalledWith(
+      '/platform/staff/1',
+      expect.objectContaining({ version: 7 })
+    );
   });
   it('bundles は /platform/capability-bundles を GET する', async () => {
     const res = await platformStaffApi.bundles();

--- a/frontend/src/entities/user/model/types.ts
+++ b/frontend/src/entities/user/model/types.ts
@@ -89,6 +89,8 @@ export interface PlatformStaffResponse {
   store_ids: number[];
   settlement_scope_type: PlatformStoreScopeType | null;
   settlement_store_ids: number[];
+  // 楽観ロック用バージョン（更新リクエストへそのまま往復する — #400）
+  version: number;
 }
 
 // スタッフ新規作成リクエスト
@@ -111,6 +113,8 @@ export interface PlatformStaffUpdateRequest {
   settlement_scope_type?: PlatformStoreScopeType | null;
   settlement_store_ids?: number[];
   enabled?: boolean;
+  // 楽観ロック用バージョン（応答の version をそのまま返送。不一致は 409 — #400）
+  version: number;
 }
 
 // 付与履歴の操作種別

--- a/frontend/src/features/staff-management/ui/StaffEditDrawer.tsx
+++ b/frontend/src/features/staff-management/ui/StaffEditDrawer.tsx
@@ -91,12 +91,25 @@ export function StaffEditDrawer({ open, onClose, staff, onUpdated }: StaffEditDr
         settlement_scope_type: settlementScopeType,
         settlement_store_ids: settlementStoreIds,
         enabled,
+        // 楽観ロック用バージョン（応答の version をそのまま往復する — #400）
+        version: staff.version,
       });
       toast.success('権限を更新しました');
       onUpdated();
       onClose();
     } catch (error) {
-      toast.error(getApiErrorMessage(error, '権限の更新に失敗しました'));
+      const status =
+        error && typeof error === 'object' && 'response' in error
+          ? (error as { response?: { status?: number } }).response?.status
+          : undefined;
+      if (status === 409) {
+        // 楽観ロック競合（#400 裁定3）: 固定文言の toast を出し、一覧を再取得してドロワーの内容を
+        // 最新値へ自動リフレッシュする（staff prop の更新で useEffect が再初期化。ローカル編集は破棄、ドロワーは開いたまま）。
+        toast.error('他の管理者が更新しました。最新の内容を確認してください');
+        onUpdated();
+      } else {
+        toast.error(getApiErrorMessage(error, '権限の更新に失敗しました'));
+      }
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
## 概要

授権状態（能力束・店舗集合・精算範囲・enabled）の read-modify-write が並行更新や陳腐化した編集フォームに静黙上書きされる問題（PR #399 レビュー指摘）を、**全実体 @Version 楽観ロック + staff API のバージョン往復（不一致→409）**で全類として閉じる。2026-07-18 grilling の裁定 3 条（機構/範囲/409 UX）に準拠。

Closes #400

## 変更内容

- **@Version 導入（裁定2=全局）**: BaseEntity / TenantScopedEntity（独立 @MappedSuperclass — 継承関係に無いことを調査で確認済み）+ 独立実体 StoreProfile・CentralMenu・StoreMenu の 5 箇所。version は `@Setter(AccessLevel.NONE)` で public setter 生成を抑止（新規 setter 禁止規約）
- **Liquibase v0.13.0**: 全 14 実体表へ `version BIGINT NOT NULL DEFAULT 0`（central 6 表 + tenant 8 表。@CollectionTable 4 表は実体でないため対象外）
- **409 基盤**: `shared/exception/ConflictException`（@ResponseStatus(CONFLICT)、ServiceException と同形の双軌先例に倣う）+ CommonExceptionHandler へ ConflictException / `ObjectOptimisticLockingFailureException` → 409 の全局映射
- **staff API バージョン往復（裁定1）**: 応答に `version`、更新リクエストは `@NotNull version` 必須、サービス層で reassign 前に明示比対 → 不一致は `StaleStaffUpdateException`（409）。陳腐フォームは JPA の @Version では捕まらない（再読込後の正当な更新に見える）ため手動比対が正
- **フロントエンド（裁定3）**: 編集ドロワーが version を往復し、409 で固定文言 toast + 一覧 refetch によるドロワー内容の自動リフレッシュ（StaffPage の編集対象を id 保持+一覧導出へ変更し、refetch がそのまま抽屉更新になる構造）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（backend unit 全緑+Jacoco≥70% / frontend Jest 158 全緑 / integration `PlatformStaffManagementIT` 14 tests 0 failures — AC1「同 version 二連 PUT の 2 発目 409・巻き戻りなし・履歴不増」/ AC2「陳腐 version の停止解除 409・静黙復活なし」の新 IT 2 本を含む。setter 抑止是正後にも integration 再実行で全緑確認）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ 13 件全緑: 年齢確認ゲート×1 / キャストのカスタムフィールド×2 / 公開キャスト詳細404×1 / 統一ログイン・店舗切替×3 / 公開サイト×1 / 公開出勤表×1 / スタッフ・権限管理×2 / 店舗設定×1 / 模版切替×1 — 全て既存文言のまま緑=既存挙動の同値証明）
- [x] ローカル code-review 実施（effort: high / 指摘: 3件 / 未修正: 2件）— kizuna-reviewer 三镜头、0 blocking。指摘1（version の public setter 生成=規約違反）は是正済み、未修正 2 件は下記備考

## 決定ログ

- **楽観ロック（クライアント往復）を採用、悲観ロックは不採用**: 病灶は並行量でなく「フォームの鮮度」——悲観ロックは並行トランザクションの直列化しかできず、後から来る陳腐フォームの提出は合法な上書きに見えるため防げない。バージョン往復だけがこれを捕まえる（grilling 裁定1）
- **@Version は全実体（BaseEntity/TenantScopedEntity+独立3実体）**: 静黙上書きという缺陥類を全倉で顕式化する（grilling 裁定2、連帯代価=14表迁移+全局409映射を確認の上で採用）。バージョン**往復契約**は実需のある staff API のみ
- **二重防護の分担**: 陳腐フォーム=サービス層の明示比対（履歴記録前に 409）/ 真の並行競合=JPA @Version の flush 時検出（トランザクション回滚で履歴も連帯消失）。どちらの経路も 409 に収斂
- **isNew() 翻転の全数調査**: @Version 追加で Spring Data の新規判定が version==null 基準へ変わるため、全 26 save 站点を追跡——手動 id 実体は StoreMenu のみ（運転時読専・Liquibase 種子のみ）、fixture は existsById 守卫あり、回帰なし（レビュー報告で CONFIRMED）

## 備考 / レビュー観点

- **kizuna-reviewer 未修正 2 件（いずれも non-blocking・現行無害の類備忘）**:
  1. `@Modifying` 批量 UPDATE（CastInvitationRepository の claimPending/invalidatePending）は version を bump しない——現在は invitation に往復契約が無く無害だが、将来バージョン往復を staff API 以外へ拡張する票では批量 UPDATE 経路の版本整合を要確認（類の種として記録）
  2. `ConflictException` の @ResponseStatus と専用 handler の双軌は won't-fix——`ServiceException` が同形の既存先例であり、仓库の確立様式に従う
- 既存行の version は 0 初期化、旧クライアントは存在しない（staff API の消費者は本 repo の管理画面のみ）ため互換性問題なし
- レビュー観点: ①サービス層比対が `recordHistory` より前にあること（陳腐 409 で履歴が残らない）②14 表と実体集合の 1:1（レビューで全数照合済み）③ドロワー 409 後の refetch→useEffect 再初期化チェーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
