### PR TITLE
docs: CLAUDE.md からコードで導出可能な技術スタック一覧とモジュールツリーを削除する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,6 @@
 
 A platform CMS/CRM/HRM system for running the operations of multiple stores under a single group.
 
-- Backend: Java 25, Spring Boot 4.1+, JUnit 5, Jacoco, Lombok, MapStruct
-- Frontend: TypeScript 5.9, React 19, Next.js 16+, Jest, ESLint, Prettier
-- Database: PostgreSQL 18+, Redis 8+, Docker volumes for persistence
-- Traefik 3+ for reverse proxy and routing
-
 Java is pinned to 25 by `backend/.java-version` (jenv, effective under `backend/`) and `backend/gradle/gradle-daemon-jvm.properties` (Gradle daemon). Builds, tests, and Spotless must run on JDK 25.
 
 ## Key documents

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Module structure (Spring Modulith)
 
-Each module under `com.kizuna` follows the DDD four layers — `domain/` / `application/` (use-case services = the transaction boundary) / `infrastructure/` / `api/` (`platform/` + `store/` controllers, `dto/` + MapStruct mappers); `shared/` is the OPEN shared kernel.
+Each module under `com.kizuna` follows the DDD four layers — `domain/` / `application/` (use-case services = the transaction boundary) / `infrastructure/` / `api/` (`dto/` + MapStruct mappers, plus `platform/` and `store/` controllers **each only when that scope is actually exposed**: a single-scope module is normal, not incomplete); `shared/` is the OPEN shared kernel.
 
 ### Layer / module rules
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,32 +1,8 @@
 # Backend (Java) Conventions
 
-- **Java version**: 25
-- **Framework**: Spring Boot 4.1+, Spring Modulith, Spring Data JPA, Spring Security, Liquibase
-- **Testing**: JUnit 5, Jacoco (LINE ≥ 70%)
-- **Code generation**: Lombok, MapStruct
-- **Database**: PostgreSQL 18+, Redis 8+
-
 ## Module structure (Spring Modulith)
 
-```
-com.kizuna
-├── shared/          # Shared kernel (OPEN module): storescope, web, config, exception, persistence
-├── store/  auth/  user/  cast/  customer/  order/
-└── menu/  settings/  storeprofile/  shift/  notification/  storage/
-```
-
-Each module follows the DDD four layers:
-
-```
-<module>/
-├── domain/          # Aggregate (JPA entity, rich model), value objects, enums, domain events, repository interfaces
-├── application/     # Use-case services (transaction boundary), read-side queries
-├── infrastructure/  # Additional adapters (interceptors, utilities, etc.)
-└── api/
-    ├── platform/    # Platform-side controllers (when needed)
-    ├── store/       # Store-side controllers (when needed)
-    └── dto/         # request/response + MapStruct mappers
-```
+Each module under `com.kizuna` follows the DDD four layers — `domain/` / `application/` (use-case services = the transaction boundary) / `infrastructure/` / `api/` (`platform/` + `store/` controllers, `dto/` + MapStruct mappers); `shared/` is the OPEN shared kernel.
 
 ### Layer / module rules
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,6 +1,5 @@
 # Frontend (TypeScript) Conventions
 
-- **Stack**: TypeScript 5.9, React 19, Next.js 16 (App Router), Jest, ESLint, Prettier
 - **UI work**: read [`DESIGN.md`](./DESIGN.md) FIRST (design system: colors/fonts/spacing/components); if a frontend-design skill is available, invoke it before writing markup.
 - **Architecture**: Feature-Sliced Design (FSD). The layer structure is machine-checked by **Steiger** in `task lint` / CI.
 


### PR DESCRIPTION
## 概要

CLAUDE.md 3 ファイルから、新しいセッションがコードベース自体（package.json / build.gradle / `ls`）から数回のツール呼び出しで再構成できる記述を削除する。毎セッションのコンテキスト常駐コストを下げ、導出不可能な事実（ゴッチャ・規約・設計理由）だけを残す。

## 変更内容

- `CLAUDE.md`: Project Overview の技術スタック一覧 4 行を削除（JDK 25 ピン留めの段落は保持）
- `backend/CLAUDE.md`: 冒頭のスタック一覧 5 行と 2 つの ASCII ディレクトリツリーを削除。ツリーが持っていた非自明な事実（application 層 = トランザクション境界、shared = OPEN モジュール、api/ の platform/store/dto 構成）は 1 文に集約して保持。Layer / module rules 以下の規約条文は無変更
- `frontend/CLAUDE.md`: Stack 一覧 1 行を削除（FSD ツリーは注釈が契約情報を含むため保持）

## 検証

<!-- 合否はすべて exit code で判定（出力は日本語ロケールのことがある） -->

- [ ] `task lint` exit 0
- [ ] `task test` exit 0
- [ ] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: なし）
- [ ] ローカルで code-review 実施済み

ドキュメント（AI 規訓ファイル）のみの削減でコード・設定・CI 定義に触れていないため、ローカルのフル検証は実施していない。パスが `backend/` / `frontend/` 配下に掛かるため、CI 側では両サイドの Lint and Test ジョブがフルゲート（lint + unit + build）として実行される。

## 決定ログ

- 削除基準は「新セッションがリポジトリを読むだけで再構成できるか」。マニフェスト由来のスタック一覧と `ls` で得られるツリーは削除対象、コードから読み取れない事実（JDK 25 の固定手段、トランザクション境界の置き場所、OPEN モジュール宣言）は保持
- ツリーの完全削除ではなく 1 文への集約を選んだのは、上記の非自明な注釈がツリー内に埋まっていたため

## 備考 / レビュー観点

- 残した 1 文に導出不可能な事実の取りこぼしがないかを重点的に見てほしい
- 本 PR は Claude Code の /doctor 診断（常駐コンテキスト削減）の提案に基づく

🤖 Generated with [Claude Code](https://claude.com/claude-code)
