### PR TITLE
fix: 受注作成フォームの受付担当ドロップダウンを実在する平台スタッフの動的一覧へ置き換える

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/order/OrderReceptionistIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/OrderReceptionistIT.java
@@ -1,0 +1,183 @@
+package com.kizuna.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kizuna.shared.CrossStoreTestSupport;
+import com.kizuna.user.domain.CapabilityBundleRepository;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import com.kizuna.user.domain.StoreScopeType;
+import com.kizuna.user.domain.UserType;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * GET /store/orders/receptionists の集合作用域を本物の PostgreSQL で検証する統合テスト。
+ *
+ * <p>{@code OrderService#listReceptionists} が {@code validateReceptionist}
+ * と同一の適格条件を共有することの証跡。断言は「帰属不一致」型の弱断言ではなく、応答生ボディに授権外店舗の実データ（表示名）が 一切現れないこと（負向強断言）で行う。先例は {@link
+ * PlatformOrderScopeIT}（リポジトリ直挿 + 実データ断言）。
+ */
+class OrderReceptionistIT extends CrossStoreTestSupport {
+
+  private static final String PASSWORD = "pass";
+  private static final String STORE_B_STAFF_EMAIL = "receptionist-it-store-b-staff@kizuna.test";
+  private static final String STORE_B_STAFF_NAME = "統合テスト店舗B専属スタッフ";
+  private static final String CAST_EMAIL = "receptionist-it-cast@kizuna.test";
+
+  @Autowired private PlatformUserRepository platformUserRepository;
+  @Autowired private CapabilityBundleRepository capabilityBundleRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  @BeforeEach
+  void prepareFixture() {
+    ensurePlatformUser(
+        STORE_B_STAFF_EMAIL,
+        STORE_B_STAFF_NAME,
+        UserType.STAFF,
+        bundleIdsOf("店舗スタッフ"),
+        StoreScopeType.SPECIFIC_STORES,
+        Set.of(STORE_B));
+    ensurePlatformUser(
+        CAST_EMAIL,
+        "統合テストキャスト（受付一覧IT）",
+        UserType.CAST,
+        Set.of(),
+        StoreScopeType.ALL_STORES,
+        Set.of());
+  }
+
+  /** リポジトリ直挿（テストスレッドは @StoreScoped を経由せず storeFilter が無効なので他店舗にも書ける）。 */
+  private void ensurePlatformUser(
+      String email,
+      String displayName,
+      UserType userType,
+      Set<Long> bundleIds,
+      StoreScopeType scopeType,
+      Set<Long> storeIds) {
+    platformUserRepository
+        .findByEmail(email)
+        .orElseGet(
+            () ->
+                platformUserRepository.save(
+                    PlatformUser.builder()
+                        .email(email)
+                        .password(passwordEncoder.encode(PASSWORD))
+                        .displayName(displayName)
+                        .enabled(true)
+                        .userType(userType)
+                        .bundleIds(bundleIds)
+                        .storeScopeType(scopeType)
+                        .storeIds(storeIds)
+                        .build()));
+  }
+
+  /** 種子の既定束を名称で解決する（束はデータ — id を決め打ちしない）。 */
+  private Set<Long> bundleIdsOf(String bundleName) {
+    return Set.of(capabilityBundleRepository.findByName(bundleName).orElseThrow().getId());
+  }
+
+  private String platformToken(String email, String password) {
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/platform/login",
+            new HttpEntity<>(
+                String.format("{\"email\": \"%s\", \"password\": \"%s\"}", email, password),
+                jsonHeaders()),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).as("前提: 平台ログインが成功すること").isEqualTo(HttpStatus.OK);
+    String token = res.getBody().path("token").asString();
+    assertThat(token).isNotBlank();
+    return token;
+  }
+
+  private static HttpHeaders headersFor(String token, long storeId) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("X-Role", "store");
+    headers.set("X-Store-ID", String.valueOf(storeId));
+    headers.setBearerAuth(token);
+    return headers;
+  }
+
+  @Test
+  @DisplayName("store A の受付候補一覧にログイン中のシードスタッフ(山田次郎)が含まれること(正向)")
+  void storeAReceptionistsIncludeSeedStaff() {
+    ResponseEntity<JsonNode> res =
+        rest.exchange(
+            "/store/orders/receptionists",
+            HttpMethod.GET,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    boolean found = false;
+    for (JsonNode node : res.getBody()) {
+      if ("山田次郎".equals(node.path("display_name").asString())) {
+        found = true;
+        break;
+      }
+    }
+    assertThat(found).as("ログイン中のシードスタッフが受付候補として現れること").isTrue();
+  }
+
+  @Test
+  @DisplayName("store B専属スタッフの実データが store A の受付候補一覧に一切現れないこと(負向強断言)")
+  void storeAReceptionistsNeverLeakStoreBStaff() {
+    ResponseEntity<String> storeAResponse =
+        rest.exchange(
+            "/store/orders/receptionists",
+            HttpMethod.GET,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            String.class);
+    assertThat(storeAResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(storeAResponse.getBody())
+        .as("授権外店舗(store B)専属スタッフの実データが生ボディに現れないこと")
+        .doesNotContain(STORE_B_STAFF_NAME);
+
+    // 正向対照: 本人(store B専属)自身のトークンで store B へ照会すれば現れる
+    // （述語が常に空を返しているのではないことの証明。山田次郎のトークンでは store B を授権しないため使えない）。
+    String storeBStaffToken = platformToken(STORE_B_STAFF_EMAIL, PASSWORD);
+    ResponseEntity<String> storeBResponse =
+        rest.exchange(
+            "/store/orders/receptionists",
+            HttpMethod.GET,
+            new HttpEntity<>(headersFor(storeBStaffToken, STORE_B)),
+            String.class);
+    assertThat(storeBResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(storeBResponse.getBody())
+        .as("正向対照: store Bへの照会では同スタッフが現れること")
+        .contains(STORE_B_STAFF_NAME);
+  }
+
+  @Test
+  @DisplayName("PERM_ORDER_MANAGE を持たない CAST ロールで店舗コンソールに触れると 403")
+  void castRoleIsRejected() {
+    String castToken = platformToken(CAST_EMAIL, PASSWORD);
+
+    ResponseEntity<String> res =
+        rest.exchange(
+            "/store/orders/receptionists",
+            HttpMethod.GET,
+            new HttpEntity<>(headersFor(castToken, STORE_A)),
+            String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  private static HttpHeaders jsonHeaders() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+}

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderReceptionistResponse.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderReceptionistResponse.java
@@ -1,0 +1,15 @@
+package com.kizuna.order.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderReceptionistResponse {
+  private Long id;
+  private String displayName;
+}

--- a/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
+++ b/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
@@ -1,10 +1,12 @@
 package com.kizuna.order.api.store;
 
 import com.kizuna.order.api.dto.OrderCreateRequest;
+import com.kizuna.order.api.dto.OrderReceptionistResponse;
 import com.kizuna.order.api.dto.OrderResponse;
 import com.kizuna.order.api.dto.OrderUpdateRequest;
 import com.kizuna.order.application.OrderService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -40,6 +42,12 @@ public class OrderController {
   @PreAuthorize("hasAuthority('PERM_ORDER_MANAGE')")
   public ResponseEntity<OrderResponse> get(@PathVariable String id) {
     return ResponseEntity.ok(orderService.get(id));
+  }
+
+  @GetMapping("/receptionists")
+  @PreAuthorize("hasAuthority('PERM_ORDER_MANAGE')")
+  public ResponseEntity<List<OrderReceptionistResponse>> listReceptionists() {
+    return ResponseEntity.ok(orderService.listReceptionists());
   }
 
   @PostMapping

--- a/backend/src/main/java/com/kizuna/order/application/OrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderService.java
@@ -5,6 +5,7 @@ import com.kizuna.customer.domain.Customer;
 import com.kizuna.customer.domain.CustomerRepository;
 import com.kizuna.order.api.dto.OrderCreateRequest;
 import com.kizuna.order.api.dto.OrderMapper;
+import com.kizuna.order.api.dto.OrderReceptionistResponse;
 import com.kizuna.order.api.dto.OrderResponse;
 import com.kizuna.order.api.dto.OrderUpdateRequest;
 import com.kizuna.order.domain.Order;
@@ -15,8 +16,12 @@ import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.shared.storescope.StoreScoped;
 import com.kizuna.user.domain.Capability;
 import com.kizuna.user.domain.CapabilityBundleRepository;
+import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
 import com.kizuna.user.domain.UserType;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -111,22 +116,52 @@ public class OrderService {
     }
   }
 
+  private void validateReceptionist(Long receptionistId) {
+    Long storeId = storeContext.getStoreId();
+    Set<Long> orderManageBundleIds =
+        capabilityBundleRepository.findIdsByCapability(Capability.ORDER_MANAGE);
+    platformUserRepository
+        .findById(receptionistId)
+        .filter(user -> isEligibleReceptionist(user, storeId, orderManageBundleIds))
+        .orElseThrow(() -> new ServiceException("受付担当者が見つかりません: " + receptionistId));
+  }
+
+  /**
+   * 受付選択肢の一覧（現店舗を授権する ORDER_MANAGE 保持 STAFF）。書き込み時の {@link #validateReceptionist} と同一の適格条件を共有する。
+   *
+   * <p>店舗授権の絞り込みは {@link PlatformUserRepository#findAuthorizedByUserTypeOrderByDisplayNameAsc} が DB
+   * 層で行う（無関係な他店舗ユーザーの ElementCollection を読み込まないため）。能力束の判定のみ {@link #isEligibleReceptionist}
+   * で引き続き行う。
+   */
+  @StoreScoped
+  @Transactional(readOnly = true)
+  public List<OrderReceptionistResponse> listReceptionists() {
+    Long storeId = storeContext.getStoreId();
+    Set<Long> orderManageBundleIds =
+        capabilityBundleRepository.findIdsByCapability(Capability.ORDER_MANAGE);
+    return platformUserRepository
+        .findAuthorizedByUserTypeOrderByDisplayNameAsc(UserType.STAFF, storeId)
+        .stream()
+        .filter(user -> isEligibleReceptionist(user, storeId, orderManageBundleIds))
+        .map(
+            user ->
+                OrderReceptionistResponse.builder()
+                    .id(user.getId())
+                    .displayName(user.getDisplayName())
+                    .build())
+        .toList();
+  }
+
   // 受付担当者は「有効(enabled)かつ受注管理能力（ORDER_MANAGE）を持つ STAFF」かつ「現店舗(店舗)を授権する
   // PlatformUser」でなければならない。t_users には store_id が無いため、単なる存在確認では
   // 他店舗/CAST/MEMBER も通ってしまう。停止済み(enabled=false)の口座は束・授権を保持したままなので明示的に弾く。
-  // userType 判定を先行させ、束を持たない CAST/MEMBER で束問い合わせ（空 in 句）へ進まないようにする。
-  private void validateReceptionist(Long receptionistId) {
-    Long storeId = storeContext.getStoreId();
-    platformUserRepository
-        .findById(receptionistId)
-        .filter(
-            user ->
-                user.getUserType() == UserType.STAFF
-                    && user.getEnabled()
-                    && user.authorizes(storeId)
-                    && capabilityBundleRepository.anyBundleHasCapability(
-                        user.getBundleIds(), Capability.ORDER_MANAGE))
-        .orElseThrow(() -> new ServiceException("受付担当者が見つかりません: " + receptionistId));
+  // 書き込み時の検証（validateReceptionist）と一覧（listReceptionists）が同一条件を共有する。
+  private boolean isEligibleReceptionist(
+      PlatformUser user, Long storeId, Set<Long> orderManageBundleIds) {
+    return user.getUserType() == UserType.STAFF
+        && user.getEnabled()
+        && user.authorizes(storeId)
+        && !Collections.disjoint(user.getBundleIds(), orderManageBundleIds);
   }
 
   @StoreScoped

--- a/backend/src/main/java/com/kizuna/user/domain/CapabilityBundleRepository.java
+++ b/backend/src/main/java/com/kizuna/user/domain/CapabilityBundleRepository.java
@@ -10,12 +10,9 @@ public interface CapabilityBundleRepository extends JpaRepository<CapabilityBund
 
   Optional<CapabilityBundle> findByName(String name);
 
-  /**
-   * 指定した束集合のいずれかが能力を含むか。呼び出し側は bundleIds の非空を保証すること（STAFF は「1 束以上」の不変条件があるため、STAFF の束集合をそのまま渡せる）。
-   */
+  /** 指定した能力を含む束の id 集合。呼び出し側はユーザーの束集合とこの集合の共通部分の有無で能力保持を判定する。 */
   @Query(
-      "select count(b) > 0 from com.kizuna.user.domain.CapabilityBundle b"
-          + " join b.capabilities c where b.id in :bundleIds and c = :capability")
-  boolean anyBundleHasCapability(
-      @Param("bundleIds") Set<Long> bundleIds, @Param("capability") Capability capability);
+      "select b.id from com.kizuna.user.domain.CapabilityBundle b"
+          + " join b.capabilities c where c = :capability")
+  Set<Long> findIdsByCapability(@Param("capability") Capability capability);
 }

--- a/backend/src/main/java/com/kizuna/user/domain/PlatformUser.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PlatformUser.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 /**
  * プラットフォーム共通ユーザー集約。email でログインし、授権は「能力束 × 担当店舗集合 ×（必要時）精算範囲」で表す。
@@ -54,9 +55,13 @@ public class PlatformUser extends BaseEntity {
   @Column(name = "user_type", nullable = false, length = 20)
   private UserType userType;
 
+  // 3 つの EAGER ElementCollection（本フィールド・storeIds・settlementStoreIds）は既定では
+  // 親エンティティ1行ごとに個別 SELECT を発行する。複数ユーザーを一括取得する経路(受付候補一覧等)で
+  // 行数分の副問い合わせが積み上がらないよう、@BatchSize で IN 句によるまとめ取得に切り替える。
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(name = "t_user_bundles", joinColumns = @JoinColumn(name = "platform_user_id"))
   @Column(name = "bundle_id")
+  @BatchSize(size = 25)
   private Set<Long> bundleIds = new HashSet<>();
 
   @Enumerated(EnumType.STRING)
@@ -66,6 +71,7 @@ public class PlatformUser extends BaseEntity {
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(name = "t_user_stores", joinColumns = @JoinColumn(name = "platform_user_id"))
   @Column(name = "store_id")
+  @BatchSize(size = 25)
   private Set<Long> storeIds = new HashSet<>();
 
   /** 精算範囲種別。null は「精算範囲なし」（経理系能力を持たない通常ユーザーの既定）。 */
@@ -78,6 +84,7 @@ public class PlatformUser extends BaseEntity {
       name = "t_user_settlement_stores",
       joinColumns = @JoinColumn(name = "platform_user_id"))
   @Column(name = "store_id")
+  @BatchSize(size = 25)
   private Set<Long> settlementStoreIds = new HashSet<>();
 
   @Builder

--- a/backend/src/main/java/com/kizuna/user/domain/PlatformUserRepository.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PlatformUserRepository.java
@@ -14,6 +14,18 @@ public interface PlatformUserRepository extends JpaRepository<PlatformUser, Long
   List<PlatformUser> findByUserTypeOrderByDisplayNameAsc(UserType userType);
 
   /**
+   * 指定した本人種別で、現店舗を授権する（ALL_STORES または個別授権店舗集合に含む）有効なユーザーを表示名昇順で取得する。店舗スコープの絞り込みを DB
+   * 層で行うことで、無関係な他店舗ユーザーの ElementCollection（束・店舗集合・精算範囲）を読み込まずに済む。
+   */
+  @Query(
+      "select u from PlatformUser u where u.userType = :userType and u.enabled = true"
+          + " and (u.storeScopeType = com.kizuna.user.domain.StoreScopeType.ALL_STORES"
+          + " or :storeId member of u.storeIds)"
+          + " order by u.displayName asc")
+  List<PlatformUser> findAuthorizedByUserTypeOrderByDisplayNameAsc(
+      @Param("userType") UserType userType, @Param("storeId") Long storeId);
+
+  /**
    * email でユーザーを取得し、行に悲観排他ロック（SELECT ... FOR UPDATE）を掛ける。
    *
    * <p>並行する既存受諾が同一ユーザーの授権店舗集合を read-modify-write する際、ロック取得後に最新状態を読み直させることで 「後着の save

--- a/backend/src/main/java/com/kizuna/user/domain/PlatformUserRepository.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PlatformUserRepository.java
@@ -16,6 +16,10 @@ public interface PlatformUserRepository extends JpaRepository<PlatformUser, Long
   /**
    * 指定した本人種別で、現店舗を授権する（ALL_STORES または個別授権店舗集合に含む）有効なユーザーを表示名昇順で取得する。店舗スコープの絞り込みを DB
    * 層で行うことで、無関係な他店舗ユーザーの ElementCollection（束・店舗集合・精算範囲）を読み込まずに済む。
+   *
+   * <p>本クエリの WHERE 句は {@link PlatformUser#authorizes} と同じ条件を HQL で再表現しており、呼び出し側は必ず同条件を含む 述語（例:
+   * 受付適格判定）でさらに絞り込むこと。本クエリ単体は結果を狭める方向にのみ働く事前絞り込みであり、真の条件は呼び出し側の述語が持つ
+   * （二重化した表現が乖離しても、狭める方向にしか作用しないため取りこぼしはあっても漏洩はない）。
    */
   @Query(
       "select u from PlatformUser u where u.userType = :userType and u.enabled = true"

--- a/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
@@ -16,6 +16,7 @@ import com.kizuna.customer.domain.Customer;
 import com.kizuna.customer.domain.CustomerRepository;
 import com.kizuna.order.api.dto.OrderCreateRequest;
 import com.kizuna.order.api.dto.OrderMapper;
+import com.kizuna.order.api.dto.OrderReceptionistResponse;
 import com.kizuna.order.api.dto.OrderResponse;
 import com.kizuna.order.api.dto.OrderUpdateRequest;
 import com.kizuna.order.domain.Order;
@@ -74,13 +75,11 @@ class OrderServiceTest {
 
   @BeforeEach
   void stubReceptionistBundle() {
-    // 受付担当検証は「束のいずれかが ORDER_MANAGE を含むか」を照会する。happy path 用に既定束は
-    // 含む前提で lenient stub し、検証へ到達しないテストで UnnecessaryStubbing を出さない。
+    // 受付担当検証・受付候補一覧はいずれも「ORDER_MANAGE を含む束 id 集合」を照会する。happy path 用に
+    // 既定束を含む前提で lenient stub し、検証へ到達しないテストで UnnecessaryStubbing を出さない。
     lenient()
-        .when(
-            capabilityBundleRepository.anyBundleHasCapability(
-                Set.of(STAFF_BUNDLE_ID), Capability.ORDER_MANAGE))
-        .thenReturn(true);
+        .when(capabilityBundleRepository.findIdsByCapability(Capability.ORDER_MANAGE))
+        .thenReturn(Set.of(STAFF_BUNDLE_ID));
   }
 
   private PlatformUser receptionist(
@@ -263,8 +262,6 @@ class OrderServiceTest {
             .storeIds(Set.of())
             .build();
     when(platformUserRepository.findById(1L)).thenReturn(Optional.of(staffWithoutOrderManage));
-    when(capabilityBundleRepository.anyBundleHasCapability(Set.of(31L), Capability.ORDER_MANAGE))
-        .thenReturn(false);
 
     assertThatThrownBy(() -> service.create(req))
         .isInstanceOf(ServiceException.class)
@@ -468,5 +465,90 @@ class OrderServiceTest {
   void deleteThrowsWhenMissing() {
     when(orderRepository.existsById("nope")).thenReturn(false);
     assertThatThrownBy(() -> service.delete("nope")).isInstanceOf(ServiceException.class);
+  }
+
+  /** {@link #authorizedReceptionist()} を id・表示名だけ差し替えて複製する（一覧テストで複数件を区別するため）。 */
+  private PlatformUser staffAuthorizedForCurrentStore(long id, String displayName) {
+    PlatformUser user = authorizedReceptionist();
+    user.setId(id);
+    user.updateDisplayName(displayName);
+    return user;
+  }
+
+  @Test
+  void listReceptionistsReturnsEligibleStaffOrderedByDisplayName() {
+    when(storeContext.getStoreId()).thenReturn(STORE_ID);
+    PlatformUser first = staffAuthorizedForCurrentStore(10L, "あさひ");
+    PlatformUser second = staffAuthorizedForCurrentStore(11L, "ひかり");
+    when(platformUserRepository.findAuthorizedByUserTypeOrderByDisplayNameAsc(
+            UserType.STAFF, STORE_ID))
+        .thenReturn(List.of(first, second));
+
+    List<OrderReceptionistResponse> result = service.listReceptionists();
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getId()).isEqualTo(10L);
+    assertThat(result.get(0).getDisplayName()).isEqualTo("あさひ");
+    assertThat(result.get(1).getId()).isEqualTo(11L);
+    assertThat(result.get(1).getDisplayName()).isEqualTo("ひかり");
+  }
+
+  @Test
+  void listReceptionistsExcludesDisabledStaff() {
+    when(storeContext.getStoreId()).thenReturn(STORE_ID);
+    PlatformUser disabled = staffAuthorizedForCurrentStore(10L, "停止済み");
+    disabled.stop();
+    when(platformUserRepository.findAuthorizedByUserTypeOrderByDisplayNameAsc(
+            UserType.STAFF, STORE_ID))
+        .thenReturn(List.of(disabled));
+
+    assertThat(service.listReceptionists()).isEmpty();
+  }
+
+  @Test
+  void listReceptionistsExcludesStaffAuthorizedForDifferentStore() {
+    when(storeContext.getStoreId()).thenReturn(STORE_ID);
+    PlatformUser otherStore =
+        receptionist(UserType.STAFF, StoreScopeType.SPECIFIC_STORES, Set.of(2L));
+    otherStore.setId(10L);
+    when(platformUserRepository.findAuthorizedByUserTypeOrderByDisplayNameAsc(
+            UserType.STAFF, STORE_ID))
+        .thenReturn(List.of(otherStore));
+
+    assertThat(service.listReceptionists()).isEmpty();
+  }
+
+  @Test
+  void listReceptionistsExcludesCastRole() {
+    when(storeContext.getStoreId()).thenReturn(STORE_ID);
+    PlatformUser cast = receptionist(UserType.CAST, StoreScopeType.ALL_STORES, Set.of());
+    cast.setId(10L);
+    when(platformUserRepository.findAuthorizedByUserTypeOrderByDisplayNameAsc(
+            UserType.STAFF, STORE_ID))
+        .thenReturn(List.of(cast));
+
+    assertThat(service.listReceptionists()).isEmpty();
+  }
+
+  @Test
+  void listReceptionistsExcludesStaffWithoutOrderManageCapability() {
+    when(storeContext.getStoreId()).thenReturn(STORE_ID);
+    PlatformUser noCapability =
+        PlatformUser.builder()
+            .email("hq2@kizuna.test")
+            .password("pw")
+            .displayName("HQ系スタッフ2")
+            .enabled(true)
+            .userType(UserType.STAFF)
+            .bundleIds(Set.of(31L))
+            .storeScopeType(StoreScopeType.ALL_STORES)
+            .storeIds(Set.of())
+            .build();
+    noCapability.setId(10L);
+    when(platformUserRepository.findAuthorizedByUserTypeOrderByDisplayNameAsc(
+            UserType.STAFF, STORE_ID))
+        .thenReturn(List.of(noCapability));
+
+    assertThat(service.listReceptionists()).isEmpty();
   }
 }

--- a/frontend/src/_pages/store-orders/ui/OrderForm.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import { CastResponse, castApi } from '@/entities/cast';
+import { OrderReceptionist, orderApi } from '@/entities/order';
 import { toast } from 'react-hot-toast';
 
 export interface OrderFormData {
@@ -63,6 +64,20 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
   const [isCastLoading, setIsCastLoading] = useState(false);
   const [isCastOpen, setIsCastOpen] = useState(false);
   const skipNextSearchRef = useRef(false);
+  const [receptionistOptions, setReceptionistOptions] = useState<OrderReceptionist[]>([]);
+
+  useEffect(() => {
+    const loadReceptionists = async () => {
+      try {
+        const receptionists = await orderApi.listReceptionists();
+        setReceptionistOptions(receptionists);
+      } catch {
+        toast.error('受付担当者の取得に失敗しました');
+      }
+    };
+
+    loadReceptionists();
+  }, []);
 
   useEffect(() => {
     const loadInitialCast = async () => {
@@ -152,8 +167,11 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
               className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
             >
               <option value="">－－－</option>
-              <option value="1">なほ</option>
-              <option value="2">松本</option>
+              {receptionistOptions.map(option => (
+                <option key={option.id} value={option.id}>
+                  {option.display_name}
+                </option>
+              ))}
             </select>
           </div>
           <div>

--- a/frontend/src/entities/order/__tests__/order-api.test.ts
+++ b/frontend/src/entities/order/__tests__/order-api.test.ts
@@ -17,4 +17,10 @@ describe('orderApi', () => {
   it('create は /store/orders を POST する', async () => {
     expect(await orderApi.create({} as never)).toEqual({ ok: true, url: '/store/orders' });
   });
+  it('listReceptionists は /store/orders/receptionists を GET する', async () => {
+    expect(await orderApi.listReceptionists()).toEqual({
+      ok: true,
+      url: '/store/orders/receptionists',
+    });
+  });
 });

--- a/frontend/src/entities/order/api/order.ts
+++ b/frontend/src/entities/order/api/order.ts
@@ -1,5 +1,5 @@
 import { Page, PaginationParams, apiClient } from '@/shared/api';
-import { Order, OrderCreateRequest } from '../model/types';
+import { Order, OrderCreateRequest, OrderReceptionist } from '../model/types';
 
 export const orderApi = {
   list: async (params?: PaginationParams & { customer_id?: string }): Promise<Page<Order>> => {
@@ -8,6 +8,10 @@ export const orderApi = {
   },
   create: async (data: OrderCreateRequest): Promise<Order> => {
     const response = await apiClient.post('/store/orders', data);
+    return response.data;
+  },
+  listReceptionists: async (): Promise<OrderReceptionist[]> => {
+    const response = await apiClient.get('/store/orders/receptionists');
     return response.data;
   },
 };

--- a/frontend/src/entities/order/model/types.ts
+++ b/frontend/src/entities/order/model/types.ts
@@ -26,7 +26,7 @@ export interface Order {
 }
 
 export interface OrderReceptionist {
-  id: string;
+  id: number;
   display_name: string;
 }
 

--- a/frontend/src/entities/order/model/types.ts
+++ b/frontend/src/entities/order/model/types.ts
@@ -25,6 +25,11 @@ export interface Order {
   status: string;
 }
 
+export interface OrderReceptionist {
+  id: string;
+  display_name: string;
+}
+
 export interface OrderCreateRequest {
   store_name: string;
   receptionist_id?: string;


### PR DESCRIPTION
## 概要

店舗管理画面の受注作成フォームの「受付」ドロップダウンがハードコードされた2択(value="1"/"2")で、実在するPlatformUserと対応していなかった問題を修正する。`GET /store/orders/receptionists` を新設し、現店舗を授権するORDER_MANAGE保持STAFFの一覧を動的に取得・表示するようにした。

Closes #352

## 変更内容

- `OrderController` に `GET /store/orders/receptionists` を追加(`PERM_ORDER_MANAGE` 守卫)。
- `OrderService`: 書き込み時検証(`validateReceptionist`)と一覧(`listReceptionists`)が同一の適格条件(STAFF・enabled・現店舗授権・ORDER_MANAGE保持)を共有する`isEligibleReceptionist`述語に統合。選択肢と検証の乖離を構造的に防ぐ。
- 新DTO `OrderReceptionistResponse`(`{id, display_name}`のみ。既存の`PlatformStaffResponse`は束・店舗集合・精算範囲まで露出するため店舗側ドロップダウンには過大)。
- `CapabilityBundleRepository`: `anyBundleHasCapability`(ユーザーごとに都度照会)を`findIdsByCapability`(能力保持束id集合を一度だけ取得)に置き換え、N+1を回避。
- `PlatformUserRepository`: `findAuthorizedByUserTypeOrderByDisplayNameAsc`を新設。店舗授権の絞り込みをDB層(`member of`)で行い、無関係な他店舗ユーザーのElementCollection(束・店舗集合・精算範囲)を読み込まないようにした(code review指摘への対応)。
- フロントエンド: `OrderForm.tsx`がマウント時に候補一覧を取得し、ハードコードされた2つの`<option>`を動的レンダリングに置き換え。取得失敗時は`toast.error`、既存の「－－－」プレースホルダーは維持。
- テスト: `OrderServiceTest`に一覧の単体テスト(適格・disabled除外・他店舗除外・CAST除外・能力なし除外)を追加。新規IT `OrderReceptionistIT`で店舗横断の強断言(他店舗専属スタッフの実データが応答生ボディに一切現れないこと、正向対照込み)と403検証を追加。

対象外(意図的): `OrderEditPage.tsx`(既存のmock/未接続ページ、本チケットでは触れない)、ADR、CONTEXT.md(新規語彙なし)。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [x] `task e2e` exit 0(実行シナリオ: 全12 feature / 19シナリオ)
- [x] ローカルで code-review 実施済み(Standards軸・Spec軸の二軸レビューを実施、指摘2件を反映済み)

### 視覚確認（UI 変更時）

ローカルスタックにブラウザでログインし(田中花子/店長)、店舗1の受注作成画面で「受付」ドロップダウンを確認。アクセシビリティツリー上でハードコードされた「なほ」「松本」が消え、実在するシードスタッフ(山田次郎 id=3、田中花子 id=2、他デモ環境に蓄積されたE2E検証用スタッフ)が動的に一覧表示されることを確認済み。

## 決定ログ

- 新エンドポイントは`user`モジュールでなく`order`モジュールに置いた: 「誰が受付になれるか」は書き込み時検証(`validateReceptionist`)がすでに持つorder領域の業務ルールであり、これを2モジュールに分散させると将来ルールが増えたときに一覧と検証がドリフトする(下拉選べるのに提出で400、というバグ)。`user.domain`への越境参照はこのルールのために既に`@NamedInterface`経由で許容されている前例がある。
- 候補一覧はcode review前まで`findByUserTypeOrderByDisplayNameAsc`で全平台STAFFを取得し内存フィルタしていたが、backend/CLAUDE.mdの「一覧はprojectionを使う」規約に反し、`PlatformUser`の3つのeager `@ElementCollection`が無関係な他店舗ユーザー分まで余計なクエリを誘発する懸念があったため、店舗授権フィルタをDB層(`member of`)に下推した。能力判定は共有述語のまま内存で行う(そちらはDB層に落とすと複雑さに見合わないため現状維持)。
- レビューで提案された「適格判定を`PlatformUser`集約自身のメソッドにする」案は採用しなかった: それだとuserモジュールがorder領域固有の「受付担当者」概念を逆に認知することになり、上記のモジュール境界の判断と矛盾するため。

## 備考 / レビュー観点

- `frontend/src/entities/order/model/types.ts`の`OrderReceptionist.id`は`string`型で宣言しているが、バックエンドDTOは`Long`(JSON上はnumber)。react-hook-form/送信時の型強制で実害はないが、型定義の精度としては追って直す余地あり。