### PR TITLE
feat: store-scoped 集約の追加配方を storescope seam へ集約する

### DIFF
--- a/backend/docs/modulith/components.puml
+++ b/backend/docs/modulith/components.puml
@@ -1,54 +1,62 @@
 @startuml
-set separator none
-title Application
+title <size:24>Application</size>
 
+set separator none
 top to bottom direction
+
+<style>
+  root {
+    BackgroundColor: #ffffff
+    FontColor: #444444
+  }
+</style>
 
 !include <C4/C4>
 !include <C4/C4_Context>
 !include <C4/C4_Component>
 
-Container_Boundary("Application.Application_boundary", "Application", $tags="") {
-  Component(Application.Application.Storage, "Storage", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Store, "Store", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Cast, "Cast", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Customer, "Customer", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Order, "Order", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Shift, "Shift", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Settings, "Settings", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Storeprofile, "Storeprofile", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.User, "User", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Auth, "Auth", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Menu, "Menu", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Notification, "Notification", $techn="Module", $descr="", $tags="", $link="")
+System_Boundary("Application_boundary", "Application", $tags="") {
+  Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+    Component(Application.Application.Notification, "Notification", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Storage, "Storage", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Store, "Store", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Cast, "Cast", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Order, "Order", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Shift, "Shift", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Customer, "Customer", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Settings, "Settings", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Storeprofile, "Storeprofile", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.User, "User", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Auth, "Auth", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Menu, "Menu", $techn="Module", $descr="", $tags="", $link="")
+  }
+
 }
 
-Rel(Application.Application.Settings, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
-Rel(Application.Application.Auth, Application.Application.User, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Auth, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Storeprofile, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Menu, Application.Application.User, "depends on", $techn="", $tags="", $link="")
+Rel(Application.Application.Cast, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
+Rel(Application.Application.Cast, Application.Application.User, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Cast, Application.Application.Store, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Notification, Application.Application.Settings, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Storage, Application.Application.User, "depends on", $techn="", $tags="", $link="")
 Rel(Application.Application.Storage, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Cast, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Cast, Application.Application.User, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Cast, Application.Application.Store, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Store, Application.Application.Storeprofile, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Store, Application.Application.Settings, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Store, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Customer, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Customer, Application.Application.Store, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Shift, Application.Application.Cast, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Shift, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.User, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
+Rel(Application.Application.Auth, Application.Application.User, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Auth, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Settings, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
+Rel(Application.Application.Customer, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
 Rel(Application.Application.Order, Application.Application.Customer, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Order, Application.Application.Cast, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Order, Application.Application.User, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Order, Application.Application.Store, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Order, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Shift, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Shift, Application.Application.Store, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Shift, Application.Application.Cast, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Storeprofile, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Store, Application.Application.Storeprofile, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Store, Application.Application.Settings, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Store, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)
+hide stereotypes
 @enduml

--- a/backend/docs/modulith/module-auth.puml
+++ b/backend/docs/modulith/module-auth.puml
@@ -1,22 +1,33 @@
 @startuml
-set separator none
-title Auth
+title <size:24>Auth</size>
 
+set separator none
 top to bottom direction
+
+<style>
+  root {
+    BackgroundColor: #ffffff
+    FontColor: #444444
+  }
+</style>
 
 !include <C4/C4>
 !include <C4/C4_Context>
 !include <C4/C4_Component>
 
-Container_Boundary("Application.Application_boundary", "Application", $tags="") {
-  Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.User, "User", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Auth, "Auth", $techn="Module", $descr="", $tags="", $link="")
+System_Boundary("Application_boundary", "Application", $tags="") {
+  Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+    Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.User, "User", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Auth, "Auth", $techn="Module", $descr="", $tags="", $link="")
+  }
+
 }
 
+Rel(Application.Application.User, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
 Rel(Application.Application.Auth, Application.Application.User, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Auth, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.User, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)
+hide stereotypes
 @enduml

--- a/backend/docs/modulith/module-cast.adoc
+++ b/backend/docs/modulith/module-cast.adoc
@@ -16,8 +16,7 @@ _Repositories_
 * `c.k.c.domain.CastInvitationRepository`
 * `c.k.c.domain.CastRepository`
 |Bean references
-|* `c.k.s.storescope.StoreContext` (in Shared)
-* `c.k.u.domain.PlatformUserRepository` (in User)
+|* `c.k.u.domain.PlatformUserRepository` (in User)
 * `c.k.s.domain.StoreRepository` (in Store)
 |Aggregate roots
 |* `c.k.c.domain.Cast`

--- a/backend/docs/modulith/module-cast.puml
+++ b/backend/docs/modulith/module-cast.puml
@@ -1,25 +1,36 @@
 @startuml
-set separator none
-title Cast
+title <size:24>Cast</size>
 
+set separator none
 top to bottom direction
+
+<style>
+  root {
+    BackgroundColor: #ffffff
+    FontColor: #444444
+  }
+</style>
 
 !include <C4/C4>
 !include <C4/C4_Context>
 !include <C4/C4_Component>
 
-Container_Boundary("Application.Application_boundary", "Application", $tags="") {
-  Component(Application.Application.Store, "Store", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Cast, "Cast", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.User, "User", $techn="Module", $descr="", $tags="", $link="")
+System_Boundary("Application_boundary", "Application", $tags="") {
+  Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+    Component(Application.Application.Store, "Store", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Cast, "Cast", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.User, "User", $techn="Module", $descr="", $tags="", $link="")
+  }
+
 }
 
-Rel(Application.Application.User, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
+Rel(Application.Application.Cast, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
 Rel(Application.Application.Cast, Application.Application.User, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Cast, Application.Application.Store, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Cast, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.User, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
 Rel(Application.Application.Store, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)
+hide stereotypes
 @enduml

--- a/backend/docs/modulith/module-customer.adoc
+++ b/backend/docs/modulith/module-customer.adoc
@@ -6,9 +6,6 @@
 |_Repositories_
 
 * `c.k.c.domain.CustomerRepository`
-|Bean references
-|* `c.k.s.storescope.StoreContext` (in Shared)
-* `c.k.s.domain.StoreRepository` (in Store)
 |Aggregate roots
 |* `c.k.c.domain.Customer`
 |===

--- a/backend/docs/modulith/module-customer.puml
+++ b/backend/docs/modulith/module-customer.puml
@@ -1,22 +1,30 @@
 @startuml
-set separator none
-title Customer
+title <size:24>Customer</size>
 
+set separator none
 top to bottom direction
+
+<style>
+  root {
+    BackgroundColor: #ffffff
+    FontColor: #444444
+  }
+</style>
 
 !include <C4/C4>
 !include <C4/C4_Context>
 !include <C4/C4_Component>
 
-Container_Boundary("Application.Application_boundary", "Application", $tags="") {
-  Component(Application.Application.Customer, "Customer", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Store, "Store", $techn="Module", $descr="", $tags="", $link="")
+System_Boundary("Application_boundary", "Application", $tags="") {
+  Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+    Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Customer, "Customer", $techn="Module", $descr="", $tags="", $link="")
+  }
+
 }
 
-Rel(Application.Application.Store, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Customer, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Customer, Application.Application.Store, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Customer, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)
+hide stereotypes
 @enduml

--- a/backend/docs/modulith/module-menu.puml
+++ b/backend/docs/modulith/module-menu.puml
@@ -1,19 +1,30 @@
 @startuml
-set separator none
-title Menu
+title <size:24>Menu</size>
 
+set separator none
 top to bottom direction
+
+<style>
+  root {
+    BackgroundColor: #ffffff
+    FontColor: #444444
+  }
+</style>
 
 !include <C4/C4>
 !include <C4/C4_Context>
 !include <C4/C4_Component>
 
-Container_Boundary("Application.Application_boundary", "Application", $tags="") {
-  Component(Application.Application.User, "User", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Menu, "Menu", $techn="Module", $descr="", $tags="", $link="")
+System_Boundary("Application_boundary", "Application", $tags="") {
+  Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+    Component(Application.Application.User, "User", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Menu, "Menu", $techn="Module", $descr="", $tags="", $link="")
+  }
+
 }
 
 Rel(Application.Application.Menu, Application.Application.User, "depends on", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)
+hide stereotypes
 @enduml

--- a/backend/docs/modulith/module-notification.puml
+++ b/backend/docs/modulith/module-notification.puml
@@ -1,19 +1,30 @@
 @startuml
-set separator none
-title Notification
+title <size:24>Notification</size>
 
+set separator none
 top to bottom direction
+
+<style>
+  root {
+    BackgroundColor: #ffffff
+    FontColor: #444444
+  }
+</style>
 
 !include <C4/C4>
 !include <C4/C4_Context>
 !include <C4/C4_Component>
 
-Container_Boundary("Application.Application_boundary", "Application", $tags="") {
-  Component(Application.Application.Notification, "Notification", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Settings, "Settings", $techn="Module", $descr="", $tags="", $link="")
+System_Boundary("Application_boundary", "Application", $tags="") {
+  Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+    Component(Application.Application.Notification, "Notification", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Settings, "Settings", $techn="Module", $descr="", $tags="", $link="")
+  }
+
 }
 
 Rel(Application.Application.Notification, Application.Application.Settings, "uses", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)
+hide stereotypes
 @enduml

--- a/backend/docs/modulith/module-order.adoc
+++ b/backend/docs/modulith/module-order.adoc
@@ -7,6 +7,6 @@
 * `c.k.c.domain.CastRepository` (in Cast)
 * `c.k.u.domain.PlatformUserRepository` (in User)
 * `c.k.u.domain.CapabilityBundleRepository` (in User)
-* `c.k.s.domain.StoreRepository` (in Store)
 * `c.k.s.storescope.StoreContext` (in Shared)
+* `c.k.s.storescope.StoreScopeExecutor` (in Shared)
 |===

--- a/backend/docs/modulith/module-order.puml
+++ b/backend/docs/modulith/module-order.puml
@@ -1,34 +1,40 @@
 @startuml
-set separator none
-title Order
+title <size:24>Order</size>
 
+set separator none
 top to bottom direction
+
+<style>
+  root {
+    BackgroundColor: #ffffff
+    FontColor: #444444
+  }
+</style>
 
 !include <C4/C4>
 !include <C4/C4_Context>
 !include <C4/C4_Component>
 
-Container_Boundary("Application.Application_boundary", "Application", $tags="") {
-  Component(Application.Application.Store, "Store", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Cast, "Cast", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Customer, "Customer", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Order, "Order", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.User, "User", $techn="Module", $descr="", $tags="", $link="")
+System_Boundary("Application_boundary", "Application", $tags="") {
+  Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+    Component(Application.Application.Cast, "Cast", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Order, "Order", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Customer, "Customer", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.User, "User", $techn="Module", $descr="", $tags="", $link="")
+  }
+
 }
 
+Rel(Application.Application.Cast, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
+Rel(Application.Application.Cast, Application.Application.User, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.User, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
-Rel(Application.Application.Customer, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Customer, Application.Application.Store, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Customer, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
 Rel(Application.Application.Order, Application.Application.Customer, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Order, Application.Application.Cast, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Order, Application.Application.User, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Order, Application.Application.Store, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Order, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Cast, Application.Application.User, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Cast, Application.Application.Store, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Cast, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Store, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)
+hide stereotypes
 @enduml

--- a/backend/docs/modulith/module-settings.puml
+++ b/backend/docs/modulith/module-settings.puml
@@ -1,19 +1,30 @@
 @startuml
-set separator none
-title Settings
+title <size:24>Settings</size>
 
+set separator none
 top to bottom direction
+
+<style>
+  root {
+    BackgroundColor: #ffffff
+    FontColor: #444444
+  }
+</style>
 
 !include <C4/C4>
 !include <C4/C4_Context>
 !include <C4/C4_Component>
 
-Container_Boundary("Application.Application_boundary", "Application", $tags="") {
-  Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Settings, "Settings", $techn="Module", $descr="", $tags="", $link="")
+System_Boundary("Application_boundary", "Application", $tags="") {
+  Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+    Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Settings, "Settings", $techn="Module", $descr="", $tags="", $link="")
+  }
+
 }
 
 Rel(Application.Application.Settings, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)
+hide stereotypes
 @enduml

--- a/backend/docs/modulith/module-shared.adoc
+++ b/backend/docs/modulith/module-shared.adoc
@@ -10,26 +10,26 @@
 _Others_
 
 * `c.k.s.config.CacheConfig`
-* `c.k.s.config.JacksonConfig`
 * `c.k.s.config.RedisConfig`
 * `c.k.s.config.S3Config`
 * `c.k.s.exception.CommonExceptionHandler`
-* `c.k.s.storescope.StoreSetFilterEnable`
+* `c.k.s.persistence.StoreScopeStampListener`
 * `c.k.s.storescope.StoreContext`
 * `c.k.s.storescope.StoreFilterEnable`
 * `c.k.s.storescope.StoreIdInterceptor`
+* `c.k.s.storescope.StoreScopeExecutor`
+* `c.k.s.storescope.StoreSetFilterEnable`
 * `c.k.s.web.RequestCorrelationFilter`
 |Properties
 |* `app.domain` -- `java.lang.String`
-* `app.jwt.expiration` -- `java.lang.Long`, default `0`
+* `app.jwt.expiration` -- `java.lang.Long`
 * `app.jwt.secret` -- `java.lang.String`
-* `app.scheme` -- `c.k.s.config.AppProperties.Scheme`, default `http`
-* `app.timezone` -- `java.lang.String`, default `Asia/Tokyo`. 「本日」判定に用いるタイムゾーン。公開出勤表などの当日算出に使用する。
+* `app.timezone` -- `java.lang.String`
 * `app.upload.access-key` -- `java.lang.String`
 * `app.upload.allowed-types` -- `java.util.List<java.lang.String>`
-* `app.upload.bucket` -- `java.lang.String`, default `uploads`
-* `app.upload.endpoint` -- `java.lang.String`, default `http://localhost:9000`
-* `app.upload.max-file-size` -- `java.lang.Long`, default `10485760`
+* `app.upload.bucket` -- `java.lang.String`
+* `app.upload.endpoint` -- `java.lang.String`
+* `app.upload.max-file-size` -- `java.lang.Long`
 * `app.upload.secret-key` -- `java.lang.String`
-* `app.upload.url-prefix` -- `java.lang.String`, default `/static/uploads/`
+* `app.upload.url-prefix` -- `java.lang.String`
 |===

--- a/backend/docs/modulith/module-shared.puml
+++ b/backend/docs/modulith/module-shared.puml
@@ -1,17 +1,27 @@
 @startuml
-set separator none
-title Shared
+title <size:24>Shared</size>
 
+set separator none
 top to bottom direction
+
+<style>
+  root {
+    BackgroundColor: #ffffff
+    FontColor: #444444
+  }
+</style>
 
 !include <C4/C4>
 !include <C4/C4_Context>
 !include <C4/C4_Component>
 
-Container_Boundary("Application.Application_boundary", "Application", $tags="") {
-  Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
+System_Boundary("Application_boundary", "Application", $tags="") {
+  Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+    Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
+  }
+
 }
 
-
 SHOW_LEGEND(true)
+hide stereotypes
 @enduml

--- a/backend/docs/modulith/module-shift.adoc
+++ b/backend/docs/modulith/module-shift.adoc
@@ -3,9 +3,7 @@
 |Base package
 |`com.kizuna.shift`
 |Bean references
-|* `c.k.s.storescope.StoreContext` (in Shared)
-* `c.k.s.domain.StoreRepository` (in Store)
-* `c.k.c.application.CastService` (in Cast)
+|* `c.k.c.application.CastService` (in Cast)
 * `c.k.c.domain.CastRepository` (in Cast)
 * `c.k.s.config.AppProperties` (in Shared)
 |===

--- a/backend/docs/modulith/module-shift.puml
+++ b/backend/docs/modulith/module-shift.puml
@@ -1,26 +1,33 @@
 @startuml
-set separator none
-title Shift
+title <size:24>Shift</size>
 
+set separator none
 top to bottom direction
+
+<style>
+  root {
+    BackgroundColor: #ffffff
+    FontColor: #444444
+  }
+</style>
 
 !include <C4/C4>
 !include <C4/C4_Context>
 !include <C4/C4_Component>
 
-Container_Boundary("Application.Application_boundary", "Application", $tags="") {
-  Component(Application.Application.Cast, "Cast", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Shift, "Shift", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Store, "Store", $techn="Module", $descr="", $tags="", $link="")
+System_Boundary("Application_boundary", "Application", $tags="") {
+  Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+    Component(Application.Application.Cast, "Cast", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Shift, "Shift", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
+  }
+
 }
 
-Rel(Application.Application.Shift, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Shift, Application.Application.Store, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Cast, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
 Rel(Application.Application.Shift, Application.Application.Cast, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Store, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Cast, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Cast, Application.Application.Store, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Shift, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)
+hide stereotypes
 @enduml

--- a/backend/docs/modulith/module-storage.puml
+++ b/backend/docs/modulith/module-storage.puml
@@ -1,17 +1,27 @@
 @startuml
-set separator none
-title Storage
+title <size:24>Storage</size>
 
+set separator none
 top to bottom direction
+
+<style>
+  root {
+    BackgroundColor: #ffffff
+    FontColor: #444444
+  }
+</style>
 
 !include <C4/C4>
 !include <C4/C4_Context>
 !include <C4/C4_Component>
 
-Container_Boundary("Application.Application_boundary", "Application", $tags="") {
-  Component(Application.Application.Storage, "Storage", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.User, "User", $techn="Module", $descr="", $tags="", $link="")
+System_Boundary("Application_boundary", "Application", $tags="") {
+  Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+    Component(Application.Application.Storage, "Storage", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.User, "User", $techn="Module", $descr="", $tags="", $link="")
+  }
+
 }
 
 Rel(Application.Application.Storage, Application.Application.User, "depends on", $techn="", $tags="", $link="")
@@ -19,4 +29,5 @@ Rel(Application.Application.Storage, Application.Application.Shared, "uses", $te
 Rel(Application.Application.User, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)
+hide stereotypes
 @enduml

--- a/backend/docs/modulith/module-store.adoc
+++ b/backend/docs/modulith/module-store.adoc
@@ -9,6 +9,8 @@
 |Bean references
 |* `c.k.s.domain.StoreProfileRepository` (in Storeprofile)
 * `c.k.s.application.SystemConfigService` (in Settings)
+* `c.k.s.storescope.StoreContext` (in Shared)
+* `c.k.s.storescope.StoreExistenceCheck` (in Shared)
 * `c.k.s.storescope.StoreIdInterceptor` (in Shared)
 |Aggregate roots
 |* `c.k.s.domain.Store`

--- a/backend/docs/modulith/module-store.puml
+++ b/backend/docs/modulith/module-store.puml
@@ -1,25 +1,36 @@
 @startuml
-set separator none
-title Store
+title <size:24>Store</size>
 
+set separator none
 top to bottom direction
+
+<style>
+  root {
+    BackgroundColor: #ffffff
+    FontColor: #444444
+  }
+</style>
 
 !include <C4/C4>
 !include <C4/C4_Context>
 !include <C4/C4_Component>
 
-Container_Boundary("Application.Application_boundary", "Application", $tags="") {
-  Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Settings, "Settings", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Storeprofile, "Storeprofile", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Store, "Store", $techn="Module", $descr="", $tags="", $link="")
+System_Boundary("Application_boundary", "Application", $tags="") {
+  Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+    Component(Application.Application.Store, "Store", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Settings, "Settings", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Storeprofile, "Storeprofile", $techn="Module", $descr="", $tags="", $link="")
+  }
+
 }
 
-Rel(Application.Application.Store, Application.Application.Storeprofile, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Store, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
-Rel(Application.Application.Store, Application.Application.Settings, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Storeprofile, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Settings, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
+Rel(Application.Application.Store, Application.Application.Storeprofile, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Store, Application.Application.Settings, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Store, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)
+hide stereotypes
 @enduml

--- a/backend/docs/modulith/module-storeprofile.puml
+++ b/backend/docs/modulith/module-storeprofile.puml
@@ -1,19 +1,30 @@
 @startuml
-set separator none
-title Storeprofile
+title <size:24>Storeprofile</size>
 
+set separator none
 top to bottom direction
+
+<style>
+  root {
+    BackgroundColor: #ffffff
+    FontColor: #444444
+  }
+</style>
 
 !include <C4/C4>
 !include <C4/C4_Context>
 !include <C4/C4_Component>
 
-Container_Boundary("Application.Application_boundary", "Application", $tags="") {
-  Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.Storeprofile, "Storeprofile", $techn="Module", $descr="", $tags="", $link="")
+System_Boundary("Application_boundary", "Application", $tags="") {
+  Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+    Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.Storeprofile, "Storeprofile", $techn="Module", $descr="", $tags="", $link="")
+  }
+
 }
 
 Rel(Application.Application.Storeprofile, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)
+hide stereotypes
 @enduml

--- a/backend/docs/modulith/module-user.puml
+++ b/backend/docs/modulith/module-user.puml
@@ -1,19 +1,30 @@
 @startuml
-set separator none
-title User
+title <size:24>User</size>
 
+set separator none
 top to bottom direction
+
+<style>
+  root {
+    BackgroundColor: #ffffff
+    FontColor: #444444
+  }
+</style>
 
 !include <C4/C4>
 !include <C4/C4_Context>
 !include <C4/C4_Component>
 
-Container_Boundary("Application.Application_boundary", "Application", $tags="") {
-  Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
-  Component(Application.Application.User, "User", $techn="Module", $descr="", $tags="", $link="")
+System_Boundary("Application_boundary", "Application", $tags="") {
+  Container_Boundary("Application.Application_boundary", "Application", $tags="") {
+    Component(Application.Application.Shared, "Shared", $techn="Module", $descr="", $tags="", $link="")
+    Component(Application.Application.User, "User", $techn="Module", $descr="", $tags="", $link="")
+  }
+
 }
 
 Rel(Application.Application.User, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)
+hide stereotypes
 @enduml

--- a/backend/src/integrationTest/java/com/kizuna/order/PlatformOrderScopeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/PlatformOrderScopeIT.java
@@ -300,6 +300,30 @@ class PlatformOrderScopeIT extends CrossStoreTestSupport {
   }
 
   @Test
+  @DisplayName("ALL_STORES でも実在しない store_id の書きは 400(500 でない — #398 裁定/StoreScopeExecutor の存在性保証)")
+  void writeToNonexistentStoreIsRejectedWith400NotServerError() {
+    long nonexistentStoreId = 999_999_999L;
+    assertThat(storeRepository.existsById(nonexistentStoreId))
+        .as("前提: 対象 storeId が実在しないこと")
+        .isFalse();
+
+    // ALL_STORES(seed HQ admin)は授権集合検査を通過するため、実在性検査が 400 の保証点となる。
+    String body =
+        String.format(
+            "{\"store_id\": %d, \"receptionist_id\": %d, \"business_date\": \"%s\","
+                + " \"cast_id\": \"dummy-cast\"}",
+            nonexistentStoreId, SEED_RECEPTIONIST_ID, LocalDate.now());
+
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/platform/orders",
+            new HttpEntity<>(body, bearerJson(platformToken(SEED_EMAIL, PASSWORD))),
+            JsonNode.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
+  @Test
   @DisplayName("授権店舗への書きはその店舗に受注を作成すること(正向対照: 負向 403 がバリデーション起因でない証明)")
   void writeToAuthorizedStoreCreatesOrderInThatStore() {
     String castId = createCastAs(STORE_A, "集合作用域IT用キャスト");

--- a/backend/src/integrationTest/java/com/kizuna/store/StoreExistenceInterceptorIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/store/StoreExistenceInterceptorIT.java
@@ -109,6 +109,10 @@ class StoreExistenceInterceptorIT extends CrossStoreTestSupport {
         rest.exchange("/store/casts", HttpMethod.GET, new HttpEntity<>(headers), String.class);
 
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(res.getBody())
+        .as("CommonExceptionHandler と同じ error キー・メッセージの JSON ボディを返すこと")
+        .contains("\"error\"")
+        .contains("店舗が見つかりません");
   }
 
   @Test
@@ -124,5 +128,6 @@ class StoreExistenceInterceptorIT extends CrossStoreTestSupport {
             "/store/casts/public", HttpMethod.GET, new HttpEntity<>(headers), String.class);
 
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(res.getBody()).contains("\"error\"").contains("店舗が見つかりません");
   }
 }

--- a/backend/src/integrationTest/java/com/kizuna/store/StoreExistenceInterceptorIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/store/StoreExistenceInterceptorIT.java
@@ -1,0 +1,128 @@
+package com.kizuna.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kizuna.shared.CrossStoreTestSupport;
+import com.kizuna.store.domain.StoreRepository;
+import com.kizuna.user.domain.Capability;
+import com.kizuna.user.domain.CapabilityBundle;
+import com.kizuna.user.domain.CapabilityBundleRepository;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import com.kizuna.user.domain.StoreScopeType;
+import com.kizuna.user.domain.UserType;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * 店舗存在性検証（{@link com.kizuna.store.infrastructure.StoreExistenceInterceptor}）の受け入れ IT（#429 / #398）。
+ *
+ * <p>陳旧化した JWT 授権集合や公開サイトの不正ヘッダで実在しない storeId が文脈に載った場合、500 や空 200 でなく 400 を返すことを固定する。 授権側は種子 HQ
+ * admin に storeBridge が無いため、ALL_STORES + STORE コンソール能力（CAST_MANAGE）を持つ束を現場作成して用いる（{@link
+ * com.kizuna.user.AuthorizationScenesIT} と同型）。
+ */
+class StoreExistenceInterceptorIT extends CrossStoreTestSupport {
+
+  private static final String PASSWORD = "pass";
+  private static final String ALL_STORES_EMAIL = "store-existence-it-allstores@kizuna.test";
+
+  /** 種子に無い束（DB データとして追加）。CAST_MANAGE は STORE コンソール能力なので storeBridge を導出させる。 */
+  private static final String ALL_STORES_BUNDLE = "店舗存在性IT_全店舗キャスト管理";
+
+  /** 実在しない storeId（自動採番の実 id 群と衝突しない大きな値）。 */
+  private static final long NONEXISTENT_STORE_ID = 999_999_999L;
+
+  @Autowired private PlatformUserRepository platformUserRepository;
+  @Autowired private CapabilityBundleRepository capabilityBundleRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+  @Autowired private StoreRepository storeRepository;
+
+  @BeforeEach
+  void prepareFixture() {
+    assertThat(storeRepository.existsById(NONEXISTENT_STORE_ID))
+        .as("前提: 対象 storeId が実在しないこと")
+        .isFalse();
+
+    CapabilityBundle bundle =
+        capabilityBundleRepository
+            .findByName(ALL_STORES_BUNDLE)
+            .orElseGet(
+                () ->
+                    capabilityBundleRepository.save(
+                        CapabilityBundle.builder()
+                            .name(ALL_STORES_BUNDLE)
+                            .capabilities(Set.of(Capability.CAST_MANAGE))
+                            .build()));
+    platformUserRepository
+        .findByEmail(ALL_STORES_EMAIL)
+        .orElseGet(
+            () ->
+                platformUserRepository.save(
+                    PlatformUser.builder()
+                        .email(ALL_STORES_EMAIL)
+                        .password(passwordEncoder.encode(PASSWORD))
+                        .displayName("店舗存在性IT 全店舗")
+                        .enabled(true)
+                        .userType(UserType.STAFF)
+                        .bundleIds(Set.of(bundle.getId()))
+                        .storeScopeType(StoreScopeType.ALL_STORES)
+                        .storeIds(Set.of())
+                        .build()));
+  }
+
+  private String platformToken(String email) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/platform/login",
+            new HttpEntity<>(
+                String.format("{\"email\": \"%s\", \"password\": \"%s\"}", email, PASSWORD),
+                headers),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).as("前提: 平台ログインが成功すること").isEqualTo(HttpStatus.OK);
+    return res.getBody().path("token").asString();
+  }
+
+  @Test
+  @DisplayName("ALL_STORES ユーザーが実在しない X-Store-ID を送ると 400（500 でも空 200 でもない）")
+  void allStoresUserWithNonexistentStoreIdGets400() {
+    String token = platformToken(ALL_STORES_EMAIL);
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(token);
+    headers.add("X-Role", "store");
+    headers.add("X-Store-ID", String.valueOf(NONEXISTENT_STORE_ID));
+
+    // /store/casts 一覧は PERM_CAST_MANAGE を要し、存在検証が無ければ storeFilter で空ページ 200 を返す端点。
+    ResponseEntity<String> res =
+        rest.exchange("/store/casts", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("匿名の公開端点でも実在しない X-Store-ID は 400（空 200 でない）")
+  void anonymousPublicEndpointWithNonexistentStoreIdGets400() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("X-Role", "store");
+    headers.add("X-Store-ID", String.valueOf(NONEXISTENT_STORE_ID));
+
+    // /store/casts/public は @PermitAll。存在検証が無ければ空リスト 200 を返す。
+    ResponseEntity<String> res =
+        rest.exchange(
+            "/store/casts/public", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+}

--- a/backend/src/integrationTest/java/com/kizuna/storeprofile/StoreProfileRoundtripIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/storeprofile/StoreProfileRoundtripIT.java
@@ -1,0 +1,66 @@
+package com.kizuna.storeprofile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kizuna.shared.CrossStoreTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * StoreProfile の String-PK 化（#429 D）後の {@code /store/config} 永続化経路を固定する IT。
+ *
+ * <p>変換済みシード行（旧 BIGINT id が VARCHAR へ移送された t_store_profiles）に対し、String PK ロード・@Version 楽観ロック・基類
+ * （StoreScopedEntity）のタイムスタンプが GET→PUT→GET の roundtrip で機能することを確認する。主体は種子の yamada.jiro （束「店舗スタッフ」=
+ * STORE_PROFILE_MANAGE 保持、店舗1）で、{@link CrossStoreTestSupport} のログイン主体をそのまま用いる。
+ */
+class StoreProfileRoundtripIT extends CrossStoreTestSupport {
+
+  @Test
+  @DisplayName("/store/config は GET→PUT→GET で更新が永続化され、id は非空 JSON 文字列であること")
+  void configRoundtripPersistsAndExposesStringId() {
+    // GET: 変換済みシード行が String PK でロードでき、id が数値でなく引用符付き JSON 文字列であること。
+    ResponseEntity<String> rawGet =
+        rest.exchange(
+            "/store/config", HttpMethod.GET, new HttpEntity<>(storeHeaders(STORE_A)), String.class);
+    assertThat(rawGet.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(rawGet.getBody())
+        .as("id は数値でなく引用符付き JSON 文字列（String PK）であること")
+        .containsPattern("\"id\"\\s*:\\s*\"[^\"]+\"");
+
+    ResponseEntity<JsonNode> got =
+        rest.exchange(
+            "/store/config",
+            HttpMethod.GET,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+    String id = got.getBody().path("id").asString();
+    assertThat(id).as("String PK が非空であること").isNotBlank();
+
+    // PUT: catch_copy を run-unique 値へ更新（@Version・updated_at が動く経路）。
+    String unique = "IT_catch_" + System.nanoTime();
+    ResponseEntity<JsonNode> put =
+        rest.exchange(
+            "/store/config",
+            HttpMethod.PUT,
+            new HttpEntity<>("{\"catch_copy\": \"" + unique + "\"}", storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(put.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(put.getBody().path("catch_copy").asString()).isEqualTo(unique);
+
+    // GET: 更新が永続化され、id は不変であること。
+    ResponseEntity<JsonNode> reget =
+        rest.exchange(
+            "/store/config",
+            HttpMethod.GET,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(reget.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(reget.getBody().path("catch_copy").asString()).isEqualTo(unique);
+    assertThat(reget.getBody().path("id").asString()).as("id は更新後も不変であること").isEqualTo(id);
+  }
+}

--- a/backend/src/main/java/com/kizuna/cast/application/CastFieldDefinitionService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastFieldDefinitionService.java
@@ -7,7 +7,6 @@ import com.kizuna.cast.api.dto.CastFieldDefinitionUpdateRequest;
 import com.kizuna.cast.domain.CastFieldDefinition;
 import com.kizuna.cast.domain.CastFieldDefinitionRepository;
 import com.kizuna.shared.exception.ServiceException;
-import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.shared.storescope.StoreScoped;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +29,6 @@ public class CastFieldDefinitionService {
 
   private final CastFieldDefinitionRepository repository;
   private final CastFieldDefinitionMapper mapper;
-  private final StoreContext storeContext;
 
   @StoreScoped
   @Transactional(readOnly = true)
@@ -49,6 +47,7 @@ public class CastFieldDefinitionService {
     }
     Integer max = repository.findMaxDisplayOrder();
     int nextOrder = max == null ? 0 : max + 1;
+    // store_id は StoreScopeStampListener が @PrePersist で採番する
     CastFieldDefinition definition =
         CastFieldDefinition.builder()
             .key(request.getKey())
@@ -56,7 +55,6 @@ public class CastFieldDefinitionService {
             .displayOrder(nextOrder)
             .isPublic(Boolean.TRUE.equals(request.getIsPublic()))
             .build();
-    definition.setStoreId(storeContext.getStoreId());
     try {
       return mapper.toResponse(repository.saveAndFlush(definition));
     } catch (DataIntegrityViolationException ex) {

--- a/backend/src/main/java/com/kizuna/cast/application/CastService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastService.java
@@ -12,9 +12,7 @@ import com.kizuna.cast.domain.CastInvitationStatus;
 import com.kizuna.cast.domain.CastPatch;
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.exception.ServiceException;
-import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.shared.storescope.StoreScoped;
-import com.kizuna.store.domain.StoreRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,8 +32,6 @@ public class CastService {
 
   private final CastRepository castRepository;
   private final CastMapper castMapper;
-  private final StoreContext storeContext;
-  private final StoreRepository storeRepository;
   private final CastInvitationService castInvitationService;
   private final CastFieldDefinitionRepository castFieldDefinitionRepository;
 
@@ -73,14 +69,8 @@ public class CastService {
   @StoreScoped
   @Transactional
   public CastResponse create(CastCreateRequest request) {
+    // store_id は StoreScopeStampListener が @PrePersist で採番する
     Cast cast = castMapper.toEntity(request);
-
-    cast.setStoreId(
-        storeRepository
-            .findById(storeContext.getStoreId())
-            .orElseThrow(() -> new ServiceException("店舗が見つかりません"))
-            .getId());
-
     return castMapper.toResponse(castRepository.save(cast));
   }
 

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
@@ -7,9 +7,7 @@ import com.kizuna.customer.api.dto.CustomerUpdateRequest;
 import com.kizuna.customer.domain.Customer;
 import com.kizuna.customer.domain.CustomerRepository;
 import com.kizuna.shared.exception.ServiceException;
-import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.shared.storescope.StoreScoped;
-import com.kizuna.store.domain.StoreRepository;
 import jakarta.persistence.criteria.Predicate;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,8 +24,6 @@ public class CustomerService {
 
   private final CustomerRepository customerRepository;
   private final CustomerMapper customerMapper;
-  private final StoreContext storeContext;
-  private final StoreRepository storeRepository;
 
   @StoreScoped
   @Transactional(readOnly = true)
@@ -80,14 +76,8 @@ public class CustomerService {
   @StoreScoped
   @Transactional
   public CustomerResponse create(CustomerCreateRequest request) {
+    // store_id は StoreScopeStampListener が @PrePersist で採番する
     Customer customer = customerMapper.toEntity(request);
-
-    customer.setStoreId(
-        storeRepository
-            .findById(storeContext.getStoreId())
-            .orElseThrow(() -> new ServiceException("店舗が見つかりません"))
-            .getId());
-
     return customerMapper.toResponse(customerRepository.save(customer));
   }
 

--- a/backend/src/main/java/com/kizuna/order/application/OrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderService.java
@@ -13,7 +13,6 @@ import com.kizuna.order.domain.OrderStatus;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.shared.storescope.StoreScoped;
-import com.kizuna.store.domain.StoreRepository;
 import com.kizuna.user.domain.Capability;
 import com.kizuna.user.domain.CapabilityBundleRepository;
 import com.kizuna.user.domain.PlatformUserRepository;
@@ -33,7 +32,6 @@ public class OrderService {
   private final CastRepository castRepository;
   private final PlatformUserRepository platformUserRepository;
   private final CapabilityBundleRepository capabilityBundleRepository;
-  private final StoreRepository storeRepository;
   private final StoreContext storeContext;
   private final OrderMapper orderMapper;
 
@@ -54,15 +52,8 @@ public class OrderService {
   @StoreScoped
   @Transactional
   public OrderResponse create(OrderCreateRequest request) {
-    // MapStructを使用して基本的なフィールドをマッピング
+    // MapStructを使用して基本的なフィールドをマッピング（store_id は StoreScopeStampListener が @PrePersist で採番）
     Order order = orderMapper.toEntity(request);
-
-    // 店舗の設定
-    order.setStoreId(
-        storeRepository
-            .findById(storeContext.getStoreId())
-            .orElseThrow(() -> new ServiceException("店舗が見つかりません"))
-            .getId());
 
     // 複雑な関連ロジックの処理（顧客のスマートリンク）
     handleCustomerLinking(request, order);
@@ -160,13 +151,8 @@ public class OrderService {
               .findByPhoneNumberAndStoreId(req.getPhoneNumber(), storeContext.getStoreId())
               .orElseGet(
                   () -> {
+                    // store_id は StoreScopeStampListener が @PrePersist で採番する
                     Customer newCustomer = orderMapper.toCustomer(req);
-                    // 店舗を明示的に設定
-                    newCustomer.setStoreId(
-                        storeRepository
-                            .findById(storeContext.getStoreId())
-                            .orElseThrow(() -> new ServiceException("店舗が見つかりません"))
-                            .getId());
                     return customerRepository.save(newCustomer);
                   });
       order.linkCustomer(customer.getId());

--- a/backend/src/main/java/com/kizuna/order/application/PlatformOrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/PlatformOrderService.java
@@ -5,14 +5,11 @@ import com.kizuna.order.api.dto.OrderResponse;
 import com.kizuna.order.api.dto.PlatformOrderCreateRequest;
 import com.kizuna.order.api.dto.PlatformOrderResponse;
 import com.kizuna.order.domain.OrderRepository;
-import com.kizuna.shared.storescope.StoreContext;
-import com.kizuna.shared.storescope.StoreScope;
+import com.kizuna.shared.storescope.StoreScopeExecutor;
 import com.kizuna.shared.storescope.StoreSetScoped;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,7 +20,7 @@ public class PlatformOrderService {
 
   private final OrderRepository orderRepository;
   private final OrderService orderService;
-  private final StoreContext storeContext;
+  private final StoreScopeExecutor storeScopeExecutor;
   private final OrderMapper orderMapper;
 
   /** 授権店舗集合での受注横断一覧。濾過は storeSetFilter（@StoreSetScoped）が機構的に行う。 */
@@ -33,19 +30,8 @@ public class PlatformOrderService {
     return orderRepository.findPlatformViews(pageable).map(orderMapper::toPlatformResponse);
   }
 
-  /** 明示的単店指定の受注作成。storeId の授権検証後、店側と同一機構（StoreContext+@StoreScoped）で実行する。 */
+  /** 明示的単店指定の受注作成。storeId の授権検証・文脈確立・後片付けは {@link StoreScopeExecutor} が担う。 */
   public OrderResponse create(PlatformOrderCreateRequest request) {
-    StoreScope scope =
-        StoreScope.fromAuthentication(SecurityContextHolder.getContext().getAuthentication());
-    if (scope == null || !scope.authorizes(request.getStoreId())) {
-      throw new AccessDeniedException("指定店舗はこのアカウントの授権店舗集合に含まれません");
-    }
-    try {
-      storeContext.setStoreId(request.getStoreId());
-      return orderService.create(request);
-    } finally {
-      // /platform は StoreIdInterceptor(afterCompletion clear)を通らないため、ここで必ず消す
-      storeContext.clear();
-    }
+    return storeScopeExecutor.runInStore(request.getStoreId(), () -> orderService.create(request));
   }
 }

--- a/backend/src/main/java/com/kizuna/shared/persistence/StoreScopeStampListener.java
+++ b/backend/src/main/java/com/kizuna/shared/persistence/StoreScopeStampListener.java
@@ -1,0 +1,45 @@
+package com.kizuna.shared.persistence;
+
+import com.kizuna.shared.storescope.StoreContext;
+import jakarta.persistence.PrePersist;
+import org.springframework.stereotype.Component;
+
+/**
+ * store-scoped エンティティの永続化直前に store_id を機構的に採番する JPA エンティティリスナ（#429）。
+ *
+ * <p>従来は各サービスの create が「店舗解決 + setStoreId」の四行様板を同型複製していた。 本リスナへ集約し、@StoreScoped の付け忘れを fail-loud
+ * で顕在化させる（従来は静默 fail-open）。
+ *
+ * <ul>
+ *   <li>store_id が既に設定済み → 尊重して素通り（CastInvitation の cast 由来 copy、IT の他店舗カナリア直挿を壊さない）。
+ *   <li>未設定かつ StoreContext 確立済み → 現店舗 id を採番。
+ *   <li>未設定かつ StoreContext 未確立 → {@link IllegalStateException}（@StoreScoped の付け忘れ、または平台側 seam
+ *       の未使用）。
+ * </ul>
+ *
+ * <p>Spring Boot は Hibernate へ SpringBeanContainer を登録するため、{@code @EntityListeners} に指定した本クラスは
+ * Spring bean として解決され StoreContext が注入される。
+ */
+@Component
+public class StoreScopeStampListener {
+
+  private final StoreContext storeContext;
+
+  public StoreScopeStampListener(StoreContext storeContext) {
+    this.storeContext = storeContext;
+  }
+
+  @PrePersist
+  public void stampStoreId(StoreScopedEntity entity) {
+    if (entity.getStoreId() != null) {
+      return;
+    }
+    if (!storeContext.hasStoreId()) {
+      throw new IllegalStateException(
+          "店舗文脈が確立されていない状態で store-scoped エンティティを永続化しようとしました（@StoreScoped の付け忘れ、"
+              + "または平台側 seam の未使用）: "
+              + entity.getClass().getName());
+    }
+    entity.setStoreId(storeContext.getStoreId());
+  }
+}

--- a/backend/src/main/java/com/kizuna/shared/persistence/StoreScopedEntity.java
+++ b/backend/src/main/java/com/kizuna/shared/persistence/StoreScopedEntity.java
@@ -1,6 +1,7 @@
 package com.kizuna.shared.persistence;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
@@ -17,6 +18,7 @@ import org.hibernate.annotations.ParamDef;
 
 /** 店舗スコープのエンティティ基盤。store_id は ID 参照（D3）で保持し、storeFilter で行レベル分離する。 */
 @MappedSuperclass
+@EntityListeners(StoreScopeStampListener.class)
 @Getter
 @Setter
 @NoArgsConstructor

--- a/backend/src/main/java/com/kizuna/shared/storescope/StoreExistenceCheck.java
+++ b/backend/src/main/java/com/kizuna/shared/storescope/StoreExistenceCheck.java
@@ -1,0 +1,15 @@
+package com.kizuna.shared.storescope;
+
+/**
+ * 店舗の実在性を問い合わせる跨モジュールポート（#429）。shared は store モジュールへ依存できないため、 インターフェースを shared 側に置き store 側が実装する
+ * （店→shared は Modulith の許容方向）。
+ *
+ * <p>単一実装のインターフェースは通常避けるが、これは跨モジュール依存を逆転させるためのポートであり、その規約の 明示的な例外にあたる。{@link StoreScopeExecutor}
+ * が平台側の店舗文脈確立時に授権検査と対で実在性を保証するのに用いる。
+ */
+@FunctionalInterface
+public interface StoreExistenceCheck {
+
+  /** 指定 storeId の店舗が実在するか。 */
+  boolean exists(long storeId);
+}

--- a/backend/src/main/java/com/kizuna/shared/storescope/StoreScopeExecutor.java
+++ b/backend/src/main/java/com/kizuna/shared/storescope/StoreScopeExecutor.java
@@ -1,5 +1,6 @@
 package com.kizuna.shared.storescope;
 
+import com.kizuna.shared.exception.ServiceException;
 import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
@@ -9,26 +10,33 @@ import org.springframework.stereotype.Component;
 /**
  * 平台側（{@code /platform/**}）で明示的単店の店舗文脈を確立して action を実行する実行 seam（#429）。
  *
- * <p>{@code /platform/**} は {@link StoreIdInterceptor} を通らないため、店舗文脈が要る平台側端点は authorize → {@link
- * StoreContext} set → finally clear の舞踏を手書きしていた（{@code PlatformOrderService.create} が唯一例だった）。
- * 金流票群（#386 等）で第二消費者がほぼ確実に出るため、その舞踏を本 seam に一本化する。
+ * <p>{@code /platform/**} は {@link StoreIdInterceptor} を通らないため、店舗文脈が要る平台側端点は authorize → 存在性検証 →
+ * {@link StoreContext} set → finally clear の舞踏を手書きしていた（{@code PlatformOrderService.create}
+ * が唯一例だった）。 金流票群（#386 等）で第二消費者がほぼ確実に出るため、その舞踏を本 seam に一本化する。
  *
- * <p>引数 storeId を {@link StoreScope#fromAuthentication} で解決した授権集合で検証し、解決不能または授権外なら
- * fail-closed（{@link AccessDeniedException}）で拒否する。検証通過後に {@link StoreContext} へ storeId を設定し、
- * try/finally で必ず消す。
+ * <p>平台側の店舗文脈確立は、{@code /store/**} のインターセプタ対（{@link StoreIdInterceptor} +
+ * StoreExistenceInterceptor）と 対称に、授権と実在性の双方を保証する。引数 storeId を {@link StoreScope#fromAuthentication}
+ * で解決した授権集合で検証し、解決不能または 授権外なら fail-closed（{@link AccessDeniedException} → 403）で拒否する。授権通過後、{@link
+ * StoreExistenceCheck} で実在性を 検証し、実在しなければ {@link ServiceException}（400 — #398 裁定「制約違反が 500 に逃げるのは
+ * bug」）で拒否する（従来サービスの {@code storeRepository.findById(...).orElseThrow} が担っていた 400 の置き換え）。検証通過後に
+ * {@link StoreContext} へ storeId を 設定し、try/finally で必ず消す。
  */
 @Component
 @RequiredArgsConstructor
 public class StoreScopeExecutor {
 
   private final StoreContext storeContext;
+  private final StoreExistenceCheck storeExistenceCheck;
 
-  /** 授権検証済みの storeId 文脈下で action を実行し、復帰時（例外時含む）に必ず文脈を消す。 */
+  /** 授権・実在検証済みの storeId 文脈下で action を実行し、復帰時（例外時含む）に必ず文脈を消す。 */
   public <T> T runInStore(Long storeId, Supplier<T> action) {
     StoreScope scope =
         StoreScope.fromAuthentication(SecurityContextHolder.getContext().getAuthentication());
     if (scope == null || !scope.authorizes(storeId)) {
       throw new AccessDeniedException("指定店舗はこのアカウントの授権店舗集合に含まれません");
+    }
+    if (!storeExistenceCheck.exists(storeId)) {
+      throw new ServiceException("店舗が見つかりません");
     }
     try {
       storeContext.setStoreId(storeId);

--- a/backend/src/main/java/com/kizuna/shared/storescope/StoreScopeExecutor.java
+++ b/backend/src/main/java/com/kizuna/shared/storescope/StoreScopeExecutor.java
@@ -1,0 +1,41 @@
+package com.kizuna.shared.storescope;
+
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+/**
+ * 平台側（{@code /platform/**}）で明示的単店の店舗文脈を確立して action を実行する実行 seam（#429）。
+ *
+ * <p>{@code /platform/**} は {@link StoreIdInterceptor} を通らないため、店舗文脈が要る平台側端点は authorize → {@link
+ * StoreContext} set → finally clear の舞踏を手書きしていた（{@code PlatformOrderService.create} が唯一例だった）。
+ * 金流票群（#386 等）で第二消費者がほぼ確実に出るため、その舞踏を本 seam に一本化する。
+ *
+ * <p>引数 storeId を {@link StoreScope#fromAuthentication} で解決した授権集合で検証し、解決不能または授権外なら
+ * fail-closed（{@link AccessDeniedException}）で拒否する。検証通過後に {@link StoreContext} へ storeId を設定し、
+ * try/finally で必ず消す。
+ */
+@Component
+@RequiredArgsConstructor
+public class StoreScopeExecutor {
+
+  private final StoreContext storeContext;
+
+  /** 授権検証済みの storeId 文脈下で action を実行し、復帰時（例外時含む）に必ず文脈を消す。 */
+  public <T> T runInStore(Long storeId, Supplier<T> action) {
+    StoreScope scope =
+        StoreScope.fromAuthentication(SecurityContextHolder.getContext().getAuthentication());
+    if (scope == null || !scope.authorizes(storeId)) {
+      throw new AccessDeniedException("指定店舗はこのアカウントの授権店舗集合に含まれません");
+    }
+    try {
+      storeContext.setStoreId(storeId);
+      return action.get();
+    } finally {
+      // /platform は StoreIdInterceptor(afterCompletion clear)を通らないため、ここで必ず消す
+      storeContext.clear();
+    }
+  }
+}

--- a/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
@@ -5,7 +5,6 @@ import com.kizuna.cast.domain.Cast;
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.config.AppProperties;
 import com.kizuna.shared.exception.ServiceException;
-import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.shared.storescope.StoreScoped;
 import com.kizuna.shift.api.dto.PublicShiftResponse;
 import com.kizuna.shift.api.dto.ShiftCreateRequest;
@@ -14,7 +13,6 @@ import com.kizuna.shift.api.dto.ShiftResponse;
 import com.kizuna.shift.api.dto.ShiftUpdateRequest;
 import com.kizuna.shift.domain.Shift;
 import com.kizuna.shift.domain.ShiftRepository;
-import com.kizuna.store.domain.StoreRepository;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -35,8 +33,6 @@ public class ShiftService {
 
   private final ShiftRepository shiftRepository;
   private final ShiftMapper shiftMapper;
-  private final StoreContext storeContext;
-  private final StoreRepository storeRepository;
   private final CastService castService;
   private final CastRepository castRepository;
   private final AppProperties appProperties;
@@ -94,14 +90,8 @@ public class ShiftService {
       throw new ServiceException("キャストが見つかりません: " + request.getCastId());
     }
 
+    // store_id は StoreScopeStampListener が @PrePersist で採番する
     Shift shift = shiftMapper.toEntity(request);
-
-    shift.setStoreId(
-        storeRepository
-            .findById(storeContext.getStoreId())
-            .orElseThrow(() -> new ServiceException("店舗が見つかりません"))
-            .getId());
-
     return shiftMapper.toResponse(shiftRepository.save(shift));
   }
 

--- a/backend/src/main/java/com/kizuna/store/infrastructure/StoreExistenceInterceptor.java
+++ b/backend/src/main/java/com/kizuna/store/infrastructure/StoreExistenceInterceptor.java
@@ -1,11 +1,13 @@
 package com.kizuna.store.infrastructure;
 
 import com.kizuna.shared.storescope.StoreContext;
-import com.kizuna.store.domain.StoreRepository;
+import com.kizuna.shared.storescope.StoreExistenceCheck;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -14,27 +16,34 @@ import org.springframework.web.servlet.HandlerInterceptor;
  *
  * <p>{@link com.kizuna.shared.storescope.StoreIdInterceptor} の後段に同一 mount（{@code /store/**}・{@code
  * /files/**}）で登録する。各サービスの create にあった {@code storeRepository.findById(...).orElseThrow} 様板を置き換える。
+ * 実在性判定は跨モジュールポート {@link StoreExistenceCheck} に収束させ、平台側の {@link
+ * com.kizuna.shared.storescope.StoreScopeExecutor} と同一の判定経路にする。
  *
  * <p>JWT の授権店舗集合は次回ログインまで陳旧化しうるため、存在しない storeId が文脈に載ることがある。純 FK 兜底だと制約違反が 500 に逃げ、#398 裁定「制約違反が
- * 500 に逃げるのは bug」と矛盾する。本インターセプタが 400 の保証点となる。
+ * 500 に逃げるのは bug」と矛盾する。本インターセプタが 400 の保証点となり、{@link
+ * com.kizuna.shared.exception.CommonExceptionHandler} と同じ {@code error} キー・削除前サービス様板と同じメッセージの JSON
+ * ボディを返す（同一パッケージの {@code MaintenanceModeInterceptor} の先例に倣う）。
  *
- * <p>店舗文脈が無い（{@code @StoreOptional} の素通り）場合は検証対象外として許可する。 shared→store の逆依存を避けるため shared
- * には置かず、StoreRepository を参照できる store モジュールに配置する。
+ * <p>店舗文脈が無い（{@code @StoreOptional} の素通り）場合は検証対象外として許可する。
  */
 @Component
 @RequiredArgsConstructor
 public class StoreExistenceInterceptor implements HandlerInterceptor {
 
   private final StoreContext storeContext;
-  private final StoreRepository storeRepository;
+  private final StoreExistenceCheck storeExistenceCheck;
 
   @Override
   public boolean preHandle(
       @NonNull HttpServletRequest request,
       @NonNull HttpServletResponse response,
-      @NonNull Object handler) {
-    if (storeContext.hasStoreId() && !storeRepository.existsById(storeContext.getStoreId())) {
+      @NonNull Object handler)
+      throws Exception {
+    if (storeContext.hasStoreId() && !storeExistenceCheck.exists(storeContext.getStoreId())) {
       response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+      response.getWriter().write("{\"error\":\"店舗が見つかりません\"}");
       return false;
     }
     return true;

--- a/backend/src/main/java/com/kizuna/store/infrastructure/StoreExistenceInterceptor.java
+++ b/backend/src/main/java/com/kizuna/store/infrastructure/StoreExistenceInterceptor.java
@@ -1,0 +1,42 @@
+package com.kizuna.store.infrastructure;
+
+import com.kizuna.shared.storescope.StoreContext;
+import com.kizuna.store.domain.StoreRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * 店舗文脈（X-Store-ID）が確立済みのとき、その store_id が実在することを毎リクエスト 1 回検証するインターセプタ（#429）。
+ *
+ * <p>{@link com.kizuna.shared.storescope.StoreIdInterceptor} の後段に同一 mount（{@code /store/**}・{@code
+ * /files/**}）で登録する。各サービスの create にあった {@code storeRepository.findById(...).orElseThrow} 様板を置き換える。
+ *
+ * <p>JWT の授権店舗集合は次回ログインまで陳旧化しうるため、存在しない storeId が文脈に載ることがある。純 FK 兜底だと制約違反が 500 に逃げ、#398 裁定「制約違反が
+ * 500 に逃げるのは bug」と矛盾する。本インターセプタが 400 の保証点となる。
+ *
+ * <p>店舗文脈が無い（{@code @StoreOptional} の素通り）場合は検証対象外として許可する。 shared→store の逆依存を避けるため shared
+ * には置かず、StoreRepository を参照できる store モジュールに配置する。
+ */
+@Component
+@RequiredArgsConstructor
+public class StoreExistenceInterceptor implements HandlerInterceptor {
+
+  private final StoreContext storeContext;
+  private final StoreRepository storeRepository;
+
+  @Override
+  public boolean preHandle(
+      @NonNull HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      @NonNull Object handler) {
+    if (storeContext.hasStoreId() && !storeRepository.existsById(storeContext.getStoreId())) {
+      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return false;
+    }
+    return true;
+  }
+}

--- a/backend/src/main/java/com/kizuna/store/infrastructure/StoreRepositoryExistenceCheck.java
+++ b/backend/src/main/java/com/kizuna/store/infrastructure/StoreRepositoryExistenceCheck.java
@@ -1,0 +1,19 @@
+package com.kizuna.store.infrastructure;
+
+import com.kizuna.shared.storescope.StoreExistenceCheck;
+import com.kizuna.store.domain.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** {@link StoreExistenceCheck} の store モジュール実装。StoreRepository の存在確認へ委譲する（#429）。 */
+@Component
+@RequiredArgsConstructor
+class StoreRepositoryExistenceCheck implements StoreExistenceCheck {
+
+  private final StoreRepository storeRepository;
+
+  @Override
+  public boolean exists(long storeId) {
+    return storeRepository.existsById(storeId);
+  }
+}

--- a/backend/src/main/java/com/kizuna/store/infrastructure/WebMvcConfig.java
+++ b/backend/src/main/java/com/kizuna/store/infrastructure/WebMvcConfig.java
@@ -11,12 +11,15 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
   @NonNull private final StoreIdInterceptor storeIdInterceptor;
   @NonNull private final MaintenanceModeInterceptor maintenanceModeInterceptor;
+  @NonNull private final StoreExistenceInterceptor storeExistenceInterceptor;
 
   public WebMvcConfig(
       @NonNull StoreIdInterceptor storeIdInterceptor,
-      @NonNull MaintenanceModeInterceptor maintenanceModeInterceptor) {
+      @NonNull MaintenanceModeInterceptor maintenanceModeInterceptor,
+      @NonNull StoreExistenceInterceptor storeExistenceInterceptor) {
     this.storeIdInterceptor = storeIdInterceptor;
     this.maintenanceModeInterceptor = maintenanceModeInterceptor;
+    this.storeExistenceInterceptor = storeExistenceInterceptor;
   }
 
   @Override
@@ -24,5 +27,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     // メンテナンス判定は店舗コンテキスト設定より先に行う
     registry.addInterceptor(maintenanceModeInterceptor).addPathPatterns("/store/**");
     registry.addInterceptor(storeIdInterceptor).addPathPatterns("/store/**", "/files/**");
+    // 店舗文脈確立（StoreIdInterceptor）の後段で、その store_id の実在性を検証する（#429・#398）
+    registry.addInterceptor(storeExistenceInterceptor).addPathPatterns("/store/**", "/files/**");
   }
 }

--- a/backend/src/main/java/com/kizuna/storeprofile/api/dto/StoreProfileResponse.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/api/dto/StoreProfileResponse.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StoreProfileResponse {
-  private Long id;
+  private String id;
   private String templateKey;
   private String logoUrl;
   private String bannerUrl;

--- a/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfile.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfile.java
@@ -1,21 +1,14 @@
 package com.kizuna.storeprofile.domain;
 
+import com.kizuna.shared.persistence.StoreScopedEntity;
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
-import jakarta.persistence.Version;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,14 +27,7 @@ import org.hibernate.annotations.Type;
 @Builder
 @ToString
 @Filter(name = "storeFilter", condition = "store_id = :storeId")
-public class StoreProfile {
-
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
-
-  @Column(name = "store_id", nullable = false, unique = true, updatable = false)
-  private Long storeId;
+public class StoreProfile extends StoreScopedEntity {
 
   @Column(name = "template_key", length = 50)
   @Builder.Default
@@ -93,43 +79,23 @@ public class StoreProfile {
   @Builder.Default
   private List<PartnerLink> partnerLinks = new ArrayList<>();
 
-  @Column(name = "created_at", nullable = false)
-  private OffsetDateTime createdAt;
-
-  @Column(name = "updated_at", nullable = false)
-  private OffsetDateTime updatedAt;
-
-  /** 楽観ロック用バージョン（全実体共通 — #400）。 */
-  @Setter(AccessLevel.NONE) // 新規 public setter 禁止規約: バージョンは JPA が管理し外部から設定させない（#400）
-  @Version
-  @Column(nullable = false)
-  private Long version;
-
-  @PrePersist
-  protected void onCreate() {
-    var now = OffsetDateTime.now();
-    this.createdAt = now;
-    this.updatedAt = now;
-  }
-
-  @PreUpdate
-  protected void onUpdate() {
-    this.updatedAt = OffsetDateTime.now();
-  }
-
   /**
    * 店舗用のデフォルト設定を生成する。
+   *
+   * <p>店舗登録（平台側・StoreContext なし）から呼ばれるため store_id を明示設定する。 StoreScopeStampListener はこの設定済み値を尊重する。
    *
    * @param storeId 対象店舗の ID
    * @return デフォルト値が設定された StoreProfile インスタンス
    */
   public static StoreProfile createDefault(Long storeId) {
-    return StoreProfile.builder()
-        .storeId(storeId)
-        .templateKey("default")
-        .mvType("image")
-        .snsLinks(new ArrayList<>())
-        .partnerLinks(new ArrayList<>())
-        .build();
+    StoreProfile profile =
+        StoreProfile.builder()
+            .templateKey("default")
+            .mvType("image")
+            .snsLinks(new ArrayList<>())
+            .partnerLinks(new ArrayList<>())
+            .build();
+    profile.setStoreId(storeId);
+    return profile;
   }
 }

--- a/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfileRepository.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfileRepository.java
@@ -3,7 +3,7 @@ package com.kizuna.storeprofile.domain;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StoreProfileRepository extends JpaRepository<StoreProfile, Long> {
+public interface StoreProfileRepository extends JpaRepository<StoreProfile, String> {
   Optional<StoreProfile> findByStoreId(Long storeId);
 
   boolean existsByStoreId(Long storeId);

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2,3 +2,6 @@ databaseChangeLog:
   - include:
       file: releases/v0.1.0/master.yaml
       relativeToChangelogFile: true
+  - include:
+      file: releases/v0.2.0/master.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.2.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.2.0/master.yaml
@@ -1,0 +1,6 @@
+# v0.2.0 = v0.1.0 ベースライン適用後の増分。#429 で StoreProfile を StoreScopedEntity へ
+# 帰隊させるための PK 型移行を含む。構成は v0.1.0 と同じ platform / store / seed の 3 層。
+databaseChangeLog:
+  - include:
+      file: store/01-store-profile-id-to-snowflake.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.2.0/store/01-store-profile-id-to-snowflake.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.2.0/store/01-store-profile-id-to-snowflake.yaml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  - changeSet:
+      id: store-v0200-001-store-profile-id-to-snowflake
+      author: kanghouchao
+      # StoreProfile を StoreScopedEntity へ帰隊させる（#429）。t_store_profiles.id を
+      # BIGINT autoincrement から他の store-scoped 表（t_orders.id 等）と同型の
+      # VARCHAR(64)（Snowflake）へ移行する。既存の数値 id はテキスト表現（"1"・"2" 等）へ
+      # 変換される（許容）。unique(store_id) と FK は store_id 列のため無変更。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        # 1) autoincrement を解除（GENERATED ... AS IDENTITY 版）。IDENTITY でなければ IF EXISTS で no-op。
+        - sql:
+            sql: ALTER TABLE t_store_profiles ALTER COLUMN id DROP IDENTITY IF EXISTS
+        # 2) sequence 由来の default（SERIAL 版）を解除。default が無ければ no-op。
+        #    1) で IDENTITY は解除済みのため identity 列への DROP DEFAULT エラーにはならない。
+        - sql:
+            sql: ALTER TABLE t_store_profiles ALTER COLUMN id DROP DEFAULT
+        # 3) 型を VARCHAR(64) へ変換（既存 id は id::text で移送）。PK pk_t_store_profiles は維持される。
+        - sql:
+            sql: "ALTER TABLE t_store_profiles ALTER COLUMN id TYPE VARCHAR(64) USING id::text"
+      rollback:
+        - sql:
+            sql: "ALTER TABLE t_store_profiles ALTER COLUMN id TYPE BIGINT USING id::bigint"

--- a/backend/src/test/java/com/kizuna/StoreIsolationTests.java
+++ b/backend/src/test/java/com/kizuna/StoreIsolationTests.java
@@ -65,6 +65,34 @@ class StoreIsolationTests {
   }
 
   @Test
+  @DisplayName("store_id 列を持つ全 @Entity が StoreScopedEntity を継承していること（豁免なし）")
+  void allStoreScopedEntitiesExtendBaseClass() throws Exception {
+    ClassPathScanningCandidateComponentProvider scanner =
+        new ClassPathScanningCandidateComponentProvider(false);
+    scanner.addIncludeFilter(new AnnotationTypeFilter(Entity.class));
+
+    List<String> offenders = new ArrayList<>();
+    List<String> scanned = new ArrayList<>();
+    for (var candidate : scanner.findCandidateComponents("com.kizuna")) {
+      Class<?> entity = Class.forName(candidate.getBeanClassName());
+      if (!hasStoreIdColumn(entity)) {
+        continue;
+      }
+      scanned.add(entity.getSimpleName());
+      // 基類継承を強制することで、@PrePersist の store_id 採番（StoreScopeStampListener）と
+      // storeFilter/@FilterDef の共通土台が全 store-scoped 集約へ機構的に効く。豁免リストは持たない。
+      if (!StoreScopedEntity.class.isAssignableFrom(entity)) {
+        offenders.add(entity.getName());
+      }
+    }
+
+    assertThat(scanned).isNotEmpty();
+    assertThat(offenders)
+        .as("store_id 列を持つが StoreScopedEntity を継承していない @Entity（採番・行レベル分離の共通土台から外れる）")
+        .isEmpty();
+  }
+
+  @Test
   @DisplayName("storeFilter は主キー直接ロード（EntityManager#find 経由の findById 等）にも適用されること")
   void storeFilterAppliesToLoadByKey() {
     // @FilterDef は Hibernate 6 で repeatable のため、storeFilter の定義を名前で取り出す

--- a/backend/src/test/java/com/kizuna/cast/application/CastFieldDefinitionServiceTest.java
+++ b/backend/src/test/java/com/kizuna/cast/application/CastFieldDefinitionServiceTest.java
@@ -15,7 +15,6 @@ import com.kizuna.cast.domain.CastFieldDefinition;
 import com.kizuna.cast.domain.CastFieldDefinitionPatch;
 import com.kizuna.cast.domain.CastFieldDefinitionRepository;
 import com.kizuna.shared.exception.ServiceException;
-import com.kizuna.shared.storescope.StoreContext;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,7 +29,6 @@ class CastFieldDefinitionServiceTest {
 
   @Mock private CastFieldDefinitionRepository repository;
   @Mock private CastFieldDefinitionMapper mapper;
-  @Mock private StoreContext storeContext;
 
   @InjectMocks private CastFieldDefinitionService service;
 
@@ -42,11 +40,10 @@ class CastFieldDefinitionServiceTest {
   }
 
   @Test
-  void create_autoNumbersFromZeroWhenEmptyAndSetsStoreId() {
+  void create_autoNumbersFromZeroWhenEmpty() {
     when(repository.existsByKey("blood_type")).thenReturn(false);
     when(repository.count()).thenReturn(0L);
     when(repository.findMaxDisplayOrder()).thenReturn(null);
-    when(storeContext.getStoreId()).thenReturn(7L);
     when(repository.saveAndFlush(any())).thenAnswer(i -> i.getArgument(0));
     when(mapper.toResponse(any())).thenReturn(new CastFieldDefinitionResponse());
 
@@ -55,7 +52,6 @@ class CastFieldDefinitionServiceTest {
     ArgumentCaptor<CastFieldDefinition> captor = ArgumentCaptor.forClass(CastFieldDefinition.class);
     verify(repository).saveAndFlush(captor.capture());
     assertThat(captor.getValue().getDisplayOrder()).isEqualTo(0);
-    assertThat(captor.getValue().getStoreId()).isEqualTo(7L);
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/cast/application/CastServiceTest.java
+++ b/backend/src/test/java/com/kizuna/cast/application/CastServiceTest.java
@@ -21,9 +21,6 @@ import com.kizuna.cast.domain.CastInvitationStatus;
 import com.kizuna.cast.domain.CastPatch;
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.exception.ServiceException;
-import com.kizuna.shared.storescope.StoreContext;
-import com.kizuna.store.domain.Store;
-import com.kizuna.store.domain.StoreRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -41,8 +38,6 @@ class CastServiceTest {
 
   @Mock private CastRepository castRepository;
   @Mock private CastMapper castMapper;
-  @Mock private StoreContext storeContext;
-  @Mock private StoreRepository storeRepository;
   @Mock private CastInvitationService castInvitationService;
   @Mock private CastFieldDefinitionRepository castFieldDefinitionRepository;
 
@@ -132,12 +127,7 @@ class CastServiceTest {
 
     Cast castEntity = Cast.builder().name("G1").build();
 
-    Store store = new Store();
-    store.setId(1L);
-
     when(castMapper.toEntity(req)).thenReturn(castEntity);
-    when(storeContext.getStoreId()).thenReturn(1L);
-    when(storeRepository.findById(1L)).thenReturn(Optional.of(store));
 
     when(castRepository.save(any()))
         .thenAnswer(
@@ -153,20 +143,6 @@ class CastServiceTest {
 
     CastResponse res = castService.create(req);
     assertThat(res.getId()).isEqualTo("g_new");
-  }
-
-  @Test
-  void create_throwsWhenStoreNotFound() {
-    CastCreateRequest req = new CastCreateRequest();
-    req.setName("G1");
-
-    when(castMapper.toEntity(req)).thenReturn(new Cast());
-    when(storeContext.getStoreId()).thenReturn(1L);
-    when(storeRepository.findById(1L)).thenReturn(Optional.empty());
-
-    assertThatThrownBy(() -> castService.create(req))
-        .isInstanceOf(ServiceException.class)
-        .hasMessageContaining("店舗が見つかりません");
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/customer/application/CustomerServiceTest.java
+++ b/backend/src/test/java/com/kizuna/customer/application/CustomerServiceTest.java
@@ -14,9 +14,6 @@ import com.kizuna.customer.domain.Customer;
 import com.kizuna.customer.domain.CustomerPatch;
 import com.kizuna.customer.domain.CustomerRepository;
 import com.kizuna.shared.exception.ServiceException;
-import com.kizuna.shared.storescope.StoreContext;
-import com.kizuna.store.domain.Store;
-import com.kizuna.store.domain.StoreRepository;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -35,8 +32,6 @@ class CustomerServiceTest {
 
   @Mock private CustomerRepository customerRepository;
   @Mock private CustomerMapper customerMapper;
-  @Mock private StoreContext storeContext;
-  @Mock private StoreRepository storeRepository;
 
   @InjectMocks private CustomerService customerService;
 
@@ -107,12 +102,7 @@ class CustomerServiceTest {
 
     Customer customerEntity = Customer.builder().name("New").build();
 
-    Store store = new Store();
-    store.setId(1L);
-
     when(customerMapper.toEntity(req)).thenReturn(customerEntity);
-    when(storeContext.getStoreId()).thenReturn(1L);
-    when(storeRepository.findById(1L)).thenReturn(Optional.of(store));
 
     when(customerRepository.save(any()))
         .thenAnswer(
@@ -130,20 +120,6 @@ class CustomerServiceTest {
     CustomerResponse res = customerService.create(req);
     assertThat(res.getId()).isEqualTo("new_id");
     assertThat(res.getName()).isEqualTo("New");
-  }
-
-  @Test
-  void create_throwsWhenStoreNotFound() {
-    CustomerCreateRequest req = new CustomerCreateRequest();
-    req.setName("New");
-
-    when(customerMapper.toEntity(req)).thenReturn(new Customer());
-    when(storeContext.getStoreId()).thenReturn(1L);
-    when(storeRepository.findById(1L)).thenReturn(Optional.empty());
-
-    assertThatThrownBy(() -> customerService.create(req))
-        .isInstanceOf(ServiceException.class)
-        .hasMessageContaining("店舗が見つかりません");
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
@@ -25,8 +25,6 @@ import com.kizuna.order.domain.OrderStatus;
 import com.kizuna.order.domain.OrderView;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreContext;
-import com.kizuna.store.domain.Store;
-import com.kizuna.store.domain.StoreRepository;
 import com.kizuna.user.domain.Capability;
 import com.kizuna.user.domain.CapabilityBundleRepository;
 import com.kizuna.user.domain.PlatformUser;
@@ -57,7 +55,6 @@ class OrderServiceTest {
   @Mock CastRepository castRepository;
   @Mock PlatformUserRepository platformUserRepository;
   @Mock CapabilityBundleRepository capabilityBundleRepository;
-  @Mock StoreRepository storeRepository;
   @Mock StoreContext storeContext;
   @Mock OrderMapper orderMapper;
 
@@ -157,7 +154,6 @@ class OrderServiceTest {
     OrderResponse res = OrderResponse.builder().status("CREATED").build();
 
     when(storeContext.getStoreId()).thenReturn(1L);
-    when(storeRepository.findById(1L)).thenReturn(Optional.of(new Store()));
     when(orderMapper.toEntity(req)).thenReturn(entity);
     when(customerRepository.existsById("c1")).thenReturn(true);
     when(castRepository.existsById("g1")).thenReturn(true);
@@ -186,7 +182,6 @@ class OrderServiceTest {
     Customer newCustomer = Customer.builder().phoneNumber("09012345678").build();
 
     when(storeContext.getStoreId()).thenReturn(1L);
-    when(storeRepository.findById(1L)).thenReturn(Optional.of(new Store()));
     when(orderMapper.toEntity(req)).thenReturn(Order.builder().build());
     when(customerRepository.findByPhoneNumberAndStoreId("09012345678", 1L))
         .thenReturn(Optional.empty());
@@ -214,7 +209,6 @@ class OrderServiceTest {
     req.setReceptionistId(1L);
 
     when(storeContext.getStoreId()).thenReturn(STORE_ID);
-    when(storeRepository.findById(STORE_ID)).thenReturn(Optional.of(new Store()));
     when(orderMapper.toEntity(req)).thenReturn(Order.builder().build());
     when(castRepository.existsById("g1")).thenReturn(true);
     // 別店舗(store_id=2)専用スコープ: 現店舗(=1)を授権しない
@@ -235,7 +229,6 @@ class OrderServiceTest {
     req.setReceptionistId(1L);
 
     when(storeContext.getStoreId()).thenReturn(STORE_ID);
-    when(storeRepository.findById(STORE_ID)).thenReturn(Optional.of(new Store()));
     when(orderMapper.toEntity(req)).thenReturn(Order.builder().build());
     when(castRepository.existsById("g1")).thenReturn(true);
     // 全店舗授権でも CAST 本人種別は受付担当者になれない
@@ -255,7 +248,6 @@ class OrderServiceTest {
     req.setReceptionistId(1L);
 
     when(storeContext.getStoreId()).thenReturn(STORE_ID);
-    when(storeRepository.findById(STORE_ID)).thenReturn(Optional.of(new Store()));
     when(orderMapper.toEntity(req)).thenReturn(Order.builder().build());
     when(castRepository.existsById("g1")).thenReturn(true);
     // 店舗を授権していても、束が ORDER_MANAGE を含まない STAFF（HQ 系束のみ等）は受付担当者になれない。
@@ -287,7 +279,6 @@ class OrderServiceTest {
     req.setReceptionistId(1L);
 
     when(storeContext.getStoreId()).thenReturn(STORE_ID);
-    when(storeRepository.findById(STORE_ID)).thenReturn(Optional.of(new Store()));
     when(orderMapper.toEntity(req)).thenReturn(Order.builder().build());
     when(castRepository.existsById("g1")).thenReturn(true);
     // 停止(enabled=false)された STAFF は束・店舗授権を保持したままだが、受付担当者にはなれない（PR#399 codex 指摘）。

--- a/backend/src/test/java/com/kizuna/order/application/PlatformOrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/PlatformOrderServiceTest.java
@@ -1,11 +1,9 @@
 package com.kizuna.order.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,55 +13,28 @@ import com.kizuna.order.api.dto.PlatformOrderCreateRequest;
 import com.kizuna.order.api.dto.PlatformOrderResponse;
 import com.kizuna.order.domain.OrderRepository;
 import com.kizuna.order.domain.PlatformOrderView;
-import com.kizuna.shared.exception.ServiceException;
-import com.kizuna.shared.storescope.StoreContext;
-import io.jsonwebtoken.Claims;
+import com.kizuna.shared.storescope.StoreScopeExecutor;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 @ExtendWith(MockitoExtension.class)
 class PlatformOrderServiceTest {
 
   @Mock OrderRepository orderRepository;
   @Mock OrderService orderService;
+  @Mock StoreScopeExecutor storeScopeExecutor;
   @Mock OrderMapper orderMapper;
 
-  // create は実物の StoreContext を注入し、OrderService.create 呼び出し時点の storeId を捕捉して検証する。
-  private final StoreContext storeContext = new StoreContext();
-  private PlatformOrderService service;
-
-  @BeforeEach
-  void setUp() {
-    service = new PlatformOrderService(orderRepository, orderService, storeContext, orderMapper);
-  }
-
-  @AfterEach
-  void clearContext() {
-    SecurityContextHolder.clearContext();
-    storeContext.clear();
-  }
-
-  private void authenticate(String scopeType, Object storeIds) {
-    Claims claims = mock(Claims.class);
-    lenient().when(claims.get("storeScopeType", String.class)).thenReturn(scopeType);
-    lenient().when(claims.get("storeIds")).thenReturn(storeIds);
-    Authentication auth = mock(Authentication.class);
-    lenient().when(auth.getDetails()).thenReturn(claims);
-    SecurityContextHolder.getContext().setAuthentication(auth);
-  }
+  @InjectMocks PlatformOrderService service;
 
   private PlatformOrderCreateRequest requestForStore(long storeId) {
     PlatformOrderCreateRequest req = new PlatformOrderCreateRequest();
@@ -89,77 +60,25 @@ class PlatformOrderServiceTest {
   }
 
   @Test
-  void createFailsClosedWhenScopeUnresolved() {
-    // 認証コンテキスト未設定 → StoreScope 解決不能
-    assertThatThrownBy(() -> service.create(requestForStore(1L)))
-        .isInstanceOf(AccessDeniedException.class);
-
-    verify(orderService, never()).create(any());
-    assertThat(storeContext.getStoreId()).isNull();
-  }
-
-  @Test
-  void createRejectsOutOfSetStore() {
-    authenticate("SPECIFIC_STORES", List.of(1));
-
-    assertThatThrownBy(() -> service.create(requestForStore(2L)))
-        .isInstanceOf(AccessDeniedException.class);
-
-    verify(orderService, never()).create(any());
-    assertThat(storeContext.getStoreId()).isNull();
-  }
-
-  @Test
-  void createSetsStoreContextForAuthorizedStoreAndClearsAfter() {
-    authenticate("SPECIFIC_STORES", List.of(1));
-    PlatformOrderCreateRequest req = requestForStore(1L);
+  void createDelegatesToExecutorWithRequestStoreId() {
+    PlatformOrderCreateRequest req = requestForStore(7L);
     OrderResponse res = OrderResponse.builder().id("o1").build();
+    when(storeScopeExecutor.runInStore(eq(7L), any())).thenReturn(res);
 
-    AtomicReference<Long> storeAtCall = new AtomicReference<>();
-    when(orderService.create(req))
-        .thenAnswer(
-            inv -> {
-              storeAtCall.set(storeContext.getStoreId());
-              return res;
-            });
-
-    OrderResponse result = service.create(req);
-
-    assertThat(result).isSameAs(res);
-    assertThat(storeAtCall.get())
-        .as("OrderService.create 呼び出し時点で StoreContext が storeId")
-        .isEqualTo(1L);
-    assertThat(storeContext.getStoreId()).as("復帰後は finally で clear 済み").isNull();
+    assertThat(service.create(req)).isSameAs(res);
   }
 
   @Test
-  void createAllowsAnyStoreForAllStoresScope() {
-    authenticate("ALL_STORES", null);
-    PlatformOrderCreateRequest req = requestForStore(999L);
+  @SuppressWarnings("unchecked")
+  void createRunsOrderServiceCreateAsScopedAction() {
+    PlatformOrderCreateRequest req = requestForStore(7L);
     OrderResponse res = OrderResponse.builder().id("o1").build();
+    when(orderService.create(req)).thenReturn(res);
+    // executor へ渡された action（Supplier）を実行させ、orderService.create が呼ばれることを固定する
+    when(storeScopeExecutor.runInStore(eq(7L), any()))
+        .thenAnswer(inv -> ((Supplier<OrderResponse>) inv.getArgument(1)).get());
 
-    AtomicReference<Long> storeAtCall = new AtomicReference<>();
-    when(orderService.create(req))
-        .thenAnswer(
-            inv -> {
-              storeAtCall.set(storeContext.getStoreId());
-              return res;
-            });
-
-    service.create(req);
-
-    assertThat(storeAtCall.get()).isEqualTo(999L);
-    assertThat(storeContext.getStoreId()).isNull();
-  }
-
-  @Test
-  void createClearsStoreContextEvenWhenOrderServiceThrows() {
-    authenticate("SPECIFIC_STORES", List.of(1));
-    PlatformOrderCreateRequest req = requestForStore(1L);
-
-    when(orderService.create(req)).thenThrow(new ServiceException("boom"));
-
-    assertThatThrownBy(() -> service.create(req)).isInstanceOf(ServiceException.class);
-    assertThat(storeContext.getStoreId()).as("例外時も finally で clear される").isNull();
+    assertThat(service.create(req)).isSameAs(res);
+    verify(orderService).create(req);
   }
 }

--- a/backend/src/test/java/com/kizuna/settings/api/platform/PlatformConfigControllerTest.java
+++ b/backend/src/test/java/com/kizuna/settings/api/platform/PlatformConfigControllerTest.java
@@ -15,6 +15,7 @@ import com.kizuna.settings.api.dto.SystemConfigUpdateRequest;
 import com.kizuna.settings.application.SystemConfigService;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreContext;
+import com.kizuna.store.domain.StoreRepository;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,6 +46,10 @@ class PlatformConfigControllerTest {
   @MockitoBean private JwtUtil jwtUtil;
 
   @MockitoBean private TokenBlacklistService tokenBlacklistService;
+
+  // StoreExistenceInterceptor（HandlerInterceptor）の依存。@WebMvcTest は HandlerInterceptor を
+  // 取り込むため、MaintenanceModeInterceptor の SystemConfigService と同様にモックを用意する。
+  @MockitoBean private StoreRepository storeRepository;
 
   @Test
   @DisplayName("PERM_SYSTEM_CONFIG_MANAGE 権限があれば設定一覧を取得できること")

--- a/backend/src/test/java/com/kizuna/settings/api/platform/PlatformConfigControllerTest.java
+++ b/backend/src/test/java/com/kizuna/settings/api/platform/PlatformConfigControllerTest.java
@@ -15,7 +15,7 @@ import com.kizuna.settings.api.dto.SystemConfigUpdateRequest;
 import com.kizuna.settings.application.SystemConfigService;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreContext;
-import com.kizuna.store.domain.StoreRepository;
+import com.kizuna.shared.storescope.StoreExistenceCheck;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,8 +48,8 @@ class PlatformConfigControllerTest {
   @MockitoBean private TokenBlacklistService tokenBlacklistService;
 
   // StoreExistenceInterceptor（HandlerInterceptor）の依存。@WebMvcTest は HandlerInterceptor を
-  // 取り込むため、MaintenanceModeInterceptor の SystemConfigService と同様にモックを用意する。
-  @MockitoBean private StoreRepository storeRepository;
+  // 取り込むため、MaintenanceModeInterceptor の SystemConfigService と同様にポートのモックを用意する。
+  @MockitoBean private StoreExistenceCheck storeExistenceCheck;
 
   @Test
   @DisplayName("PERM_SYSTEM_CONFIG_MANAGE 権限があれば設定一覧を取得できること")

--- a/backend/src/test/java/com/kizuna/shared/persistence/StoreScopeStampListenerTest.java
+++ b/backend/src/test/java/com/kizuna/shared/persistence/StoreScopeStampListenerTest.java
@@ -1,0 +1,56 @@
+package com.kizuna.shared.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.kizuna.shared.storescope.StoreContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link StoreScopeStampListener} の @PrePersist 採番挙動を固定する。実 {@link StoreContext}（ThreadLocal）を用い、
+ * 設定済み尊重・文脈からの採番・文脈欠如での fail-loud の三分岐を検証する。
+ */
+class StoreScopeStampListenerTest {
+
+  private final StoreContext storeContext = new StoreContext();
+  private final StoreScopeStampListener listener = new StoreScopeStampListener(storeContext);
+
+  /** テスト用の具象 store-scoped エンティティ（JPA 不使用の POJO）。 */
+  private static final class TestEntity extends StoreScopedEntity {}
+
+  @AfterEach
+  void clearContext() {
+    storeContext.clear();
+  }
+
+  @Test
+  void preSetStoreIdIsRespected() {
+    storeContext.setStoreId(99L);
+    TestEntity entity = new TestEntity();
+    entity.setStoreId(5L);
+
+    listener.stampStoreId(entity);
+
+    assertThat(entity.getStoreId()).as("設定済みの値は文脈より優先される").isEqualTo(5L);
+  }
+
+  @Test
+  void stampsFromContextWhenUnset() {
+    storeContext.setStoreId(42L);
+    TestEntity entity = new TestEntity();
+
+    listener.stampStoreId(entity);
+
+    assertThat(entity.getStoreId()).isEqualTo(42L);
+  }
+
+  @Test
+  void failsLoudWhenContextMissing() {
+    TestEntity entity = new TestEntity();
+
+    assertThatThrownBy(() -> listener.stampStoreId(entity))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("店舗文脈");
+  }
+}

--- a/backend/src/test/java/com/kizuna/shared/storescope/StoreScopeExecutorTest.java
+++ b/backend/src/test/java/com/kizuna/shared/storescope/StoreScopeExecutorTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
+import com.kizuna.shared.exception.ServiceException;
 import io.jsonwebtoken.Claims;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -25,7 +26,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 class StoreScopeExecutorTest {
 
   private final StoreContext storeContext = new StoreContext();
-  private final StoreScopeExecutor executor = new StoreScopeExecutor(storeContext);
+
+  /** 店舗存在性ポートの返値をテストごとに切り替える（既定は実在）。 */
+  private boolean storeExists = true;
+
+  private final StoreScopeExecutor executor =
+      new StoreScopeExecutor(storeContext, storeId -> storeExists);
 
   @AfterEach
   void clearContext() {
@@ -78,6 +84,27 @@ class StoreScopeExecutorTest {
 
     assertThat(ran).isFalse();
     assertThat(storeContext.getStoreId()).isNull();
+  }
+
+  @Test
+  void rejectsNonexistentStoreWith400AndNeverSetsContext() {
+    authenticate("ALL_STORES", null);
+    storeExists = false;
+    AtomicBoolean ran = new AtomicBoolean(false);
+
+    assertThatThrownBy(
+            () ->
+                executor.runInStore(
+                    999L,
+                    () -> {
+                      ran.set(true);
+                      return "x";
+                    }))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("店舗が見つかりません");
+
+    assertThat(ran).as("action は実行されないこと").isFalse();
+    assertThat(storeContext.getStoreId()).as("存在しない店舗では文脈を設定しないこと").isNull();
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/shared/storescope/StoreScopeExecutorTest.java
+++ b/backend/src/test/java/com/kizuna/shared/storescope/StoreScopeExecutorTest.java
@@ -1,0 +1,132 @@
+package com.kizuna.shared.storescope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import io.jsonwebtoken.Claims;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * {@link StoreScopeExecutor} の授権検査・文脈 set→action→clear ライフサイクル（例外時の clear 含む）を実 {@link
+ * StoreContext} で固定する。旧 PlatformOrderServiceTest が実 StoreContext で担っていた検証を本 seam のテストへ移した。
+ */
+@ExtendWith(MockitoExtension.class)
+class StoreScopeExecutorTest {
+
+  private final StoreContext storeContext = new StoreContext();
+  private final StoreScopeExecutor executor = new StoreScopeExecutor(storeContext);
+
+  @AfterEach
+  void clearContext() {
+    SecurityContextHolder.clearContext();
+    storeContext.clear();
+  }
+
+  private void authenticate(String scopeType, Object storeIds) {
+    Claims claims = mock(Claims.class);
+    lenient().when(claims.get("storeScopeType", String.class)).thenReturn(scopeType);
+    lenient().when(claims.get("storeIds")).thenReturn(storeIds);
+    Authentication auth = mock(Authentication.class);
+    lenient().when(auth.getDetails()).thenReturn(claims);
+    SecurityContextHolder.getContext().setAuthentication(auth);
+  }
+
+  @Test
+  void failsClosedWhenScopeUnresolved() {
+    // 認証コンテキスト未設定 → StoreScope 解決不能
+    AtomicBoolean ran = new AtomicBoolean(false);
+
+    assertThatThrownBy(
+            () ->
+                executor.runInStore(
+                    1L,
+                    () -> {
+                      ran.set(true);
+                      return "x";
+                    }))
+        .isInstanceOf(AccessDeniedException.class);
+
+    assertThat(ran).as("action は実行されないこと").isFalse();
+    assertThat(storeContext.getStoreId()).isNull();
+  }
+
+  @Test
+  void rejectsOutOfSetStore() {
+    authenticate("SPECIFIC_STORES", List.of(1));
+    AtomicBoolean ran = new AtomicBoolean(false);
+
+    assertThatThrownBy(
+            () ->
+                executor.runInStore(
+                    2L,
+                    () -> {
+                      ran.set(true);
+                      return "x";
+                    }))
+        .isInstanceOf(AccessDeniedException.class);
+
+    assertThat(ran).isFalse();
+    assertThat(storeContext.getStoreId()).isNull();
+  }
+
+  @Test
+  void runsActionUnderStoreScopeAndClearsAfter() {
+    authenticate("SPECIFIC_STORES", List.of(1));
+    AtomicReference<Long> storeAtCall = new AtomicReference<>();
+
+    String result =
+        executor.runInStore(
+            1L,
+            () -> {
+              storeAtCall.set(storeContext.getStoreId());
+              return "ok";
+            });
+
+    assertThat(result).isEqualTo("ok");
+    assertThat(storeAtCall.get()).as("action 実行時点で StoreContext が storeId").isEqualTo(1L);
+    assertThat(storeContext.getStoreId()).as("復帰後は finally で clear 済み").isNull();
+  }
+
+  @Test
+  void allowsAnyStoreForAllStoresScope() {
+    authenticate("ALL_STORES", null);
+    AtomicReference<Long> storeAtCall = new AtomicReference<>();
+
+    executor.runInStore(
+        999L,
+        () -> {
+          storeAtCall.set(storeContext.getStoreId());
+          return "ok";
+        });
+
+    assertThat(storeAtCall.get()).isEqualTo(999L);
+    assertThat(storeContext.getStoreId()).isNull();
+  }
+
+  @Test
+  void clearsContextEvenWhenActionThrows() {
+    authenticate("SPECIFIC_STORES", List.of(1));
+
+    assertThatThrownBy(
+            () ->
+                executor.runInStore(
+                    1L,
+                    () -> {
+                      throw new IllegalStateException("boom");
+                    }))
+        .isInstanceOf(IllegalStateException.class);
+
+    assertThat(storeContext.getStoreId()).as("例外時も finally で clear される").isNull();
+  }
+}

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
@@ -11,7 +11,6 @@ import com.kizuna.cast.domain.Cast;
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.config.AppProperties;
 import com.kizuna.shared.exception.ServiceException;
-import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.shift.api.dto.PublicShiftResponse;
 import com.kizuna.shift.api.dto.ShiftCreateRequest;
 import com.kizuna.shift.api.dto.ShiftMapper;
@@ -20,8 +19,6 @@ import com.kizuna.shift.api.dto.ShiftUpdateRequest;
 import com.kizuna.shift.domain.Shift;
 import com.kizuna.shift.domain.ShiftPatch;
 import com.kizuna.shift.domain.ShiftRepository;
-import com.kizuna.store.domain.Store;
-import com.kizuna.store.domain.StoreRepository;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -39,8 +36,6 @@ class ShiftServiceTest {
 
   @Mock private ShiftRepository shiftRepository;
   @Mock private ShiftMapper shiftMapper;
-  @Mock private StoreContext storeContext;
-  @Mock private StoreRepository storeRepository;
   @Mock private CastService castService;
   @Mock private CastRepository castRepository;
   @Mock private AppProperties appProperties;
@@ -73,17 +68,13 @@ class ShiftServiceTest {
   }
 
   @Test
-  void create_setsStoreIdAndSaves() {
+  void create_savesAndReturns() {
     ShiftCreateRequest req = validCreateRequest();
 
     Shift entity = Shift.builder().castId("c1").status("TENTATIVE").build();
-    Store store = new Store();
-    store.setId(1L);
 
     when(castService.existsForCurrentStore("c1")).thenReturn(true);
     when(shiftMapper.toEntity(req)).thenReturn(entity);
-    when(storeContext.getStoreId()).thenReturn(1L);
-    when(storeRepository.findById(1L)).thenReturn(Optional.of(store));
     when(shiftRepository.save(any()))
         .thenAnswer(
             i -> {
@@ -98,7 +89,6 @@ class ShiftServiceTest {
 
     ShiftResponse res = shiftService.create(req);
     assertThat(res.getId()).isEqualTo("s_new");
-    assertThat(entity.getStoreId()).isEqualTo(1L);
   }
 
   @Test
@@ -110,20 +100,6 @@ class ShiftServiceTest {
     assertThatThrownBy(() -> shiftService.create(req))
         .isInstanceOf(ServiceException.class)
         .hasMessageContaining("開始時刻と終了時刻");
-  }
-
-  @Test
-  void create_throwsWhenStoreNotFound() {
-    ShiftCreateRequest req = validCreateRequest();
-
-    when(castService.existsForCurrentStore("c1")).thenReturn(true);
-    when(shiftMapper.toEntity(req)).thenReturn(Shift.builder().build());
-    when(storeContext.getStoreId()).thenReturn(1L);
-    when(storeRepository.findById(1L)).thenReturn(Optional.empty());
-
-    assertThatThrownBy(() -> shiftService.create(req))
-        .isInstanceOf(ServiceException.class)
-        .hasMessageContaining("店舗が見つかりません");
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/storeprofile/application/StoreProfileServiceTest.java
+++ b/backend/src/test/java/com/kizuna/storeprofile/application/StoreProfileServiceTest.java
@@ -52,7 +52,7 @@ class StoreProfileServiceTest {
 
     StoreProfileResponse response = storeProfileService.get();
 
-    assertThat(response.getId()).isEqualTo(1L);
+    assertThat(response.getId()).isEqualTo("1");
     assertThat(response.getTemplateKey()).isEqualTo("default");
     assertThat(response.getLogoUrl()).isEqualTo("https://example.com/logo.png");
   }
@@ -156,7 +156,7 @@ class StoreProfileServiceTest {
 
   private StoreProfile createTestConfig() {
     StoreProfile config = new StoreProfile();
-    config.setId(1L);
+    config.setId("1");
     config.setTemplateKey("default");
     config.setLogoUrl("https://example.com/logo.png");
     config.setMvType("image");
@@ -169,7 +169,7 @@ class StoreProfileServiceTest {
 
   private StoreProfileResponse createTestResponse() {
     return StoreProfileResponse.builder()
-        .id(1L)
+        .id("1")
         .templateKey("default")
         .logoUrl("https://example.com/logo.png")
         .mvType("image")

--- a/frontend/src/entities/store-profile/model/types.ts
+++ b/frontend/src/entities/store-profile/model/types.ts
@@ -14,7 +14,7 @@ export interface PartnerLink {
 
 // 店舗サイト設定レスポンス
 export interface StoreProfileResponse {
-  id: number;
+  id: string;
   template_key: string;
   logo_url?: string;
   banner_url?: string;


### PR DESCRIPTION
## 概要

新しい store-scoped 集約を追加する際の五段配方（基類継承・@Filter・storeId 手動設定・存在性検証・@StoreScoped）のうち人の記憶に依存していた部分を storescope seam へ吞み込み、店舗存在性の保証点を「文脈確立点」（店舗側=インターセプタ / 平台側=実行 seam）へ集約する。#379〜#397 の spec 票群で配方が繰り返される前の深化。

Closes #429

## 変更内容

- **@PrePersist 採番**: `StoreScopeStampListener`（SpringBeanContainer 経由の DI）が `StoreContext` から store_id を自動採番。設定済み値は尊重（CastInvitation の cast 由来 copy・IT の canary 直挿を保護）、文脈欠落は fail-loud。5 箇所+2 変種の「店舗解決+setStoreId」四行様板を全削除
- **店舗存在性インターセプタ**: `StoreExistenceInterceptor`（store モジュール、StoreIdInterceptor 後段、`/store/**`・`/files/**`）が毎リクエスト 1 回検証、`{"error":"店舗が見つかりません"}` の 400（陳旧 JWT の storeId が FK 違反 500 に逃げる経路を封鎖 — #398 裁定準拠）
- **StoreProfile 帰隊**: `StoreScopedEntity` 継承化+PK BIGINT IDENTITY→VARCHAR(64)/Snowflake 移行（v0.2.0 新 changeset、既存 id は `id::text` 変換、baseline 不可触）。子表 FK なし・seed 2 行は変換で追随・frontend は id 型のみ追随
- **fitness test 拡張**: `StoreIsolationTests` に「store_id 列保持 @Entity は StoreScopedEntity 継承必須（豁免なし）」を追加（埋め込み違反で負向検証済み）
- **平台側実行 seam**: `StoreScopeExecutor`（shared/storescope）が authorize+存在性検証+set+finally clear の舞踏を吞む。`PlatformOrderService.create` を移行し手書き set/clear を撤去。存在性は `StoreExistenceCheck` port（shared 定義・store 実装 = Modulith 許容方向の跨模块 port）経由
- **Modulith docs 追随**: order/customer/shift の `StoreRepository` 依存辺消滅、shared/store の新 Bean を反映（`all-docs.adoc` は並び替えのみのため据え置き）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（backend 単体 337+、integration 全緑 — 移行 replay・リスナ実 DI・帰隊 roundtrip・400 保証 IT 含む）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 18/18 全緑）
- [x] ローカルで code-review 実施済み（fable 二軸 Standards/Spec、指摘対応 4 commits）

## 決定ログ

- 存在性検証の置き場は grilling 裁定どおり「文脈確立点」: 店舗側は store モジュールのインターセプタ（shared→store の逆依存回避）、平台側は実行 seam 内の port 経由。実装中に発見した平台経路の 400→500 退行（ALL_STORES ユーザー×実在しない storeId）はこの原則の適用で修復し、IT で固定
- 採番リスナは静的 ThreadLocal 橋ではなく SpringBeanContainer の DI を採用（IT が実挙動を証明）
- StoreProfile PK 移行は帰隊の前提として同票内で実施（ユーザー裁定）。既存数値 id はテキスト表現へ変換し連続性を維持
- fail-loud 例外（文脈なし persist=開発者エラー）は 500 で正しい — ユーザー起因の経路はインターセプタ/executor が 400 を保証済み

## 備考 / レビュー観点

- **⚠️ 共有 dev 卷に v0.2.0 適用済み**（e2e 実行時）: master ビルドのイメージは StoreProfile 経路で dev DB と非互換のため、本 PR のマージ窓口は最短推奨（既知の坑C）
- changeset の rollback は型のみ復元（IDENTITY は復元しない）— 規約上の要求なし、記録のみ
- `StoreIsolationTests` の検出は `@Column(name="store_id")` 宣言ベース — `@JoinColumn` 経由で同列を持つ変則実体は検出外（#216 由来の既存検出定義を踏襲、既知の境界として記録)
- `@WebMvcTest`（PlatformConfigControllerTest）は interceptor 依存の `StoreExistenceCheck` を `@MockitoBean` 供給 — 新 interceptor 追加時は slice test への波及に注意

🤖 Generated with [Claude Code](https://claude.com/claude-code)