### PR TITLE
refactor: 認証エラー応答を例外型→固定文言マッピングへ分離する

### DIFF
--- a/backend/src/main/java/com/kizuna/shared/exception/CommonExceptionHandler.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/CommonExceptionHandler.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -19,12 +21,23 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 @ControllerAdvice
 public class CommonExceptionHandler {
 
+  /** 例外の内部 message をワイヤ契約へ漏らさないよう、型ごとに固定文言へ写像する。 */
   @ExceptionHandler(AuthenticationException.class)
   public ResponseEntity<Map<String, Object>> handle(AuthenticationException ex) {
     log.error(ex.getMessage());
     Map<String, Object> body = new HashMap<>();
-    body.put("error", ex.getMessage());
+    body.put("error", authErrorMessage(ex));
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+  }
+
+  private String authErrorMessage(AuthenticationException ex) {
+    if (ex instanceof DisabledException) {
+      return "アカウントが無効化されています";
+    }
+    if (ex instanceof BadCredentialsException) {
+      return "メールアドレスまたはパスワードが正しくありません";
+    }
+    return "認証に失敗しました";
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/test/java/com/kizuna/shared/exception/CommonExceptionHandlerTest.java
+++ b/backend/src/test/java/com/kizuna/shared/exception/CommonExceptionHandlerTest.java
@@ -1,0 +1,49 @@
+package com.kizuna.shared.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+
+/** {@link CommonExceptionHandler} の AuthenticationException 型別文言マッピングの単体テスト。 */
+class CommonExceptionHandlerTest {
+
+  private final CommonExceptionHandler handler = new CommonExceptionHandler();
+
+  @Test
+  @DisplayName("DisabledException は 401 かつ固定文言「アカウントが無効化されています」")
+  void disabledExceptionReturnsFixedMessage() {
+    ResponseEntity<Map<String, Object>> response =
+        handler.handle(new DisabledException("internal detail not for wire"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(response.getBody()).containsEntry("error", "アカウントが無効化されています");
+  }
+
+  @Test
+  @DisplayName("BadCredentialsException は 401 かつ固定文言「メールアドレスまたはパスワードが正しくありません」")
+  void badCredentialsExceptionReturnsFixedMessage() {
+    ResponseEntity<Map<String, Object>> response =
+        handler.handle(new BadCredentialsException("internal detail not for wire"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(response.getBody()).containsEntry("error", "メールアドレスまたはパスワードが正しくありません");
+  }
+
+  @Test
+  @DisplayName("その他の AuthenticationException は 401 かつ汎用固定文言「認証に失敗しました」で内部 message は透過しない")
+  void otherAuthenticationExceptionReturnsGenericFixedMessage() {
+    ResponseEntity<Map<String, Object>> response =
+        handler.handle(new InsufficientAuthenticationException("internal detail not for wire"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(response.getBody()).containsEntry("error", "認証に失敗しました");
+    assertThat(response.getBody()).doesNotContainValue("internal detail not for wire");
+  }
+}


### PR DESCRIPTION
## 概要

`CommonExceptionHandler` の `AuthenticationException` ハンドラを、`ex.getMessage()` 透過から「例外型 → 固定文言」写像へ変更する（挙動=文言・ステータスは不変）。統一ログインを Spring Security 標準スタックへ移行するシリーズの前捌き。

Closes #436

## 変更内容

- `backend/src/main/java/com/kizuna/shared/exception/CommonExceptionHandler.java`: `AuthenticationException` ハンドラを型別固定文言マッピングへ変更（`AccessDeniedException` ハンドラと同じ様式）。内部 `ex.getMessage()` は引き続き `log.error` にのみ出力し、応答 body には出さない。
- `backend/src/test/java/com/kizuna/shared/exception/CommonExceptionHandlerTest.java`(新規): 型別 3 分岐を固定するユニットテスト。

### 文言契約(1 バイトも変更なし)

| 例外型 | body の error 文言 |
|---|---|
| `DisabledException` | `アカウントが無効化されています` |
| `BadCredentialsException` | `メールアドレスまたはパスワードが正しくありません` |
| その他の `AuthenticationException`(新規汎用フォールバック) | `認証に失敗しました` |

`DisabledException`/`BadCredentialsException` は現行 `PlatformAuthService` が投げている message と同一文言を維持。汎用フォールバックは #437 以降フレームワークが英語メッセージ(`Bad credentials` 等)を投げるケースに備えた防御。

## 検証

- [x] `./gradlew spotlessCheck test` exit 0（新規 `CommonExceptionHandlerTest` 3 件緑 + 既存 unit 全緑）
- [x] `./gradlew test --tests "com.kizuna.auth.*PlatformAuthServiceTest"` exit 0（20 tests, 0 failures — auth パッケージ未変更につき影響なし確認）
- [x] `./gradlew compileIntegrationTestJava` exit 0（integration はステータスのみ断言のため影響なしと判断。DB 起動を伴う実行はローカルで別途補完可能）
- [ ] `task e2e`（本変更は文言・ステータス不変のワイヤ契約固定のみのため対象外）
- [x] ローカルで diff レビュー実施済み

### 前端ゼロ改修の確認

`frontend/src/shared/lib/apiError.ts` の `getApiErrorMessage` は `response.data.error` を最優先で返す（`message`・fallback より先）。本 PR は 3 型すべてで既存と同一の `error` 文言を維持するため、ログイン失敗トースト表示は不変。フロントエンド側の変更は不要かつ実施していない。

## 決定ログ

- `AccessDeniedException` ハンドラ(同ファイル 53-59 行)の「型→固定文言」実装様式にそのまま倣った。新規の抽象化・共通ヘルパーは導入していない。
- `PlatformAuthService`(`com.kizuna.auth` パッケージ)には触れていない。ハンドラ側リテラルと `PlatformAuthService.INVALID_CREDENTIALS_MESSAGE` が同じ値で並存する過渡期の重複は意図的（auth 側の収斂は #437 の担当）。
- テストはハンドラを直接 `new` して呼ぶ軽量な単体テスト（MockMvc は不要と判断）。

## 備考 / レビュー観点

- 本 PR は挙動変更ゼロの契約固定（リファクタ）。文言・ステータスコードは 1 バイトも変えていない。
- integration テストは DB 起動を伴うため worktree 内ではコンパイル確認(`compileIntegrationTestJava`)のみ実施。フルの `PlatformAuthIT` 実行はローカルで別途補完可能（ステータスのみ断言のテストのため影響なしと判断）。
- 後続 #437(login を `DaoAuthenticationProvider` へ移行)がこのマッピングを土台にする想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)