### PR TITLE
refactor(frontend): オーダーフォームを shadcn プリミティブへ restyle する

### DIFF
--- a/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
@@ -71,6 +71,12 @@ describe('店側オーダー画面と API JSON（snake_case）の整合', () => 
     const body = mockedOrderApi.create.mock.calls[0][0] as unknown as Record<string, unknown>;
     expect(body).toHaveProperty('business_date');
     expect(body).toHaveProperty('course_minutes', 60);
+    // セレクト未操作時の既定ペイロード（挙動維持の錨）
+    expect(body).toHaveProperty('classification', 'ーー');
+    expect(body).toHaveProperty('has_pet', false);
+    expect(body).toHaveProperty('discount_name', '');
+    // 受付未選択は '' のまま → マッピングで undefined になり送信時に欠落する
+    expect(body).toHaveProperty('receptionist_id', undefined);
     expect(body).not.toHaveProperty('store_name');
     expect(body).not.toHaveProperty('storeName');
     expect(body).not.toHaveProperty('businessDate');

--- a/frontend/src/_pages/store-orders/ui/OrderForm.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderForm.tsx
@@ -6,6 +6,30 @@ import { useRouter } from 'next/navigation';
 import { CastResponse, castApi } from '@/entities/cast';
 import { OrderReceptionist, orderApi } from '@/entities/order';
 import { toast } from 'react-hot-toast';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from '@/shared/ui';
+
+// Radix Select は value="" を許容しないため、空選択を表す番兵値。
+// onValueChange 側で '' に戻すことで送信ペイロードは従来どおり空文字になる。
+const SELECT_NONE = '__none__';
 
 export interface OrderFormData {
   receptionistId: string;
@@ -44,11 +68,14 @@ interface OrderFormProps {
 
 export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProps) {
   const router = useRouter();
-  const { register, handleSubmit, setValue } = useForm<OrderFormData>({
+  const form = useForm<OrderFormData>({
     defaultValues: {
+      receptionistId: '',
       businessDate: new Date().toISOString().split('T')[0],
+      classification: 'ーー',
       courseMinutes: 60,
       extensionMinutes: 0,
+      discountName: '',
       manualDiscount: 0,
       usedPoints: 0,
       manualGrantPoints: 0,
@@ -57,6 +84,7 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
       ...initialData,
     },
   });
+  const { register, handleSubmit, setValue, control } = form;
 
   const [castNameInput, setCastNameInput] = useState('');
   const [castOptions, setCastOptions] = useState<CastResponse[]>([]);
@@ -139,256 +167,273 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
   };
 
   return (
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className="space-y-8 bg-white p-8 rounded-xl shadow-sm border border-gray-100"
-    >
-      {/* 1. 基本情報 */}
-      <section>
-        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
-          基本情報
-        </h3>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">受付</label>
-            <select
-              {...register('receptionistId')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            >
-              <option value="">－－－</option>
-              {receptionistOptions.map(option => (
-                <option key={option.id} value={option.id}>
-                  {option.display_name}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">営業日</label>
-            <input
-              type="date"
-              {...register('businessDate')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-        </div>
+    <Form {...form}>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        {/* 1. 基本情報 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>基本情報</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <FormField
+                control={control}
+                name="receptionistId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>受付</FormLabel>
+                    <Select
+                      value={field.value ? field.value : SELECT_NONE}
+                      onValueChange={v => field.onChange(v === SELECT_NONE ? '' : v)}
+                    >
+                      <FormControl>
+                        <SelectTrigger className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value={SELECT_NONE}>－－－</SelectItem>
+                        {receptionistOptions.map(option => (
+                          <SelectItem key={option.id} value={String(option.id)}>
+                            {option.display_name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
+              />
+              <div className="grid gap-2">
+                <Label htmlFor="businessDate">営業日</Label>
+                <Input id="businessDate" type="date" {...register('businessDate')} />
+              </div>
+            </div>
 
-        <div className="mt-6">
-          <label className="block text-sm font-medium text-gray-700 mb-1">到着予定時刻</label>
-          <div className="flex items-center space-x-2">
-            <input
-              type="time"
-              {...register('arrivalStartTime')}
-              className="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-            <span className="text-gray-500">～</span>
-            <input
-              type="time"
-              {...register('arrivalEndTime')}
-              className="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-        </div>
-      </section>
+            <div className="grid gap-2">
+              <Label>到着予定時刻</Label>
+              <div className="flex items-center gap-2">
+                <Input type="time" className="w-fit" {...register('arrivalStartTime')} />
+                <span className="text-muted-foreground">～</span>
+                <Input type="time" className="w-fit" {...register('arrivalEndTime')} />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
-      {/* 2. お客様情報 */}
-      <section>
-        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
-          お客様情報
-        </h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">お客様名</label>
-            <input
-              type="text"
-              {...register('customerName')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">電話番号</label>
-            <input
-              type="text"
-              {...register('phoneNumber')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div className="md:col-span-2">
-            <label className="block text-sm font-medium text-gray-700 mb-1">住所</label>
-            <input
-              type="text"
-              {...register('address')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">建物</label>
-            <input
-              type="text"
-              {...register('buildingName')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">区分</label>
-            <select
-              {...register('classification')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            >
-              <option value="ーー">ーー</option>
-              <option value="自宅">自宅</option>
-              <option value="ラブホ">ラブホ</option>
-              <option value="ビジホ">ビジホ</option>
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">ペット有無</label>
-            <select
-              {...register('hasPet')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            >
-              <option value="false">なし</option>
-              <option value="true">あり</option>
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">目印</label>
-            <input
-              type="text"
-              {...register('landmark')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-        </div>
-      </section>
+        {/* 2. お客様情報 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>お客様情報</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="grid gap-2">
+                <Label htmlFor="customerName">お客様名</Label>
+                <Input id="customerName" type="text" {...register('customerName')} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="phoneNumber">電話番号</Label>
+                <Input id="phoneNumber" type="text" {...register('phoneNumber')} />
+              </div>
+              <div className="grid gap-2 md:col-span-2">
+                <Label htmlFor="address">住所</Label>
+                <Input id="address" type="text" {...register('address')} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="buildingName">建物</Label>
+                <Input id="buildingName" type="text" {...register('buildingName')} />
+              </div>
+              <FormField
+                control={control}
+                name="classification"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>区分</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="ーー">ーー</SelectItem>
+                        <SelectItem value="自宅">自宅</SelectItem>
+                        <SelectItem value="ラブホ">ラブホ</SelectItem>
+                        <SelectItem value="ビジホ">ビジホ</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={control}
+                name="hasPet"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>ペット有無</FormLabel>
+                    <Select
+                      value={String(field.value)}
+                      onValueChange={v => field.onChange(v === 'true')}
+                    >
+                      <FormControl>
+                        <SelectTrigger className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="false">なし</SelectItem>
+                        <SelectItem value="true">あり</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
+              />
+              <div className="grid gap-2">
+                <Label htmlFor="landmark">目印</Label>
+                <Input id="landmark" type="text" {...register('landmark')} />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
-      {/* 3. コース・料金 */}
-      <section>
-        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
-          コース・料金
-        </h3>
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-          <div className="relative">
-            <label className="block text-sm font-medium text-gray-700 mb-1">キャスト</label>
-            <input
-              type="text"
-              value={castNameInput}
-              onChange={e => handleCastInputChange(e.target.value)}
-              onFocus={() => castOptions.length > 0 && setIsCastOpen(true)}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-              placeholder="名前で検索"
-              role="combobox"
-              aria-expanded={isCastOpen}
-              aria-controls="cast-suggestions"
-              autoComplete="off"
-            />
-            <input type="hidden" {...register('castId')} />
-            {isCastOpen && (
-              <div
-                id="cast-suggestions"
-                role="listbox"
-                className="absolute z-20 mt-1 w-full rounded-md border border-gray-200 bg-white shadow-lg"
-              >
-                {isCastLoading ? (
-                  <div className="px-4 py-2 text-sm text-gray-500">検索中...</div>
-                ) : castOptions.length === 0 ? (
-                  <div className="px-4 py-2 text-sm text-gray-500">該当するキャストがいません</div>
-                ) : (
-                  <ul className="max-h-56 overflow-auto py-1">
-                    {castOptions.map(cast => (
-                      <li key={cast.id}>
-                        <button
-                          type="button"
-                          onClick={() => handleCastSelect(cast)}
-                          className="flex w-full items-center justify-between px-4 py-2 text-left text-sm text-gray-700 hover:bg-indigo-50"
-                          role="option"
-                        >
-                          <span className="font-medium text-gray-900">{cast.name}</span>
-                          <span className="text-xs text-gray-400">ID: {cast.id}</span>
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
+        {/* 3. コース・料金 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>コース・料金</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+              <div className="relative grid gap-2">
+                <Label htmlFor="castName">キャスト</Label>
+                <Input
+                  id="castName"
+                  type="text"
+                  value={castNameInput}
+                  onChange={e => handleCastInputChange(e.target.value)}
+                  onFocus={() => castOptions.length > 0 && setIsCastOpen(true)}
+                  placeholder="名前で検索"
+                  role="combobox"
+                  aria-expanded={isCastOpen}
+                  aria-controls="cast-suggestions"
+                  autoComplete="off"
+                />
+                <input type="hidden" {...register('castId')} />
+                {isCastOpen && (
+                  <div
+                    id="cast-suggestions"
+                    role="listbox"
+                    className="absolute top-full z-20 mt-1 w-full rounded-md border border-border bg-popover shadow-lg"
+                  >
+                    {isCastLoading ? (
+                      <div className="px-4 py-2 text-sm text-muted-foreground">検索中...</div>
+                    ) : castOptions.length === 0 ? (
+                      <div className="px-4 py-2 text-sm text-muted-foreground">
+                        該当するキャストがいません
+                      </div>
+                    ) : (
+                      <ul className="max-h-56 overflow-auto py-1">
+                        {castOptions.map(cast => (
+                          <li key={cast.id}>
+                            <button
+                              type="button"
+                              onClick={() => handleCastSelect(cast)}
+                              className="flex w-full items-center justify-between px-4 py-2 text-left text-sm text-foreground hover:bg-blue-50"
+                              role="option"
+                            >
+                              <span className="font-medium">{cast.name}</span>
+                              <span className="text-xs text-muted-foreground">ID: {cast.id}</span>
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
                 )}
               </div>
-            )}
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">ｺｰｽ(分)</label>
-            <select
-              {...register('courseMinutes')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            >
-              <option value="60">60</option>
-              <option value="90">90</option>
-              <option value="120">120</option>
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">延長</label>
-            <input
-              type="number"
-              {...register('extensionMinutes')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">割引</label>
-            <select
-              {...register('discountName')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            >
-              <option value="">なし</option>
-              <option value="一番最初割">一番最初割</option>
-            </select>
-          </div>
-        </div>
-      </section>
+              <FormField
+                control={control}
+                name="courseMinutes"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>ｺｰｽ(分)</FormLabel>
+                    <Select
+                      value={String(field.value)}
+                      onValueChange={v => field.onChange(Number(v))}
+                    >
+                      <FormControl>
+                        <SelectTrigger className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="60">60</SelectItem>
+                        <SelectItem value="90">90</SelectItem>
+                        <SelectItem value="120">120</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
+              />
+              <div className="grid gap-2">
+                <Label htmlFor="extensionMinutes">延長</Label>
+                <Input id="extensionMinutes" type="number" {...register('extensionMinutes')} />
+              </div>
+              <FormField
+                control={control}
+                name="discountName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>割引</FormLabel>
+                    <Select
+                      value={field.value ? field.value : SELECT_NONE}
+                      onValueChange={v => field.onChange(v === SELECT_NONE ? '' : v)}
+                    >
+                      <FormControl>
+                        <SelectTrigger className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value={SELECT_NONE}>なし</SelectItem>
+                        <SelectItem value="一番最初割">一番最初割</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
+              />
+            </div>
+          </CardContent>
+        </Card>
 
-      {/* 4. その他 */}
-      <section>
-        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
-          その他
-        </h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">備考</label>
-            <textarea
-              {...register('remarks')}
-              rows={3}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              キャスト・ドライバーへのメッセージ
-            </label>
-            <textarea
-              {...register('castDriverMessage')}
-              rows={3}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-        </div>
-      </section>
+        {/* 4. その他 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>その他</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="grid gap-2">
+                <Label htmlFor="remarks">備考</Label>
+                <Textarea id="remarks" rows={3} {...register('remarks')} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="castDriverMessage">キャスト・ドライバーへのメッセージ</Label>
+                <Textarea id="castDriverMessage" rows={3} {...register('castDriverMessage')} />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
-      {/* ボタン */}
-      <div className="flex justify-end space-x-4 pt-6 border-t border-gray-100">
-        <button
-          type="button"
-          onClick={() => router.back()}
-          className="px-6 py-2.5 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors"
-        >
-          キャンセル
-        </button>
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="px-10 py-2.5 rounded-md bg-indigo-600 text-white font-semibold shadow-lg shadow-indigo-200 hover:bg-indigo-700 disabled:opacity-50 transition-all"
-        >
-          {isSubmitting ? '登録中...' : '登録する'}
-        </button>
-      </div>
-    </form>
+        {/* ボタン */}
+        <div className="flex justify-end gap-4">
+          <Button type="button" variant="outline" onClick={() => router.back()}>
+            キャンセル
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? '登録中...' : '登録する'}
+          </Button>
+        </div>
+      </form>
+    </Form>
   );
 }


### PR DESCRIPTION
## 概要

shadcn/ui 移行(地図 #458)のページ restyle パイロット。OrderForm を shadcn プリミティブへリスタイルし、**以降のページ restyle で横展開する RHF 統合パターンを確立**する。挙動維持のリスタイルで、送信ペイロードの形・フィールド名は不変。

Closes #470

## 変更内容

- native `<input>`/`<textarea>` → shadcn `Input`/`Textarea`(`register` 継続)。
- native `<select>` → shadcn `Select`(Radix)を **`FormField`** 経由で結線。フォーム全体を `<Form {...form}>`(FormProvider)で包む。
- 4 セクションを `Card`、ボタンを `Button`(登録=default/blue、キャンセル=outline)、indigo→blue。
- キャスト「名前で検索」コンボボックスは**現状維持**(可視入力の Input 化 + hover 色のみ。検索ロジック不変)。
- 併せて既存の input 欠様式(`@tailwindcss/forms` 未導入で border が出ていなかった)を shadcn Input で解消。

### 確立したパターン(横展開ルール)

**ネイティブ実体のコントロール → `register`。Radix 制御コンポーネント → `FormField`。フォームは常に `<Form {...form}>` で包む(生 Controller は使わない)。** Radix `SelectItem` は `value=""` を throw するため空値 select はセンチネル(`__none__`)で双方向マップ。空値/デフォルト select は `defaultValues` 補完でペイロードを保存。

## 検証

- [x] `task -d frontend lint` exit 0
- [x] `task -d frontend test` exit 0(既存 OrdersPage テスト維持 + 未操作パスのペイロードを固定)
- [x] `task -d frontend build` exit 0
- [x] ローカル code-review 実施済み(2 軸、ペイロード等価性を重点)。blocking/should-fix の**コード修正なし**。
- [ ] **マージ前推奨の手動スモーク**: 新規オーダー画面で 5 つの Select(受付/区分/ペット有無/ｺｰｽ/割引)を実際に操作し、devtools で POST ボディの型(has_pet=boolean、course_minutes=number、receptionist_id=undefined、discount_name/receptionist は文字列)を確認。

## 決定ログ

- **RHF 統合**: register フィールドを Controller 化しない(controlled/uncontrolled 警告と回帰面拡大を避ける)。制御コンポーネントのみ FormField。
- **ペイロード保存**: `receptionistId:''`/`classification:'ーー'`/`discountName:''` を defaultValues に追加(従来 register がマウント時 DOM から拾っていた値の明示化)。`receptionist_id` は消費側 `|| undefined` で undefined になる点も含め一致を確認・テストで固定。
- **型還元**: `onValueChange` で `Number(v)`(ｺｰｽ)/`v==='true'`(ペット)によりデフォルト時の型(数値/boolean)を復元。

## 備考 / レビュー観点

- **カバレッジギャップ(承認事項)**: 5 つの Select の**操作パス**には自動テストが無い(追加テストは未操作パスを固定、e2e に建単シナリオ無し)。現コードは読解で正しさを確認済みだが、将来これらの型還元 handler を壊しても赤くならない。マージ前の手動スモーク推奨 + e2e 建単シナリオを別チケットで検討。
- nit（dark 有効化票で回収予定）: キャスト候補 hover を `bg-accent` へ、到着予定時刻の Label に htmlFor。
- **follow-up 別チケット**: ① キャスト検索を Combobox プリミティブ化(要 Popover+Command 生成)② hasPet の boolean/'true'文字列 型混在の解消。
- push/PR まで実施。**マージは owner が手動**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
