### PR TITLE
fix: Order.storeName を非正規化冗長フィールドとしてフロントエンド・バックエンド・DBから削除する

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,7 +52,7 @@ _Avoid_: 各コンポーネントでの me()/stores() 個別取得、店舗パ�
 _Avoid_: Member と Customer の混用、「会員」を店舗台帳の意味で使うこと
 
 **Order（注文）**:
-顧客の店舗における 1 回の予約／受注記録。Customer、Cast、および接客担当（PlatformUser）に紐づく。
+顧客の店舗における 1 回の予約／受注記録。Customer、Cast、および接客担当（PlatformUser）に紐づく。店舗への帰属は `store_id`（StoreScopedEntity）のみで表し、店舗名を非正規化して保存しない（表示が必要な場合は Store への JOIN で導出する。ADR 0003）。
 _Avoid_: Reservation, Booking
 
 **出勤希望（ShiftRequest）**:
@@ -75,5 +75,4 @@ _Avoid_: TenantMenu（旧名）
 
 ## Open questions（未解決の論点）
 
-- **Order.storeName**：注文上の自由テキストの「店名」フィールド。Tenant と店舗は 1:1 と確認済みのため、このフィールドの実際の意味（屋号／ブランド／チャネル名？）は明確化後に改名または削除する。
 - **Customer.rank / classification**：いずれも自由テキストで、等級／区分の正式な値体系は未定義（DB デフォルトは rank='SILVER'）。UI はテキスト入力で暫定対応し、業務側で値集合が確定次第 enum + ドロップダウンに収束させる。

--- a/backend/src/integrationTest/java/com/kizuna/auth/PlatformBridgeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/auth/PlatformBridgeIT.java
@@ -64,9 +64,7 @@ class PlatformBridgeIT extends CrossStoreTestSupport {
   /** ログアウト検証専用ユーザー（他ケースのトークンを巻き込まないため独立させる）。 */
   private static final String LOGOUT_EMAIL = "bridge-logout@kizuna.test";
 
-  private static final String MARKER_S1_STORE_NAME = "店舗1過橋受注";
   private static final String MARKER_S1_REMARKS = "BRIDGE_MARKER_S1";
-  private static final String CANARY_S2_STORE_NAME = "店舗2機密受注";
   private static final String CANARY_S2_REMARKS = "STORE2_LEAK_CANARY";
 
   /** マーカー受注の営業日（PlatformOrderScopeIT の 2999-01-01 と区別する）。 */
@@ -81,8 +79,8 @@ class PlatformBridgeIT extends CrossStoreTestSupport {
   @BeforeEach
   void prepareBridgeFixture() {
     // store1 に正向マーカー、store2（v0.5.0 シードの実在店舗 = STORE_B）にカナリアを直挿する。
-    ensureMarkerOrder(STORE_A, MARKER_S1_STORE_NAME, MARKER_S1_REMARKS);
-    ensureMarkerOrder(STORE_B, CANARY_S2_STORE_NAME, CANARY_S2_REMARKS);
+    ensureMarkerOrder(STORE_A, MARKER_S1_REMARKS);
+    ensureMarkerOrder(STORE_B, CANARY_S2_REMARKS);
 
     ensurePlatformUser(CAST_EMAIL, UserType.CAST, Set.of(), StoreScopeType.ALL_STORES, Set.of());
     ensurePlatformUser(
@@ -94,7 +92,7 @@ class PlatformBridgeIT extends CrossStoreTestSupport {
   }
 
   /** リポジトリ直挿（テストスレッドは @StoreScoped を経由せず storeFilter が無効なので他店舗にも書ける）。 */
-  private void ensureMarkerOrder(long storeId, String storeName, String remarks) {
+  private void ensureMarkerOrder(long storeId, String remarks) {
     boolean exists =
         orderRepository.findAll().stream()
             .anyMatch(
@@ -107,7 +105,6 @@ class PlatformBridgeIT extends CrossStoreTestSupport {
     }
     Order order =
         Order.builder()
-            .storeName(storeName)
             .remarks(remarks)
             .businessDate(MARKER_DATE)
             .status(OrderStatus.CREATED)
@@ -217,8 +214,7 @@ class PlatformBridgeIT extends CrossStoreTestSupport {
     assertThat(store1.getBody())
         .as("店舗1の一覧は店舗1マーカーを含み、店舗2カナリアを一切含まないこと")
         .contains(MARKER_S1_REMARKS)
-        .doesNotContain(CANARY_S2_REMARKS)
-        .doesNotContain(CANARY_S2_STORE_NAME);
+        .doesNotContain(CANARY_S2_REMARKS);
 
     ResponseEntity<String> store2 = getStoreOrdersRaw(bridgeHeaders(token, STORE_B));
     assertThat(store2.getStatusCode()).as("授権内の正側: 店舗2も読めること").isEqualTo(HttpStatus.OK);
@@ -234,8 +230,7 @@ class PlatformBridgeIT extends CrossStoreTestSupport {
     assertThat(read.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     assertThat(read.getBody() == null ? "" : read.getBody())
         .as("拒否応答に店舗2の実データが一切現れないこと")
-        .doesNotContain(CANARY_S2_REMARKS)
-        .doesNotContain(CANARY_S2_STORE_NAME);
+        .doesNotContain(CANARY_S2_REMARKS);
 
     long before = castCountForStore(STORE_B);
     ResponseEntity<String> write =

--- a/backend/src/integrationTest/java/com/kizuna/order/PlatformOrderScopeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/PlatformOrderScopeIT.java
@@ -34,7 +34,7 @@ import tools.jackson.databind.JsonNode;
 /**
  * 集合作用域の実データ非漏洩を本物の PostgreSQL で強断言する統合テスト。
  *
- * <p>断言は「帰属不一致」型の弱断言ではなく、応答生ボディに授権外店舗の実データ（店舗名・カナリア文字列）が 一切現れないこと（AC2）で行う。読みは storeSetFilter が
+ * <p>断言は「帰属不一致」型の弱断言ではなく、応答生ボディに授権外店舗の実データ（店舗ID・カナリア文字列）が 一切現れないこと（AC2）で行う。読みは storeSetFilter が
  * session 層で機構的に濾過し、書きは明示的単店 storeId の 授権検証（{@code PlatformOrderService.create}）が担う。先例は {@link
  * com.kizuna.menu.MenuCrossStoreIT}（リポジトリ直挿 + 実データ断言）と {@link
  * com.kizuna.auth.PlatformAuthIT}（平台トークン取得 + planted-user）。
@@ -51,13 +51,13 @@ class PlatformOrderScopeIT extends CrossStoreTestSupport {
 
   private static final String STORE_B_DOMAIN = "platform-scope-it.kizuna.test";
 
-  private static final String MARKER_A_STORE_NAME = "店舗A受注マーカー";
   private static final String MARKER_A_REMARKS = "SCOPE_MARKER_A";
-  private static final String CANARY_B_STORE_NAME = "店舗B機密受注";
   private static final String CANARY_B_REMARKS = "SCOPE_LEAK_CANARY_B";
 
-  /** マーカー受注が一覧の先頭ページに現れるよう、他 IT の受注より新しい営業日を使う。 */
-  private static final LocalDate MARKER_DATE = LocalDate.of(2999, 1, 1);
+  /** マーカー受注が一覧の先頭ページに現れるよう、他 IT の受注より新しい営業日を使う。店舗ごとに異なる値とし受注を識別する。 */
+  private static final LocalDate MARKER_A_DATE = LocalDate.of(2999, 1, 1);
+
+  private static final LocalDate CANARY_B_DATE = LocalDate.of(2999, 1, 2);
 
   /** v0.5.0 central/01 の山田次郎シード(platform_users id=3, STORE_STAFF, SPECIFIC_STORES{1})。受付担当として使用。 */
   private static final long SEED_RECEPTIONIST_ID = 3L;
@@ -79,8 +79,8 @@ class PlatformOrderScopeIT extends CrossStoreTestSupport {
             .orElseGet(() -> storeRepository.save(new Store("集合作用域IT第二店舗", STORE_B_DOMAIN, null)));
     storeBId = storeB.getId();
 
-    ensureMarkerOrder(STORE_A, MARKER_A_STORE_NAME, MARKER_A_REMARKS);
-    ensureMarkerOrder(storeBId, CANARY_B_STORE_NAME, CANARY_B_REMARKS);
+    ensureMarkerOrder(STORE_A, MARKER_A_DATE, MARKER_A_REMARKS);
+    ensureMarkerOrder(storeBId, CANARY_B_DATE, CANARY_B_REMARKS);
 
     ensurePlatformUser(
         SPECIFIC_EMAIL,
@@ -92,22 +92,21 @@ class PlatformOrderScopeIT extends CrossStoreTestSupport {
   }
 
   /** リポジトリ直挿（テストスレッドは @StoreScoped を経由せず storeFilter が無効なので他店舗にも書ける）。 */
-  private void ensureMarkerOrder(long storeId, String storeName, String remarks) {
+  private void ensureMarkerOrder(long storeId, LocalDate businessDate, String remarks) {
     boolean exists =
         orderRepository.findAll().stream()
             .anyMatch(
                 o ->
                     o.getStoreId() != null
                         && storeId == o.getStoreId()
-                        && storeName.equals(o.getStoreName()));
+                        && businessDate.equals(o.getBusinessDate()));
     if (exists) {
       return;
     }
     Order order =
         Order.builder()
-            .storeName(storeName)
             .remarks(remarks)
-            .businessDate(MARKER_DATE)
+            .businessDate(businessDate)
             .status(OrderStatus.CREATED)
             .build();
     order.setStoreId(storeId);
@@ -212,7 +211,7 @@ class PlatformOrderScopeIT extends CrossStoreTestSupport {
 
     boolean hasMarker = false;
     for (JsonNode node : content) {
-      if (MARKER_A_STORE_NAME.equals(node.path("store_name").asString())) {
+      if (MARKER_A_DATE.toString().equals(node.path("business_date").asString())) {
         hasMarker = true;
         break;
       }
@@ -225,7 +224,7 @@ class PlatformOrderScopeIT extends CrossStoreTestSupport {
   }
 
   @Test
-  @DisplayName("集合外店舗の実データ(店舗B機密受注/カナリア)が応答の生ボディに一切現れないこと(AC2)")
+  @DisplayName("集合外店舗の実データ(store_id/カナリア)が応答の生ボディに一切現れないこと(AC2)")
   void outOfSetRealDataNeverAppearsInResponse() {
     ResponseEntity<String> res =
         rest.exchange(
@@ -236,9 +235,9 @@ class PlatformOrderScopeIT extends CrossStoreTestSupport {
 
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(res.getBody())
-        .as("授権外店舗の店舗名・カナリア文字列が生ボディに現れないこと")
+        .as("授権外店舗の店舗ID・カナリア文字列が生ボディに現れないこと")
         .doesNotContain(CANARY_B_REMARKS)
-        .doesNotContain(CANARY_B_STORE_NAME);
+        .doesNotContain("\"store_id\":" + storeBId);
   }
 
   @Test
@@ -253,15 +252,15 @@ class PlatformOrderScopeIT extends CrossStoreTestSupport {
 
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
     JsonNode content = res.getBody().path("content");
-    List<String> storeNames = new ArrayList<>();
+    List<String> businessDates = new ArrayList<>();
     Set<Long> storeIds = new HashSet<>();
     content.forEach(
         node -> {
-          storeNames.add(node.path("store_name").asString());
+          businessDates.add(node.path("business_date").asString());
           storeIds.add(node.path("store_id").asLong());
         });
 
-    assertThat(storeNames).contains(MARKER_A_STORE_NAME, CANARY_B_STORE_NAME);
+    assertThat(businessDates).contains(MARKER_A_DATE.toString(), CANARY_B_DATE.toString());
     assertThat(storeIds).contains(STORE_A, storeBId);
   }
 

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderCreateRequest.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderCreateRequest.java
@@ -9,8 +9,6 @@ import lombok.Data;
 
 @Data
 public class OrderCreateRequest {
-  private String storeName;
-
   @NotNull(message = "受付は必須です")
   private Long receptionistId;
 

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderResponse.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderResponse.java
@@ -14,7 +14,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class OrderResponse {
   private String id;
-  private String storeName;
   private Long receptionistId;
   private String receptionistName; // Helper for display
   private LocalDate businessDate;

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderUpdateRequest.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderUpdateRequest.java
@@ -8,8 +8,6 @@ import lombok.Data;
 
 @Data
 public class OrderUpdateRequest {
-  private String storeName;
-
   @NotNull(message = "受付は必須です")
   private Long receptionistId;
 

--- a/backend/src/main/java/com/kizuna/order/api/dto/PlatformOrderResponse.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/PlatformOrderResponse.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 public class PlatformOrderResponse {
   private String id;
   private Long storeId;
-  private String storeName;
   private LocalDate businessDate;
   private LocalTime arrivalScheduledStartTime;
   private LocalTime arrivalScheduledEndTime;

--- a/backend/src/main/java/com/kizuna/order/domain/Order.java
+++ b/backend/src/main/java/com/kizuna/order/domain/Order.java
@@ -27,9 +27,6 @@ import org.hibernate.annotations.Type;
 @Builder
 public class Order extends StoreScopedEntity {
 
-  @Column(name = "store_name")
-  private String storeName;
-
   @Column(name = "receptionist_id")
   private Long receptionistId;
 
@@ -118,9 +115,6 @@ public class Order extends StoreScopedEntity {
 
   /** 部分更新コマンドを適用する。null のフィールドは変更しない。 */
   public void apply(OrderPatch patch) {
-    if (patch.storeName() != null) {
-      this.storeName = patch.storeName();
-    }
     if (patch.arrivalScheduledStartTime() != null) {
       this.arrivalScheduledStartTime = patch.arrivalScheduledStartTime();
     }
@@ -184,14 +178,6 @@ public class Order extends StoreScopedEntity {
 
   @Override
   public String toString() {
-    return "Order(id="
-        + getId()
-        + ", storeName="
-        + storeName
-        + ", businessDate="
-        + businessDate
-        + ", status="
-        + status
-        + ")";
+    return "Order(id=" + getId() + ", businessDate=" + businessDate + ", status=" + status + ")";
   }
 }

--- a/backend/src/main/java/com/kizuna/order/domain/OrderPatch.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderPatch.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 /** 注文の部分更新コマンド。null のフィールドは「変更しない」を意味する。 */
 public record OrderPatch(
-    String storeName,
     LocalTime arrivalScheduledStartTime,
     LocalTime arrivalScheduledEndTime,
     Integer courseMinutes,

--- a/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
@@ -15,7 +15,7 @@ public interface OrderRepository
   // Order / Cast は HQL の予約語と衝突しうるため FQCN でエンティティを参照する。
   String VIEW_SELECT =
       """
-      select o.id as id, o.storeName as storeName,
+      select o.id as id,
              o.receptionistId as receptionistId, u.displayName as receptionistName,
              o.businessDate as businessDate,
              o.arrivalScheduledStartTime as arrivalScheduledStartTime,
@@ -51,7 +51,7 @@ public interface OrderRepository
   // 店舗（store）表示名の join は張らない。
   String PLATFORM_VIEW_SELECT =
       """
-      select o.id as id, o.storeId as storeId, o.storeName as storeName,
+      select o.id as id, o.storeId as storeId,
              o.businessDate as businessDate,
              o.arrivalScheduledStartTime as arrivalScheduledStartTime,
              o.arrivalScheduledEndTime as arrivalScheduledEndTime,

--- a/backend/src/main/java/com/kizuna/order/domain/OrderView.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderView.java
@@ -9,8 +9,6 @@ public interface OrderView {
 
   String getId();
 
-  String getStoreName();
-
   Long getReceptionistId();
 
   String getReceptionistName();

--- a/backend/src/main/java/com/kizuna/order/domain/PlatformOrderView.java
+++ b/backend/src/main/java/com/kizuna/order/domain/PlatformOrderView.java
@@ -13,8 +13,6 @@ public interface PlatformOrderView {
 
   Long getStoreId();
 
-  String getStoreName();
-
   LocalDate getBusinessDate();
 
   LocalTime getArrivalScheduledStartTime();

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -8,3 +8,6 @@ databaseChangeLog:
   - include:
       file: releases/v0.3.0/master.yaml
       relativeToChangelogFile: true
+  - include:
+      file: releases/v0.4.0/master.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.4.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.4.0/master.yaml
@@ -1,0 +1,6 @@
+# v0.4.0 = Order の店舗帰属を store_id に一本化する。
+# 構成は v0.1.0 / v0.2.0 / v0.3.0 と同じ platform / store / seed の 3 層のうち store のみ。
+databaseChangeLog:
+  - include:
+      file: store/01-order-drop-store-name.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.4.0/store/01-order-drop-store-name.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.4.0/store/01-order-drop-store-name.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: store-v0400-001-order-drop-store-name
+      author: kanghouchao
+      # Order の店舗帰属は store_id（FK）のみが正とする。自由入力の store_name は重複した表現のため廃止する。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - dropColumn:
+            tableName: t_orders
+            columnName: store_name
+      rollback:
+        - addColumn:
+            tableName: t_orders
+            columns:
+              - column:
+                  name: store_name
+                  type: VARCHAR(255)
+                  remarks: 店舗名

--- a/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
@@ -67,7 +67,7 @@ class OrderServiceTest {
   private static final long STORE_ID = 1L;
 
   private OrderPatch emptyPatch() {
-    return new OrderPatch(null, null, null, null, null, null, null, null, null, null, null, null);
+    return new OrderPatch(null, null, null, null, null, null, null, null, null, null, null);
   }
 
   /** 受付担当ヘルパーが持つ既定束 id。@BeforeEach で ORDER_MANAGE を含むものとして緩く stub する。 */
@@ -321,8 +321,7 @@ class OrderServiceTest {
     when(storeContext.getStoreId()).thenReturn(STORE_ID);
     when(orderMapper.toPatch(any(OrderUpdateRequest.class)))
         .thenReturn(
-            new OrderPatch(
-                "新しい店名", null, null, null, null, null, null, null, null, null, null, null));
+            new OrderPatch(null, null, null, null, null, "新しい割引名", null, null, null, null, null));
     when(castRepository.existsById("g2")).thenReturn(true);
     when(platformUserRepository.findById(2L)).thenReturn(Optional.of(authorizedReceptionist()));
     when(orderRepository.save(any(Order.class))).thenAnswer(i -> i.getArgument(0));
@@ -336,7 +335,7 @@ class OrderServiceTest {
 
     service.update("o1", req);
 
-    assertThat(existing.getStoreName()).isEqualTo("新しい店名");
+    assertThat(existing.getDiscountName()).isEqualTo("新しい割引名");
   }
 
   @Test

--- a/docs/adr/0003-store-scoped-entities-do-not-denormalize-store-name.md
+++ b/docs/adr/0003-store-scoped-entities-do-not-denormalize-store-name.md
@@ -1,0 +1,11 @@
+# 店舗作用域集約は店舗の表示名を非正規化保存しない
+
+Status: Accepted
+
+## Context
+
+`Order.storeName`（#452 で削除）は「店舗の表示名」を `Order` 行に非正規化保存した自由文字列で、正規の帰属先である `store_id` と重複していた。`Shift`/`Cast` は同種の要求を `st.name as storeName` という `Store` への JOIN 投影で満たしており、`Order` だけが非正規化された例外だった。
+
+## Decision
+
+店舗作用域エンティティ（`StoreScopedEntity` 継承）は、店舗名など `store_id` から導出可能な情報を自身の列として重複保存しない。表示が必要になった時点で `Store` への JOIN 投影（`Shift`/`Cast` の既存パターン）で都度導出する。`Order` の店舗横断一覧（`PLATFORM_VIEW_SELECT`）は #452 の時点でこの表示要求自体が存在しない（フロントエンド未消費）ため、JOIN を追加せず `store_id` のみを返す——ADR 0002 が前提とする「Cast/Customer 等への join を意図的に張っていない」という記述と矛盾しない。

--- a/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
@@ -35,7 +35,6 @@ describe('店側オーダー画面と API JSON（snake_case）の整合', () => 
       content: [
         {
           id: '1',
-          store_name: '沼津H',
           business_date: '2026-07-03',
           customer_name: '山田太郎',
           cast_name: '花子',
@@ -56,8 +55,7 @@ describe('店側オーダー画面と API JSON（snake_case）の整合', () => 
 
     render(<OrderListPage />);
 
-    expect(await screen.findByText('沼津H')).toBeInTheDocument();
-    expect(screen.getByText('2026-07-03')).toBeInTheDocument();
+    expect(await screen.findByText('2026-07-03')).toBeInTheDocument();
     expect(screen.getByText('山田太郎')).toBeInTheDocument();
     expect(screen.getByText('花子')).toBeInTheDocument();
     expect(screen.getByText('60 分')).toBeInTheDocument();
@@ -71,9 +69,9 @@ describe('店側オーダー画面と API JSON（snake_case）の整合', () => 
 
     await waitFor(() => expect(mockedOrderApi.create).toHaveBeenCalledTimes(1));
     const body = mockedOrderApi.create.mock.calls[0][0] as unknown as Record<string, unknown>;
-    expect(body).toHaveProperty('store_name', '沼津H');
     expect(body).toHaveProperty('business_date');
     expect(body).toHaveProperty('course_minutes', 60);
+    expect(body).not.toHaveProperty('store_name');
     expect(body).not.toHaveProperty('storeName');
     expect(body).not.toHaveProperty('businessDate');
   });

--- a/frontend/src/_pages/store-orders/ui/OrderCreatePage.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderCreatePage.tsx
@@ -17,7 +17,6 @@ export default function CreateOrderPage() {
     setIsSubmitting(true);
     try {
       const request: OrderCreateRequest = {
-        store_name: data.storeName,
         receptionist_id: data.receptionistId || undefined,
         business_date: data.businessDate,
         arrival_scheduled_start_time: data.arrivalStartTime

--- a/frontend/src/_pages/store-orders/ui/OrderEditPage.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderEditPage.tsx
@@ -15,7 +15,6 @@ export default function EditOrderPage() {
   // Mock initial data - in real app, fetch by id
   const mockInitialData: Partial<OrderFormData> = {
     customerName: '山田太郎',
-    storeName: '沼津H',
     courseMinutes: 60,
     phoneNumber: '09012345678',
   };

--- a/frontend/src/_pages/store-orders/ui/OrderForm.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderForm.tsx
@@ -8,7 +8,6 @@ import { OrderReceptionist, orderApi } from '@/entities/order';
 import { toast } from 'react-hot-toast';
 
 export interface OrderFormData {
-  storeName: string;
   receptionistId: string;
   businessDate: string;
   arrivalStartTime: string;
@@ -150,16 +149,6 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
           基本情報
         </h3>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">店舗名</label>
-            <select
-              {...register('storeName')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            >
-              <option value="沼津H">沼津H</option>
-              <option value="横浜F">横浜F</option>
-            </select>
-          </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">受付</label>
             <select

--- a/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
@@ -41,7 +41,7 @@ export default function OrderListPage() {
             <thead className="bg-gray-50">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  店舗 / 営業日
+                  営業日
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   お客様名
@@ -64,7 +64,6 @@ export default function OrderListPage() {
               {orders.map(order => (
                 <tr key={order.id} className="hover:bg-gray-50 transition-colors">
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm font-medium text-gray-900">{order.store_name}</div>
                     <div className="text-sm text-gray-500">{order.business_date}</div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">

--- a/frontend/src/entities/order/model/types.ts
+++ b/frontend/src/entities/order/model/types.ts
@@ -1,7 +1,6 @@
 // バックエンド API の JSON キーに一致（Jackson グローバル SNAKE_CASE）
 export interface Order {
   id: string;
-  store_name: string;
   receptionist_id?: string;
   receptionist_name?: string;
   business_date: string;
@@ -31,7 +30,6 @@ export interface OrderReceptionist {
 }
 
 export interface OrderCreateRequest {
-  store_name: string;
   receptionist_id?: string;
   business_date: string;
   arrival_scheduled_start_time?: string;


### PR DESCRIPTION
## 概要

`Order.storeName`（店舗名の自由テキストフィールド）を `store_id` への非正規化重複として、フロントエンド・バックエンド・DBスキーマから完全に削除する。

Closes #452

## 変更内容

- `Order.java`/`OrderPatch`/`OrderCreateRequest`/`OrderUpdateRequest`/`OrderResponse`/`PlatformOrderResponse`/`OrderView`/`PlatformOrderView` から `storeName` を削除
- `OrderRepository` の `VIEW_SELECT`/`PLATFORM_VIEW_SELECT` から `store_name` 投影を除去(`Store` への JOIN は追加しない — ADR 0003 参照)
- 新規 Liquibase migration(`releases/v0.4.0`)で `t_orders.store_name` を DROP COLUMN(適用済み `v0.1.0` は未編集)
- `PlatformOrderScopeIT`: `PlatformOrderResponse` が `remarks` を投影しないため実は恒久的に空振りしていた AC2 断言(他店舗実データ非漏洩の強断言)を `store_id` ベースへ修正。マーカー識別も店舗ごとに異なる `business_date` ベースへ変更
- `PlatformBridgeIT`: 同型の死んだ `store_name` 断言・未使用パラメータを除去(`remarks` ベースの断言は元々実働していたため変更なし)
- フロントエンド: `OrderForm.tsx` の店舗名ドロップダウン削除、`OrdersPage.tsx` の列見出しを「営業日」単独へ簡略化(このページは常に単一店舗スコープのため)、関連する型・テストを更新
- `CONTEXT.md`: `Order.storeName` の Open question を解消(エントリ削除)、`Order` の用語定義に非正規化禁止の方針を追記
- `docs/adr/0003-store-scoped-entities-do-not-denormalize-store-name.md` を新設: 「店舗作用域エンティティは `store_id` から導出可能な情報を非正規化保存しない」という一般原則を記録(既存 ADR 0002 の前提と整合)

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0(frontend + backend unit + backend integration すべて含む)
- [x] `task build` exit 0(frontend + backend)
- [ ] `task e2e` exit 0 — 未実施。`e2e/` を grep し、削除対象のドロップダウン/表示に依存するシナリオが存在しないことは確認済み
- [ ] ローカルで code-review 実施済み — `/code-review` スキルは未実施。実装後に diff を手動監査し、実装 agent が「不許碰」指定だった `PlatformBridgeIT.java` をコンパイルのため已むを得ず改変した際に残した死んだ断言(`storeName` ベースの空振りチェック)を発見・修正済み

## 決定ログ

issue 本文のスコープに加え、実装前の domain-modeling グリリングセッションで以下を確定した:

1. `PlatformOrderScopeIT` の AC2 検証力喪失(issue 本文は「実装時に要確認」としていたが、実際には確実に空振りになることが判明)を本 PR のスコープに含めた。修正は `PlatformOrderResponse` へのフィールド追加ではなく、既存投影済みの `store_id`/`business_date` を使う方針とした
2. `OrdersPage` の列は「営業日」単独に簡略化(店舗名は行間で不変なため表示する意味がない)
3. `OrderForm.tsx` の他の固定 `<option>`(区分/ペット有無/コース/割引)や `carrier`/`mediaName` は同一根因か未判定のため、本 issue のスコープには含めていない
4. `PLATFORM_VIEW_SELECT` への `Store` JOIN 追加は見送り — 現状フロントエンドから一切消費されていない店舗横断一覧に、使われる予定のない表示機能を先回りして足さない判断
5. 上記の一般原則を ADR 0003 として記録

## 備考 / レビュー観点

- `PlatformOrderScopeIT`/`PlatformBridgeIT` の書き換えが、変更前と同等の断言強度(「帰属不一致」の弱い断言ではなく「実データが生ボディに一切現れない」強断言)を維持できているかを重点的に見てほしい
- `OrderServiceTest.updateAppliesPatchFields` は `storeName` ではなく `discountName` の patch 適用を検証するよう差し替えた
- マージ前に `task e2e` とローカル `/code-review` の実施を推奨
