### PR TITLE
refactor(backend): DB 層の命名を tenant→store 語彙へ収束させる (#405)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -43,7 +43,7 @@ Each module follows the DDD four layers:
 - **Imports**: no inline FQCN usage, no wildcard imports (`*`); one explicit import per class.
 - **Formatting**: Spotless + Google Java Format. JDK 21 is pinned by `backend/.java-version` (jenv) and `backend/gradle/gradle-daemon-jvm.properties` (daemon JVM), so `./gradlew spotlessApply` runs locally as-is. Fallback only if the active JDK is not 21: `docker run --rm -u root -v "$PWD":/app -w /app gradle:9.2.1-jdk21-ubi-minimal gradle spotlessApply --no-daemon`.
 - **Coverage**: the only Jacoco exclusions are `**/api/dto/**` (DTOs + MapStruct-generated code) and `**/shared/config/**` (pure configuration). **The domain layer must always be covered.**
-- **DB migrations**: Liquibase (YAML under `db/changelog/releases/<version>/central|tenant/`).
+- **DB migrations**: Liquibase (YAML under `db/changelog/releases/<version>/platform|store/` from v0.14.0 onward; historical releases ≤ v0.13.0 keep `central|tenant/`).
 - **Config values**: read from `AppProperties` (shared/config). No hardcoding.
 - **Logging**: keep the `req=<id> tenant=<id>` format.
 - **Modulith docs**: `ModularityTests` generates them under `backend/docs/modulith/` (committed). The Documenter's Rel-line ordering is unstable, so unless there is a structural change, revert the diff with checkout.

--- a/backend/src/integrationTest/java/com/kizuna/auth/PlatformBridgeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/auth/PlatformBridgeIT.java
@@ -86,7 +86,7 @@ class PlatformBridgeIT extends CrossTenantTestSupport {
         Set.of(TENANT_A));
   }
 
-  /** リポジトリ直挿（テストスレッドは @TenantScoped を経由せず tenantFilter が無効なので他テナントにも書ける）。 */
+  /** リポジトリ直挿（テストスレッドは @TenantScoped を経由せず storeFilter が無効なので他テナントにも書ける）。 */
   private void ensureMarkerOrder(long tenantId, String storeName, String remarks) {
     boolean exists =
         orderRepository.findAll().stream()

--- a/backend/src/integrationTest/java/com/kizuna/auth/PlatformBridgeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/auth/PlatformBridgeIT.java
@@ -92,8 +92,8 @@ class PlatformBridgeIT extends CrossTenantTestSupport {
         orderRepository.findAll().stream()
             .anyMatch(
                 o ->
-                    o.getTenantId() != null
-                        && tenantId == o.getTenantId()
+                    o.getStoreId() != null
+                        && tenantId == o.getStoreId()
                         && remarks.equals(o.getRemarks()));
     if (exists) {
       return;
@@ -105,7 +105,7 @@ class PlatformBridgeIT extends CrossTenantTestSupport {
             .businessDate(MARKER_DATE)
             .status(OrderStatus.CREATED)
             .build();
-    order.setTenantId(tenantId);
+    order.setStoreId(tenantId);
     orderRepository.save(order);
   }
 
@@ -187,7 +187,7 @@ class PlatformBridgeIT extends CrossTenantTestSupport {
 
   private long castCountForTenant(long tenantId) {
     return castRepository.findAll().stream()
-        .filter(c -> c.getTenantId() != null && tenantId == c.getTenantId())
+        .filter(c -> c.getStoreId() != null && tenantId == c.getStoreId())
         .count();
   }
 

--- a/backend/src/integrationTest/java/com/kizuna/cast/CastFieldDefinitionCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/cast/CastFieldDefinitionCrossTenantIT.java
@@ -23,12 +23,12 @@ import org.springframework.http.ResponseEntity;
 /**
  * カスタムフィールド定義・値のクロステナント分離を本物の PostgreSQL で検証する統合テスト（issue #277）。
  *
- * <p>新規テーブル {@code t_cast_field_definitions} と {@code t_casts.custom_fields} に tenantFilter
- * が実際に効くこと （#227 の applyToLoadByKey 型の穴が無いこと）を、リポジトリ直挿し＋実データ非混入の強アサーションで固定する
+ * <p>新規テーブル {@code t_cast_field_definitions} と {@code t_casts.custom_fields} に storeFilter が実際に効くこと
+ * （#227 の applyToLoadByKey 型の穴が無いこと）を、リポジトリ直挿し＋実データ非混入の強アサーションで固定する
  * （弱い「所有者不一致」ではなく他テナントの値・ラベルが本文に一切現れないことを断言）。
  *
  * <p>定義 CRUD は {@code ROLE_STORE_MANAGER} 限定のため、店舗{1,2} 授権の店長シードユーザー tanaka.hanako を使う。 tanaka
- * は両テナントに授権されるため、越境は「インターセプタのスコープ拒否 403」ではなく「tenantFilter による不可視化 → 400（見つからない）」として現れる。純粋なヘッダ詐称 403
+ * は両テナントに授権されるため、越境は「インターセプタのスコープ拒否 403」ではなく「storeFilter による不可視化 → 400（見つからない）」として現れる。純粋なヘッダ詐称 403
  * は基底クラスの yamada（店舗{1} 授権）で別途固定する。
  */
 class CastFieldDefinitionCrossTenantIT extends CrossTenantTestSupport {
@@ -89,7 +89,7 @@ class CastFieldDefinitionCrossTenantIT extends CrossTenantTestSupport {
     return id;
   }
 
-  /** tenantFilter を経由しない直挿しで第二テナント(=2)に定義を用意する（save で tenant_id を明示）。 */
+  /** storeFilter を経由しない直挿しで第二テナント(=2)に定義を用意する（save で store_id を明示）。 */
   private CastFieldDefinition insertDefinitionForTenantB(
       String key, String label, boolean isPublic) {
     CastFieldDefinition definition =
@@ -111,7 +111,7 @@ class CastFieldDefinitionCrossTenantIT extends CrossTenantTestSupport {
   }
 
   @Test
-  @DisplayName("他テナントの定義は tenantFilter で不可視化され、GET一覧に現れず PUT/DELETE も 400 になること")
+  @DisplayName("他テナントの定義は storeFilter で不可視化され、GET一覧に現れず PUT/DELETE も 400 になること")
   void foreignTenantDefinitionIsInvisibleAndUnmutable() {
     String keyA = "blood_type_" + nonce;
     String idA = createDefinitionAs(TENANT_A, keyA, "血液型A", true);

--- a/backend/src/integrationTest/java/com/kizuna/cast/CastFieldDefinitionCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/cast/CastFieldDefinitionCrossTenantIT.java
@@ -99,14 +99,14 @@ class CastFieldDefinitionCrossTenantIT extends CrossTenantTestSupport {
             .displayOrder(0)
             .isPublic(isPublic)
             .build();
-    definition.setTenantId(TENANT_B);
+    definition.setStoreId(TENANT_B);
     return fieldDefinitionRepository.save(definition);
   }
 
   private Cast insertActiveCastForTenantB(Map<String, String> customFields) {
     Cast cast =
         Cast.builder().name("テナントBキャスト").status("ACTIVE").customFields(customFields).build();
-    cast.setTenantId(TENANT_B);
+    cast.setStoreId(TENANT_B);
     return castRepository.save(cast);
   }
 

--- a/backend/src/integrationTest/java/com/kizuna/cast/CastInvitationApiIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/cast/CastInvitationApiIT.java
@@ -215,7 +215,7 @@ class CastInvitationApiIT extends CrossTenantTestSupport {
   @Test
   @DisplayName("他テナントの档案 ID を自店文脈から発行しても 400 で拒否され、他テナントのデータが不変であること")
   void crossTenantIssueIsRejectedAndForeignDataUnchanged() {
-    // リポジトリ直挿（テストスレッドは @TenantScoped を経由せず tenantFilter が無効なので他テナントにも書ける）。
+    // リポジトリ直挿（テストスレッドは @TenantScoped を経由せず storeFilter が無効なので他テナントにも書ける）。
     Cast foreignCast = Cast.builder().name("他テナント機密キャスト").build();
     foreignCast.setStoreId(foreignTenantId);
     String foreignCastId = castRepository.save(foreignCast).getId();

--- a/backend/src/integrationTest/java/com/kizuna/cast/CastInvitationApiIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/cast/CastInvitationApiIT.java
@@ -164,7 +164,7 @@ class CastInvitationApiIT extends CrossTenantTestSupport {
             .expiresAt(OffsetDateTime.now().plusHours(72))
             .acceptedAt(OffsetDateTime.now())
             .build();
-    accepted.setTenantId(TENANT_A);
+    accepted.setStoreId(TENANT_A);
     String acceptedId = castInvitationRepository.save(accepted).getId();
 
     ResponseEntity<JsonNode> res = issueInvitation(castId, TENANT_A, managerToken);
@@ -208,7 +208,7 @@ class CastInvitationApiIT extends CrossTenantTestSupport {
             .status(CastInvitation.Status.PENDING)
             .expiresAt(OffsetDateTime.now().plusHours(72))
             .build();
-    invitation.setTenantId(TENANT_A);
+    invitation.setStoreId(TENANT_A);
     return invitation;
   }
 
@@ -217,7 +217,7 @@ class CastInvitationApiIT extends CrossTenantTestSupport {
   void crossTenantIssueIsRejectedAndForeignDataUnchanged() {
     // リポジトリ直挿（テストスレッドは @TenantScoped を経由せず tenantFilter が無効なので他テナントにも書ける）。
     Cast foreignCast = Cast.builder().name("他テナント機密キャスト").build();
-    foreignCast.setTenantId(foreignTenantId);
+    foreignCast.setStoreId(foreignTenantId);
     String foreignCastId = castRepository.save(foreignCast).getId();
 
     // tanaka の授権店舗(店舗1)文脈から、他テナントの档案 ID を発行しようとする。
@@ -250,7 +250,7 @@ class CastInvitationApiIT extends CrossTenantTestSupport {
             .status(CastInvitation.Status.PENDING)
             .expiresAt(OffsetDateTime.now().minusHours(1))
             .build();
-    expiredInvitation.setTenantId(TENANT_A);
+    expiredInvitation.setStoreId(TENANT_A);
     castInvitationRepository.save(expiredInvitation);
 
     // 連携済み: 档案に平台身分を紐づける。

--- a/backend/src/integrationTest/java/com/kizuna/cast/PlatformCastInvitationAcceptanceIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/cast/PlatformCastInvitationAcceptanceIT.java
@@ -356,7 +356,7 @@ class PlatformCastInvitationAcceptanceIT extends CrossTenantTestSupport {
             .status(status)
             .expiresAt(expiresAt)
             .build();
-    invitation.setTenantId(tenantId);
+    invitation.setStoreId(tenantId);
     castInvitationRepository.save(invitation);
     return token;
   }

--- a/backend/src/integrationTest/java/com/kizuna/customer/CustomerCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/CustomerCrossTenantIT.java
@@ -14,8 +14,8 @@ import org.springframework.http.ResponseEntity;
 /**
  * Customer のクロステナント分離を本物の PostgreSQL で検証する統合テスト。
  *
- * <p>commit 5b39c06（tenantFilter の applyToLoadByKey=true 補完）の回帰テスト。 tenant A が作成した Customer を
- * tenant B が GET /tenant/customers/{id}（findById 経由） で読めないことを固定する。PR-B の手動 curl 検証の自動化（issue #225）。
+ * <p>commit 5b39c06（storeFilter の applyToLoadByKey=true 補完）の回帰テスト。 tenant A が作成した Customer を tenant
+ * B が GET /tenant/customers/{id}（findById 経由） で読めないことを固定する。PR-B の手動 curl 検証の自動化（issue #225）。
  *
  * <p>認証・テナントヘッダ組立は {@link CrossTenantTestSupport} に共通化（issue #226 で 3 クラス目の重複を抽出）。
  */

--- a/backend/src/integrationTest/java/com/kizuna/menu/MenuCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/menu/MenuCrossTenantIT.java
@@ -23,7 +23,7 @@ import org.springframework.http.ResponseEntity;
  * StoreMenu のクロステナント分離を本物の PostgreSQL で検証する統合テスト（issue #227）。
  *
  * <p>StoreMenu には作成 API がなくデータは Liquibase シード（tenant 1 のみ）に由来するため、
- * リポジトリ直挿しで第二テナントとそのメニューを自前で用意する（リポジトリ直接呼び出しは {@code @TenantScoped} を経由せず tenantFilter
+ * リポジトリ直挿しで第二テナントとそのメニューを自前で用意する（リポジトリ直接呼び出しは {@code @TenantScoped} を経由せず storeFilter
  * が無効なので、他テナントのデータも書ける）。 GET /tenant/menus/me が X-Tenant-ID の切替でテナント間のメニューを混在させないことを固定する。
  */
 class MenuCrossTenantIT extends CrossTenantTestSupport {

--- a/backend/src/integrationTest/java/com/kizuna/menu/MenuCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/menu/MenuCrossTenantIT.java
@@ -51,7 +51,7 @@ class MenuCrossTenantIT extends CrossTenantTestSupport {
     if (!menuRepository.existsById(TENANT_B_MENU_ID)) {
       StoreMenu menu = new StoreMenu();
       menu.setId(TENANT_B_MENU_ID);
-      menu.setTenantId(tenantBId);
+      menu.setStoreId(tenantBId);
       menu.setLabel(TENANT_B_MENU_LABEL);
       menu.setSortOrder(10);
       menuRepository.save(menu);

--- a/backend/src/integrationTest/java/com/kizuna/order/PlatformOrderScopeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/PlatformOrderScopeIT.java
@@ -92,7 +92,7 @@ class PlatformOrderScopeIT extends CrossTenantTestSupport {
     ensurePlatformUser(CAST_EMAIL, UserType.CAST, Set.of(), StoreScopeType.ALL_STORES, Set.of());
   }
 
-  /** リポジトリ直挿（テストスレッドは @TenantScoped を経由せず tenantFilter が無効なので他テナントにも書ける）。 */
+  /** リポジトリ直挿（テストスレッドは @TenantScoped を経由せず storeFilter が無効なので他テナントにも書ける）。 */
   private void ensureMarkerOrder(long tenantId, String storeName, String remarks) {
     boolean exists =
         orderRepository.findAll().stream()

--- a/backend/src/integrationTest/java/com/kizuna/order/PlatformOrderScopeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/PlatformOrderScopeIT.java
@@ -98,8 +98,8 @@ class PlatformOrderScopeIT extends CrossTenantTestSupport {
         orderRepository.findAll().stream()
             .anyMatch(
                 o ->
-                    o.getTenantId() != null
-                        && tenantId == o.getTenantId()
+                    o.getStoreId() != null
+                        && tenantId == o.getStoreId()
                         && storeName.equals(o.getStoreName()));
     if (exists) {
       return;
@@ -111,7 +111,7 @@ class PlatformOrderScopeIT extends CrossTenantTestSupport {
             .businessDate(MARKER_DATE)
             .status(OrderStatus.CREATED)
             .build();
-    order.setTenantId(tenantId);
+    order.setStoreId(tenantId);
     orderRepository.save(order);
   }
 
@@ -178,7 +178,7 @@ class PlatformOrderScopeIT extends CrossTenantTestSupport {
 
   private long orderCountForTenant(long tenantId) {
     return orderRepository.findAll().stream()
-        .filter(o -> o.getTenantId() != null && tenantId == o.getTenantId())
+        .filter(o -> o.getStoreId() != null && tenantId == o.getStoreId())
         .count();
   }
 
@@ -324,7 +324,7 @@ class PlatformOrderScopeIT extends CrossTenantTestSupport {
     assertThat(newId).isNotBlank();
 
     Order created = orderRepository.findById(newId).orElseThrow();
-    assertThat(created.getTenantId()).as("授権店舗(tenant 1)に永続化されていること").isEqualTo(TENANT_A);
+    assertThat(created.getStoreId()).as("授権店舗(tenant 1)に永続化されていること").isEqualTo(TENANT_A);
   }
 
   @Test

--- a/backend/src/integrationTest/java/com/kizuna/shift/ShiftCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/shift/ShiftCrossTenantIT.java
@@ -62,7 +62,7 @@ class ShiftCrossTenantIT extends CrossTenantTestSupport {
    */
   private String createForeignCast(String name) {
     Cast cast = Cast.builder().name(name).build();
-    cast.setTenantId(ensureForeignTenantId());
+    cast.setStoreId(ensureForeignTenantId());
     return castRepository.save(cast).getId();
   }
 
@@ -335,7 +335,7 @@ class ShiftCrossTenantIT extends CrossTenantTestSupport {
   /** 第二テナントの ACTIVE な Cast をリポジトリ直挿しで用意する（公開エンドポイントは ACTIVE のみ結合するため）。 */
   private String createActiveForeignCast(String name, long tenantId) {
     Cast cast = Cast.builder().name(name).status("ACTIVE").build();
-    cast.setTenantId(tenantId);
+    cast.setStoreId(tenantId);
     return castRepository.save(cast).getId();
   }
 
@@ -350,7 +350,7 @@ class ShiftCrossTenantIT extends CrossTenantTestSupport {
             .endTime(endTime)
             .status("CONFIRMED")
             .build();
-    shift.setTenantId(tenantId);
+    shift.setStoreId(tenantId);
     shiftRepository.save(shift);
   }
 

--- a/backend/src/integrationTest/java/com/kizuna/shift/ShiftCrossTenantIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/shift/ShiftCrossTenantIT.java
@@ -43,8 +43,7 @@ class ShiftCrossTenantIT extends CrossTenantTestSupport {
 
   /**
    * クロステナント検証用の第二テナントを用意し、採番された実 id を返す（MenuCrossTenantIT と同型）。 シードにはテナント 1 しか無く、定数 {@code
-   * TENANT_B}=2 は central_tenants に実在しないため、直挿し先の tenant_id を FK 違反させずに得るには実テナントを find-or-create
-   * する必要がある。
+   * TENANT_B}=2 は t_stores に実在しないため、直挿し先の store_id を FK 違反させずに得るには実テナントを find-or-create する必要がある。
    */
   private long ensureForeignTenantId() {
     return tenantRepository
@@ -57,7 +56,7 @@ class ShiftCrossTenantIT extends CrossTenantTestSupport {
 
   /**
    * 他テナントの Cast をリポジトリ直挿しで用意する。 HTTP 経由の作成は tenant A の JWT + 他テナントの X-Tenant-ID が
-   * TenantIdInterceptor に 403 で弾かれるため、{@code @TenantScoped} を経由せず tenantFilter が無効な
+   * TenantIdInterceptor に 403 で弾かれるため、{@code @TenantScoped} を経由せず storeFilter が無効な
    * リポジトリ直接呼び出しで他テナントのデータを書く（MenuCrossTenantIT と同型）。帰属先は実在する第二テナントの採番 id を使う。
    */
   private String createForeignCast(String name) {

--- a/backend/src/integrationTest/java/com/kizuna/tenant/SeedSequenceAlignmentIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/tenant/SeedSequenceAlignmentIT.java
@@ -57,7 +57,7 @@ class SeedSequenceAlignmentIT {
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
     headers.setBearerAuth(platformLogin());
-    // domain には一意制約（uq_central_tenants_domain）があるため、
+    // domain には一意制約（uq_t_stores_domain）があるため、
     // 同一 DB へ手動で再実行しても衝突しないよう実行ごとに一意化する
     String body =
         String.format(

--- a/backend/src/integrationTest/java/com/kizuna/tenant/SeedSequenceAlignmentIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/tenant/SeedSequenceAlignmentIT.java
@@ -32,7 +32,7 @@ class SeedSequenceAlignmentIT {
 
   /** 明示 id を播種している autoIncrement 表（issue #237 の setval 対象、#322 で platform_users を追加）。 */
   private static final List<String> SEEDED_IDENTITY_TABLES =
-      List.of("central_tenants", "central_menus", "platform_users");
+      List.of("t_stores", "central_menus", "t_users");
 
   @Autowired private TestRestTemplate rest;
   @Autowired private JdbcTemplate jdbcTemplate;

--- a/backend/src/integrationTest/java/com/kizuna/tenant/TenantDeletionCascadeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/tenant/TenantDeletionCascadeIT.java
@@ -107,11 +107,11 @@ class TenantDeletionCascadeIT {
 
   private long countStoreGrants(long storeId) {
     return jdbcTemplate.queryForObject(
-        "SELECT count(*) FROM platform_user_stores WHERE store_id = ?", Long.class, storeId);
+        "SELECT count(*) FROM t_user_stores WHERE store_id = ?", Long.class, storeId);
   }
 
   private long countPlatformUser(long userId) {
     return jdbcTemplate.queryForObject(
-        "SELECT count(*) FROM platform_users WHERE id = ?", Long.class, userId);
+        "SELECT count(*) FROM t_users WHERE id = ?", Long.class, userId);
   }
 }

--- a/backend/src/integrationTest/java/com/kizuna/user/AuthorizationScenesIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/AuthorizationScenesIT.java
@@ -87,7 +87,7 @@ class AuthorizationScenesIT extends CrossTenantTestSupport {
         castRepository.findAll().stream().anyMatch(c -> CAST_CANARY_NAME.equals(c.getName()));
     if (!canaryExists) {
       Cast cast = Cast.builder().name(CAST_CANARY_NAME).status("在籍").build();
-      cast.setTenantId(TENANT_A);
+      cast.setStoreId(TENANT_A);
       castRepository.save(cast);
     }
   }

--- a/backend/src/integrationTest/java/com/kizuna/user/AuthorizationScenesIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/AuthorizationScenesIT.java
@@ -82,7 +82,7 @@ class AuthorizationScenesIT extends CrossTenantTestSupport {
         StoreScopeType.SPECIFIC_STORES,
         Set.of(TENANT_A));
 
-    // 内部キャスト情報のカナリア（リポジトリ直挿 — テストスレッドは tenantFilter を経由しない）。
+    // 内部キャスト情報のカナリア（リポジトリ直挿 — テストスレッドは storeFilter を経由しない）。
     boolean canaryExists =
         castRepository.findAll().stream().anyMatch(c -> CAST_CANARY_NAME.equals(c.getName()));
     if (!canaryExists) {

--- a/backend/src/main/java/com/kizuna/cast/application/CastFieldDefinitionService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastFieldDefinitionService.java
@@ -18,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * カスタムフィールド定義の CRUD ユースケース。
  *
- * <p>重複 key・件数上限はいずれも {@link ServiceException}（400）で統一する。DB 一意制約 {@code (tenant_id, key)}
+ * <p>重複 key・件数上限はいずれも {@link ServiceException}（400）で統一する。DB 一意制約 {@code (store_id, key)}
  * を最終防波堤とし、悲観ロックは導入しない（{@code CastInvitationAcceptanceService} のメール重複チェックと同じ許容パターン）。
  */
 @Service
@@ -60,7 +60,7 @@ public class CastFieldDefinitionService {
     try {
       return mapper.toResponse(repository.saveAndFlush(definition));
     } catch (DataIntegrityViolationException ex) {
-      // 事前チェックをすり抜けた並行 create が (tenant_id, key) 一意制約に当たったレース。
+      // 事前チェックをすり抜けた並行 create が (store_id, key) 一意制約に当たったレース。
       // 事前チェックと同一の 400（ServiceException）へ変換する（saveAndFlush で違反をこの try 内に顕在化させる）。
       throw new ServiceException("このキーは既に登録されています: " + request.getKey());
     }

--- a/backend/src/main/java/com/kizuna/cast/application/CastFieldDefinitionService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastFieldDefinitionService.java
@@ -56,7 +56,7 @@ public class CastFieldDefinitionService {
             .displayOrder(nextOrder)
             .isPublic(Boolean.TRUE.equals(request.getIsPublic()))
             .build();
-    definition.setTenantId(tenantContext.getTenantId());
+    definition.setStoreId(tenantContext.getTenantId());
     try {
       return mapper.toResponse(repository.saveAndFlush(definition));
     } catch (DataIntegrityViolationException ex) {

--- a/backend/src/main/java/com/kizuna/cast/application/CastInvitationAcceptanceService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastInvitationAcceptanceService.java
@@ -52,7 +52,7 @@ public class CastInvitationAcceptanceService {
     CastInvitation invitation = findByToken(token);
     Cast cast = requireCast(invitation.getCastId());
     return new CastInvitationDetailResponse(
-        storeName(invitation.getTenantId()),
+        storeName(invitation.getStoreId()),
         cast.getName(),
         viewStatus(invitation),
         invitation.getExpiresAt());
@@ -79,10 +79,10 @@ public class CastInvitationAcceptanceService {
                 .enabled(true)
                 .userType(UserType.CAST)
                 .storeScopeType(StoreScopeType.SPECIFIC_STORES)
-                .storeIds(Set.of(invitation.getTenantId()))
+                .storeIds(Set.of(invitation.getStoreId()))
                 .build());
     link(cast, user.getId());
-    return new CastAcceptanceResponse(storeName(invitation.getTenantId()));
+    return new CastAcceptanceResponse(storeName(invitation.getStoreId()));
   }
 
   /**
@@ -111,12 +111,12 @@ public class CastInvitationAcceptanceService {
     // SPECIFIC_STORES の場合のみ招待店舗を冪等 union して再割当する（束・精算範囲は触らない — CAST は保持しない）。
     if (user.getStoreScopeType() == StoreScopeType.SPECIFIC_STORES) {
       Set<Long> storeIds = new HashSet<>(user.getStoreIds());
-      storeIds.add(invitation.getTenantId());
+      storeIds.add(invitation.getStoreId());
       user.reassignStores(StoreScopeType.SPECIFIC_STORES, storeIds);
       platformUserRepository.save(user);
     }
     link(cast, user.getId());
-    return new CastAcceptanceResponse(storeName(invitation.getTenantId()));
+    return new CastAcceptanceResponse(storeName(invitation.getStoreId()));
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/cast/application/CastInvitationAcceptanceService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastInvitationAcceptanceService.java
@@ -36,7 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CastInvitationAcceptanceService {
 
-  private static final String EMAIL_UNIQUE_CONSTRAINT = "uq_platform_users_email";
+  private static final String EMAIL_UNIQUE_CONSTRAINT = "uq_t_users_email";
   private static final String DUPLICATE_EMAIL_MESSAGE =
       "このメールアドレスは既に登録されています。既存アカウントでログインして受諾してください";
 

--- a/backend/src/main/java/com/kizuna/cast/application/CastInvitationService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastInvitationService.java
@@ -34,7 +34,7 @@ public class CastInvitationService {
   private final CastInvitationRepository castInvitationRepository;
 
   /**
-   * 招待を発行する。紐づき済みの档案は拒否し、既存の PENDING 招待を全て失効させてから最新 1 枚を新規発行する。 tenantFilter により他テナントの档案は見えず
+   * 招待を発行する。紐づき済みの档案は拒否し、既存の PENDING 招待を全て失効させてから最新 1 枚を新規発行する。 storeFilter により他テナントの档案は見えず
    * ServiceException となる（越権はインターセプタが先に 403）。
    *
    * <p>档案あたりの有効な招待は最大 1 枚であることを部分ユニークインデックス {@code uq_t_cast_invitations_pending_cast}（{@code WHERE
@@ -88,7 +88,7 @@ public class CastInvitationService {
     }
   }
 
-  /** ページ内の档案について招待状態（四態）を一括導出する。呼び出し元の tenantFilter 有効なトランザクション内で使う。 */
+  /** ページ内の档案について招待状態（四態）を一括導出する。呼び出し元の storeFilter 有効なトランザクション内で使う。 */
   public Map<String, CastInvitationStatus> deriveStatuses(List<Cast> casts) {
     if (casts.isEmpty()) {
       return Map.of();

--- a/backend/src/main/java/com/kizuna/cast/application/CastInvitationService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastInvitationService.java
@@ -77,7 +77,7 @@ public class CastInvitationService {
             .token(generateToken())
             .expiresAt(OffsetDateTime.now().plus(CastInvitation.VALIDITY))
             .build();
-    invitation.setTenantId(cast.getTenantId());
+    invitation.setStoreId(cast.getStoreId());
     try {
       CastInvitation saved = castInvitationRepository.saveAndFlush(invitation);
       return new CastInvitationResponse(saved.getToken(), saved.getExpiresAt());

--- a/backend/src/main/java/com/kizuna/cast/application/CastService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastService.java
@@ -61,8 +61,8 @@ public class CastService {
   }
 
   /**
-   * 指定 id のキャストが現在テナントに属するか判定する（他モジュールからの帰属チェック用ポート）。 tenantFilter が効くため、他テナントのキャストは存在しないものとして
-   * false を返す。
+   * 指定 id のキャストが現在テナントに属するか判定する（他モジュールからの帰属チェック用ポート）。 storeFilter が効くため、他テナントのキャストは存在しないものとして false
+   * を返す。
    */
   @TenantScoped
   @Transactional(readOnly = true)

--- a/backend/src/main/java/com/kizuna/cast/application/CastService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastService.java
@@ -75,7 +75,7 @@ public class CastService {
   public CastResponse create(CastCreateRequest request) {
     Cast cast = castMapper.toEntity(request);
 
-    cast.setTenantId(
+    cast.setStoreId(
         tenantRepository
             .findById(tenantContext.getTenantId())
             .orElseThrow(() -> new ServiceException("テナントが見つかりません"))

--- a/backend/src/main/java/com/kizuna/cast/domain/Cast.java
+++ b/backend/src/main/java/com/kizuna/cast/domain/Cast.java
@@ -16,7 +16,7 @@ import org.hibernate.annotations.Type;
 
 @Entity
 @Table(name = "t_casts")
-@Filter(name = "tenantFilter", condition = "tenant_id = :tenantId")
+@Filter(name = "tenantFilter", condition = "store_id = :storeId")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/kizuna/cast/domain/Cast.java
+++ b/backend/src/main/java/com/kizuna/cast/domain/Cast.java
@@ -1,6 +1,6 @@
 package com.kizuna.cast.domain;
 
-import com.kizuna.shared.persistence.TenantScopedEntity;
+import com.kizuna.shared.persistence.StoreScopedEntity;
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,12 +16,12 @@ import org.hibernate.annotations.Type;
 
 @Entity
 @Table(name = "t_casts")
-@Filter(name = "tenantFilter", condition = "store_id = :storeId")
+@Filter(name = "storeFilter", condition = "store_id = :storeId")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Cast extends TenantScopedEntity {
+public class Cast extends StoreScopedEntity {
 
   @Column(name = "name", nullable = false)
   private String name;

--- a/backend/src/main/java/com/kizuna/cast/domain/CastFieldDefinition.java
+++ b/backend/src/main/java/com/kizuna/cast/domain/CastFieldDefinition.java
@@ -18,7 +18,7 @@ import org.hibernate.annotations.Filter;
  */
 @Entity
 @Table(name = "t_cast_field_definitions")
-@Filter(name = "tenantFilter", condition = "tenant_id = :tenantId")
+@Filter(name = "tenantFilter", condition = "store_id = :storeId")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/kizuna/cast/domain/CastFieldDefinition.java
+++ b/backend/src/main/java/com/kizuna/cast/domain/CastFieldDefinition.java
@@ -1,6 +1,6 @@
 package com.kizuna.cast.domain;
 
-import com.kizuna.shared.persistence.TenantScopedEntity;
+import com.kizuna.shared.persistence.StoreScopedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -18,12 +18,12 @@ import org.hibernate.annotations.Filter;
  */
 @Entity
 @Table(name = "t_cast_field_definitions")
-@Filter(name = "tenantFilter", condition = "store_id = :storeId")
+@Filter(name = "storeFilter", condition = "store_id = :storeId")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class CastFieldDefinition extends TenantScopedEntity {
+public class CastFieldDefinition extends StoreScopedEntity {
 
   @Column(name = "key", nullable = false, updatable = false, length = 50)
   private String key;

--- a/backend/src/main/java/com/kizuna/cast/domain/CastFieldDefinitionRepository.java
+++ b/backend/src/main/java/com/kizuna/cast/domain/CastFieldDefinitionRepository.java
@@ -4,7 +4,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-/** カスタムフィールド定義のリポジトリ。tenantFilter 前提のためテナント条件は書かない（CastRepository と同流儀）。 */
+/** カスタムフィールド定義のリポジトリ。storeFilter 前提のためテナント条件は書かない（CastRepository と同流儀）。 */
 public interface CastFieldDefinitionRepository extends JpaRepository<CastFieldDefinition, String> {
 
   boolean existsByKey(String key);

--- a/backend/src/main/java/com/kizuna/cast/domain/CastInvitation.java
+++ b/backend/src/main/java/com/kizuna/cast/domain/CastInvitation.java
@@ -1,6 +1,6 @@
 package com.kizuna.cast.domain;
 
-import com.kizuna.shared.persistence.TenantScopedEntity;
+import com.kizuna.shared.persistence.StoreScopedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -17,12 +17,12 @@ import org.hibernate.annotations.Filter;
 /** キャスト招待集約。1 档案につき有効な招待は最新の 1 枚のみ（再発行で旧 PENDING は失効する）。 リンク発行後の受諾で {@link Cast} に平台身分を紐づける。 */
 @Entity
 @Table(name = "t_cast_invitations")
-@Filter(name = "tenantFilter", condition = "store_id = :storeId")
+@Filter(name = "storeFilter", condition = "store_id = :storeId")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class CastInvitation extends TenantScopedEntity {
+public class CastInvitation extends StoreScopedEntity {
 
   /** 招待リンクの有効期間（ドメイン所有の定数）。 */
   public static final Duration VALIDITY = Duration.ofHours(72);

--- a/backend/src/main/java/com/kizuna/cast/domain/CastInvitation.java
+++ b/backend/src/main/java/com/kizuna/cast/domain/CastInvitation.java
@@ -17,7 +17,7 @@ import org.hibernate.annotations.Filter;
 /** キャスト招待集約。1 档案につき有効な招待は最新の 1 枚のみ（再発行で旧 PENDING は失効する）。 リンク発行後の受諾で {@link Cast} に平台身分を紐づける。 */
 @Entity
 @Table(name = "t_cast_invitations")
-@Filter(name = "tenantFilter", condition = "tenant_id = :tenantId")
+@Filter(name = "tenantFilter", condition = "store_id = :storeId")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
@@ -82,7 +82,7 @@ public class CustomerService {
   public CustomerResponse create(CustomerCreateRequest request) {
     Customer customer = customerMapper.toEntity(request);
 
-    customer.setTenantId(
+    customer.setStoreId(
         tenantRepository
             .findById(tenantContext.getTenantId())
             .orElseThrow(() -> new ServiceException("テナントが見つかりません"))

--- a/backend/src/main/java/com/kizuna/customer/domain/Customer.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/Customer.java
@@ -12,7 +12,7 @@ import org.hibernate.annotations.Filter;
 
 @Entity
 @Table(name = "t_customers")
-@Filter(name = "tenantFilter", condition = "tenant_id = :tenantId")
+@Filter(name = "tenantFilter", condition = "store_id = :storeId")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/kizuna/customer/domain/Customer.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/Customer.java
@@ -1,6 +1,6 @@
 package com.kizuna.customer.domain;
 
-import com.kizuna.shared.persistence.TenantScopedEntity;
+import com.kizuna.shared.persistence.StoreScopedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -12,12 +12,12 @@ import org.hibernate.annotations.Filter;
 
 @Entity
 @Table(name = "t_customers")
-@Filter(name = "tenantFilter", condition = "store_id = :storeId")
+@Filter(name = "storeFilter", condition = "store_id = :storeId")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Customer extends TenantScopedEntity {
+public class Customer extends StoreScopedEntity {
 
   @Column(name = "name")
   private String name;

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
@@ -9,5 +9,5 @@ public interface CustomerRepository
 
   Optional<Customer> findByPhoneNumber(String phoneNumber);
 
-  Optional<Customer> findByPhoneNumberAndTenantId(String phoneNumber, Long tenantId);
+  Optional<Customer> findByPhoneNumberAndStoreId(String phoneNumber, Long storeId);
 }

--- a/backend/src/main/java/com/kizuna/menu/application/StoreMenuService.java
+++ b/backend/src/main/java/com/kizuna/menu/application/StoreMenuService.java
@@ -25,6 +25,6 @@ public class StoreMenuService {
       return Collections.emptyList();
     }
     return MenuTreeAssembler.assemble(
-        menuRepository.findByTenantIdAndParentIsNullOrderBySortOrderAsc(tenantId));
+        menuRepository.findByStoreIdAndParentIsNullOrderBySortOrderAsc(tenantId));
   }
 }

--- a/backend/src/main/java/com/kizuna/menu/domain/StoreMenu.java
+++ b/backend/src/main/java/com/kizuna/menu/domain/StoreMenu.java
@@ -25,13 +25,13 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Setter
 @Entity
 @Table(name = "t_menus")
-@Filter(name = "tenantFilter", condition = "tenant_id = :tenantId")
+@Filter(name = "tenantFilter", condition = "store_id = :storeId")
 public class StoreMenu implements MenuNode {
 
   @Id private String id;
 
-  @Column(name = "tenant_id", nullable = false)
-  private Long tenantId;
+  @Column(name = "store_id", nullable = false)
+  private Long storeId;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "parent_id")

--- a/backend/src/main/java/com/kizuna/menu/domain/StoreMenu.java
+++ b/backend/src/main/java/com/kizuna/menu/domain/StoreMenu.java
@@ -25,7 +25,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Setter
 @Entity
 @Table(name = "t_menus")
-@Filter(name = "tenantFilter", condition = "store_id = :storeId")
+@Filter(name = "storeFilter", condition = "store_id = :storeId")
 public class StoreMenu implements MenuNode {
 
   @Id private String id;

--- a/backend/src/main/java/com/kizuna/menu/domain/StoreMenuRepository.java
+++ b/backend/src/main/java/com/kizuna/menu/domain/StoreMenuRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreMenuRepository extends JpaRepository<StoreMenu, String> {
   @EntityGraph(attributePaths = {"children"})
-  List<StoreMenu> findByTenantIdAndParentIsNullOrderBySortOrderAsc(Long tenantId);
+  List<StoreMenu> findByStoreIdAndParentIsNullOrderBySortOrderAsc(Long storeId);
 }

--- a/backend/src/main/java/com/kizuna/order/application/OrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderService.java
@@ -58,7 +58,7 @@ public class OrderService {
     Order order = orderMapper.toEntity(request);
 
     // テナントの設定
-    order.setTenantId(
+    order.setStoreId(
         tenantRepository
             .findById(tenantContext.getTenantId())
             .orElseThrow(() -> new ServiceException("テナントが見つかりません"))
@@ -157,12 +157,12 @@ public class OrderService {
       // 顧客の検索または作成
       Customer customer =
           customerRepository
-              .findByPhoneNumberAndTenantId(req.getPhoneNumber(), tenantContext.getTenantId())
+              .findByPhoneNumberAndStoreId(req.getPhoneNumber(), tenantContext.getTenantId())
               .orElseGet(
                   () -> {
                     Customer newCustomer = orderMapper.toCustomer(req);
                     // テナントを明示的に設定
-                    newCustomer.setTenantId(
+                    newCustomer.setStoreId(
                         tenantRepository
                             .findById(tenantContext.getTenantId())
                             .orElseThrow(() -> new ServiceException("テナントが見つかりません"))

--- a/backend/src/main/java/com/kizuna/order/application/OrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderService.java
@@ -121,7 +121,7 @@ public class OrderService {
   }
 
   // 受付担当者は「有効(enabled)かつ受注管理能力（ORDER_MANAGE）を持つ STAFF」かつ「現テナント(店舗)を授権する
-  // PlatformUser」でなければならない。platform_users には tenant_id が無いため、単なる存在確認では
+  // PlatformUser」でなければならない。t_users には store_id が無いため、単なる存在確認では
   // 他店舗/CAST/MEMBER も通ってしまう。停止済み(enabled=false)の口座は束・授権を保持したままなので明示的に弾く。
   // userType 判定を先行させ、束を持たない CAST/MEMBER で束問い合わせ（空 in 句）へ進まないようにする。
   private void validateReceptionist(Long receptionistId) {

--- a/backend/src/main/java/com/kizuna/order/domain/Order.java
+++ b/backend/src/main/java/com/kizuna/order/domain/Order.java
@@ -1,6 +1,6 @@
 package com.kizuna.order.domain;
 
-import com.kizuna.shared.persistence.TenantScopedEntity;
+import com.kizuna.shared.persistence.StoreScopedEntity;
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,13 +19,13 @@ import org.hibernate.annotations.Type;
 
 @Entity
 @Table(name = "t_orders")
-@Filter(name = "tenantFilter", condition = "store_id = :storeId")
+@Filter(name = "storeFilter", condition = "store_id = :storeId")
 @Filter(name = "storeSetFilter", condition = "store_id in (:storeIds)")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Order extends TenantScopedEntity {
+public class Order extends StoreScopedEntity {
 
   @Column(name = "store_name")
   private String storeName;

--- a/backend/src/main/java/com/kizuna/order/domain/Order.java
+++ b/backend/src/main/java/com/kizuna/order/domain/Order.java
@@ -19,8 +19,8 @@ import org.hibernate.annotations.Type;
 
 @Entity
 @Table(name = "t_orders")
-@Filter(name = "tenantFilter", condition = "tenant_id = :tenantId")
-@Filter(name = "storeSetFilter", condition = "tenant_id in (:storeIds)")
+@Filter(name = "tenantFilter", condition = "store_id = :storeId")
+@Filter(name = "storeSetFilter", condition = "store_id in (:storeIds)")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
@@ -51,7 +51,7 @@ public interface OrderRepository
   // 店舗（tenant）表示名の join は張らない。
   String PLATFORM_VIEW_SELECT =
       """
-      select o.id as id, o.tenantId as storeId, o.storeName as storeName,
+      select o.id as id, o.storeId as storeId, o.storeName as storeName,
              o.businessDate as businessDate,
              o.arrivalScheduledStartTime as arrivalScheduledStartTime,
              o.arrivalScheduledEndTime as arrivalScheduledEndTime,

--- a/backend/src/main/java/com/kizuna/settings/domain/SystemConfig.java
+++ b/backend/src/main/java/com/kizuna/settings/domain/SystemConfig.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 @Entity
-@Table(name = "central_configs")
+@Table(name = "t_system_configs")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/backend/src/main/java/com/kizuna/shared/persistence/StoreScopedEntity.java
+++ b/backend/src/main/java/com/kizuna/shared/persistence/StoreScopedEntity.java
@@ -15,7 +15,7 @@ import lombok.ToString;
 import org.hibernate.annotations.FilterDef;
 import org.hibernate.annotations.ParamDef;
 
-/** テナントスコープのエンティティ基盤。tenant_id は ID 参照（D3）で保持し、tenantFilter で行レベル分離する。 */
+/** テナントスコープのエンティティ基盤。store_id は ID 参照（D3）で保持し、storeFilter で行レベル分離する。 */
 @MappedSuperclass
 @Getter
 @Setter

--- a/backend/src/main/java/com/kizuna/shared/persistence/StoreScopedEntity.java
+++ b/backend/src/main/java/com/kizuna/shared/persistence/StoreScopedEntity.java
@@ -22,14 +22,14 @@ import org.hibernate.annotations.ParamDef;
 @NoArgsConstructor
 @ToString
 @FilterDef(
-    name = "tenantFilter",
+    name = "storeFilter",
     applyToLoadByKey = true,
     parameters = @ParamDef(name = "storeId", type = Long.class))
 @FilterDef(
     name = "storeSetFilter",
     applyToLoadByKey = true,
     parameters = @ParamDef(name = "storeIds", type = Long.class))
-public abstract class TenantScopedEntity {
+public abstract class StoreScopedEntity {
 
   @Id @SnowflakeId private String id;
 

--- a/backend/src/main/java/com/kizuna/shared/persistence/TenantScopedEntity.java
+++ b/backend/src/main/java/com/kizuna/shared/persistence/TenantScopedEntity.java
@@ -24,7 +24,7 @@ import org.hibernate.annotations.ParamDef;
 @FilterDef(
     name = "tenantFilter",
     applyToLoadByKey = true,
-    parameters = @ParamDef(name = "tenantId", type = Long.class))
+    parameters = @ParamDef(name = "storeId", type = Long.class))
 @FilterDef(
     name = "storeSetFilter",
     applyToLoadByKey = true,
@@ -33,8 +33,8 @@ public abstract class TenantScopedEntity {
 
   @Id @SnowflakeId private String id;
 
-  @Column(name = "tenant_id", updatable = false)
-  private Long tenantId;
+  @Column(name = "store_id", updatable = false)
+  private Long storeId;
 
   @Column(name = "created_at", nullable = false)
   private OffsetDateTime createdAt;

--- a/backend/src/main/java/com/kizuna/shared/tenancy/StoreSetFilterEnable.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/StoreSetFilterEnable.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
  * {@code @StoreSetScoped} が付いたメソッドで Hibernate の storeSetFilter を有効化する Aspect（#323 集合作用域）。
  *
  * <p>認証済み平台トークンの授権店舗集合を {@link StoreScope} で解決し、SPECIFIC_STORES の場合のみ storeSetFilter（{@code
- * tenant_id in (:storeIds)}）を有効化する。ALL_STORES はフィルタ無効＝全店可視。授権集合を解決できない呼び出しは fail-closed に {@link
+ * store_id in (:storeIds)}）を有効化する。ALL_STORES はフィルタ無効＝全店可視。授権集合を解決できない呼び出しは fail-closed に {@link
  * AccessDeniedException} で拒否する。{@link TenantFilterEnable} と同型の {@code @Order} 指定（トランザクション advisor
  * との相対順序）を逐字踏襲する。
  */

--- a/backend/src/main/java/com/kizuna/shared/tenancy/StoreSetScoped.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/StoreSetScoped.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 /**
  * 集合作用域: 付与されたメソッドで Hibernate の {@code storeSetFilter} を有効化する（#323）。
  *
- * <p>認証済み平台トークンの授権店舗集合（{@link StoreScope}）に基づき、SPECIFIC_STORES では {@code tenant_id in (:storeIds)}
+ * <p>認証済み平台トークンの授権店舗集合（{@link StoreScope}）に基づき、SPECIFIC_STORES では {@code store_id in (:storeIds)}
  * で行レベルに濾過し、ALL_STORES ではフィルタ無効＝全店可視とする。授権集合を解決できない呼び出しは fail-closed に拒否される。
  */
 @Target(ElementType.METHOD)

--- a/backend/src/main/java/com/kizuna/shared/tenancy/TenantFilterEnable.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/TenantFilterEnable.java
@@ -33,7 +33,7 @@ public class TenantFilterEnable {
       entityManager
           .unwrap(org.hibernate.Session.class)
           .enableFilter("tenantFilter")
-          .setParameter("tenantId", tenantContext.getTenantId());
+          .setParameter("storeId", tenantContext.getTenantId());
     }
     return pjp.proceed();
   }

--- a/backend/src/main/java/com/kizuna/shared/tenancy/TenantFilterEnable.java
+++ b/backend/src/main/java/com/kizuna/shared/tenancy/TenantFilterEnable.java
@@ -32,7 +32,7 @@ public class TenantFilterEnable {
     if (tenantContext.isTenant()) {
       entityManager
           .unwrap(org.hibernate.Session.class)
-          .enableFilter("tenantFilter")
+          .enableFilter("storeFilter")
           .setParameter("storeId", tenantContext.getTenantId());
     }
     return pjp.proceed();

--- a/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
@@ -96,7 +96,7 @@ public class ShiftService {
 
     Shift shift = shiftMapper.toEntity(request);
 
-    shift.setTenantId(
+    shift.setStoreId(
         tenantRepository
             .findById(tenantContext.getTenantId())
             .orElseThrow(() -> new ServiceException("テナントが見つかりません"))

--- a/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
@@ -52,7 +52,7 @@ public class ShiftService {
   /**
    * 公開出勤表用に「本日（app.timezone）」の確定（CONFIRMED）シフトを start_time 昇順で返す。 ACTIVE でないキャストのシフトは公開一覧 ({@code
    * /tenant/casts/public}) に整合させて除外する。cast 表示情報は公開されている cast.domain（{@link Cast}）を
-   * 直接参照して結合する（cast.api.dto は公開面ではないため）。tenantFilter は {@code @TenantScoped} によりセッション全体で有効なので
+   * 直接参照して結合する（cast.api.dto は公開面ではないため）。storeFilter は {@code @TenantScoped} によりセッション全体で有効なので
    * t_casts 参照も現テナントに絞られる。
    */
   @TenantScoped

--- a/backend/src/main/java/com/kizuna/shift/domain/Shift.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/Shift.java
@@ -1,6 +1,6 @@
 package com.kizuna.shift.domain;
 
-import com.kizuna.shared.persistence.TenantScopedEntity;
+import com.kizuna.shared.persistence.StoreScopedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
@@ -14,12 +14,12 @@ import org.hibernate.annotations.Filter;
 
 @Entity
 @Table(name = "t_shifts")
-@Filter(name = "tenantFilter", condition = "store_id = :storeId")
+@Filter(name = "storeFilter", condition = "store_id = :storeId")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Shift extends TenantScopedEntity {
+public class Shift extends StoreScopedEntity {
 
   @Column(name = "cast_id", nullable = false, length = 64)
   private String castId;

--- a/backend/src/main/java/com/kizuna/shift/domain/Shift.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/Shift.java
@@ -14,7 +14,7 @@ import org.hibernate.annotations.Filter;
 
 @Entity
 @Table(name = "t_shifts")
-@Filter(name = "tenantFilter", condition = "tenant_id = :tenantId")
+@Filter(name = "tenantFilter", condition = "store_id = :storeId")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/kizuna/storeprofile/api/dto/StoreProfileMapper.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/api/dto/StoreProfileMapper.java
@@ -28,7 +28,7 @@ public interface StoreProfileMapper {
    */
   @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
   @Mapping(target = "id", ignore = true)
-  @Mapping(target = "tenantId", ignore = true)
+  @Mapping(target = "storeId", ignore = true)
   @Mapping(target = "createdAt", ignore = true)
   @Mapping(target = "updatedAt", ignore = true)
   void updateEntityFromRequest(

--- a/backend/src/main/java/com/kizuna/storeprofile/application/StoreProfileService.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/application/StoreProfileService.java
@@ -26,7 +26,7 @@ public class StoreProfileService {
     Long tenantId = tenantContext.getTenantId();
     StoreProfile config =
         storeProfileRepository
-            .findByTenantId(tenantId)
+            .findByStoreId(tenantId)
             .orElseThrow(() -> new ServiceException("テナント設定が見つかりません"));
     return storeProfileMapper.toResponse(config);
   }
@@ -37,7 +37,7 @@ public class StoreProfileService {
     Long tenantId = tenantContext.getTenantId();
     StoreProfile config =
         storeProfileRepository
-            .findByTenantId(tenantId)
+            .findByStoreId(tenantId)
             .orElseThrow(() -> new ServiceException("テナント設定が見つかりません"));
     storeProfileMapper.updateEntityFromRequest(request, config);
     return storeProfileMapper.toResponse(storeProfileRepository.saveAndFlush(config));

--- a/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfile.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfile.java
@@ -26,7 +26,7 @@ import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.Type;
 
 @Entity
-@Table(name = "t_tenant_configs")
+@Table(name = "t_store_profiles")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfile.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfile.java
@@ -33,7 +33,7 @@ import org.hibernate.annotations.Type;
 @AllArgsConstructor
 @Builder
 @ToString
-@Filter(name = "tenantFilter", condition = "store_id = :storeId")
+@Filter(name = "storeFilter", condition = "store_id = :storeId")
 public class StoreProfile {
 
   @Id

--- a/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfile.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfile.java
@@ -33,15 +33,15 @@ import org.hibernate.annotations.Type;
 @AllArgsConstructor
 @Builder
 @ToString
-@Filter(name = "tenantFilter", condition = "tenant_id = :tenantId")
+@Filter(name = "tenantFilter", condition = "store_id = :storeId")
 public class StoreProfile {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(name = "tenant_id", nullable = false, unique = true, updatable = false)
-  private Long tenantId;
+  @Column(name = "store_id", nullable = false, unique = true, updatable = false)
+  private Long storeId;
 
   @Column(name = "template_key", length = 50)
   @Builder.Default
@@ -120,12 +120,12 @@ public class StoreProfile {
   /**
    * テナント用のデフォルト設定を生成する。
    *
-   * @param tenantId 対象テナントの ID
+   * @param storeId 対象テナントの ID
    * @return デフォルト値が設定された StoreProfile インスタンス
    */
-  public static StoreProfile createDefault(Long tenantId) {
+  public static StoreProfile createDefault(Long storeId) {
     return StoreProfile.builder()
-        .tenantId(tenantId)
+        .storeId(storeId)
         .templateKey("default")
         .mvType("image")
         .snsLinks(new ArrayList<>())

--- a/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfileRepository.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfileRepository.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreProfileRepository extends JpaRepository<StoreProfile, Long> {
-  Optional<StoreProfile> findByTenantId(Long tenantId);
+  Optional<StoreProfile> findByStoreId(Long storeId);
 
-  boolean existsByTenantId(Long tenantId);
+  boolean existsByStoreId(Long storeId);
 }

--- a/backend/src/main/java/com/kizuna/tenant/domain/Tenant.java
+++ b/backend/src/main/java/com/kizuna/tenant/domain/Tenant.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "central_tenants")
+@Table(name = "t_stores")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
+++ b/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
@@ -45,7 +45,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PlatformStaffService {
 
-  private static final String EMAIL_UNIQUE_CONSTRAINT = "uq_platform_users_email";
+  private static final String EMAIL_UNIQUE_CONSTRAINT = "uq_t_users_email";
 
   private final PlatformUserRepository repository;
   private final CapabilityBundleRepository capabilityBundleRepository;

--- a/backend/src/main/java/com/kizuna/user/domain/CapabilityBundle.java
+++ b/backend/src/main/java/com/kizuna/user/domain/CapabilityBundle.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
  * の集合で保持する（跨集約 ID 参照）。
  */
 @Entity
-@Table(name = "platform_capability_bundles")
+@Table(name = "t_capability_bundles")
 @Getter
 @NoArgsConstructor
 public class CapabilityBundle extends BaseEntity {
@@ -33,7 +33,7 @@ public class CapabilityBundle extends BaseEntity {
 
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(
-      name = "platform_capability_bundle_items",
+      name = "t_capability_bundle_items",
       joinColumns = @JoinColumn(name = "bundle_id"))
   @Column(name = "capability", nullable = false, length = 50)
   @Enumerated(EnumType.STRING)

--- a/backend/src/main/java/com/kizuna/user/domain/GrantHistory.java
+++ b/backend/src/main/java/com/kizuna/user/domain/GrantHistory.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
  * <p>対象ユーザーは跨集約 ID 参照（{@code platformUserId}）。detail には束名・店舗集合・精算範囲の快照（JSON 文字列）を保存する。
  */
 @Entity
-@Table(name = "platform_grant_history")
+@Table(name = "t_grant_history")
 @Getter
 @NoArgsConstructor
 public class GrantHistory extends BaseEntity {

--- a/backend/src/main/java/com/kizuna/user/domain/PlatformUser.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PlatformUser.java
@@ -33,7 +33,7 @@ import lombok.NoArgsConstructor;
  * </ul>
  */
 @Entity
-@Table(name = "platform_users")
+@Table(name = "t_users")
 @Getter
 @NoArgsConstructor
 public class PlatformUser extends BaseEntity {
@@ -55,9 +55,7 @@ public class PlatformUser extends BaseEntity {
   private UserType userType;
 
   @ElementCollection(fetch = FetchType.EAGER)
-  @CollectionTable(
-      name = "platform_user_bundles",
-      joinColumns = @JoinColumn(name = "platform_user_id"))
+  @CollectionTable(name = "t_user_bundles", joinColumns = @JoinColumn(name = "platform_user_id"))
   @Column(name = "bundle_id")
   private Set<Long> bundleIds = new HashSet<>();
 
@@ -66,9 +64,7 @@ public class PlatformUser extends BaseEntity {
   private StoreScopeType storeScopeType;
 
   @ElementCollection(fetch = FetchType.EAGER)
-  @CollectionTable(
-      name = "platform_user_stores",
-      joinColumns = @JoinColumn(name = "platform_user_id"))
+  @CollectionTable(name = "t_user_stores", joinColumns = @JoinColumn(name = "platform_user_id"))
   @Column(name = "store_id")
   private Set<Long> storeIds = new HashSet<>();
 
@@ -79,7 +75,7 @@ public class PlatformUser extends BaseEntity {
 
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(
-      name = "platform_user_settlement_stores",
+      name = "t_user_settlement_stores",
       joinColumns = @JoinColumn(name = "platform_user_id"))
   @Column(name = "store_id")
   private Set<Long> settlementStoreIds = new HashSet<>();

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -38,3 +38,6 @@ databaseChangeLog:
   - include:
       file: releases/v0.13.0/master.yaml
       relativeToChangelogFile: true
+  - include:
+      file: releases/v0.14.0/master.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.14.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.14.0/master.yaml
@@ -1,0 +1,7 @@
+databaseChangeLog:
+  - include:
+      file: platform/01-rename-platform-tables.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: store/01-rename-store-profile-table.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.14.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.14.0/master.yaml
@@ -5,3 +5,6 @@ databaseChangeLog:
   - include:
       file: store/01-rename-store-profile-table.yaml
       relativeToChangelogFile: true
+  - include:
+      file: store/02-rename-tenant-id-columns.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.14.0/platform/01-rename-platform-tables.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.14.0/platform/01-rename-platform-tables.yaml
@@ -1,0 +1,154 @@
+databaseChangeLog:
+  # tenant/central 語彙から store/platform 語彙への DB 命名収束（#404 / #405）。
+  # 挙動不変の改名。歴史 changeset は checksum 保護のため編集せず、本 v0.14.0 で ALTER のみで是正する。
+  # 組み込み renameTable / renameSequence は自動ロールバック対応のため changeSet を分け、
+  # 制約・インデックスの raw SQL 改名は明示 rollback を持つ別 changeSet に置く
+  # （changeSet 単位の rollback 指定は自動ロールバックを上書きするため混在させない）。
+  - changeSet:
+      id: platform-v0140-001-rename-platform-tables
+      author: kanghouchao
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - renameTable:
+            oldTableName: central_tenants
+            newTableName: t_stores
+        - renameTable:
+            oldTableName: central_configs
+            newTableName: t_system_configs
+        - renameTable:
+            oldTableName: platform_users
+            newTableName: t_users
+        - renameTable:
+            oldTableName: platform_capability_bundles
+            newTableName: t_capability_bundles
+        - renameTable:
+            oldTableName: platform_capability_bundle_items
+            newTableName: t_capability_bundle_items
+        - renameTable:
+            oldTableName: platform_user_bundles
+            newTableName: t_user_bundles
+        - renameTable:
+            oldTableName: platform_user_stores
+            newTableName: t_user_stores
+        - renameTable:
+            oldTableName: platform_user_settlement_stores
+            newTableName: t_user_settlement_stores
+        - renameTable:
+            oldTableName: platform_grant_history
+            newTableName: t_grant_history
+        # ALTER TABLE RENAME は IDENTITY 所有シーケンスを改名しないため明示的に追随させる。
+        - renameSequence:
+            oldSequenceName: central_tenants_id_seq
+            newSequenceName: t_stores_id_seq
+        - renameSequence:
+            oldSequenceName: central_configs_id_seq
+            newSequenceName: t_system_configs_id_seq
+        - renameSequence:
+            oldSequenceName: platform_users_id_seq
+            newSequenceName: t_users_id_seq
+        - renameSequence:
+            oldSequenceName: platform_capability_bundles_id_seq
+            newSequenceName: t_capability_bundles_id_seq
+        - renameSequence:
+            oldSequenceName: platform_grant_history_id_seq
+            newSequenceName: t_grant_history_id_seq
+  - changeSet:
+      id: platform-v0140-002-rename-platform-constraints
+      author: kanghouchao
+      # 制約・インデックス名は表名改名に追随しないため raw SQL で改名する。
+      # UNIQUE / PK の裏付けインデックスは制約改名で自動追随する（別途 ALTER INDEX 不要）。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - sql:
+            sql: ALTER TABLE t_stores RENAME CONSTRAINT pk_central_tenants TO pk_t_stores
+        - sql:
+            sql: ALTER TABLE t_stores RENAME CONSTRAINT uq_central_tenants_domain TO uq_t_stores_domain
+        - sql:
+            sql: ALTER TABLE t_system_configs RENAME CONSTRAINT pk_central_configs TO pk_t_system_configs
+        - sql:
+            sql: ALTER TABLE t_system_configs RENAME CONSTRAINT uq_central_configs_key TO uq_t_system_configs_key
+        - sql:
+            sql: ALTER TABLE t_users RENAME CONSTRAINT pk_platform_users TO pk_t_users
+        - sql:
+            sql: ALTER TABLE t_users RENAME CONSTRAINT uq_platform_users_email TO uq_t_users_email
+        - sql:
+            sql: ALTER TABLE t_capability_bundles RENAME CONSTRAINT pk_platform_capability_bundles TO pk_t_capability_bundles
+        - sql:
+            sql: ALTER TABLE t_capability_bundles RENAME CONSTRAINT uq_platform_capability_bundles_name TO uq_t_capability_bundles_name
+        - sql:
+            sql: ALTER TABLE t_capability_bundle_items RENAME CONSTRAINT pk_platform_capability_bundle_items TO pk_t_capability_bundle_items
+        - sql:
+            sql: ALTER TABLE t_capability_bundle_items RENAME CONSTRAINT fk_platform_capability_bundle_items_bundle TO fk_t_capability_bundle_items_bundle
+        - sql:
+            sql: ALTER TABLE t_user_bundles RENAME CONSTRAINT pk_platform_user_bundles TO pk_t_user_bundles
+        - sql:
+            sql: ALTER TABLE t_user_bundles RENAME CONSTRAINT fk_platform_user_bundles_user TO fk_t_user_bundles_user
+        - sql:
+            sql: ALTER TABLE t_user_bundles RENAME CONSTRAINT fk_platform_user_bundles_bundle TO fk_t_user_bundles_bundle
+        - sql:
+            sql: ALTER TABLE t_user_stores RENAME CONSTRAINT pk_platform_user_stores TO pk_t_user_stores
+        - sql:
+            sql: ALTER TABLE t_user_stores RENAME CONSTRAINT fk_platform_user_stores_user TO fk_t_user_stores_user
+        - sql:
+            sql: ALTER TABLE t_user_stores RENAME CONSTRAINT fk_platform_user_stores_store TO fk_t_user_stores_store
+        - sql:
+            sql: ALTER TABLE t_user_settlement_stores RENAME CONSTRAINT pk_platform_user_settlement_stores TO pk_t_user_settlement_stores
+        - sql:
+            sql: ALTER TABLE t_user_settlement_stores RENAME CONSTRAINT fk_platform_user_settlement_stores_user TO fk_t_user_settlement_stores_user
+        - sql:
+            sql: ALTER TABLE t_user_settlement_stores RENAME CONSTRAINT fk_platform_user_settlement_stores_store TO fk_t_user_settlement_stores_store
+        - sql:
+            sql: ALTER TABLE t_grant_history RENAME CONSTRAINT pk_platform_grant_history TO pk_t_grant_history
+        - sql:
+            sql: ALTER TABLE t_grant_history RENAME CONSTRAINT fk_platform_grant_history_user TO fk_t_grant_history_user
+        - sql:
+            sql: ALTER INDEX idx_platform_grant_history_user RENAME TO idx_t_grant_history_user
+      rollback:
+        - sql:
+            sql: ALTER INDEX idx_t_grant_history_user RENAME TO idx_platform_grant_history_user
+        - sql:
+            sql: ALTER TABLE t_grant_history RENAME CONSTRAINT fk_t_grant_history_user TO fk_platform_grant_history_user
+        - sql:
+            sql: ALTER TABLE t_grant_history RENAME CONSTRAINT pk_t_grant_history TO pk_platform_grant_history
+        - sql:
+            sql: ALTER TABLE t_user_settlement_stores RENAME CONSTRAINT fk_t_user_settlement_stores_store TO fk_platform_user_settlement_stores_store
+        - sql:
+            sql: ALTER TABLE t_user_settlement_stores RENAME CONSTRAINT fk_t_user_settlement_stores_user TO fk_platform_user_settlement_stores_user
+        - sql:
+            sql: ALTER TABLE t_user_settlement_stores RENAME CONSTRAINT pk_t_user_settlement_stores TO pk_platform_user_settlement_stores
+        - sql:
+            sql: ALTER TABLE t_user_stores RENAME CONSTRAINT fk_t_user_stores_store TO fk_platform_user_stores_store
+        - sql:
+            sql: ALTER TABLE t_user_stores RENAME CONSTRAINT fk_t_user_stores_user TO fk_platform_user_stores_user
+        - sql:
+            sql: ALTER TABLE t_user_stores RENAME CONSTRAINT pk_t_user_stores TO pk_platform_user_stores
+        - sql:
+            sql: ALTER TABLE t_user_bundles RENAME CONSTRAINT fk_t_user_bundles_bundle TO fk_platform_user_bundles_bundle
+        - sql:
+            sql: ALTER TABLE t_user_bundles RENAME CONSTRAINT fk_t_user_bundles_user TO fk_platform_user_bundles_user
+        - sql:
+            sql: ALTER TABLE t_user_bundles RENAME CONSTRAINT pk_t_user_bundles TO pk_platform_user_bundles
+        - sql:
+            sql: ALTER TABLE t_capability_bundle_items RENAME CONSTRAINT fk_t_capability_bundle_items_bundle TO fk_platform_capability_bundle_items_bundle
+        - sql:
+            sql: ALTER TABLE t_capability_bundle_items RENAME CONSTRAINT pk_t_capability_bundle_items TO pk_platform_capability_bundle_items
+        - sql:
+            sql: ALTER TABLE t_capability_bundles RENAME CONSTRAINT uq_t_capability_bundles_name TO uq_platform_capability_bundles_name
+        - sql:
+            sql: ALTER TABLE t_capability_bundles RENAME CONSTRAINT pk_t_capability_bundles TO pk_platform_capability_bundles
+        - sql:
+            sql: ALTER TABLE t_users RENAME CONSTRAINT uq_t_users_email TO uq_platform_users_email
+        - sql:
+            sql: ALTER TABLE t_users RENAME CONSTRAINT pk_t_users TO pk_platform_users
+        - sql:
+            sql: ALTER TABLE t_system_configs RENAME CONSTRAINT uq_t_system_configs_key TO uq_central_configs_key
+        - sql:
+            sql: ALTER TABLE t_system_configs RENAME CONSTRAINT pk_t_system_configs TO pk_central_configs
+        - sql:
+            sql: ALTER TABLE t_stores RENAME CONSTRAINT uq_t_stores_domain TO uq_central_tenants_domain
+        - sql:
+            sql: ALTER TABLE t_stores RENAME CONSTRAINT pk_t_stores TO pk_central_tenants

--- a/backend/src/main/resources/db/changelog/releases/v0.14.0/store/01-rename-store-profile-table.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.14.0/store/01-rename-store-profile-table.yaml
@@ -1,0 +1,31 @@
+databaseChangeLog:
+  # t_tenant_configs（店舗公開サイト設定）を t_store_profiles へ改名する（#404 / #405）。
+  # 列 tenant_id / FK / インデックス / 無名 unique は Task 2（02-rename-tenant-id-columns）で追随する。
+  - changeSet:
+      id: store-v0140-001-rename-store-profile-table
+      author: kanghouchao
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - renameTable:
+            oldTableName: t_tenant_configs
+            newTableName: t_store_profiles
+        # ALTER TABLE RENAME は IDENTITY 所有シーケンスを改名しないため明示的に追随させる。
+        - renameSequence:
+            oldSequenceName: t_tenant_configs_id_seq
+            newSequenceName: t_store_profiles_id_seq
+  - changeSet:
+      id: store-v0140-002-rename-store-profile-pk
+      author: kanghouchao
+      # PK は作成時に無名指定のため PostgreSQL 自動名 t_tenant_configs_pkey を持つ。
+      # 表名改名に追随しないため raw SQL で pk_t_store_profiles へ改名する。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - sql:
+            sql: ALTER TABLE t_store_profiles RENAME CONSTRAINT t_tenant_configs_pkey TO pk_t_store_profiles
+      rollback:
+        - sql:
+            sql: ALTER TABLE t_store_profiles RENAME CONSTRAINT pk_t_store_profiles TO t_tenant_configs_pkey

--- a/backend/src/main/resources/db/changelog/releases/v0.14.0/store/02-rename-tenant-id-columns.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.14.0/store/02-rename-tenant-id-columns.yaml
@@ -1,0 +1,115 @@
+databaseChangeLog:
+  # 店舗スコープ 8 表の tenant_id 列を store_id へ改名する（#404 / #405）。
+  # 対象は central_tenants(→t_stores) を参照する live 8 表のみ。
+  # #406 判断待ちの遺留表（t_pages / t_resource_* / central_group_*）の tenant_id は改名しない。
+  # 組み込み renameColumn は自動ロールバック対応のため単独 changeSet に置き、
+  # FK・インデックス・無名 unique の raw SQL 改名は明示 rollback を持つ別 changeSet に分ける。
+  - changeSet:
+      id: store-v0140-003-rename-tenant-id-columns
+      author: kanghouchao
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - renameColumn:
+            tableName: t_orders
+            oldColumnName: tenant_id
+            newColumnName: store_id
+            columnDataType: BIGINT
+        - renameColumn:
+            tableName: t_casts
+            oldColumnName: tenant_id
+            newColumnName: store_id
+            columnDataType: BIGINT
+        - renameColumn:
+            tableName: t_customers
+            oldColumnName: tenant_id
+            newColumnName: store_id
+            columnDataType: BIGINT
+        - renameColumn:
+            tableName: t_shifts
+            oldColumnName: tenant_id
+            newColumnName: store_id
+            columnDataType: BIGINT
+        - renameColumn:
+            tableName: t_cast_field_definitions
+            oldColumnName: tenant_id
+            newColumnName: store_id
+            columnDataType: BIGINT
+        - renameColumn:
+            tableName: t_cast_invitations
+            oldColumnName: tenant_id
+            newColumnName: store_id
+            columnDataType: BIGINT
+        - renameColumn:
+            tableName: t_menus
+            oldColumnName: tenant_id
+            newColumnName: store_id
+            columnDataType: BIGINT
+        - renameColumn:
+            tableName: t_store_profiles
+            oldColumnName: tenant_id
+            newColumnName: store_id
+            columnDataType: BIGINT
+  - changeSet:
+      id: store-v0140-004-rename-tenant-scoped-constraints
+      author: kanghouchao
+      # FK・インデックス・無名 unique 制約名は列改名に追随しないため raw SQL で改名する。
+      # 無名 unique（t_tenant_configs_tenant_id_key）は列 unique:true の PostgreSQL 自動名。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - sql:
+            sql: ALTER TABLE t_orders RENAME CONSTRAINT fk_t_orders_tenant TO fk_t_orders_store
+        - sql:
+            sql: ALTER TABLE t_casts RENAME CONSTRAINT fk_t_casts_tenant TO fk_t_casts_store
+        - sql:
+            sql: ALTER TABLE t_customers RENAME CONSTRAINT fk_t_customers_tenant TO fk_t_customers_store
+        - sql:
+            sql: ALTER TABLE t_shifts RENAME CONSTRAINT fk_t_shifts_tenant TO fk_t_shifts_store
+        - sql:
+            sql: ALTER TABLE t_cast_invitations RENAME CONSTRAINT fk_t_cast_invitations_tenant TO fk_t_cast_invitations_store
+        - sql:
+            sql: ALTER TABLE t_cast_field_definitions RENAME CONSTRAINT fk_t_cast_field_definitions_tenant TO fk_t_cast_field_definitions_store
+        - sql:
+            sql: ALTER TABLE t_menus RENAME CONSTRAINT fk_t_menus_tenant TO fk_t_menus_store
+        - sql:
+            sql: ALTER TABLE t_store_profiles RENAME CONSTRAINT fk_tenant_config_tenant TO fk_t_store_profiles_store
+        - sql:
+            sql: ALTER INDEX idx_t_menus_tenant RENAME TO idx_t_menus_store
+        - sql:
+            sql: ALTER INDEX idx_t_shifts_tenant_work_date RENAME TO idx_t_shifts_store_work_date
+        - sql:
+            sql: ALTER INDEX idx_tenant_config_tenant_id RENAME TO idx_t_store_profiles_store_id
+        - sql:
+            sql: ALTER TABLE t_cast_field_definitions RENAME CONSTRAINT uq_t_cast_field_definitions_tenant_key TO uq_t_cast_field_definitions_store_key
+        - sql:
+            sql: ALTER TABLE t_store_profiles RENAME CONSTRAINT t_tenant_configs_tenant_id_key TO uq_t_store_profiles_store_id
+      rollback:
+        - sql:
+            sql: ALTER TABLE t_store_profiles RENAME CONSTRAINT uq_t_store_profiles_store_id TO t_tenant_configs_tenant_id_key
+        - sql:
+            sql: ALTER TABLE t_cast_field_definitions RENAME CONSTRAINT uq_t_cast_field_definitions_store_key TO uq_t_cast_field_definitions_tenant_key
+        - sql:
+            sql: ALTER INDEX idx_t_store_profiles_store_id RENAME TO idx_tenant_config_tenant_id
+        - sql:
+            sql: ALTER INDEX idx_t_shifts_store_work_date RENAME TO idx_t_shifts_tenant_work_date
+        - sql:
+            sql: ALTER INDEX idx_t_menus_store RENAME TO idx_t_menus_tenant
+        - sql:
+            sql: ALTER TABLE t_store_profiles RENAME CONSTRAINT fk_t_store_profiles_store TO fk_tenant_config_tenant
+        - sql:
+            sql: ALTER TABLE t_menus RENAME CONSTRAINT fk_t_menus_store TO fk_t_menus_tenant
+        - sql:
+            sql: ALTER TABLE t_cast_field_definitions RENAME CONSTRAINT fk_t_cast_field_definitions_store TO fk_t_cast_field_definitions_tenant
+        - sql:
+            sql: ALTER TABLE t_cast_invitations RENAME CONSTRAINT fk_t_cast_invitations_store TO fk_t_cast_invitations_tenant
+        - sql:
+            sql: ALTER TABLE t_shifts RENAME CONSTRAINT fk_t_shifts_store TO fk_t_shifts_tenant
+        - sql:
+            sql: ALTER TABLE t_customers RENAME CONSTRAINT fk_t_customers_store TO fk_t_customers_tenant
+        - sql:
+            sql: ALTER TABLE t_casts RENAME CONSTRAINT fk_t_casts_store TO fk_t_casts_tenant
+        - sql:
+            sql: ALTER TABLE t_orders RENAME CONSTRAINT fk_t_orders_store TO fk_t_orders_tenant

--- a/backend/src/test/java/com/kizuna/TenantIsolationTests.java
+++ b/backend/src/test/java/com/kizuna/TenantIsolationTests.java
@@ -19,8 +19,8 @@ import org.springframework.core.type.filter.AnnotationTypeFilter;
 /**
  * テナント行レベル分離の不変量を機械検証する（#208, PR-B）。
  *
- * <p>tenant_id 列を持つ @Entity は、継承経路（TenantScopedEntity）に関わらず、サービス層の {@code @TenantScoped}（{@code
- * TenantFilterEnable}）が有効化する Hibernate フィルタ {@code tenantFilter} の対象でなければならない。 {@code @Filter}
+ * <p>store_id 列を持つ @Entity は、継承経路（StoreScopedEntity）に関わらず、サービス層の {@code @TenantScoped}（{@code
+ * TenantFilterEnable}）が有効化する Hibernate フィルタ {@code storeFilter} の対象でなければならない。 {@code @Filter}
  * が無いエンティティはフィルタが有効でも全テナントの行を返してしまう（#216 の「@Filter を忘れる」事故と同型）。
  */
 class TenantIsolationTests {
@@ -28,8 +28,8 @@ class TenantIsolationTests {
   private static final String EXPECTED_CONDITION = "store_id = :storeId";
 
   @Test
-  @DisplayName("tenant_id 列を持つ全 @Entity が tenantFilter の @Filter を宣言していること")
-  void allTenantScopedEntitiesDeclareTenantFilter() throws Exception {
+  @DisplayName("store_id 列を持つ全 @Entity が storeFilter の @Filter を宣言していること")
+  void allStoreScopedEntitiesDeclareStoreFilter() throws Exception {
     ClassPathScanningCandidateComponentProvider scanner =
         new ClassPathScanningCandidateComponentProvider(false);
     scanner.addIncludeFilter(new AnnotationTypeFilter(Entity.class));
@@ -38,20 +38,20 @@ class TenantIsolationTests {
     List<String> scanned = new ArrayList<>();
     for (var candidate : scanner.findCandidateComponents("com.kizuna")) {
       Class<?> entity = Class.forName(candidate.getBeanClassName());
-      if (!hasTenantIdColumn(entity)) {
+      if (!hasStoreIdColumn(entity)) {
         continue;
       }
       scanned.add(entity.getSimpleName());
-      // @Filter は Hibernate 6 で repeatable のため、tenantFilter を宣言していれば
+      // @Filter は Hibernate 6 で repeatable のため、storeFilter を宣言していれば
       // 他フィルタ（storeSetFilter 等）が並置されていても違反としない。
-      boolean declaresTenantFilter = false;
+      boolean declaresStoreFilter = false;
       for (Filter filter : entity.getAnnotationsByType(Filter.class)) {
         if ("storeFilter".equals(filter.name()) && EXPECTED_CONDITION.equals(filter.condition())) {
-          declaresTenantFilter = true;
+          declaresStoreFilter = true;
           break;
         }
       }
-      if (!declaresTenantFilter) {
+      if (!declaresStoreFilter) {
         offenders.add(entity.getName());
       }
     }
@@ -59,36 +59,36 @@ class TenantIsolationTests {
     assertThat(scanned).isNotEmpty();
     assertThat(offenders)
         .as(
-            "@Filter(name=\"tenantFilter\", condition=\"%s\") が無い tenant_id 列保持エンティティ",
+            "@Filter(name=\"storeFilter\", condition=\"%s\") が無い store_id 列保持エンティティ",
             EXPECTED_CONDITION)
         .isEmpty();
   }
 
   @Test
-  @DisplayName("tenantFilter は主キー直接ロード（EntityManager#find 経由の findById 等）にも適用されること")
+  @DisplayName("storeFilter は主キー直接ロード（EntityManager#find 経由の findById 等）にも適用されること")
   void tenantFilterAppliesToLoadByKey() {
-    // @FilterDef は Hibernate 6 で repeatable のため、tenantFilter の定義を名前で取り出す
+    // @FilterDef は Hibernate 6 で repeatable のため、storeFilter の定義を名前で取り出す
     // （storeSetFilter 等が並置されていても getAnnotation は container を返し null になるため）。
-    FilterDef tenantFilterDef = null;
+    FilterDef storeFilterDef = null;
     for (FilterDef filterDef : StoreScopedEntity.class.getAnnotationsByType(FilterDef.class)) {
       if ("storeFilter".equals(filterDef.name())) {
-        tenantFilterDef = filterDef;
+        storeFilterDef = filterDef;
         break;
       }
     }
 
-    assertThat(tenantFilterDef)
-        .as("TenantScopedEntity が tenantFilter の @FilterDef を宣言していること")
+    assertThat(storeFilterDef)
+        .as("StoreScopedEntity が storeFilter の @FilterDef を宣言していること")
         .isNotNull();
-    assertThat(tenantFilterDef.applyToLoadByKey())
+    assertThat(storeFilterDef.applyToLoadByKey())
         .as(
             "applyToLoadByKey=false だと Session#find（Spring Data JPA の findById 実装経路）に"
                 + " filter が効かず、他テナントの ID を直接指定した読み取りが素通りする")
         .isTrue();
   }
 
-  /** tenant_id 列は TenantScopedEntity 経由（継承フィールド）でも、エンティティ自身の宣言でも良い。 */
-  private static boolean hasTenantIdColumn(Class<?> type) {
+  /** store_id 列は StoreScopedEntity 経由（継承フィールド）でも、エンティティ自身の宣言でも良い。 */
+  private static boolean hasStoreIdColumn(Class<?> type) {
     for (Class<?> c = type; c != null && c != Object.class; c = c.getSuperclass()) {
       for (Field field : c.getDeclaredFields()) {
         // @ElementCollection の @Column は集合テーブルの列（PlatformUser.storeIds 等の授権店舗集合）であり、

--- a/backend/src/test/java/com/kizuna/TenantIsolationTests.java
+++ b/backend/src/test/java/com/kizuna/TenantIsolationTests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.kizuna.shared.persistence.TenantScopedEntity;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -24,7 +25,7 @@ import org.springframework.core.type.filter.AnnotationTypeFilter;
  */
 class TenantIsolationTests {
 
-  private static final String EXPECTED_CONDITION = "tenant_id = :tenantId";
+  private static final String EXPECTED_CONDITION = "store_id = :storeId";
 
   @Test
   @DisplayName("tenant_id 列を持つ全 @Entity が tenantFilter の @Filter を宣言していること")
@@ -90,8 +91,13 @@ class TenantIsolationTests {
   private static boolean hasTenantIdColumn(Class<?> type) {
     for (Class<?> c = type; c != null && c != Object.class; c = c.getSuperclass()) {
       for (Field field : c.getDeclaredFields()) {
+        // @ElementCollection の @Column は集合テーブルの列（PlatformUser.storeIds 等の授権店舗集合）であり、
+        // 本体テーブルの行識別列ではないため店舗フィルタの対象判定から除外する。
+        if (field.isAnnotationPresent(ElementCollection.class)) {
+          continue;
+        }
         Column column = field.getAnnotation(Column.class);
-        if (column != null && "tenant_id".equals(column.name())) {
+        if (column != null && "store_id".equals(column.name())) {
           return true;
         }
       }

--- a/backend/src/test/java/com/kizuna/TenantIsolationTests.java
+++ b/backend/src/test/java/com/kizuna/TenantIsolationTests.java
@@ -2,7 +2,7 @@ package com.kizuna;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.kizuna.shared.persistence.TenantScopedEntity;
+import com.kizuna.shared.persistence.StoreScopedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
@@ -46,7 +46,7 @@ class TenantIsolationTests {
       // 他フィルタ（storeSetFilter 等）が並置されていても違反としない。
       boolean declaresTenantFilter = false;
       for (Filter filter : entity.getAnnotationsByType(Filter.class)) {
-        if ("tenantFilter".equals(filter.name()) && EXPECTED_CONDITION.equals(filter.condition())) {
+        if ("storeFilter".equals(filter.name()) && EXPECTED_CONDITION.equals(filter.condition())) {
           declaresTenantFilter = true;
           break;
         }
@@ -70,8 +70,8 @@ class TenantIsolationTests {
     // @FilterDef は Hibernate 6 で repeatable のため、tenantFilter の定義を名前で取り出す
     // （storeSetFilter 等が並置されていても getAnnotation は container を返し null になるため）。
     FilterDef tenantFilterDef = null;
-    for (FilterDef filterDef : TenantScopedEntity.class.getAnnotationsByType(FilterDef.class)) {
-      if ("tenantFilter".equals(filterDef.name())) {
+    for (FilterDef filterDef : StoreScopedEntity.class.getAnnotationsByType(FilterDef.class)) {
+      if ("storeFilter".equals(filterDef.name())) {
         tenantFilterDef = filterDef;
         break;
       }

--- a/backend/src/test/java/com/kizuna/cast/application/CastFieldDefinitionServiceTest.java
+++ b/backend/src/test/java/com/kizuna/cast/application/CastFieldDefinitionServiceTest.java
@@ -55,7 +55,7 @@ class CastFieldDefinitionServiceTest {
     ArgumentCaptor<CastFieldDefinition> captor = ArgumentCaptor.forClass(CastFieldDefinition.class);
     verify(repository).saveAndFlush(captor.capture());
     assertThat(captor.getValue().getDisplayOrder()).isEqualTo(0);
-    assertThat(captor.getValue().getTenantId()).isEqualTo(7L);
+    assertThat(captor.getValue().getStoreId()).isEqualTo(7L);
   }
 
   @Test
@@ -119,7 +119,7 @@ class CastFieldDefinitionServiceTest {
     when(repository.count()).thenReturn(0L);
     when(repository.findMaxDisplayOrder()).thenReturn(null);
     when(repository.saveAndFlush(any()))
-        .thenThrow(new DataIntegrityViolationException("uq_t_cast_field_definitions_tenant_key"));
+        .thenThrow(new DataIntegrityViolationException("uq_t_cast_field_definitions_store_key"));
 
     assertThatThrownBy(() -> service.create(createRequest("blood_type", "血液型")))
         .isInstanceOf(ServiceException.class)

--- a/backend/src/test/java/com/kizuna/cast/application/CastInvitationAcceptanceServiceTest.java
+++ b/backend/src/test/java/com/kizuna/cast/application/CastInvitationAcceptanceServiceTest.java
@@ -55,7 +55,7 @@ class CastInvitationAcceptanceServiceTest {
             .status(status)
             .expiresAt(expiresAt)
             .build();
-    invitation.setTenantId(tenantId);
+    invitation.setStoreId(tenantId);
     return invitation;
   }
 

--- a/backend/src/test/java/com/kizuna/cast/application/CastInvitationServiceTest.java
+++ b/backend/src/test/java/com/kizuna/cast/application/CastInvitationServiceTest.java
@@ -40,7 +40,7 @@ class CastInvitationServiceTest {
   private Cast cast(String id, Long platformUserId) {
     Cast cast = Cast.builder().name("キャスト").platformUserId(platformUserId).build();
     cast.setId(id);
-    cast.setTenantId(1L);
+    cast.setStoreId(1L);
     return cast;
   }
 

--- a/backend/src/test/java/com/kizuna/menu/application/StoreMenuServiceTest.java
+++ b/backend/src/test/java/com/kizuna/menu/application/StoreMenuServiceTest.java
@@ -57,7 +57,7 @@ class StoreMenuServiceTest {
     m2.setPermission("ADMIN_ONLY"); // 権限に存在しない
     m2.setChildren(List.of());
 
-    when(menuRepository.findByTenantIdAndParentIsNullOrderBySortOrderAsc(1L))
+    when(menuRepository.findByStoreIdAndParentIsNullOrderBySortOrderAsc(1L))
         .thenReturn(List.of(m1, m2));
 
     List<MenuVO> result = menuService.getMyMenus();

--- a/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
@@ -188,7 +188,7 @@ class OrderServiceTest {
     when(tenantContext.getTenantId()).thenReturn(1L);
     when(tenantRepository.findById(1L)).thenReturn(Optional.of(new Tenant()));
     when(orderMapper.toEntity(req)).thenReturn(Order.builder().build());
-    when(customerRepository.findByPhoneNumberAndTenantId("09012345678", 1L))
+    when(customerRepository.findByPhoneNumberAndStoreId("09012345678", 1L))
         .thenReturn(Optional.empty());
     when(castRepository.existsById("g1")).thenReturn(true);
     when(platformUserRepository.findById(1L)).thenReturn(Optional.of(authorizedReceptionist()));

--- a/backend/src/test/java/com/kizuna/shared/tenancy/TenantFilterEnableTest.java
+++ b/backend/src/test/java/com/kizuna/shared/tenancy/TenantFilterEnableTest.java
@@ -38,7 +38,7 @@ class TenantFilterEnableTest {
   void enablesFilterWhenTenantContextPresent() throws Throwable {
     tenantContext.setTenantId(42L);
     when(entityManager.unwrap(Session.class)).thenReturn(session);
-    when(session.enableFilter("tenantFilter")).thenReturn(filter);
+    when(session.enableFilter("storeFilter")).thenReturn(filter);
     when(pjp.proceed()).thenReturn("result");
 
     Object result = aspect.enableTenantFilterForTenantServiceMethods(pjp);

--- a/backend/src/test/java/com/kizuna/shared/tenancy/TenantFilterEnableTest.java
+++ b/backend/src/test/java/com/kizuna/shared/tenancy/TenantFilterEnableTest.java
@@ -44,7 +44,7 @@ class TenantFilterEnableTest {
     Object result = aspect.enableTenantFilterForTenantServiceMethods(pjp);
 
     assertThat(result).isEqualTo("result");
-    verify(filter).setParameter("tenantId", 42L);
+    verify(filter).setParameter("storeId", 42L);
     verify(pjp).proceed();
   }
 

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
@@ -98,7 +98,7 @@ class ShiftServiceTest {
 
     ShiftResponse res = shiftService.create(req);
     assertThat(res.getId()).isEqualTo("s_new");
-    assertThat(entity.getTenantId()).isEqualTo(1L);
+    assertThat(entity.getStoreId()).isEqualTo(1L);
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/storeprofile/application/StoreProfileServiceTest.java
+++ b/backend/src/test/java/com/kizuna/storeprofile/application/StoreProfileServiceTest.java
@@ -47,7 +47,7 @@ class StoreProfileServiceTest {
   void get_returnsExistingConfig() {
     StoreProfile config = createTestConfig();
     StoreProfileResponse expected = createTestResponse();
-    when(storeProfileRepository.findByTenantId(TENANT_ID)).thenReturn(Optional.of(config));
+    when(storeProfileRepository.findByStoreId(TENANT_ID)).thenReturn(Optional.of(config));
     when(storeProfileMapper.toResponse(config)).thenReturn(expected);
 
     StoreProfileResponse response = tenantConfigService.get();
@@ -59,7 +59,7 @@ class StoreProfileServiceTest {
 
   @Test
   void get_throwsExceptionIfNotExists() {
-    when(storeProfileRepository.findByTenantId(TENANT_ID)).thenReturn(Optional.empty());
+    when(storeProfileRepository.findByStoreId(TENANT_ID)).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> tenantConfigService.get())
         .isInstanceOf(ServiceException.class)
@@ -69,7 +69,7 @@ class StoreProfileServiceTest {
   @Test
   void update_modifiesFields() {
     StoreProfile config = createTestConfig();
-    when(storeProfileRepository.findByTenantId(TENANT_ID)).thenReturn(Optional.of(config));
+    when(storeProfileRepository.findByStoreId(TENANT_ID)).thenReturn(Optional.of(config));
     when(storeProfileRepository.saveAndFlush(any())).thenReturn(config);
 
     StoreProfileUpdateRequest request = new StoreProfileUpdateRequest();
@@ -102,7 +102,7 @@ class StoreProfileServiceTest {
   @Test
   void update_modifiesSnsLinks() {
     StoreProfile config = createTestConfig();
-    when(storeProfileRepository.findByTenantId(TENANT_ID)).thenReturn(Optional.of(config));
+    when(storeProfileRepository.findByStoreId(TENANT_ID)).thenReturn(Optional.of(config));
     when(storeProfileRepository.saveAndFlush(any())).thenReturn(config);
 
     StoreProfileUpdateRequest request = new StoreProfileUpdateRequest();
@@ -124,7 +124,7 @@ class StoreProfileServiceTest {
   @Test
   void update_modifiesPartnerLinks() {
     StoreProfile config = createTestConfig();
-    when(storeProfileRepository.findByTenantId(TENANT_ID)).thenReturn(Optional.of(config));
+    when(storeProfileRepository.findByStoreId(TENANT_ID)).thenReturn(Optional.of(config));
     when(storeProfileRepository.saveAndFlush(any())).thenReturn(config);
 
     StoreProfileUpdateRequest request = new StoreProfileUpdateRequest();
@@ -145,7 +145,7 @@ class StoreProfileServiceTest {
 
   @Test
   void update_throwsExceptionIfNotExists() {
-    when(storeProfileRepository.findByTenantId(TENANT_ID)).thenReturn(Optional.empty());
+    when(storeProfileRepository.findByStoreId(TENANT_ID)).thenReturn(Optional.empty());
 
     StoreProfileUpdateRequest request = new StoreProfileUpdateRequest();
 

--- a/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
@@ -311,7 +311,7 @@ class PlatformStaffServiceTest {
                 "save failed",
                 new RuntimeException(
                     "ERROR: duplicate key value violates unique constraint"
-                        + " \"uq_platform_users_email\"")));
+                        + " \"uq_t_users_email\"")));
 
     assertThatThrownBy(() -> service.create(req, ACTOR))
         .isInstanceOf(DuplicateStaffEmailException.class);
@@ -449,7 +449,7 @@ class PlatformStaffServiceTest {
                 "save failed",
                 new RuntimeException(
                     "ERROR: duplicate key value violates unique constraint"
-                        + " \"uq_platform_users_email\"")));
+                        + " \"uq_t_users_email\"")));
 
     assertThatThrownBy(
             () ->


### PR DESCRIPTION
## 概要

#404(命名・スキーマ収束 spec)の分割チケット A。DB 層の tenant→store 語彙収束を新規 Liquibase changeset(v0.14.0、新フォルダ規約 platform|store 初適用)とエンティティ側の同一 PR 原子変更で行う。テーブル 10 表・IDENTITY シーケンス 6 本・列 tenant_id→store_id(8 表)・基底クラス TenantScopedEntity→StoreScopedEntity・フィルタ tenantFilter→storeFilter を改名。挙動変更ゼロ(API パス・JSON キー・フィルタ機構は不変)。

Closes #405

## 変更内容

- **テーブル改名(v0.14.0/platform, store)**: central_tenants→t_stores、central_configs→t_system_configs、t_tenant_configs→t_store_profiles、platform_users→t_users、platform_capability_bundles→t_capability_bundles、platform_grant_history→t_grant_history、@CollectionTable 4 表(platform_user_bundles/stores/settlement_stores→t_user_*、platform_capability_bundle_items→t_capability_bundle_items)
- **付随オブジェクト**: IDENTITY 所有シーケンス 6 本(PostgreSQL は renameTable で自動改名しないため renameSequence)、表名埋め込みの PK/UQ/FK/インデックス名(無名の t_tenant_configs_pkey / t_tenant_configs_tenant_id_key は raw SQL で命名)。制約・インデックス改名は Liquibase に change type がないため raw SQL + 明示 rollback
- **列改名**: 店舗スコープ 8 表の tenant_id→store_id + tenant 語彙の FK/インデックス/ユニーク名(fk_*_tenant→fk_*_store 等)
- **Java 追随**: @Table/@CollectionTable 文字列、StoreScopedEntity(プロパティ storeId、@FilterDef パラメータ)、@Filter 条件 9 エンティティ、派生クエリ 4 件+呼び出し元、JPQL(PLATFORM_VIEW_SELECT)、MapStruct @Mapping、実行時制約名定数 EMAIL_UNIQUE_CONSTRAINT(uq_t_users_email)×2、テスト 3 source set のリテラル
- **フィルタ名**: tenantFilter→storeFilter(applyToLoadByKey=true 維持。storeSetFilter は名称不変、条件の物理列名のみ追随)
- **レビュー反映**: 改名で孤児化したコメント・ガード文言・backend/CLAUDE.md の Liquibase フォルダ規約行を新語彙へ追随

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [x] `task e2e` exit 0(実行シナリオ: 年齢確認ゲート / キャストのカスタムフィールド ×2 / 公開キャスト詳細のクロステナント越権 404 / 統一ログイン・ロール自動ルーティング・店舗切替 ×3 / 公開サイト表示 / 公開出勤表 / スタッフ・権限管理 ×2 / 店舗設定の保存 / 模版切替 — 13/13 pass)
- [x] ローカル code-review 実施（effort: high / 指摘: 3件 / 未修正: 0件）

補足: e2e はコミット d1a6736 時点で実行。以降の差分(e53d14e)はコメント・ドキュメント・テスト文字列のみであることを diff で確認済み(main 側の変更行は全て注釈行)。lint/test/build は最終ツリーで再実行済み。QA で移行後 DB を psql 照会し、旧テーブル名 0 件・新 10 表存在・対象 8 表の tenant_id 0 件/store_id 8 件・v0.14.0 全 changeset EXECUTED を確認。データ生存確認: t_stores=2 / t_users=45 / t_store_profiles=2。

## 決定ログ

- **changeset を rollback 意味論で分割**: changeSet レベルの rollback ブロックは組み込み change の自動 rollback を丸ごと置換するため、組み込み rename(自動 rollback)と raw SQL(明示 rollback)を別 changeSet に分離
- **シーケンス改名を明示実施**: PostgreSQL の renameTable は所有シーケンスを改名しない。pg_get_serial_sequence 経由の既存参照(setval 同期・SeedSequenceAlignmentIT)は挙動不変のため、語彙残留の根絶のみが目的
- **platform_user_id 列は不変**: 退場するのは central/tenant 語彙であり platform 概念(PlatformUser)は存続するため
- **TenantIsolationTests に @ElementCollection 除外を追加**: 探測列を store_id へ変えると PlatformUser の授権店舗集合列(collection table の @Column)が偽陽性になるため。実店舗域エンティティの store_id は引き続き捕捉され、不変条件は弱まらない
- **歴史 changeset(v0.5.0 シードの旧テーブル名埋め込み SQL)は無修正**: フレッシュ DB 再生時は v0.14.0 改名より前に実行されるため正しい(checksum 保護とも整合)
- **レビュー体制**: 本 run は kizuna-reviewer に代えユーザー指示により /code-review(fable、Standards/Spec 二軸)で実施。指摘 3 件(①backend/CLAUDE.md フォルダ規約行の乖離 ②改名で孤児化した prose 一式 ③遺留テーブル除外の明示)→ ①② は e53d14e で修正、③ は本文備考に記載

## 備考 / レビュー観点

- **遺留テーブルは対象外**: central_groups / central_group_tenants / central_group_admins / t_pages / t_resource_*(エンティティなき遺留表)は tenant 語彙を保持したまま。削除可否の判断は #406 で別途行う(central_tenants 改名は FK が OID 参照のためこれらを壊さない)
- **tenant 語彙の残余は計画的**: TenantContext / TenantIdInterceptor / @TenantScoped / X-Tenant-ID ヘッダ / shared/tenancy パッケージ / ログ書式 tenant= は票 E(#404 決定 7)で改名予定。TenantFilterEnable クラス内 javadoc 等の微小な残存 prose も同票で収束
- **central_menus は票 B**(メニュー統合、#404 決定 2)まで現状維持
- **⚠️ 共有 dev ボリュームへ v0.14.0 適用済み**: QA の task e2e 実行により dev DB は改名後スキーマ。本 PR マージまで master 検出の旧コードは dev DB と不整合(データは ALTER のみで保全)。早期マージ推奨
- 重点レビュー観点: v0.14.0 の 4 changeset(rename の網羅性・rollback 逆順)、EMAIL_UNIQUE_CONSTRAINT の同期(重複メール 409/4xx 系判定が制約名文字列に依存)
