### PR TITLE
refactor: /platform/login を Spring Security 標準認証スタックへ移行する

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/auth/PlatformAuthIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/auth/PlatformAuthIT.java
@@ -40,6 +40,12 @@ class PlatformAuthIT {
   private static final String SPECIFIC_EMAIL = "manager@kizuna.test";
   private static final String SPECIFIC_PASSWORD = "pass";
 
+  private static final String DISABLED_EMAIL = "disabled@kizuna.test";
+  private static final String DISABLED_PASSWORD = "pass";
+
+  private static final String INVALID_CREDENTIALS_MESSAGE = "メールアドレスまたはパスワードが正しくありません";
+  private static final String DISABLED_ACCOUNT_MESSAGE = "アカウントが無効化されています";
+
   @Autowired private TestRestTemplate rest;
   @Autowired private CapabilityBundleRepository capabilityBundleRepository;
   @Autowired private PlatformUserRepository platformUserRepository;
@@ -84,11 +90,46 @@ class PlatformAuthIT {
   }
 
   @Test
-  @DisplayName("誤パスワードは 401（403 でないこと = CSRF 免除の回帰ガード）")
+  @DisplayName("誤パスワードは 401（403 でないこと = CSRF 免除の回帰ガード）+ 標準スタックの資格情報文言を返す")
   void wrongPasswordReturns401NotForbidden() {
     ResponseEntity<JsonNode> res = platformLogin(SEED_EMAIL, "wrong-password");
 
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(res.getBody().path("error").asString()).isEqualTo(INVALID_CREDENTIALS_MESSAGE);
+  }
+
+  @Test
+  @DisplayName("不存在メールは誤パスワードと同一の 401 文言を返す（AuthenticationManager の列挙耐性が実 DB で担保される）")
+  void missingEmailReturnsSameMessageAsWrongPassword() {
+    ResponseEntity<JsonNode> res = platformLogin("missing@kizuna.test", "whatever-password");
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(res.getBody().path("error").asString()).isEqualTo(INVALID_CREDENTIALS_MESSAGE);
+  }
+
+  @Test
+  @DisplayName("無効化アカウントは正パスワードでも 401 + 無効化文言を返す（enabled 判定がパスワード照合に先行する）")
+  void disabledAccountWithCorrectPasswordReturns401DisabledMessage() {
+    platformUserRepository
+        .findByEmail(DISABLED_EMAIL)
+        .orElseGet(
+            () ->
+                platformUserRepository.save(
+                    PlatformUser.builder()
+                        .email(DISABLED_EMAIL)
+                        .password(passwordEncoder.encode(DISABLED_PASSWORD))
+                        .displayName("無効化済み")
+                        .enabled(false)
+                        .userType(UserType.STAFF)
+                        .bundleIds(managerBundleIds())
+                        .storeScopeType(StoreScopeType.SPECIFIC_STORES)
+                        .storeIds(Set.of(1L))
+                        .build()));
+
+    ResponseEntity<JsonNode> res = platformLogin(DISABLED_EMAIL, DISABLED_PASSWORD);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(res.getBody().path("error").asString()).isEqualTo(DISABLED_ACCOUNT_MESSAGE);
   }
 
   @Test

--- a/backend/src/integrationTest/java/com/kizuna/auth/PlatformAuthIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/auth/PlatformAuthIT.java
@@ -24,7 +24,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import tools.jackson.databind.JsonNode;
 
 /**
- * 統一（プラットフォーム）認証境界の統合テスト（#322）。本物の PostgreSQL/Redis に対して検証する。
+ * 統一（プラットフォーム）認証境界の統合テスト。本物の PostgreSQL/Redis に対して検証する。
  *
  * <p>様式は {@link com.kizuna.menu.MenuCrossStoreIT}（リポジトリ直挿 + 実データ断言）に倣う。 匿名ログインの CSRF 免除、シード資格情報での
  * me 応答、および平台トークンの店舗端点への過橋拒否を HTTP 境界で固定する。
@@ -178,7 +178,7 @@ class PlatformAuthIT {
   }
 
   @Test
-  @DisplayName("platform トークンで店舗ヘッダなしの store 系 GET は 403（過橋 #324: 拒否主体は interceptor fail-closed）")
+  @DisplayName("platform トークンで店舗ヘッダなしの store 系 GET は 403（過橋: 拒否主体は interceptor fail-closed）")
   void platformTokenRejectedOnStoreEndpoint() {
     HttpHeaders headers = new HttpHeaders();
     headers.setBearerAuth(platformToken(SEED_EMAIL, SEED_PASSWORD));

--- a/backend/src/main/java/com/kizuna/auth/application/PlatformAuthService.java
+++ b/backend/src/main/java/com/kizuna/auth/application/PlatformAuthService.java
@@ -3,6 +3,7 @@ package com.kizuna.auth.application;
 import com.kizuna.auth.api.dto.PlatformMeResponse;
 import com.kizuna.auth.api.dto.Token;
 import com.kizuna.auth.infrastructure.JwtUtil;
+import com.kizuna.auth.infrastructure.PlatformUserDetails;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.domain.Capability;
 import com.kizuna.user.domain.CapabilityBundleRepository;
@@ -18,67 +19,43 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.DisabledException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * 統一（プラットフォーム）ログイン。既存の platform/store 二軌のコードパスに触れないため AuthenticationManager を経由せず、findByEmail +
- * enabled 判定 + パスワード照合を自前で行う。判定順は DaoAuthenticationProvider に倣い enabled を先行させ、無効化ユーザーはパスワードの正誤に関わらず
- * {@link DisabledException} を投げる（無効化アカウントでのパスワード正誤オラクルを塞ぐ）。 メール不存在時は既知メール（誤パスワード）との応答時間差を無くすため、ダミーの
- * bcrypt 照合を 1 回行ってからパスワード不一致と同一メッセージの {@link BadCredentialsException} を投げる（列挙耐性: メッセージ均一 +
- * タイミング均一。 DaoAuthenticationProvider.mitigateAgainstTimingAttack と同趣旨）。いずれの例外も {@code
- * AuthenticationException} 系のため 401 で応答される。
+ * 統一（プラットフォーム）ログイン。認証判定は AuthenticationManager（DaoAuthenticationProvider + 自作
+ * UserDetailsService）に委譲する。メール不存在・パスワード不一致は BadCredentialsException、無効化アカウントはパスワードの正誤に関わらず
+ * DisabledException が投げられる（enabled 判定がパスワード照合に先行するため、無効化アカウントでのパスワード正誤オラクルを塞ぐ）。列挙耐性・タイミング均一化も
+ * フレームワークの既定挙動が担う。いずれの例外も {@code AuthenticationException} 系のため 401 で応答される。
  *
  * <p>authorities の発行（#382 / #398）: STAFF は保持束の能力並集を {@code PERM_} 形式で発行し、CAST / MEMBER は本人種別標識
  * {@code ROLE_CAST} / {@code ROLE_MEMBER} のみを発行する。授権変更は次回ログインから反映される（会話失効なし — #325 既定）。
  */
 @Service
+@RequiredArgsConstructor
 public class PlatformAuthService {
-
-  private static final String INVALID_CREDENTIALS_MESSAGE = "メールアドレスまたはパスワードが正しくありません";
 
   private final PlatformUserRepository userRepository;
   private final CapabilityBundleRepository capabilityBundleRepository;
   private final PasswordEncoder passwordEncoder;
   private final JwtUtil jwtUtil;
   private final AuthSessionService authSessionService;
-
-  /** メール不存在時のタイミング均一化に用いるダミー bcrypt ハッシュ（秘密値ではない固定文字列を構築時に符号化）。 */
-  private final String userNotFoundEncodedPassword;
-
-  public PlatformAuthService(
-      PlatformUserRepository userRepository,
-      CapabilityBundleRepository capabilityBundleRepository,
-      PasswordEncoder passwordEncoder,
-      JwtUtil jwtUtil,
-      AuthSessionService authSessionService) {
-    this.userRepository = userRepository;
-    this.capabilityBundleRepository = capabilityBundleRepository;
-    this.passwordEncoder = passwordEncoder;
-    this.jwtUtil = jwtUtil;
-    this.authSessionService = authSessionService;
-    this.userNotFoundEncodedPassword = passwordEncoder.encode("userNotFoundPassword");
-  }
+  private final AuthenticationManager authenticationManager;
 
   @Transactional(readOnly = true)
   public Token login(String email, String password) {
     // 平台側 email は小文字で保存されるため（保存済みシードは全て小文字）、照合前に正規化する。
     String normalizedEmail = email.toLowerCase(Locale.ROOT);
-    PlatformUser user = userRepository.findByEmail(normalizedEmail).orElse(null);
-    if (user == null) {
-      // メール不存在でも既知メール（誤パスワード）と同等の時間を要するようダミー照合を実行する。
-      passwordEncoder.matches(password, userNotFoundEncodedPassword);
-      throw new BadCredentialsException(INVALID_CREDENTIALS_MESSAGE);
-    }
-    if (!user.getEnabled()) {
-      throw new DisabledException("アカウントが無効化されています");
-    }
-    if (!passwordEncoder.matches(password, user.getPassword())) {
-      throw new BadCredentialsException(INVALID_CREDENTIALS_MESSAGE);
-    }
+    Authentication authentication =
+        authenticationManager.authenticate(
+            UsernamePasswordAuthenticationToken.unauthenticated(normalizedEmail, password));
+    // principal は認証成功時に自作 UserDetails が保持する PlatformUser（二次クエリを避ける）。
+    PlatformUser user = ((PlatformUserDetails) authentication.getPrincipal()).getPlatformUser();
 
     Set<Capability> capabilities = capabilitiesOf(user);
     Map<String, Object> claims = new HashMap<>();

--- a/backend/src/main/java/com/kizuna/auth/application/PlatformAuthService.java
+++ b/backend/src/main/java/com/kizuna/auth/application/PlatformAuthService.java
@@ -33,8 +33,8 @@ import org.springframework.transaction.annotation.Transactional;
  * DisabledException が投げられる（enabled 判定がパスワード照合に先行するため、無効化アカウントでのパスワード正誤オラクルを塞ぐ）。列挙耐性・タイミング均一化も
  * フレームワークの既定挙動が担う。いずれの例外も {@code AuthenticationException} 系のため 401 で応答される。
  *
- * <p>authorities の発行（#382 / #398）: STAFF は保持束の能力並集を {@code PERM_} 形式で発行し、CAST / MEMBER は本人種別標識
- * {@code ROLE_CAST} / {@code ROLE_MEMBER} のみを発行する。授権変更は次回ログインから反映される（会話失効なし — #325 既定）。
+ * <p>authorities の発行: STAFF は保持束の能力並集を {@code PERM_} 形式で発行し、CAST / MEMBER は本人種別標識 {@code ROLE_CAST}
+ * / {@code ROLE_MEMBER} のみを発行する。授権変更は次回ログインから反映される（会話中は失効しない既定挙動）。
  */
 @Service
 @RequiredArgsConstructor
@@ -112,7 +112,7 @@ public class PlatformAuthService {
         user.getStoreIds().stream().sorted().toList());
   }
 
-  /** 保持束の能力並集。STAFF 以外は能力を持たない（本人種別 — #320 既定）。 */
+  /** 保持束の能力並集。STAFF 以外は能力を持たない（本人種別の既定）。 */
   private Set<Capability> capabilitiesOf(PlatformUser user) {
     if (user.getUserType() != UserType.STAFF) {
       return Set.of();
@@ -131,7 +131,7 @@ public class PlatformAuthService {
   }
 
   private static boolean hasStoreConsole(Set<Capability> capabilities) {
-    // 標識能力はコンソール入場・店舗文脈確立の資格にしない（PR #411 codex 指摘）。STORE_MENU_VIEW 単独では
+    // 標識能力はコンソール入場・店舗文脈確立の資格にしない。STORE_MENU_VIEW 単独では
     // storeBridge も店舗コンソール着地も許さず、実運用の STORE 能力（STORE_MENU_VIEW 以外）を要求する。
     return capabilities.stream()
         .anyMatch(

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/PlatformUserDetails.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/PlatformUserDetails.java
@@ -1,0 +1,42 @@
+package com.kizuna.auth.infrastructure;
+
+import com.kizuna.user.domain.PlatformUser;
+import java.util.Collection;
+import java.util.Collections;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+/**
+ * DaoAuthenticationProvider が扱う認証主体。JWT claims（authorities / storeBridge 等）は認証成功後に呼び出し側が {@link
+ * PlatformUser} から算出するため、ここでの authorities は空のまま返す。
+ */
+@Getter
+public class PlatformUserDetails implements UserDetails {
+
+  private final PlatformUser platformUser;
+
+  public PlatformUserDetails(PlatformUser platformUser) {
+    this.platformUser = platformUser;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public String getPassword() {
+    return platformUser.getPassword();
+  }
+
+  @Override
+  public String getUsername() {
+    return platformUser.getEmail();
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return platformUser.getEnabled();
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/PlatformUserDetailsService.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/PlatformUserDetailsService.java
@@ -1,0 +1,24 @@
+package com.kizuna.auth.infrastructure;
+
+import com.kizuna.user.domain.PlatformUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+/** DaoAuthenticationProvider から呼び出される認証主体の取得元。email は呼び出し側で正規化済みの値を受け取る。 */
+@Service
+@RequiredArgsConstructor
+public class PlatformUserDetailsService implements UserDetailsService {
+
+  private final PlatformUserRepository userRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    return userRepository
+        .findByEmail(email)
+        .map(PlatformUserDetails::new)
+        .orElseThrow(() -> new UsernameNotFoundException(email));
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/SecurityConfig.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/SecurityConfig.java
@@ -3,6 +3,8 @@ package com.kizuna.auth.infrastructure;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -55,5 +57,15 @@ public class SecurityConfig {
   @Bean
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
+  }
+
+  /**
+   * 単一の UserDetailsService Bean + PasswordEncoder Bean から Boot が自動組み立てた DaoAuthenticationProvider
+   * を公開する。
+   */
+  @Bean
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
+      throws Exception {
+    return configuration.getAuthenticationManager();
   }
 }

--- a/backend/src/test/java/com/kizuna/auth/application/PlatformAuthServiceTest.java
+++ b/backend/src/test/java/com/kizuna/auth/application/PlatformAuthServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import com.kizuna.auth.api.dto.PlatformMeResponse;
 import com.kizuna.auth.api.dto.Token;
 import com.kizuna.auth.infrastructure.JwtUtil;
+import com.kizuna.auth.infrastructure.PlatformUserDetails;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.domain.Capability;
 import com.kizuna.user.domain.CapabilityBundle;
@@ -30,8 +31,9 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
@@ -45,10 +47,20 @@ class PlatformAuthServiceTest {
   @Mock private PasswordEncoder passwordEncoder;
   @Mock private JwtUtil jwtUtil;
   @Mock private AuthSessionService authSessionService;
+  @Mock private AuthenticationManager authenticationManager;
+  @Mock private Authentication authentication;
 
   @Captor private ArgumentCaptor<Map<String, Object>> claimsCaptor;
 
   @InjectMocks private PlatformAuthService authService;
+
+  /** authenticationManager.authenticate が指定ユーザーを principal に持つ成功済み Authentication を返すよう配線する。 */
+  private void stubSuccessfulAuthentication(String email, String password, PlatformUser user) {
+    when(authenticationManager.authenticate(
+            UsernamePasswordAuthenticationToken.unauthenticated(email, password)))
+        .thenReturn(authentication);
+    when(authentication.getPrincipal()).thenReturn(new PlatformUserDetails(user));
+  }
 
   private PlatformUser hqAdmin() {
     return PlatformUser.builder()
@@ -80,8 +92,7 @@ class PlatformAuthServiceTest {
 
   @Test
   void login_staff_issuesSortedPermAuthoritiesWithoutRoleClaim() {
-    when(userRepository.findByEmail("admin@kizuna.test")).thenReturn(Optional.of(hqAdmin()));
-    when(passwordEncoder.matches("pass", "stored-hash")).thenReturn(true);
+    stubSuccessfulAuthentication("admin@kizuna.test", "pass", hqAdmin());
     when(capabilityBundleRepository.findAllById(Set.of(HQ_BUNDLE_ID)))
         .thenReturn(List.of(hqBundle()));
     Token mockToken = new Token("platform_token", 12345L);
@@ -128,8 +139,7 @@ class PlatformAuthServiceTest {
             .storeScopeType(StoreScopeType.SPECIFIC_STORES)
             .storeIds(Set.of(1L))
             .build();
-    when(userRepository.findByEmail("staff@kizuna.test")).thenReturn(Optional.of(staff));
-    when(passwordEncoder.matches("pass", "stored-hash")).thenReturn(true);
+    stubSuccessfulAuthentication("staff@kizuna.test", "pass", staff);
     when(capabilityBundleRepository.findAllById(Set.of(STORE_BUNDLE_ID)))
         .thenReturn(
             List.of(
@@ -167,8 +177,7 @@ class PlatformAuthServiceTest {
             .storeScopeType(StoreScopeType.SPECIFIC_STORES)
             .storeIds(Set.of(1L))
             .build();
-    when(userRepository.findByEmail("menu@kizuna.test")).thenReturn(Optional.of(staff));
-    when(passwordEncoder.matches("pass", "stored-hash")).thenReturn(true);
+    stubSuccessfulAuthentication("menu@kizuna.test", "pass", staff);
     when(capabilityBundleRepository.findAllById(Set.of(STORE_BUNDLE_ID)))
         .thenReturn(
             List.of(
@@ -201,8 +210,7 @@ class PlatformAuthServiceTest {
             .storeScopeType(StoreScopeType.SPECIFIC_STORES)
             .storeIds(Set.of(1L))
             .build();
-    when(userRepository.findByEmail("manager@kizuna.test")).thenReturn(Optional.of(staff));
-    when(passwordEncoder.matches("pass", "stored-hash")).thenReturn(true);
+    stubSuccessfulAuthentication("manager@kizuna.test", "pass", staff);
     when(capabilityBundleRepository.findAllById(Set.of(STORE_BUNDLE_ID)))
         .thenReturn(
             List.of(
@@ -235,8 +243,7 @@ class PlatformAuthServiceTest {
             .storeScopeType(StoreScopeType.SPECIFIC_STORES)
             .storeIds(Set.of(1L))
             .build();
-    when(userRepository.findByEmail("cast@kizuna.test")).thenReturn(Optional.of(cast));
-    when(passwordEncoder.matches("pass", "stored-hash")).thenReturn(true);
+    stubSuccessfulAuthentication("cast@kizuna.test", "pass", cast);
     when(jwtUtil.generateToken(eq("cast@kizuna.test"), eq(JwtUtil.ISSUER_PLATFORM), any()))
         .thenReturn(new Token("t", 1L));
 
@@ -254,8 +261,7 @@ class PlatformAuthServiceTest {
 
   @Test
   void login_mixedCaseEmail_resolvesToLowercaseUser() {
-    when(userRepository.findByEmail("admin@kizuna.test")).thenReturn(Optional.of(hqAdmin()));
-    when(passwordEncoder.matches("pass", "stored-hash")).thenReturn(true);
+    stubSuccessfulAuthentication("admin@kizuna.test", "pass", hqAdmin());
     when(capabilityBundleRepository.findAllById(Set.of(HQ_BUNDLE_ID)))
         .thenReturn(List.of(hqBundle()));
     when(jwtUtil.generateToken(eq("admin@kizuna.test"), eq(JwtUtil.ISSUER_PLATFORM), any()))
@@ -264,48 +270,11 @@ class PlatformAuthServiceTest {
     Token res = authService.login("ADMIN@Kizuna.TEST", "pass");
 
     assertThat(res.token()).isEqualTo("platform_token");
-    // 照合は小文字正規化後の email で行う（保存済みシードは全て小文字）。
-    verify(userRepository).findByEmail("admin@kizuna.test");
-  }
-
-  @Test
-  void login_emailNotFound_throwsBadCredentials() {
-    when(userRepository.findByEmail("missing@kizuna.test")).thenReturn(Optional.empty());
-
-    assertThatThrownBy(() -> authService.login("missing@kizuna.test", "pass"))
-        .isInstanceOf(BadCredentialsException.class)
-        .hasMessage("メールアドレスまたはパスワードが正しくありません");
-
-    // 列挙耐性: メール不存在でもダミー bcrypt 照合を 1 回行い、既知メール（誤パスワード）との応答時間差を作らない。
-    verify(passwordEncoder).matches(eq("pass"), any());
-  }
-
-  @Test
-  void login_wrongPassword_throwsBadCredentials() {
-    when(userRepository.findByEmail("admin@kizuna.test")).thenReturn(Optional.of(hqAdmin()));
-    when(passwordEncoder.matches("wrong", "stored-hash")).thenReturn(false);
-
-    assertThatThrownBy(() -> authService.login("admin@kizuna.test", "wrong"))
-        .isInstanceOf(BadCredentialsException.class)
-        .hasMessage("メールアドレスまたはパスワードが正しくありません");
-  }
-
-  @Test
-  void login_disabledUser_correctPassword_throwsDisabled() {
-    when(userRepository.findByEmail("admin@kizuna.test")).thenReturn(Optional.of(disabledUser()));
-
-    // enabled 判定がパスワード照合より先行するため、正しいパスワードでも DisabledException になる。
-    assertThatThrownBy(() -> authService.login("admin@kizuna.test", "pass"))
-        .isInstanceOf(DisabledException.class);
-  }
-
-  @Test
-  void login_disabledUser_wrongPassword_throwsDisabled() {
-    when(userRepository.findByEmail("admin@kizuna.test")).thenReturn(Optional.of(disabledUser()));
-
-    // 誤パスワードでも enabled 判定が先行するため DisabledException（無効化アカウントでのパスワード正誤オラクルを塞ぐ）。
-    assertThatThrownBy(() -> authService.login("admin@kizuna.test", "wrong"))
-        .isInstanceOf(DisabledException.class);
+    // 照合は小文字正規化後の email を AuthenticationManager へ渡す（保存済みシードは全て小文字）。
+    ArgumentCaptor<UsernamePasswordAuthenticationToken> tokenCaptor =
+        ArgumentCaptor.forClass(UsernamePasswordAuthenticationToken.class);
+    verify(authenticationManager).authenticate(tokenCaptor.capture());
+    assertThat(tokenCaptor.getValue().getPrincipal()).isEqualTo("admin@kizuna.test");
   }
 
   @Test
@@ -518,18 +487,5 @@ class PlatformAuthServiceTest {
     assertThat(user.getPassword()).isEqualTo("new-encoded-hash");
     verify(userRepository).save(user);
     verify(authSessionService).invalidate("Bearer tok");
-  }
-
-  private PlatformUser disabledUser() {
-    return PlatformUser.builder()
-        .email("admin@kizuna.test")
-        .password("stored-hash")
-        .displayName("HQ管理者")
-        .enabled(false)
-        .userType(UserType.STAFF)
-        .bundleIds(Set.of(HQ_BUNDLE_ID))
-        .storeScopeType(StoreScopeType.ALL_STORES)
-        .storeIds(Set.of())
-        .build();
   }
 }

--- a/backend/src/test/java/com/kizuna/auth/application/PlatformAuthServiceTest.java
+++ b/backend/src/test/java/com/kizuna/auth/application/PlatformAuthServiceTest.java
@@ -193,7 +193,7 @@ class PlatformAuthServiceTest {
     verify(jwtUtil)
         .generateToken(eq("menu@kizuna.test"), eq(JwtUtil.ISSUER_PLATFORM), claimsCaptor.capture());
     Map<String, Object> claims = claimsCaptor.getValue();
-    // 標識能力（STORE_MENU_VIEW）単独では店舗文脈を確立できない（PR #411 codex 指摘）。
+    // 標識能力（STORE_MENU_VIEW）単独では店舗文脈を確立できない。
     assertThat(claims.get("storeBridge")).isEqualTo(false);
   }
 
@@ -324,7 +324,7 @@ class PlatformAuthServiceTest {
 
   @Test
   void me_hybridStaffWithPlatformAndStoreCapabilities_returnsPlatformConsoleAndStoreBridgeTrue() {
-    // 混成束（PLATFORM 能力と実運用 STORE 能力の併持）: 着地は platform 優先のまま store_bridge=true（#428 AC1）。
+    // 混成束（PLATFORM 能力と実運用 STORE 能力の併持）: 着地は platform 優先のまま store_bridge=true。
     PlatformUser staff =
         PlatformUser.builder()
             .email("hybrid@kizuna.test")
@@ -428,7 +428,7 @@ class PlatformAuthServiceTest {
     Optional<PlatformMeResponse> res = authService.me("menu@kizuna.test");
 
     assertThat(res).isPresent();
-    // 標識のみの束は店舗コンソールに着地しない（fail-closed — PR #411 codex 指摘）。
+    // 標識のみの束は店舗コンソールに着地しない（fail-closed）。
     assertThat(res.get().console()).isEqualTo("none");
     assertThat(res.get().capabilities()).containsExactly("STORE_MENU_VIEW");
     // 標識能力（STORE_MENU_VIEW）単独では店舗文脈を確立できないため false。

--- a/backend/src/test/java/com/kizuna/auth/infrastructure/PlatformUserDetailsServiceTest.java
+++ b/backend/src/test/java/com/kizuna/auth/infrastructure/PlatformUserDetailsServiceTest.java
@@ -1,0 +1,58 @@
+package com.kizuna.auth.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import com.kizuna.user.domain.StoreScopeType;
+import com.kizuna.user.domain.UserType;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class PlatformUserDetailsServiceTest {
+
+  @Mock private PlatformUserRepository userRepository;
+
+  @InjectMocks private PlatformUserDetailsService service;
+
+  @Test
+  void loadUserByUsername_existingEmail_returnsUserDetailsWrappingPlatformUser() {
+    PlatformUser user =
+        PlatformUser.builder()
+            .email("admin@kizuna.test")
+            .password("stored-hash")
+            .displayName("HQ管理者")
+            .enabled(true)
+            .userType(UserType.STAFF)
+            .bundleIds(Set.of(10L))
+            .storeScopeType(StoreScopeType.ALL_STORES)
+            .storeIds(Set.of())
+            .build();
+    when(userRepository.findByEmail("admin@kizuna.test")).thenReturn(Optional.of(user));
+
+    UserDetails result = service.loadUserByUsername("admin@kizuna.test");
+
+    assertThat(result.getUsername()).isEqualTo("admin@kizuna.test");
+    assertThat(result.getPassword()).isEqualTo("stored-hash");
+    assertThat(result.isEnabled()).isTrue();
+    assertThat(((PlatformUserDetails) result).getPlatformUser()).isSameAs(user);
+  }
+
+  @Test
+  void loadUserByUsername_missingEmail_throwsUsernameNotFoundException() {
+    when(userRepository.findByEmail("missing@kizuna.test")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.loadUserByUsername("missing@kizuna.test"))
+        .isInstanceOf(UsernameNotFoundException.class);
+  }
+}


### PR DESCRIPTION
<!-- タイトルは conventional commit 形式（feat/fix/chore/refactor …）・日本語 -->

## 概要

`/platform/login` の自前認証(findByEmail + enabled 判定 + パスワード照合 + ダミー bcrypt でのタイミング均一化)を Spring Security 標準スタック(`AuthenticationManager` / `DaoAuthenticationProvider` / 自作 `UserDetailsService`)へ移行する。列挙耐性・タイミング攻撃対策・enabled 先行判定はフレームワークへ委譲し、claims 組み立て・JWT 発行は現行仕様のまま維持する。

Closes #437

## 変更内容

- `PlatformUserDetails`(新規, `auth/infrastructure`): `PlatformUser` を保持する `UserDetails`。`getAuthorities()` は空リスト（claims の authorities は login が別途算出するため）。
- `PlatformUserDetailsService`(新規, `auth/infrastructure`): `findByEmail` → 見つからなければ `UsernameNotFoundException`。
- `SecurityConfig`: `AuthenticationManager` Bean を追加（`AuthenticationConfiguration#getAuthenticationManager()` を公開し、単一の `UserDetailsService` Bean + 既存 `PasswordEncoder` Bean から Boot が自動組み立てる `DaoAuthenticationProvider` をそのまま使う）。既存 filter chain・既存コンストラクタは無変更。
- `PlatformAuthService.login`: `authenticationManager.authenticate(...)` を呼び、成功後は principal(`PlatformUserDetails`)から `PlatformUser` を取り出して従来どおり claims を組み立てる（二次クエリなし）。email の小文字正規化は login 側で維持。

### 削除した自前セマンティクス

- `findByEmail` の in-service 呼び出し・`passwordEncoder.matches` の in-service 呼び出し・enabled 手動判定（すべて `DaoAuthenticationProvider` へ委譲）
- `userNotFoundEncodedPassword` フィールドとその構築時 encode（ダミー bcrypt によるタイミング均一化。`DaoAuthenticationProvider.mitigateAgainstTimingAttack` が同趣旨をフレームワーク側で担う）
- `INVALID_CREDENTIALS_MESSAGE` 定数（メッセージは `CommonExceptionHandler` が例外型から一元的に写像 — #436 で確立済み）
- `userNotFoundEncodedPassword` を消したことでコンストラクタが純代入になったため `@RequiredArgsConstructor` 化

### テスト降格（単体 → 統合）

`PlatformAuthServiceTest` から次の 4 テストを削除した。これらは自前実装固有の安全セマンティクス（dummy encode 実行・enabled 先行・文言）を検証するもので、標準スタックへの移行後はフレームワーク責務になったため単体では検証できない：

- `login_emailNotFound_throwsBadCredentials`
- `login_wrongPassword_throwsBadCredentials`
- `login_disabledUser_correctPassword_throwsDisabled`
- `login_disabledUser_wrongPassword_throwsDisabled`

代わりに `PlatformAuthIT`（実 DB/Redis 上の統合テスト）へ次の 2 テストを追加し、標準スタック全体（`AuthenticationManager` → `CommonExceptionHandler`）が実際に正しい例外型・文言を返すことを端到端で固定した（誤パスワードと正常ログインの既存テストも本票で body 文言の断言を追加/確認済み）：

- `missingEmailReturnsSameMessageAsWrongPassword`（不存在メールが誤パスワードと同一文言 = 列挙耐性）
- `disabledAccountWithCorrectPasswordReturns401DisabledMessage`（無効化アカウントは正パスワードでも無効化文言）

成功系の claims 検証テスト（`login_staff_*` / `login_cast_*` / `login_mixedCaseEmail_*`）は `authenticationManager.authenticate` を mock する形に改造した上で保持。`login_mixedCaseEmail` は `AuthenticationManager` へ渡る username が小文字であることを `ArgumentCaptor` で検証する形に変更。me/updateMe/changePassword 系テストは無変更。

`PlatformUserDetailsService` の単体テストを新規追加（存在するメール → `UserDetails` 到達、不存在メール → `UsernameNotFoundException`）。

## 検証

<!-- 合否はすべて exit code で判定（出力は日本語ロケールのことがある） -->

- [x] `./gradlew spotlessCheck test` exit 0（backend 全 unit green。改造後 `PlatformAuthServiceTest` 16 件 + 新規 `PlatformUserDetailsServiceTest` 2 件含む）
- [x] `./gradlew jacocoTestCoverageVerification` exit 0（カバレッジゲート green）
- [x] `task -d backend lint` exit 0
- [x] `task build service=backend` exit 0
- [x] **`task test-integration` exit 0（`PlatformAuthIT` を worktree 内の ephemeral compose スタックで実走済み、7 件 green — 本票の要求である統合テストは実走・確認済み）**
- [ ] `task lint` / `task test` / `task build`（frontend 側含むフルスタック）は未実行 — フロントエンド変更なしのため backend 側のみ検証。マージ前に通常の CI ゲートで確認される
- [ ] `task e2e` 未実行（プロジェクト規約どおり PR 作者のローカル責任）
- [ ] ローカルでの code-review 未実施（別途実施予定）

## 決定ログ

- **`AuthenticationManager` の配線は自動組み立てを採用**（`AuthenticationConfiguration#getAuthenticationManager()` を Bean として公開）。手動で `new DaoAuthenticationProvider(...)` する代替も検討したが、実際に解決される Spring Security バージョンは 7.1.0（`spring-boot-starter-security` 経由、Boot 4.1.0 が引き込む — 計画書が前提としていた 6.4 とは異なる）で、このバージョンのコンストラクタは `DaoAuthenticationProvider(UserDetailsService)` のみを取り `PasswordEncoder` は `setPasswordEncoder(...)` セッターで別途注入する形に変わっている。自動組み立て（`InitializeUserDetailsBeanManagerConfigurer`）は単一の `UserDetailsService` Bean + 単一の `PasswordEncoder` Bean を検出して同じ配線を行うため、手動組み立てより脆弱性が少ないと判断しそのまま採用した。ソース(`spring-security-core`/`spring-security-config` 7.1.0)を解凍して `AbstractUserDetailsAuthenticationProvider` / `DaoAuthenticationProvider` / `InitializeUserDetailsBeanManagerConfigurer` を直接確認し、`hideUserNotFoundExceptions`(既定 true)・`mitigateAgainstTimingAttack`・enabled 先行判定（`preAuthenticationChecks` が `additionalAuthenticationChecks` より先に走り、無効化時は結果を握りつぶしてパスワード正誤を問わず `DisabledException` を投げる）が計画書どおりの契約を満たすことを裏付けた。
- `UserDetails` インタフェース自体が `isAccountNonExpired/isAccountNonLocked/isCredentialsNonExpired` に `default true` を持つ（このバージョンから）ため、`PlatformUserDetails` では `getAuthorities` / `getPassword` / `getUsername` / `isEnabled` のみをオーバーライドし、冗長な明示オーバーライドは書かなかった。

## 備考 / レビュー観点

- **フロントエンドは無変更**（`frontend/` に diff なし）。`/platform/login` の応答形状(200 時のボディ)・エラー文言は #436 のハンドラがそのまま担うため、UI 側の表示は不変。
- 起動時の "Using generated security password" ログが消えることは `PlatformUserDetailsService` Bean が単一存在する副産物として期待される挙動（Boot の `UserDetailsServiceAutoConfiguration` は既存の `UserDetailsService`/`AuthenticationManager`/`AuthenticationProvider` Bean があると自動生成ユーザーを作らない）だが、本 PR では起動ログを直接目視確認していない。気になる場合は `task up` 後の `task logs service=backend` で確認いただきたい。
- 範囲は auth パッケージ内に限定（`PlatformAuthService.login` のみ・`SecurityConfig` は Bean 追加のみ・新規 `UserDetailsService`/`UserDetails`・関連テスト）。`jwtAuthenticationFilter` / Bearer 検証 / `JwtUtil` の発行・解析 / oauth2 依存追加は範囲外（#438/#439）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
