### PR TITLE
fix: 写真アップロードが multipart で送信されず失敗する不具合を修正する

### DIFF
--- a/frontend/src/shared/api/__tests__/file.test.ts
+++ b/frontend/src/shared/api/__tests__/file.test.ts
@@ -1,0 +1,30 @@
+import { apiClient, fileApi } from '@/shared/api';
+
+// apiClient の既定 Content-Type は application/json のため、上書きが無いと axios の
+// transformRequest が FormData を JSON 文字列へ変換し、multipart として送られない。
+// アダプタは transformRequest の後に走るので、ここで config.data の型を検証すれば
+// 変換の有無をそのまま確認できる（境界付きヘッダは実 xhr アダプタでしか付かないため検証しない）。
+describe('fileApi.upload', () => {
+  it('multipart のまま送信する（FormData が JSON へ変換されない）', async () => {
+    let capturedData: unknown;
+    const original = apiClient.defaults.adapter;
+    apiClient.defaults.adapter = (async (config: { data: unknown }) => {
+      capturedData = config.data;
+      return {
+        data: { url: '/uploads/a.png', originalName: 'a.png', size: 1 },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+      };
+    }) as typeof apiClient.defaults.adapter;
+
+    try {
+      await fileApi.upload(new File(['x'], 'a.png', { type: 'image/png' }), 'public');
+    } finally {
+      apiClient.defaults.adapter = original;
+    }
+
+    expect(capturedData).toBeInstanceOf(FormData);
+  });
+});

--- a/frontend/src/shared/api/file.ts
+++ b/frontend/src/shared/api/file.ts
@@ -6,8 +6,12 @@ export const fileApi = {
     const formData = new FormData();
     formData.append('file', file);
     formData.append('bucket', bucket);
-    // axiosが自動的に境界を設定するため、Content-Typeヘッダーは手動で設定しない
-    const response = await apiClient.post('/files/upload', formData);
+    // apiClient の既定 Content-Type は application/json のため、この上書きが無いと axios の
+    // transformRequest が FormData を JSON へ変換してしまい multipart として送られない。
+    // multipart/form-data を明示すると JSON 変換を回避でき、境界はブラウザが自動付与する。
+    const response = await apiClient.post('/files/upload', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
     return response.data;
   },
 };


### PR DESCRIPTION
## 概要

`/store/{id}/casts/create`（新規キャスト登録）等で写真をアップロードすると、バックエンドで `MultipartException: Current request is not a multipart request` が発生して失敗していた不具合を修正する。原因はフロントの axios 設定側にある。

## 変更内容

- `frontend/src/shared/api/file.ts`: アップロード要求に `Content-Type: multipart/form-data` を明示し、axios の transformRequest による FormData → JSON 変換を回避する（境界はブラウザが自動付与する）。
- `frontend/src/shared/api/__tests__/file.test.ts`: `config.data` が FormData のまま送信されることを検証する回帰テストを追加。

## 検証

- [x] `npm run lint`（frontend）exit 0（既存の any 警告のみ・本変更の新規 error なし）
- [x] `npx jest src/shared/api`（frontend）5 suites / 22 tests 通過
- [x] 追加テストが修正前は red、修正後は green（赤→緑を確認）
- [x] ローカルで実機再現・修正後の写真アップロード成功を確認済み（報告者確認）
- [ ] `task test` exit 0
- [ ] `task build` exit 0

## 決定ログ

**根本原因**: `apiClient`（`frontend/src/shared/api/client.ts`）はインスタンス既定で `Content-Type: application/json` を設定している。axios 1.x の `transformRequest` は「FormData かつ Content-Type が application/json」のとき FormData を `JSON.stringify(formDataToJSON(data))` へ変換する。ブラウザ用アダプタが FormData の Content-Type を undefined に落として境界を付与する処理は transformRequest の**後**に走るため、その時点で data は既に文字列であり到達しない。結果として `application/json` + JSON body が送信され、`@RequestParam MultipartFile` が multipart として解釈できずに例外となっていた。

**採った案（本 PR）**: アップロード要求のみ `Content-Type: multipart/form-data` を明示。この値は application/json ではないため JSON 変換分岐を回避でき、後段のアダプタが境界付きヘッダへ置換する。変更範囲が最小。

**見送った案**: インスタンス既定の `Content-Type: application/json` の撤廃。全リクエストに影響が及び blast radius が大きいわりに利得がないため不採用。

## 備考 / レビュー観点

- `grep -rn "new FormData" frontend/src` で FormData を POST する箇所は `file.ts` の 1 箇所のみと確認済み（同根因の別変種なし）。
- 追加テストはアダプタをモックし `config.data` の型を検証している。境界付きヘッダは実 xhr アダプタでしか付かないため、ヘッダではなく data 型を検証対象にしている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)