### PR TITLE
refactor(frontend): Headless UI を shadcn/Radix へ移行し依存を撤去する

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "kizuna",
       "version": "0.1.1",
       "dependencies": {
-        "@headlessui/react": "2.2.10",
         "@heroicons/react": "2.2.0",
         "axios": "1.18.1",
         "class-variance-authority": "0.7.1",
@@ -986,21 +985,6 @@
         "@floating-ui/utils": "^0.2.10"
       }
     },
-    "node_modules/@floating-ui/react": {
-      "version": "0.26.28",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
-      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.2",
-        "@floating-ui/utils": "^0.2.8",
-        "tabbable": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
     "node_modules/@floating-ui/react-dom": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
@@ -1019,26 +1003,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
-    },
-    "node_modules/@headlessui/react": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.10.tgz",
-      "integrity": "sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react": "^0.26.16",
-        "@react-aria/focus": "^3.20.2",
-        "@react-aria/interactions": "^3.25.0",
-        "@tanstack/react-virtual": "^3.13.9",
-        "use-sync-external-store": "^1.5.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^18 || ^19 || ^19.0.0-rc"
-      }
     },
     "node_modules/@heroicons/react": {
       "version": "2.2.0",
@@ -3996,103 +3960,6 @@
       "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
       "license": "MIT"
     },
-    "node_modules/@react-aria/focus": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.2.tgz",
-      "integrity": "sha512-JWaCR7wJVggj+ldmM/cb/DXFg47CXR55lznJhZBh4XVqJjMKwaOOqpT5vNN7kpC1wUpXicGNuDnJDN1S/+6dhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-aria/interactions": "^3.25.6",
-        "@react-aria/utils": "^3.31.0",
-        "@react-types/shared": "^3.32.1",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/interactions": {
-      "version": "3.25.6",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.6.tgz",
-      "integrity": "sha512-5UgwZmohpixwNMVkMvn9K1ceJe6TzlRlAfuYoQDUuOkk62/JVJNDLAPKIf5YMRc7d2B0rmfgaZLMtbREb0Zvkw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.10",
-        "@react-aria/utils": "^3.31.0",
-        "@react-stately/flags": "^3.1.2",
-        "@react-types/shared": "^3.32.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/ssr": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
-      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/utils": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.31.0.tgz",
-      "integrity": "sha512-ABOzCsZrWzf78ysswmguJbx3McQUja7yeGj6/vZo4JVsZNlxAN+E9rs381ExBRI0KzVo6iBTeX5De8eMZPJXig==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.10",
-        "@react-stately/flags": "^3.1.2",
-        "@react-stately/utils": "^3.10.8",
-        "@react-types/shared": "^3.32.1",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-stately/flags": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
-      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@react-stately/utils": {
-      "version": "3.10.8",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.8.tgz",
-      "integrity": "sha512-SN3/h7SzRsusVQjQ4v10LaVsDc81jyyR0DD5HnsQitm/I5WDpaSr2nRHtyloPFU48jlql1XX/S04T2DLQM7Y3g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-types/shared": {
-      "version": "3.32.1",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.32.1.tgz",
-      "integrity": "sha512-famxyD5emrGGpFuUlgOP6fVW2h/ZaF405G5KDi3zPHzyjAWys/8W6NAVJtNbkCkhedmvL0xOhvt8feGXyXaw5w==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -4138,15 +4005,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
-      }
-    },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -4496,33 +4354,6 @@
         "@tailwindcss/oxide": "4.3.2",
         "postcss": "^8.5.15",
         "tailwindcss": "4.3.2"
-      }
-    },
-    "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.12",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
-      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/virtual-core": "3.13.12"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.12",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
-      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -13677,12 +13508,6 @@
         "url": "https://opencollective.com/synckit"
       }
     },
-    "node_modules/tabbable": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.3.0.tgz",
-      "integrity": "sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==",
-      "license": "MIT"
-    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -14340,15 +14165,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,6 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@headlessui/react": "2.2.10",
     "@heroicons/react": "2.2.0",
     "axios": "1.18.1",
     "class-variance-authority": "0.7.1",

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldCreateModal.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldCreateModal.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { CastFieldDefinitionCreateRequest, castFieldDefinitionApi } from '@/entities/cast';
 import { getApiErrorMessage } from '@/shared/lib';
+import { Dialog, DialogContent, DialogTitle } from '@/shared/ui';
 
 interface CastFieldCreateModalProps {
   open: boolean;
@@ -54,72 +54,78 @@ export function CastFieldCreateModal({ open, onClose, onCreated }: CastFieldCrea
   };
 
   return (
-    <Dialog open={open} onClose={onClose} className="relative z-50">
-      <div className="fixed inset-0 bg-gray-900/40" aria-hidden="true" />
-      <div className="fixed inset-0 flex items-center justify-center p-4">
-        <DialogPanel className="w-full max-w-md rounded-[10px] border border-gray-200 bg-white shadow-lg">
-          <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
-            フィールドを追加
-          </DialogTitle>
-          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
-            <div>
-              <label htmlFor="field-key" className="mb-1 block text-sm font-medium text-gray-700">
-                key
-              </label>
-              <input
-                id="field-key"
-                type="text"
-                {...register('key', {
-                  required: true,
-                  // バックエンドの @Pattern と同期。constructor・prototype は
-                  // react-hook-form の register 内部予約名で、定義化するとキャスト
-                  // 編集フォームの描画をクラッシュさせるため作成時に拒否する。
-                  pattern: /^(?!constructor$|prototype$)[a-z][a-z0-9_]*$/,
-                })}
-                className={inputClass}
-              />
-              <p className="mt-1 text-xs text-gray-500">
-                英小文字で始まり、英小文字・数字・アンダースコアのみ使用できます(作成後は変更できません)
-              </p>
-            </div>
-            <div>
-              <label htmlFor="field-label" className="mb-1 block text-sm font-medium text-gray-700">
-                label
-              </label>
-              <input
-                id="field-label"
-                type="text"
-                {...register('label', { required: true })}
-                className={inputClass}
-              />
-            </div>
-            <label className="flex items-center gap-2 text-sm text-gray-700">
-              <input
-                type="checkbox"
-                {...register('is_public')}
-                className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-              />
-              公開する(公開詳細ページに表示)
+    <Dialog
+      open={open}
+      onOpenChange={next => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        aria-describedby={undefined}
+        className="gap-0 rounded-[10px] border-gray-200 p-0 sm:max-w-md"
+      >
+        <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
+          フィールドを追加
+        </DialogTitle>
+        <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
+          <div>
+            <label htmlFor="field-key" className="mb-1 block text-sm font-medium text-gray-700">
+              key
             </label>
-            <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
-              <button
-                type="button"
-                onClick={onClose}
-                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              >
-                キャンセル
-              </button>
-              <button
-                type="submit"
-                disabled={isSubmitting}
-                className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              >
-                {isSubmitting ? '追加中...' : '追加する'}
-              </button>
-            </div>
-          </form>
-        </DialogPanel>
-      </div>
+            <input
+              id="field-key"
+              type="text"
+              {...register('key', {
+                required: true,
+                // バックエンドの @Pattern と同期。constructor・prototype は
+                // react-hook-form の register 内部予約名で、定義化するとキャスト
+                // 編集フォームの描画をクラッシュさせるため作成時に拒否する。
+                pattern: /^(?!constructor$|prototype$)[a-z][a-z0-9_]*$/,
+              })}
+              className={inputClass}
+            />
+            <p className="mt-1 text-xs text-gray-500">
+              英小文字で始まり、英小文字・数字・アンダースコアのみ使用できます(作成後は変更できません)
+            </p>
+          </div>
+          <div>
+            <label htmlFor="field-label" className="mb-1 block text-sm font-medium text-gray-700">
+              label
+            </label>
+            <input
+              id="field-label"
+              type="text"
+              {...register('label', { required: true })}
+              className={inputClass}
+            />
+          </div>
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              {...register('is_public')}
+              className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            公開する(公開詳細ページに表示)
+          </label>
+          <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              {isSubmitting ? '追加中...' : '追加する'}
+            </button>
+          </div>
+        </form>
+      </DialogContent>
     </Dialog>
   );
 }

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldEditModal.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldEditModal.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
@@ -10,6 +9,7 @@ import {
   castFieldDefinitionApi,
 } from '@/entities/cast';
 import { getApiErrorMessage } from '@/shared/lib';
+import { Dialog, DialogContent, DialogTitle } from '@/shared/ui';
 
 interface CastFieldEditModalProps {
   open: boolean;
@@ -70,73 +70,79 @@ export function CastFieldEditModal({
   };
 
   return (
-    <Dialog open={open && definition !== null} onClose={onClose} className="relative z-50">
-      <div className="fixed inset-0 bg-gray-900/40" aria-hidden="true" />
-      <div className="fixed inset-0 flex items-center justify-center p-4">
-        <DialogPanel className="w-full max-w-md rounded-[10px] border border-gray-200 bg-white shadow-lg">
-          <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
-            フィールドを編集
-          </DialogTitle>
-          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
-            <div>
-              <span className="mb-1 block text-sm font-medium text-gray-700">key</span>
-              <p className="text-sm text-gray-500">{definition?.key}</p>
-            </div>
-            <div>
-              <label
-                htmlFor="field-edit-label"
-                className="mb-1 block text-sm font-medium text-gray-700"
-              >
-                label
-              </label>
-              <input
-                id="field-edit-label"
-                type="text"
-                {...register('label', { required: true })}
-                className={inputClass}
-              />
-            </div>
-            <div>
-              <label
-                htmlFor="field-edit-display-order"
-                className="mb-1 block text-sm font-medium text-gray-700"
-              >
-                表示順
-              </label>
-              <input
-                id="field-edit-display-order"
-                type="number"
-                {...register('display_order', { valueAsNumber: true, required: true })}
-                className={inputClass}
-              />
-            </div>
-            <label className="flex items-center gap-2 text-sm text-gray-700">
-              <input
-                type="checkbox"
-                {...register('is_public')}
-                className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-              />
-              公開する(公開詳細ページに表示)
+    <Dialog
+      open={open && definition !== null}
+      onOpenChange={next => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        aria-describedby={undefined}
+        className="gap-0 rounded-[10px] border-gray-200 p-0 sm:max-w-md"
+      >
+        <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
+          フィールドを編集
+        </DialogTitle>
+        <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
+          <div>
+            <span className="mb-1 block text-sm font-medium text-gray-700">key</span>
+            <p className="text-sm text-gray-500">{definition?.key}</p>
+          </div>
+          <div>
+            <label
+              htmlFor="field-edit-label"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              label
             </label>
-            <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
-              <button
-                type="button"
-                onClick={onClose}
-                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              >
-                キャンセル
-              </button>
-              <button
-                type="submit"
-                disabled={isSubmitting}
-                className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              >
-                {isSubmitting ? '保存中...' : '保存する'}
-              </button>
-            </div>
-          </form>
-        </DialogPanel>
-      </div>
+            <input
+              id="field-edit-label"
+              type="text"
+              {...register('label', { required: true })}
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="field-edit-display-order"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              表示順
+            </label>
+            <input
+              id="field-edit-display-order"
+              type="number"
+              {...register('display_order', { valueAsNumber: true, required: true })}
+              className={inputClass}
+            />
+          </div>
+          <label className="flex items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              {...register('is_public')}
+              className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            公開する(公開詳細ページに表示)
+          </label>
+          <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              {isSubmitting ? '保存中...' : '保存する'}
+            </button>
+          </div>
+        </form>
+      </DialogContent>
     </Dialog>
   );
 }

--- a/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { CastResponse } from '@/entities/cast';
 import { ShiftResponse, shiftApi } from '@/entities/shift';
+import { Dialog, DialogContent, DialogTitle } from '@/shared/ui';
 
 interface ShiftFormValues {
   cast_id: string;
@@ -109,96 +109,102 @@ export function ShiftFormModal({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} className="relative z-50">
-      <div className="fixed inset-0 bg-gray-900/40" aria-hidden="true" />
-      <div className="fixed inset-0 flex items-center justify-center p-4">
-        <DialogPanel className="w-full max-w-md rounded-[10px] border border-gray-200 bg-white shadow-lg">
-          <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
-            {editing ? 'シフトを編集' : 'シフトを追加'}
-          </DialogTitle>
-          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
+    <Dialog
+      open={open}
+      onOpenChange={next => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        aria-describedby={undefined}
+        className="gap-0 rounded-[10px] border-gray-200 p-0 sm:max-w-md"
+      >
+        <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
+          {editing ? 'シフトを編集' : 'シフトを追加'}
+        </DialogTitle>
+        <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700">キャスト</label>
+            <select {...register('cast_id', { required: true })} className={inputClass}>
+              {casts.length === 0 && <option value="">キャストが未登録です</option>}
+              {casts.map(c => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700">日付</label>
+            <input
+              type="date"
+              {...register('work_date', { required: true })}
+              className={inputClass}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">キャスト</label>
-              <select {...register('cast_id', { required: true })} className={inputClass}>
-                {casts.length === 0 && <option value="">キャストが未登録です</option>}
-                {casts.map(c => (
-                  <option key={c.id} value={c.id}>
-                    {c.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">日付</label>
+              <label className="mb-1 block text-sm font-medium text-gray-700">開始</label>
               <input
-                type="date"
-                {...register('work_date', { required: true })}
+                type="time"
+                {...register('start_time', { required: true })}
                 className={inputClass}
               />
             </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="mb-1 block text-sm font-medium text-gray-700">開始</label>
-                <input
-                  type="time"
-                  {...register('start_time', { required: true })}
-                  className={inputClass}
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-medium text-gray-700">終了</label>
-                <input
-                  type="time"
-                  {...register('end_time', { required: true })}
-                  className={inputClass}
-                />
-              </div>
-            </div>
-            <p className="text-xs text-gray-500">
-              終了が開始以前のときは翌日にまたがる勤務として扱います。
-            </p>
             <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">ステータス</label>
-              <select {...register('status')} className={inputClass}>
-                {STATUS_OPTIONS.map(o => (
-                  <option key={o.value} value={o.value}>
-                    {o.label}
-                  </option>
-                ))}
-              </select>
+              <label className="mb-1 block text-sm font-medium text-gray-700">終了</label>
+              <input
+                type="time"
+                {...register('end_time', { required: true })}
+                className={inputClass}
+              />
             </div>
-            <div className="flex items-center justify-between border-t border-gray-200 pt-4">
-              <div>
-                {editing && (
-                  <button
-                    type="button"
-                    onClick={handleDelete}
-                    className="rounded text-sm font-medium text-red-600 hover:text-red-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                  >
-                    削除
-                  </button>
-                )}
-              </div>
-              <div className="flex gap-3">
+          </div>
+          <p className="text-xs text-gray-500">
+            終了が開始以前のときは翌日にまたがる勤務として扱います。
+          </p>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700">ステータス</label>
+            <select {...register('status')} className={inputClass}>
+              {STATUS_OPTIONS.map(o => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center justify-between border-t border-gray-200 pt-4">
+            <div>
+              {editing && (
                 <button
                   type="button"
-                  onClick={onClose}
-                  className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                  onClick={handleDelete}
+                  className="rounded text-sm font-medium text-red-600 hover:text-red-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
                 >
-                  キャンセル
+                  削除
                 </button>
-                <button
-                  type="submit"
-                  disabled={isSubmitting}
-                  className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                >
-                  {isSubmitting ? '保存中...' : '保存する'}
-                </button>
-              </div>
+              )}
             </div>
-          </form>
-        </DialogPanel>
-      </div>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+              >
+                キャンセル
+              </button>
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+              >
+                {isSubmitting ? '保存中...' : '保存する'}
+              </button>
+            </div>
+          </div>
+        </form>
+      </DialogContent>
     </Dialog>
   );
 }

--- a/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
@@ -103,7 +103,7 @@ export default function ShiftsPage() {
         <p className="mt-1 text-sm text-gray-500">キャストの出勤シフトを登録・確認できます。</p>
       </div>
 
-      <Tabs value={tab} onValueChange={setTab}>
+      <Tabs value={tab} onValueChange={setTab} className="gap-0">
         <TabsList
           variant="line"
           className="h-auto w-full justify-start gap-6 rounded-none border-b border-gray-200 p-0"

--- a/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
@@ -1,23 +1,24 @@
 'use client';
 
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react';
 import { CalendarDaysIcon, ClockIcon, InboxIcon } from '@heroicons/react/24/outline';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { CastResponse, castApi } from '@/entities/cast';
 import { ShiftResponse, shiftApi } from '@/entities/shift';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/ui';
 import { monthRange, toDateStr } from '../lib/datetime';
 import { ShiftCalendar } from './ShiftCalendar';
 import { ShiftFormModal } from './ShiftFormModal';
 import { ShiftRequestInbox } from './ShiftRequestInbox';
 import { ShiftTimeline } from './ShiftTimeline';
 
-const CALENDAR_TAB = 0;
-const TIMELINE_TAB = 1;
+const CALENDAR_TAB = 'calendar';
+const TIMELINE_TAB = 'timeline';
+const REQUESTS_TAB = 'requests';
 
 /** 出勤管理ページ。カレンダー俯瞰・日別タイムライン・出勤希望 inbox をタブで切り替える。 */
 export default function ShiftsPage() {
-  const [tab, setTab] = useState(CALENDAR_TAB);
+  const [tab, setTab] = useState<string>(CALENDAR_TAB);
   const [month, setMonth] = useState(() => {
     const now = new Date();
     return new Date(now.getFullYear(), now.getMonth(), 1);
@@ -92,12 +93,8 @@ export default function ShiftsPage() {
     setTab(TIMELINE_TAB);
   };
 
-  const tabClass = (selected: boolean) =>
-    `border-b-2 px-1 py-3 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-      selected
-        ? 'border-blue-600 text-blue-600'
-        : 'border-transparent text-gray-500 hover:text-gray-700'
-    }`;
+  const tabTriggerClass =
+    'h-auto flex-none rounded-none border-0 border-b-2 border-transparent px-1 py-3 text-sm font-medium text-gray-500 shadow-none after:hidden hover:text-gray-700 data-[state=active]:border-blue-600 data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:shadow-none';
 
   return (
     <div className="space-y-6">
@@ -106,52 +103,53 @@ export default function ShiftsPage() {
         <p className="mt-1 text-sm text-gray-500">キャストの出勤シフトを登録・確認できます。</p>
       </div>
 
-      <TabGroup selectedIndex={tab} onChange={setTab}>
-        <TabList className="flex gap-6 border-b border-gray-200">
-          <Tab className={({ selected }) => tabClass(selected)}>
+      <Tabs value={tab} onValueChange={setTab}>
+        <TabsList
+          variant="line"
+          className="h-auto w-full justify-start gap-6 rounded-none border-b border-gray-200 p-0"
+        >
+          <TabsTrigger value={CALENDAR_TAB} className={tabTriggerClass}>
             <span className="inline-flex items-center gap-1.5">
               <CalendarDaysIcon className="h-4 w-4" />
               カレンダー
             </span>
-          </Tab>
-          <Tab className={({ selected }) => tabClass(selected)}>
+          </TabsTrigger>
+          <TabsTrigger value={TIMELINE_TAB} className={tabTriggerClass}>
             <span className="inline-flex items-center gap-1.5">
               <ClockIcon className="h-4 w-4" />
               タイムライン
             </span>
-          </Tab>
-          <Tab className={({ selected }) => tabClass(selected)}>
+          </TabsTrigger>
+          <TabsTrigger value={REQUESTS_TAB} className={tabTriggerClass}>
             <span className="inline-flex items-center gap-1.5">
               <InboxIcon className="h-4 w-4" />
               出勤希望
             </span>
-          </Tab>
-        </TabList>
-        <TabPanels className="mt-6">
-          <TabPanel>
-            <ShiftCalendar
-              month={month}
-              shifts={shifts}
-              onPrevMonth={() => setMonth(m => new Date(m.getFullYear(), m.getMonth() - 1, 1))}
-              onNextMonth={() => setMonth(m => new Date(m.getFullYear(), m.getMonth() + 1, 1))}
-              onSelectDate={selectDay}
-            />
-          </TabPanel>
-          <TabPanel>
-            <ShiftTimeline
-              date={selectedDate}
-              shifts={shifts}
-              casts={casts}
-              loading={loading}
-              onAddShift={openAdd}
-              onEditShift={openEdit}
-            />
-          </TabPanel>
-          <TabPanel>
-            <ShiftRequestInbox casts={casts} onApproved={reloadShifts} />
-          </TabPanel>
-        </TabPanels>
-      </TabGroup>
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value={CALENDAR_TAB} className="mt-6">
+          <ShiftCalendar
+            month={month}
+            shifts={shifts}
+            onPrevMonth={() => setMonth(m => new Date(m.getFullYear(), m.getMonth() - 1, 1))}
+            onNextMonth={() => setMonth(m => new Date(m.getFullYear(), m.getMonth() + 1, 1))}
+            onSelectDate={selectDay}
+          />
+        </TabsContent>
+        <TabsContent value={TIMELINE_TAB} className="mt-6">
+          <ShiftTimeline
+            date={selectedDate}
+            shifts={shifts}
+            casts={casts}
+            loading={loading}
+            onAddShift={openAdd}
+            onEditShift={openEdit}
+          />
+        </TabsContent>
+        <TabsContent value={REQUESTS_TAB} className="mt-6">
+          <ShiftRequestInbox casts={casts} onApproved={reloadShifts} />
+        </TabsContent>
+      </Tabs>
 
       <ShiftFormModal
         open={modalOpen}

--- a/frontend/src/features/cast-invitation/ui/InvitationModal.tsx
+++ b/frontend/src/features/cast-invitation/ui/InvitationModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
 import { toast } from 'react-hot-toast';
+import { Dialog, DialogContent, DialogTitle } from '@/shared/ui';
 
 interface InvitationModalProps {
   open: boolean;
@@ -24,56 +24,62 @@ export function InvitationModal({ open, link, expiresAt, onClose }: InvitationMo
   };
 
   return (
-    <Dialog open={open} onClose={onClose} className="relative z-50">
-      <div className="fixed inset-0 bg-gray-900/40" aria-hidden="true" />
-      <div className="fixed inset-0 flex items-center justify-center p-4">
-        <DialogPanel className="w-full max-w-md rounded-[10px] border border-gray-200 bg-white shadow-lg">
-          <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
-            招待リンクを発行しました
-          </DialogTitle>
-          <div className="space-y-4 px-6 py-5">
-            <div>
-              <label
-                htmlFor="cast-invitation-link"
-                className="mb-1 block text-sm font-medium text-gray-700"
-              >
-                招待リンク
-              </label>
-              <input
-                id="cast-invitation-link"
-                type="text"
-                readOnly
-                value={link}
-                className="w-full rounded-md border-gray-300 bg-gray-50 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500"
-              />
-            </div>
-            {expiresAt && (
-              <p className="text-sm text-gray-600">
-                有効期限: {new Date(expiresAt).toLocaleString('ja-JP')}
-              </p>
-            )}
-            <p className="text-xs text-gray-500">
-              既に他店舗のキャストとして登録済みの場合、既存アカウントでログインして受諾すると本店舗の権限が追加されます。
-            </p>
-            <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
-              <button
-                type="button"
-                onClick={onClose}
-                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              >
-                閉じる
-              </button>
-              <button
-                type="button"
-                onClick={handleCopy}
-                className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              >
-                コピー
-              </button>
-            </div>
+    <Dialog
+      open={open}
+      onOpenChange={next => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        aria-describedby={undefined}
+        className="gap-0 rounded-[10px] border-gray-200 p-0 sm:max-w-md"
+      >
+        <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
+          招待リンクを発行しました
+        </DialogTitle>
+        <div className="space-y-4 px-6 py-5">
+          <div>
+            <label
+              htmlFor="cast-invitation-link"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              招待リンク
+            </label>
+            <input
+              id="cast-invitation-link"
+              type="text"
+              readOnly
+              value={link}
+              className="w-full rounded-md border-gray-300 bg-gray-50 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            />
           </div>
-        </DialogPanel>
-      </div>
+          {expiresAt && (
+            <p className="text-sm text-gray-600">
+              有効期限: {new Date(expiresAt).toLocaleString('ja-JP')}
+            </p>
+          )}
+          <p className="text-xs text-gray-500">
+            既に他店舗のキャストとして登録済みの場合、既存アカウントでログインして受諾すると本店舗の権限が追加されます。
+          </p>
+          <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              閉じる
+            </button>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              コピー
+            </button>
+          </div>
+        </div>
+      </DialogContent>
     </Dialog>
   );
 }

--- a/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
+++ b/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
@@ -10,6 +9,7 @@ import {
   platformStaffApi,
 } from '@/entities/user';
 import { getApiErrorMessage, useManagedList } from '@/shared/lib';
+import { Dialog, DialogContent, DialogTitle } from '@/shared/ui';
 import { BundlePicker } from './BundlePicker';
 import { SettlementScopePicker } from './SettlementScopePicker';
 import { StoreSetPicker } from './StoreSetPicker';
@@ -83,94 +83,100 @@ export function StaffCreateModal({ open, onClose, onCreated }: StaffCreateModalP
   };
 
   return (
-    <Dialog open={open} onClose={onClose} className="relative z-50">
-      <div className="fixed inset-0 bg-gray-900/40" aria-hidden="true" />
-      <div className="fixed inset-0 flex items-center justify-center p-4">
-        <DialogPanel className="max-h-full w-full max-w-md overflow-y-auto rounded-[10px] border border-gray-200 bg-white shadow-lg">
-          <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
-            スタッフを追加
-          </DialogTitle>
-          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
-            <div>
-              <label htmlFor="staff-email" className="mb-1 block text-sm font-medium text-gray-700">
-                メールアドレス
-              </label>
-              <input
-                id="staff-email"
-                type="email"
-                {...register('email', { required: true })}
-                className={inputClass}
-              />
-            </div>
-            <div>
-              <label
-                htmlFor="staff-password"
-                className="mb-1 block text-sm font-medium text-gray-700"
-              >
-                初期パスワード
-              </label>
-              <input
-                id="staff-password"
-                type="password"
-                {...register('password', { required: true })}
-                className={inputClass}
-              />
-            </div>
-            <div>
-              <label
-                htmlFor="staff-display-name"
-                className="mb-1 block text-sm font-medium text-gray-700"
-              >
-                氏名
-              </label>
-              <input
-                id="staff-display-name"
-                type="text"
-                {...register('display_name', { required: true })}
-                className={inputClass}
-              />
-            </div>
-            <BundlePicker
-              bundles={bundles}
-              isLoading={bundlesLoading}
-              bundleIds={bundleIds}
-              onChange={setBundleIds}
+    <Dialog
+      open={open}
+      onOpenChange={next => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        aria-describedby={undefined}
+        className="max-h-[calc(100vh-2rem)] gap-0 overflow-y-auto rounded-[10px] border-gray-200 p-0 sm:max-w-md"
+      >
+        <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
+          スタッフを追加
+        </DialogTitle>
+        <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
+          <div>
+            <label htmlFor="staff-email" className="mb-1 block text-sm font-medium text-gray-700">
+              メールアドレス
+            </label>
+            <input
+              id="staff-email"
+              type="email"
+              {...register('email', { required: true })}
+              className={inputClass}
             />
-            <StoreSetPicker
-              storeScopeType={storeScopeType}
-              storeIds={storeIds}
-              onChange={next => {
-                setStoreScopeType(next.storeScopeType);
-                setStoreIds(next.storeIds);
-              }}
+          </div>
+          <div>
+            <label
+              htmlFor="staff-password"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              初期パスワード
+            </label>
+            <input
+              id="staff-password"
+              type="password"
+              {...register('password', { required: true })}
+              className={inputClass}
             />
-            <SettlementScopePicker
-              scopeType={settlementScopeType}
-              storeIds={settlementStoreIds}
-              onChange={next => {
-                setSettlementScopeType(next.scopeType);
-                setSettlementStoreIds(next.storeIds);
-              }}
+          </div>
+          <div>
+            <label
+              htmlFor="staff-display-name"
+              className="mb-1 block text-sm font-medium text-gray-700"
+            >
+              氏名
+            </label>
+            <input
+              id="staff-display-name"
+              type="text"
+              {...register('display_name', { required: true })}
+              className={inputClass}
             />
-            <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
-              <button
-                type="button"
-                onClick={onClose}
-                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              >
-                キャンセル
-              </button>
-              <button
-                type="submit"
-                disabled={isSubmitting}
-                className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              >
-                {isSubmitting ? '追加中...' : '追加する'}
-              </button>
-            </div>
-          </form>
-        </DialogPanel>
-      </div>
+          </div>
+          <BundlePicker
+            bundles={bundles}
+            isLoading={bundlesLoading}
+            bundleIds={bundleIds}
+            onChange={setBundleIds}
+          />
+          <StoreSetPicker
+            storeScopeType={storeScopeType}
+            storeIds={storeIds}
+            onChange={next => {
+              setStoreScopeType(next.storeScopeType);
+              setStoreIds(next.storeIds);
+            }}
+          />
+          <SettlementScopePicker
+            scopeType={settlementScopeType}
+            storeIds={settlementStoreIds}
+            onChange={next => {
+              setSettlementScopeType(next.scopeType);
+              setSettlementStoreIds(next.storeIds);
+            }}
+          />
+          <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              {isSubmitting ? '追加中...' : '追加する'}
+            </button>
+          </div>
+        </form>
+      </DialogContent>
     </Dialog>
   );
 }

--- a/frontend/src/features/staff-management/ui/StaffEditDrawer.tsx
+++ b/frontend/src/features/staff-management/ui/StaffEditDrawer.tsx
@@ -125,7 +125,7 @@ export function StaffEditDrawer({ open, onClose, staff, onUpdated }: StaffEditDr
       <DialogContent
         showCloseButton={false}
         aria-describedby={undefined}
-        className="inset-y-0 top-0 right-0 left-auto flex h-full max-w-md translate-x-0 translate-y-0 flex-col gap-0 overflow-y-auto rounded-none border-l border-gray-200 p-0 sm:max-w-md"
+        className="inset-y-0 top-0 right-0 left-auto flex h-full max-w-md translate-x-0 translate-y-0 flex-col gap-0 overflow-y-auto rounded-none border-y-0 border-r-0 border-l border-gray-200 p-0 sm:max-w-md"
       >
         <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
           {staff?.display_name} の権限を編集

--- a/frontend/src/features/staff-management/ui/StaffEditDrawer.tsx
+++ b/frontend/src/features/staff-management/ui/StaffEditDrawer.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import {
@@ -13,6 +12,7 @@ import {
   platformStaffApi,
 } from '@/entities/user';
 import { getApiErrorMessage, useManagedList } from '@/shared/lib';
+import { Dialog, DialogContent, DialogTitle } from '@/shared/ui';
 import { bundleSetLabel } from '../lib/bundleSetLabel';
 import { storeSetLabel } from '../lib/storeSetLabel';
 import { BundlePicker } from './BundlePicker';
@@ -116,106 +116,112 @@ export function StaffEditDrawer({ open, onClose, staff, onUpdated }: StaffEditDr
   };
 
   return (
-    <Dialog open={open && staff !== null} onClose={onClose} className="relative z-50">
-      <div className="fixed inset-0 bg-gray-900/40" aria-hidden="true" />
-      <div className="fixed inset-0 flex justify-end">
-        <DialogPanel className="flex h-full w-full max-w-md flex-col overflow-y-auto border-l border-gray-200 bg-white shadow-lg">
-          <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
-            {staff?.display_name} の権限を編集
-          </DialogTitle>
-          <div className="flex-1 space-y-4 px-6 py-5">
-            <BundlePicker
-              bundles={bundles}
-              isLoading={bundlesLoading}
-              bundleIds={bundleIds}
-              onChange={setBundleIds}
-            />
-            <StoreSetPicker
-              storeScopeType={storeScopeType}
-              storeIds={storeIds}
-              onChange={next => {
-                setStoreScopeType(next.storeScopeType);
-                setStoreIds(next.storeIds);
-              }}
-            />
-            <SettlementScopePicker
-              scopeType={settlementScopeType}
-              storeIds={settlementStoreIds}
-              onChange={next => {
-                setSettlementScopeType(next.scopeType);
-                setSettlementStoreIds(next.storeIds);
-              }}
-            />
-            <div>
-              <span className="mb-1 block text-sm font-medium text-gray-700">状態</span>
-              <div className="flex items-center gap-4">
-                <label className="flex items-center gap-2 text-sm text-gray-700">
-                  <input
-                    type="radio"
-                    name="staff-enabled"
-                    checked={enabled}
-                    onChange={() => setEnabled(true)}
-                    className="border-gray-300 text-blue-600 focus:ring-blue-500"
-                  />
-                  有効
-                </label>
-                <label className="flex items-center gap-2 text-sm text-gray-700">
-                  <input
-                    type="radio"
-                    name="staff-enabled"
-                    checked={!enabled}
-                    onChange={() => setEnabled(false)}
-                    className="border-gray-300 text-blue-600 focus:ring-blue-500"
-                  />
-                  停止
-                </label>
-              </div>
-              <p className="mt-1 text-xs text-gray-500">
-                停止してもアカウントは削除されず、過去の操作記録は保持されます。
-              </p>
+    <Dialog
+      open={open && staff !== null}
+      onOpenChange={next => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        aria-describedby={undefined}
+        className="inset-y-0 top-0 right-0 left-auto flex h-full max-w-md translate-x-0 translate-y-0 flex-col gap-0 overflow-y-auto rounded-none border-l border-gray-200 p-0 sm:max-w-md"
+      >
+        <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
+          {staff?.display_name} の権限を編集
+        </DialogTitle>
+        <div className="flex-1 space-y-4 px-6 py-5">
+          <BundlePicker
+            bundles={bundles}
+            isLoading={bundlesLoading}
+            bundleIds={bundleIds}
+            onChange={setBundleIds}
+          />
+          <StoreSetPicker
+            storeScopeType={storeScopeType}
+            storeIds={storeIds}
+            onChange={next => {
+              setStoreScopeType(next.storeScopeType);
+              setStoreIds(next.storeIds);
+            }}
+          />
+          <SettlementScopePicker
+            scopeType={settlementScopeType}
+            storeIds={settlementStoreIds}
+            onChange={next => {
+              setSettlementScopeType(next.scopeType);
+              setSettlementStoreIds(next.storeIds);
+            }}
+          />
+          <div>
+            <span className="mb-1 block text-sm font-medium text-gray-700">状態</span>
+            <div className="flex items-center gap-4">
+              <label className="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="radio"
+                  name="staff-enabled"
+                  checked={enabled}
+                  onChange={() => setEnabled(true)}
+                  className="border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                有効
+              </label>
+              <label className="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="radio"
+                  name="staff-enabled"
+                  checked={!enabled}
+                  onChange={() => setEnabled(false)}
+                  className="border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                停止
+              </label>
             </div>
-            <div>
-              <p className="mb-1 text-sm font-medium text-gray-700">この設定の結果</p>
-              <p className="rounded-md bg-blue-50 p-3 text-sm text-blue-800">{summary}</p>
-            </div>
-            <div>
-              <p className="mb-1 text-sm font-medium text-gray-700">付与履歴</p>
-              {history.length === 0 ? (
-                <p className="text-sm text-gray-500">履歴はありません</p>
-              ) : (
-                <ul className="space-y-1 rounded-md border border-gray-200 p-3">
-                  {history.map(entry => (
-                    <li key={entry.id} className="text-xs text-gray-600">
-                      <span className="font-medium text-gray-900">
-                        {GRANT_ACTION_LABELS[entry.action] ?? entry.action}
-                      </span>
-                      {' — '}
-                      {new Date(entry.created_at).toLocaleString('ja-JP')} / {entry.actor_email}
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
+            <p className="mt-1 text-xs text-gray-500">
+              停止してもアカウントは削除されず、過去の操作記録は保持されます。
+            </p>
           </div>
-          <div className="flex justify-end gap-3 border-t border-gray-200 px-6 py-4">
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
-              キャンセル
-            </button>
-            <button
-              type="button"
-              onClick={submit}
-              disabled={isSubmitting}
-              className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
-              {isSubmitting ? '保存中...' : '保存する'}
-            </button>
+          <div>
+            <p className="mb-1 text-sm font-medium text-gray-700">この設定の結果</p>
+            <p className="rounded-md bg-blue-50 p-3 text-sm text-blue-800">{summary}</p>
           </div>
-        </DialogPanel>
-      </div>
+          <div>
+            <p className="mb-1 text-sm font-medium text-gray-700">付与履歴</p>
+            {history.length === 0 ? (
+              <p className="text-sm text-gray-500">履歴はありません</p>
+            ) : (
+              <ul className="space-y-1 rounded-md border border-gray-200 p-3">
+                {history.map(entry => (
+                  <li key={entry.id} className="text-xs text-gray-600">
+                    <span className="font-medium text-gray-900">
+                      {GRANT_ACTION_LABELS[entry.action] ?? entry.action}
+                    </span>
+                    {' — '}
+                    {new Date(entry.created_at).toLocaleString('ja-JP')} / {entry.actor_email}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+        <div className="flex justify-end gap-3 border-t border-gray-200 px-6 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={isSubmitting}
+            className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            {isSubmitting ? '保存中...' : '保存する'}
+          </button>
+        </div>
+      </DialogContent>
     </Dialog>
   );
 }

--- a/frontend/src/widgets/header/ui/Header.tsx
+++ b/frontend/src/widgets/header/ui/Header.tsx
@@ -1,9 +1,14 @@
 'use client';
 
 import Link from 'next/link';
-import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
 import { useAuth, useStoreContext } from '@/entities/user';
 import { isStoreDomain, storePath } from '@/shared/lib';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/shared/ui';
 import { BellIcon, BuildingStorefrontIcon, UserCircleIcon } from '@heroicons/react/24/outline';
 
 export function Header() {
@@ -37,27 +42,23 @@ export function Header() {
         <div className="h-8 w-px bg-gray-200" />
 
         {stores && stores.length > 0 && (
-          <Menu as="div" className="relative">
-            <MenuButton
-              disabled={stores.length === 0}
-              className="flex items-center gap-2 rounded-md border border-gray-200 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
+          <DropdownMenu>
+            <DropdownMenuTrigger className="flex items-center gap-2 rounded-md border border-gray-200 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500">
               <BuildingStorefrontIcon className="h-5 w-5 text-gray-400" />
               <span>{currentStoreName || '店舗を選択'}</span>
-            </MenuButton>
-            <MenuItems className="absolute right-0 mt-2 w-56 bg-white rounded-md shadow-lg py-1 border border-gray-100 focus:outline-none">
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" sideOffset={8} className="w-56">
               {stores.map(store => (
-                <MenuItem key={store.id}>
-                  <button
-                    onClick={() => switchStore(store.id)}
-                    className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
-                  >
-                    {store.name}
-                  </button>
-                </MenuItem>
+                <DropdownMenuItem
+                  key={store.id}
+                  onSelect={() => switchStore(store.id)}
+                  className="px-4 py-2 text-sm text-gray-700"
+                >
+                  {store.name}
+                </DropdownMenuItem>
               ))}
-            </MenuItems>
-          </Menu>
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
 
         <div className="flex items-center space-x-4">

--- a/frontend/src/widgets/header/ui/__tests__/Header.test.tsx
+++ b/frontend/src/widgets/header/ui/__tests__/Header.test.tsx
@@ -4,13 +4,18 @@ import { useStoreContext } from '@/entities/user';
 import { isStoreDomain } from '@/shared/lib';
 import type { PlatformStore } from '@/entities/user';
 
-// Headless UI の Menu は開閉時に ResizeObserver を使うが jsdom には無いため最小スタブを差す。
+// Radix の DropdownMenu は Popper（floating-ui）で位置決めし、開閉時に ResizeObserver を、
+// フォーカス移動時に scrollIntoView を、トリガーで hasPointerCapture を使うが、いずれも
+// jsdom には無いため最小スタブを差す。
 class ResizeObserverStub {
   observe() {}
   unobserve() {}
   disconnect() {}
 }
 global.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+Element.prototype.scrollIntoView = jest.fn();
+Element.prototype.hasPointerCapture = jest.fn();
+Element.prototype.releasePointerCapture = jest.fn();
 
 // 現在店舗・授権店舗・切替は店舗コンテキストが担い、その全ケースは StoreContext.test.tsx で検証する。
 // ここでは context 出力（stores / currentStoreId）に対する Header 自身の表示条件・ラベル・
@@ -70,7 +75,7 @@ describe('Header 店舗切替の常設化（店舗コンテキスト集約）', 
     expect(screen.getByRole('button', { name: '店舗A' })).toBeInTheDocument();
   });
 
-  it('店舗切替クリックは context の switchStore に店舗 id を委譲する', () => {
+  it('店舗切替クリックは context の switchStore に店舗 id を委譲する', async () => {
     withContext(
       [
         { id: 1, name: '店舗A' },
@@ -80,8 +85,10 @@ describe('Header 店舗切替の常設化（店舗コンテキスト集約）', 
     );
 
     render(<Header />);
-    fireEvent.click(screen.getByRole('button', { name: '店舗A' }));
-    fireEvent.click(screen.getByRole('menuitem', { name: '店舗B' }));
+    // Radix のトリガーは pointerdown/キー入力で開く。jsdom の fireEvent.click は
+    // pointerdown を合成しないため、キーボードでメニューを開いてから項目を選ぶ。
+    fireEvent.keyDown(screen.getByRole('button', { name: '店舗A' }), { key: 'Enter' });
+    fireEvent.click(await screen.findByRole('menuitem', { name: '店舗B' }));
 
     expect(mockSwitchStore).toHaveBeenCalledWith(2);
   });


### PR DESCRIPTION
## 概要

shadcn/ui 移行(地図 #458)の第3歩。既存の `@headlessui/react` 使用を全て shadcn/Radix プリミティブへ置換し、`@headlessui/react` 依存を撤去する。**機能等価**が主眼で、見た目の変更は最小限(restyle は後続票)。

Closes #468

## 変更内容

- **Dialog×6** → shadcn `Dialog`:InvitationModal / StaffCreateModal / StaffEditDrawer / ShiftFormModal / CastFieldCreateModal / CastFieldEditModal。手書きバックドロップ + 中央寄せラッパを削除(`DialogContent` が Overlay/中央配置/フォーカストラップを内蔵)。`open`/`onClose` → `open`/`onOpenChange`(`if (!next) onClose()`)。各モーダルは既存の閉じるボタンを保持(`showCloseButton={false}`)。
- **Menu×1** → shadcn `DropdownMenu`:`widgets/header/ui/Header.tsx`(店舗切替)。`switchStore` は `onSelect` に配線。`Header.test.tsx` を Radix の DOM(Portal・キーボード起動)へ更新。
- **Tab×1** → shadcn `Tabs`:`_pages/store-shifts/ui/ShiftsPage.tsx`。index 制御 → value 文字列制御(calendar/timeline/requests)。
- `@headlessui/react` を package.json / lock から撤去(`grep` で使用ゼロを確認)。`@heroicons/react` は継続使用のため残置。
- レビュー指摘対応(cosmetic): StaffEditDrawer の枠線を左辺のみへ、Tabs のタブ〜本文間隔を従来の 24px へ。

## 検証

- [x] `task -d frontend lint` exit 0
- [x] `task -d frontend test` exit 0(Jest 52 suites / 266 tests)
- [x] `task -d frontend build` exit 0(production build、8 ファイル型検査通過)
- [ ] `task test`(integration)/ `task e2e`: frontend 限定・API 契約無変更のため該当なし
- [x] ローカルで code-review 実施済み(2 軸、行為等価性を重点)。blocking / should-fix なし。

### 視覚確認(UI 変更時)

**要手動スモーク**: 移行 8 ファイルのうち 6 ファイル(InvitationModal / StaffCreateModal / StaffEditDrawer / ShiftFormModal / CastFieldEditModal / ShiftsPage)は `collectCoverageFrom` 対象外でランタイムテストが無く、型検査 + lint + レビューの静的検証のみ。**マージ前に StaffEditDrawer(右ドロワー)とシフトのタブ切替の目視確認を推奨**。Header と CastFieldCreateModal はランタイムテストあり(緑)。

## 決定ログ

- **機能等価を優先**:プリミティブ焼き込み由来の軽微な見た目差(overlay `gray-900/40`→`black/50`、DialogTitle の line-height)は許容し、restyle は別票へ。
- **StaffEditDrawer は Radix Dialog のまま**位置を className で右ドロワー化(shadcn `Sheet` は未導入。将来 Sheet 追加時の置換候補)。
- **Header は `onSelect`**(onClick フォールバックは不要だった。jsdom テストはキーボード起動 + `findByRole` で対応)。dead code だった `disabled={stores.length===0}` を除去。
- **Tabs は index→value**:全参照(range memo・selectDay・状態)を文字列へ統一。line variant の焼き込み下線と二重にならないよう `after:hidden` を付与し、`data-[state=active]:border-blue-600` を活性インジケータとする。

## 備考 / レビュー観点

- 最重点は行為等価性(実業務 UI)。特に StaffEditDrawer のドロワー描画と ShiftsPage のタブ挙動(「日付クリック→タイムラインへ遷移」を含む)。
- 別件(本 PR 範囲外): `src/shared/api/__tests__/file.test.ts` に master 由来の既存 tsc エラー(TS2352)。CI 門禁外だが別チケットで対応予定。
- push/PR まで実施。**マージは owner が手動**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
