### PR TITLE
docs(cast): module-cast の Modulith docs を #277 の構造変更に追随させる

### DIFF
--- a/backend/docs/modulith/module-cast.adoc
+++ b/backend/docs/modulith/module-cast.adoc
@@ -5,19 +5,22 @@
 |Spring components
 |_Services_
 
+* `c.k.c.application.CastFieldDefinitionService`
 * `c.k.c.application.CastInvitationAcceptanceService`
 * `c.k.c.application.CastInvitationService`
 * `c.k.c.application.CastService`
 
 _Repositories_
 
+* `c.k.c.domain.CastFieldDefinitionRepository`
 * `c.k.c.domain.CastInvitationRepository`
 * `c.k.c.domain.CastRepository`
 |Bean references
-|* `c.k.u.domain.PlatformUserRepository` (in User)
+|* `c.k.s.tenancy.TenantContext` (in Shared)
+* `c.k.u.domain.PlatformUserRepository` (in User)
 * `c.k.t.domain.TenantRepository` (in Tenant)
-* `c.k.s.tenancy.TenantContext` (in Shared)
 |Aggregate roots
 |* `c.k.c.domain.Cast`
+* `c.k.c.domain.CastFieldDefinition`
 * `c.k.c.domain.CastInvitation`
 |===


### PR DESCRIPTION
## 概要

`backend/docs/modulith/module-cast.adoc` を `ModularityTests` で再生成し、#277 で追加された `CastFieldDefinition` 関連の構造（Service/Repository/集約）を反映させる。

Closes #410

## 変更内容

- `backend/docs/modulith/module-cast.adoc` を `./gradlew test --tests com.kizuna.ModularityTests` の再生成出力へ更新（`CastFieldDefinitionService`/`CastFieldDefinitionRepository`/`CastFieldDefinition` 集約を追加、Bean references の並び順も再生成結果に追随）
- `backend/docs/modulith/module-cast.puml` は据え置き（再生成 diff は `Rel(...)` 行の順序入れ替えのみで、行集合をソート比較すると完全一致 = 構造変更なし。`backend/CLAUDE.md` の「Documenter の Rel 順は不安定なので構造変更がなければ revert」規約どおり）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task test-unit` + `task test-integration` いずれも exit 0）
- [x] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: 対象外 — 挙動変更なし、ドキュメントのみのためE2Eシナリオなし）
- [x] ローカル code-review 実施（effort: medium / 指摘: 0件 / 未修正: 0件）

### 視覚確認（UI 変更時）

対象外（UI変更なし）

## 決定ログ

- `module-cast.adoc` は2回連続で `ModularityTests` を実行し出力が完全一致することを確認済み（安定）。差分は `CastFieldDefinitionService`/`Repository`/集約の追加のみで、他の `.adoc` ファイルとの再生成比較でも今回の差分以外に漏れがないことを確認した。
- `module-cast.puml` はコミットしない判断とした。再生成すると `Rel(...)` 行の並び順が2回の実行間でも変化する（`Documenter` の既知の不安定挙動）が、行をソートして比較すると新旧で完全一致し実質的な構造変更はゼロ。`backend/CLAUDE.md` の規約（構造変更がなければ revert）に従い、既存内容を維持した。
- ローカル code-review は two-axis `/code-review` skill（Standards + Spec、両者とも `sonnet` で並列実行）で実施。Standards 軸は `backend/CLAUDE.md` の Modulith docs 規約・言語ポリシーとの整合を検証（違反なし）、Spec 軸は issue #410 の記述と再生成結果の一致を検証（違反なし）。両軸とも指摘 0 件。

## 備考 / レビュー観点

- #409（票B メニュー統合）の module-menu docs 再生成作業中に発見された派生issueであり、cast モジュールのみを対象とした独立の小票。
