### PR TITLE
fix(backend): 残留テストコンテナの再利用による統合テスト偽陽性を実行前 down で根治する

### DIFF
--- a/backend/Taskfile.yml
+++ b/backend/Taskfile.yml
@@ -49,6 +49,9 @@ tasks:
       - echo "🧪  バックエンドの統合テストを実行中（compose ネットワーク接続）..."
       # -v を付けない: 唯一のボリュームは gradle キャッシュで、消すと毎回フル再取得になり
       # 依存解決の flaky 要因になる。DB は tmpfs のためコンテナ削除だけで使い捨てが成立する
+      # 事前 down: 前回 run が中断されると defer が走らず依存コンテナが残留し、
+      # `docker compose run` がそれを静かに再利用して tmpfs DB の汚れが偽陽性を生む（#412）
+      - docker compose -f docker-compose.test.yml down
       - defer: docker compose -f docker-compose.test.yml down
       - docker compose -f docker-compose.test.yml run --rm integration-test
 


### PR DESCRIPTION
## 概要

`task test-integration` が前回 run の残留 `kizuna-backend-test-*` コンテナを静かに再利用し、tmpfs DB に残った前回データで非冪等 IT（`PlatformStaffManagementIT` 等）が duplicate 400 の偽陽性 fail を起こす問題（#409 QA で実測）を、実行前の `docker compose down` 追加で根治する。

Closes #412

## 変更内容

- `backend/Taskfile.yml` の `test-integration` に、`docker compose run` の直前の事前 `docker compose -f docker-compose.test.yml down` を追加（コマンド 1 行 + 日本語コメント 2 行、計 3 行のみ）。
- 既存の `defer: down`（正常終了時の後始末）と「`-v` を付けない」方針（gradle キャッシュボリューム保持）はそのまま維持。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: 該当なし — バックエンドのテストハーネス（Taskfile）のみの変更で、ユーザー可視の振る舞い・UI 面の変更が一切ないため `.feature` シナリオ追加対象外）
- [x] ローカル code-review 実施（effort: medium / 指摘: 0件 / 未修正: 0件）

issue の再現手順ベースの検証（verifier 実施・すべて exit code 判定）:

1. **残留 + 汚れ DB でも緑（本題）**: `docker compose -f backend/docker-compose.test.yml run --rm integration-test` を裸実行して依存コンテナを残留させ（database コンテナ ID `5b8b2e2bc5f7` を記録）、その状態で `task -d backend test-integration` → exit 0。task ログ上で旧コンテナの Stopping→Removing→新規 Creating を実況確認し、旧 ID が `docker ps -a` に不存在（再利用ではなく再作成）であることを照合。修正前はこの手順で staff 作成系 IT が duplicate fail していた。
2. **クリーン状態でも従来どおり緑**: 残留ゼロ確認後の `task -d backend test-integration` → exit 0（コンテナ非存在時の事前 `down` も exit 0 で新たな失敗要因にならないことを実測）。
3. **gradle キャッシュボリューム存続**: 全手順後も `kizuna-backend-test_gradle-it-cache` が `docker volume ls` に残存。

### 視覚確認（UI 変更時）

該当なし（テストハーネスのみ・UI 変更なし）

## 決定ログ

- issue 票面の 3 候補（①実行前 down / ②`up -d --force-recreate` + `run --no-deps` の二段式 / ③IT fixture 冪等化統一）から**①を採用**（ユーザー裁定済み）。②は `docker compose run` に `--force-recreate` フラグが存在しないため構造の複雑化に対して追加収益ゼロ。③は冪等 fixture が汚れ DB をむしろ隠蔽し（票面自身が指摘するとおり `PlatformBridgeIT` の `orElseGet` は汚れ DB でも通る）、断言強度を下げる方向のため見送り。
- `defer: down` は削除せず併存させる。事前 down は「前回 run が中断（Ctrl+C・タイムアウト・task を介さない裸 `compose run`）して defer が走らなかった」場合の保険であり、役割が異なる。
- 並行実行（main checkout + worktree から同時に test-integration）は compose プロジェクト名が `kizuna-backend-test` 固定のため従来から競合するが、従来の「静黙にお互いの DB を共有・汚染」から「一方が他方のコンテナを落として明示的に失敗」へ変わる。fail-loud の方が望ましく、相互排除機構の導入はスコープ外（必要になれば別票）。

## 備考 / レビュー観点

- pre-push ローカルレビュー（kizuna-reviewer, fresh spawn）: 指摘 0 件。反証として「コンテナ非存在時の down が非ゼロにならないか（実測 exit 0）」「`defer` との実行順序（`--dry` で 事前 down → run → defer down を実測）」「root Taskfile の e2e タスクに同根因がないか（`task up` + `defer down` の別方式で該当せず）」を確認済み。
- プロダクトコード・DB migration・認可への変更は一切なし。
