### PR TITLE
test: fileApi.upload テストの mock 応答を API 契約の snake_case へ揃える

### DIFF
--- a/frontend/src/shared/api/__tests__/file.test.ts
+++ b/frontend/src/shared/api/__tests__/file.test.ts
@@ -11,7 +11,7 @@ describe('fileApi.upload', () => {
     apiClient.defaults.adapter = (async (config: { data: unknown }) => {
       capturedData = config.data;
       return {
-        data: { url: '/uploads/a.png', originalName: 'a.png', size: 1 },
+        data: { url: '/uploads/a.png', original_name: 'a.png', size: 1 },
         status: 200,
         statusText: 'OK',
         headers: {},


### PR DESCRIPTION
## 概要

`fileApi.upload` の回帰テストの mock 応答が `originalName` を使っていたが、`FileUploadResponse`（`shared/api/types.ts`）の実フィールドは `original_name`（snake_case）。API 契約を正しく模した値へ揃える。#456 のローカル code-review（Standards 軸）で指摘された軽微な不整合の対応。

## 変更内容

- `frontend/src/shared/api/__tests__/file.test.ts`: mock 応答のキーを `originalName` → `original_name` に修正。

## 検証

- [x] `npx jest src/shared/api/__tests__/file.test.ts` 通過
- [ ] `task test` exit 0
- [ ] `task build` exit 0

## 決定ログ

frontend/CLAUDE.md「API 関連の型およびプロパティ名は snake_case（バックエンド JSON キーに一致）」に準拠。mock adapter の戻り値は `{data: unknown}` 型のため TS の型検査は通っており（テストは `capturedData instanceof FormData` のみ検証）、挙動への影響は無いが、API 契約を不正確に模していたため修正する。

## 備考 / レビュー観点

軽微な整合性修正のみ。挙動変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)