### PR TITLE
chore: v0.1.0時代の遺留テーブル11件を削除する

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -41,3 +41,6 @@ databaseChangeLog:
   - include:
       file: releases/v0.14.0/master.yaml
       relativeToChangelogFile: true
+  - include:
+      file: releases/v0.15.0/master.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.15.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.15.0/master.yaml
@@ -1,0 +1,7 @@
+databaseChangeLog:
+  - include:
+      file: store/01-drop-orphaned-content-tables.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: platform/01-drop-orphaned-group-tables.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.15.0/platform/01-drop-orphaned-group-tables.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.15.0/platform/01-drop-orphaned-group-tables.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: platform-v0150-001-drop-orphaned-group-tables
+      author: kanghouchao
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        # v0.1.0 時代の「租户组（グループ）」構想の遺留テーブル群を撤去する（#406）。
+        # 2026-07-11 の平台化転向（PlatformUser + StoreScope）が同じ業務要求を別機構で
+        # 満たしており、JPA エンティティもコード参照も持たない死んだテーブルである。
+        # 子表（関連テーブル）→親表の順で dropTable する。
+        - dropTable:
+            tableName: central_group_tenants
+            cascadeConstraints: true
+        - dropTable:
+            tableName: central_group_admins
+            cascadeConstraints: true
+        - dropTable:
+            tableName: central_groups
+            cascadeConstraints: true

--- a/backend/src/main/resources/db/changelog/releases/v0.15.0/store/01-drop-orphaned-content-tables.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.15.0/store/01-drop-orphaned-content-tables.yaml
@@ -1,0 +1,36 @@
+databaseChangeLog:
+  - changeSet:
+      id: store-v0150-001-drop-orphaned-content-tables
+      author: kanghouchao
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        # v0.1.0 時代の遺留コンテンツ／汎用リソースエンジンのテーブル群を撤去する（#406）。
+        # t_pages は #392（公開コンテンツの正式スペック）に、t_resource_* は同スペックへ
+        # 取って代わられ、JPA エンティティもコード参照も持たない死んだテーブルである。
+        # 子表（関連テーブル）→親表の順で dropTable する。
+        - dropTable:
+            tableName: t_resource_versions
+            cascadeConstraints: true
+        - dropTable:
+            tableName: t_resource_tag_links
+            cascadeConstraints: true
+        - dropTable:
+            tableName: t_resource_tenant_access
+            cascadeConstraints: true
+        - dropTable:
+            tableName: t_resources
+            cascadeConstraints: true
+        - dropTable:
+            tableName: t_resource_schemas
+            cascadeConstraints: true
+        - dropTable:
+            tableName: t_resource_tags
+            cascadeConstraints: true
+        - dropTable:
+            tableName: t_resource_types
+            cascadeConstraints: true
+        - dropTable:
+            tableName: t_pages
+            cascadeConstraints: true


### PR DESCRIPTION
## 概要

エンティティを持たないv0.1.0時代の遺留テーブル11件（central_groups系3件・t_pages・t_resource_*系7件）を新規 Liquibase changeset（v0.15.0）で削除する。コード変更は一切なし（既存の JPA エンティティ・サービス・コントローラーいずれからも参照されていないことを確認済み）。

Closes #406

## 変更内容

- `backend/src/main/resources/db/changelog/releases/v0.15.0/store/01-drop-orphaned-content-tables.yaml`（新規）: `t_pages` と `t_resource_types` / `t_resource_schemas` / `t_resources` / `t_resource_tenant_access` / `t_resource_tags` / `t_resource_tag_links` / `t_resource_versions` の計 8 表を子表→親表順で `dropTable`（`cascadeConstraints: true`）
- `backend/src/main/resources/db/changelog/releases/v0.15.0/platform/01-drop-orphaned-group-tables.yaml`（新規）: `central_group_tenants` / `central_group_admins` / `central_groups` の計 3 表を子表→親表順で `dropTable`（`cascadeConstraints: true`）
- `backend/src/main/resources/db/changelog/releases/v0.15.0/master.yaml`（新規）: store → platform の順で include（`t_resource_*` から `central_groups` への 4 本の外部キーを先に消してから親を落とす順序）
- `backend/src/main/resources/db/changelog/db.changelog-master.yaml`: 末尾に v0.15.0 の include を追記

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（backend 統合テストは tmpfs Postgres で v0.1.0→v0.15.0 の全 changelog を新規適用、正常終了）
- [x] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: 該当なし — ユーザー可視の振る舞い変更が一切ない DB 専用クリーンアップのため `.feature` シナリオを追加していない）
- [x] ローカル code-review 実施（effort: high / 指摘: 0件 / 未修正: 0件）

### 視覚確認（UI 変更時）

該当なし（UI 変更なし、バックエンドの DB スキーマ変更のみ）

## 決定ログ

- **削除可否の判断根拠**：issue #406 上で grilling（対話式インタビュー）を実施し確定。`central_groups`/`central_group_tenants`/`central_group_admins` は起源 #42（2025-09-30 close）の「租户组」構想だが、2026-07-11 の平台化転向（PlatformUser + StoreScope）が同じ業務要求を別機構で満たしており復活予定なし。`t_pages` と `t_resource_*` 系は起源 #63（2026-01-22 close）の汎用 CMS/Resource エンジン構想だが、公開コンテンツの正式仕様は #392（新規スペック、上書き対象なしと明記）が具体的な集約モデルで別途定めており、こちらも復活予定なし。#173（CSV/Excel インポート/エクスポート）は無関係と確認済み。裁定の詳細は issue #406 のコメント参照。
- **ADR は作成しない**：`domain-modeling` skill の 3 条件（難逆転／文脈なしで意外／実質的なトレードオフ）はいずれも満たすが、対話内で裁定根拠を十分に記録できたため作成しないと判断（用户裁定）。
- **`dropForeignKeyConstraint` を明示せず `cascadeConstraints: true` に一任**：v0.8.0 の同型 drop 先例（`central/01-drop-legacy-auth-tables.yaml` 等）に倣った。`central_groups` を参照する 4 本の外部キー（`fk_t_resource_types_group` 等）は store 側ファイルで先に対象表ごと落ちるため、実際には cascade が発火する場面は存在しない（QA で確認済み）。
- **rollback 節を付けない**：v0.8.0 の drop 先例にも rollback 節はなく、本 PR も同じ判断（dropTable の自動ロールバックは非対応、明示 rollback も付けない）。
- **コード変更ゼロ**：11 表いずれも JPA エンティティが存在せず、backend/frontend/e2e 全体を grep して参照ゼロを確認済み。シード/初期データにも対象表への insert なし。

## 備考 / レビュー観点

- 本 PR は**不可逆な DROP TABLE**（high-risk tier）。QA で共有 dev 卷への実際の適用（`task up`）と直接 SQL 確認（11 表の消滅・4 本の外部キーの消滅・Liquibase `DATABASECHANGELOG` の実行記録）を実施済み。コード参照がゼロのため、#405（改名, PR #407）で懸念された「共有卷適用後に master コードが非互換になる」窓は本件には存在しない。
- ローカル code-review（`kizuna-reviewer` 相当、fable モデル）で 0 件（blocking/non-blocking 共に）。
- #404 の残り分割票（B=メニュー統合 → C=API 双空間 → D=前端ルーティング → E=識別子/ドキュメント）は本 PR のスコープ外で別途対応。
