### PR TITLE
feat: 集合作用域の拡張ガードとして storeSetFilter を全 StoreScopedEntity へ静的宣言する

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/order/PlatformOrderScopeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/PlatformOrderScopeIT.java
@@ -218,6 +218,10 @@ class PlatformOrderScopeIT extends CrossStoreTestSupport {
       }
     }
     assertThat(hasMarker).as("授権店舗の正向マーカーが一覧に含まれること").isTrue();
+
+    assertThat(res.getBody().path("total_elements").asLong())
+        .as("total_elements が授権店舗(store A)の実件数と一致し、集合外店舗の件数を含まないこと")
+        .isEqualTo(orderCountForStore(STORE_A));
   }
 
   @Test

--- a/backend/src/main/java/com/kizuna/cast/domain/Cast.java
+++ b/backend/src/main/java/com/kizuna/cast/domain/Cast.java
@@ -17,6 +17,7 @@ import org.hibernate.annotations.Type;
 @Entity
 @Table(name = "t_casts")
 @Filter(name = "storeFilter", condition = "store_id = :storeId")
+@Filter(name = "storeSetFilter", condition = "store_id in (:storeIds)")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/kizuna/cast/domain/CastFieldDefinition.java
+++ b/backend/src/main/java/com/kizuna/cast/domain/CastFieldDefinition.java
@@ -19,6 +19,7 @@ import org.hibernate.annotations.Filter;
 @Entity
 @Table(name = "t_cast_field_definitions")
 @Filter(name = "storeFilter", condition = "store_id = :storeId")
+@Filter(name = "storeSetFilter", condition = "store_id in (:storeIds)")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/kizuna/cast/domain/CastInvitation.java
+++ b/backend/src/main/java/com/kizuna/cast/domain/CastInvitation.java
@@ -18,6 +18,7 @@ import org.hibernate.annotations.Filter;
 @Entity
 @Table(name = "t_cast_invitations")
 @Filter(name = "storeFilter", condition = "store_id = :storeId")
+@Filter(name = "storeSetFilter", condition = "store_id in (:storeIds)")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/kizuna/customer/domain/Customer.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/Customer.java
@@ -13,6 +13,7 @@ import org.hibernate.annotations.Filter;
 @Entity
 @Table(name = "t_customers")
 @Filter(name = "storeFilter", condition = "store_id = :storeId")
+@Filter(name = "storeSetFilter", condition = "store_id in (:storeIds)")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/kizuna/shift/domain/Shift.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/Shift.java
@@ -15,6 +15,7 @@ import org.hibernate.annotations.Filter;
 @Entity
 @Table(name = "t_shifts")
 @Filter(name = "storeFilter", condition = "store_id = :storeId")
+@Filter(name = "storeSetFilter", condition = "store_id in (:storeIds)")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/kizuna/shift/domain/ShiftRequest.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/ShiftRequest.java
@@ -22,6 +22,7 @@ import org.hibernate.annotations.Filter;
 @Entity
 @Table(name = "t_shift_requests")
 @Filter(name = "storeFilter", condition = "store_id = :storeId")
+@Filter(name = "storeSetFilter", condition = "store_id in (:storeIds)")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfile.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/domain/StoreProfile.java
@@ -27,6 +27,7 @@ import org.hibernate.annotations.Type;
 @Builder
 @ToString
 @Filter(name = "storeFilter", condition = "store_id = :storeId")
+@Filter(name = "storeSetFilter", condition = "store_id in (:storeIds)")
 public class StoreProfile extends StoreScopedEntity {
 
   @Column(name = "template_key", length = 50)

--- a/backend/src/test/java/com/kizuna/StoreIsolationTests.java
+++ b/backend/src/test/java/com/kizuna/StoreIsolationTests.java
@@ -26,6 +26,7 @@ import org.springframework.core.type.filter.AnnotationTypeFilter;
 class StoreIsolationTests {
 
   private static final String EXPECTED_CONDITION = "store_id = :storeId";
+  private static final String EXPECTED_SET_CONDITION = "store_id in (:storeIds)";
 
   @Test
   @DisplayName("store_id 列を持つ全 @Entity が storeFilter の @Filter を宣言していること")
@@ -61,6 +62,48 @@ class StoreIsolationTests {
         .as(
             "@Filter(name=\"storeFilter\", condition=\"%s\") が無い store_id 列保持エンティティ",
             EXPECTED_CONDITION)
+        .isEmpty();
+  }
+
+  /**
+   * {@code @Filter(storeSetFilter)} の宣言は、対象エンティティを実際に読む {@code @StoreSetScoped}
+   * メソッドが存在しなければ休眠（dormant）のままになる。 宣言済みであることは、そのエンティティが集合作用域の平台横断一覧に既に対応済みであることを意味しない。
+   */
+  @Test
+  @DisplayName("store_id 列を持つ全 @Entity が storeSetFilter の @Filter を宣言していること")
+  void allStoreScopedEntitiesDeclareStoreSetFilter() throws Exception {
+    ClassPathScanningCandidateComponentProvider scanner =
+        new ClassPathScanningCandidateComponentProvider(false);
+    scanner.addIncludeFilter(new AnnotationTypeFilter(Entity.class));
+
+    List<String> offenders = new ArrayList<>();
+    List<String> scanned = new ArrayList<>();
+    for (var candidate : scanner.findCandidateComponents("com.kizuna")) {
+      Class<?> entity = Class.forName(candidate.getBeanClassName());
+      if (!hasStoreIdColumn(entity)) {
+        continue;
+      }
+      scanned.add(entity.getSimpleName());
+      // @Filter は Hibernate 6 で repeatable のため、storeSetFilter を宣言していれば
+      // 他フィルタ（storeFilter 等）が並置されていても違反としない。
+      boolean declaresStoreSetFilter = false;
+      for (Filter filter : entity.getAnnotationsByType(Filter.class)) {
+        if ("storeSetFilter".equals(filter.name())
+            && EXPECTED_SET_CONDITION.equals(filter.condition())) {
+          declaresStoreSetFilter = true;
+          break;
+        }
+      }
+      if (!declaresStoreSetFilter) {
+        offenders.add(entity.getName());
+      }
+    }
+
+    assertThat(scanned).isNotEmpty();
+    assertThat(offenders)
+        .as(
+            "@Filter(name=\"storeSetFilter\", condition=\"%s\") が無い store_id 列保持エンティティ",
+            EXPECTED_SET_CONDITION)
         .isEmpty();
   }
 

--- a/docs/adr/0002-store-scoped-entities-declare-filters-statically.md
+++ b/docs/adr/0002-store-scoped-entities-declare-filters-statically.md
@@ -1,0 +1,53 @@
+# StoreScopedEntity は storeFilter・storeSetFilter を静的に全量宣言する
+
+Status: Accepted
+
+## Context
+
+集合作用域（`StoreScope` / `storeSetFilter` / `@StoreSetScoped`）は、`@StoreSetScoped` を付けたサービスメソッド実行時に
+Hibernate の二次フィルタ `storeSetFilter` を有効化して読みを授権店舗集合に濾過する。フィルタは対象 `@Entity` が自身のクラスに
+`@Filter(name="storeSetFilter", condition="store_id in (:storeIds)")` を宣言していない限り**静かに no-op** となり、
+SPECIFIC_STORES ユーザーへ全店舗の行を返す fail-open になる。
+
+単店版（`storeFilter` / `@StoreScoped`）にはこの不変量を機械検証する `StoreIsolationTests` が既にあるが、判定基準は
+「`store_id` 列を持つ全 `@Entity`」という実体自身の構造から静的に導出できる集合だった。対して `storeSetFilter` が要る集合は
+「`@StoreSetScoped` メソッドが実際に読むエンティティ」であり、これは実体の構造からは導出できず、コード上のどのサービスメソッドが
+どのエンティティを読むかという到達可能性（データフロー）に依存する。
+
+到達可能性を機械的に閉じる案として、ArchUnit・コンパイル時チェッカ（Error Prone 等）・Hibernate の
+`@FilterDef(autoEnabled=true)` によるランタイム反転・`@StoreSetScoped` メソッドと対象エンティティの手書き登録台帳（反射で
+使用箇所数と照合）を検討した。ArchUnit とコンパイル時チェッカは、対象メソッドが Spring Data リポジトリ + JPQL 文字列
+（`PlatformOrderView` 投影）経由でエンティティに到達するため、バイトコード解析ではその経路を追えず不成立。ランタイム反転は
+Hibernate コミュニティに確立された先例がなく、作用域機構全体の再設計になり本件のスコープを超える。登録台帳は「新規登録の
+更新漏れ」自体を機械的には検知できず（登録済みエンティティの宣言漏れしか拾えない）、維持コストも残る。
+
+## Decision
+
+到達可能性の判定を諦め、`StoreScopedEntity` を継承する全エンティティ（現在 8 個: `Order` `Cast` `CastFieldDefinition`
+`CastInvitation` `Customer` `Shift` `ShiftRequest` `StoreProfile`）に、現に `@StoreSetScoped` から読まれているかに関わらず
+`@Filter(name="storeSetFilter", condition="store_id in (:storeIds)")` を静的に宣言させる。`StoreIsolationTests` に
+`storeFilter` 版と同型の機械検証を追加し、以後どのエンティティも宣言漏れがあれば単体テストで fail-loud にする。
+
+未使用の Hibernate `@Filter` は明示的に有効化されない限りランタイムコストを持たない。現時点で唯一の `@StoreSetScoped`
+使用箇所である `PlatformOrderService.list()` が呼ぶ `OrderRepository.findPlatformViews` は `Order` 単体を select する
+JPQL（`PLATFORM_VIEW_SELECT`）で、`Cast`/`Customer` 等への join を意図的に張っていない（既存コメント「店舗（表示名）の
+join は張らない」）。よって現時点では、他 7 エンティティへの宣言追加は実行時挙動を一切変えない。
+
+## Consequences
+
+`storeSetFilter` を宣言していても、そのエンティティを実際に読む `@StoreSetScoped` メソッドが存在しない限り宣言は
+休眠（dormant）状態のままになる。ソースだけを見ると「このエンティティは既に集合作用域の平台横断一覧に対応済み」と
+誤読されうるため、その旨は `StoreIsolationTests` の新規テストメソッドの Javadoc に一箇所だけ明記し、各エンティティ側には
+コメントを重複させない。将来 `@StoreSetScoped` を新しい集約へ拡張する側は、対象エンティティへの `@Filter` 追加を
+意識する必要がなくなり、`@StoreSetScoped` を付けて濾過を有効化する作業だけに集中できる。
+
+Hibernate の session フィルタは有効化した呼び出し元に関わらず、その Session 内で読まれる**全エンティティ**に及ぶ —
+将来 `@StoreSetScoped` メソッドが `Cast`/`Customer` 等への join や遅延ロードを新たに持ち込んだ場合、それらのエンティティは
+（本 ADR により既に `@Filter` 宣言済みのため）追加の意識なく自動的に濾過対象へ入る。狙って有効化した対象以外にも及ぶという
+意味で影響範囲は静的に読み切れないが、方向は常に「安全側」（濾過が想定より広くかかる）であり fail-open の再発ではない。
+
+本設計が捉えられない残存ケースが一つある：`@StoreSetScoped` が `StoreScopedEntity` を継承しない型（素の DTO や
+`StoreScopedEntity` 系統外のエンティティ）を読む状況を将来作った場合、`StoreIsolationTests` の走査対象外のため
+このガードは無力（フィルタは静かに no-op のまま）。現行 8 エンティティは全て `StoreScopedEntity` 継承であり
+`StoreIsolationTests` の別テストが「`store_id` 列を持つ実体は例外なく `StoreScopedEntity` を継承する」ことを
+既に固定しているため、今のところ実害はない。


### PR DESCRIPTION
## 概要

`@StoreSetScoped` が有効化する Hibernate フィルタ `storeSetFilter` は、対象エンティティが `@Filter` を宣言していない限り静かに no-op（fail-open）になる。到達可能性の機械判定は静的解析・実行時反転とも不成立のため（ADR 0002）、`StoreScopedEntity` を継承する全 8 エンティティへ無条件で `@Filter(storeSetFilter)` を静的宣言し、宣言漏れを fail-loud に固定する。

Closes #339

## 変更内容

- `docs/adr/0002-store-scoped-entities-declare-filters-statically.md` を追加（検討した代替案と決定の記録）
- `Cast`/`CastFieldDefinition`/`CastInvitation`/`Customer`/`Shift`/`ShiftRequest`/`StoreProfile` に `@Filter(name="storeSetFilter", condition="store_id in (:storeIds)")` を追加（`Order` は既存）
- `StoreIsolationTests` に `allStoreScopedEntitiesDeclareStoreSetFilter` を追加。`allStoreScopedEntitiesDeclareStoreFilter` と同型の機械検証で、宣言漏れがあれば単体テストで赤くなる。宣言が休眠状態になりうる旨は新規テストメソッドの Javadoc に一箇所だけ明記（各エンティティへのコメント重複はしない）
- `PlatformOrderScopeIT#specificScopeListReturnsOnlyAuthorizedStores` に、応答の `total_elements`（トップレベル・snake_case）が授権店舗(store A)の実件数と一致することの断言を追加

## 検証

- [x] `task lint` exit 0
- [x] `task test`（unit + integration）exit 0
- [x] `task build` exit 0
- [ ] `task e2e`（未実施 — 本変更は永続化層の Hibernate フィルタ宣言とテストのみで、API 契約・UI 挙動に変化がないため e2e シナリオへの影響なし）
- [x] ローカルで code-review 実施済み（mattpocock-skills:code-review、Standards/Spec 両軸）

## 決定ログ

- 到達可能性（どの `@StoreSetScoped` メソッドがどのエンティティを読むか）の機械判定は、ArchUnit・コンパイル時チェッカ・Hibernate `@FilterDef(autoEnabled=true)` 反転・手書き登録台帳のいずれも不成立と判断し断念（詳細は ADR 0002 参照）。判定面を「到達可能性」から「`StoreScopedEntity` 継承という静的構造」に切り替え、全量宣言で fail-open を機構的に閉じた。
- 現時点で `@StoreSetScoped` の唯一の使用箇所（`PlatformOrderService.list()`）は `Order` 単体を select し他 7 エンティティへの join を持たないため、本変更は実行時挙動を一切変えない（未有効化の Hibernate `@Filter` は零コスト）。

## 備考 / レビュー観点

- `/code-review` の Standards 軸で 1 件（`total_elements` 断言の `(AC2)` ラベルが同ファイル内の既存 `(AC2)` テスト — #323 由来の AC 番号 — と衝突）を指摘され、ラベルを外して修正済み。Spec 軸は指摘なし。
- 宣言追加が休眠状態になりうる点（実際に読む `@StoreSetScoped` メソッドが無い限り無効）は ADR の Consequences に明記。将来 `@StoreSetScoped` を第二集約へ拡張する側は本 PR の対象外。