### PR TITLE
refactor(frontend): 顧客管理スライスを shadcn プリミティブへ restyle する

### DIFF
--- a/frontend/src/_pages/store-customers/__tests__/CustomersPage.test.tsx
+++ b/frontend/src/_pages/store-customers/__tests__/CustomersPage.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CustomersPage from '../ui/CustomersPage';
+import CustomerCreatePage from '../ui/CustomerCreatePage';
+import { CustomerForm } from '../ui/CustomerForm';
+import { customerApi } from '@/entities/customer';
+
+// Radix Checkbox は <form> 内で hidden な BubbleInput を描画し、その採寸に
+// ResizeObserver を使う。jsdom には未実装のため最小スタブを供給する。
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverStub;
+
+jest.mock('@/entities/customer', () => ({
+  customerApi: {
+    list: jest.fn(),
+    create: jest.fn(),
+  },
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+  useParams: () => ({ storeId: '1' }),
+}));
+
+const mockedCustomerApi = customerApi as jest.Mocked<typeof customerApi>;
+
+describe('店側顧客画面と API JSON（snake_case）の整合', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('一覧はバックエンドが実際に返す snake_case のフィールドを表示すること', async () => {
+    // バックエンドは Jackson グローバル SNAKE_CASE（既知の実レスポンス形）
+    mockedCustomerApi.list.mockResolvedValue({
+      content: [
+        {
+          id: '1',
+          name: '山田太郎',
+          phone_number: '090-1111-2222',
+          line_id: 'yamada',
+          rank: 'GOLD',
+          classification: '常連',
+          points: 120,
+          ng_type: '注意',
+        },
+      ],
+      total_pages: 1,
+      total_elements: 1,
+      size: 20,
+      number: 0,
+    } as never);
+
+    render(<CustomersPage />);
+
+    expect(await screen.findByText('山田太郎')).toBeInTheDocument();
+    expect(screen.getByText('090-1111-2222')).toBeInTheDocument();
+    expect(screen.getByText('yamada')).toBeInTheDocument();
+    // NG バッジは ng_type をそのまま表示する
+    expect(screen.getByText('注意')).toBeInTheDocument();
+  });
+
+  it('新規登録はバックエンドの DTO に合わせ snake_case キーで POST すること', async () => {
+    mockedCustomerApi.create.mockResolvedValue({} as never);
+
+    render(<CustomerCreatePage />);
+    // name は required のため、未入力だと create が呼ばれない
+    fireEvent.change(screen.getByLabelText('名前 *'), { target: { value: '田中花子' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(mockedCustomerApi.create).toHaveBeenCalledTimes(1));
+    const body = mockedCustomerApi.create.mock.calls[0][0] as unknown as Record<string, unknown>;
+    expect(body).toHaveProperty('name', '田中花子');
+    // 未操作チェックボックスは boolean false のまま（挙動維持の錨）
+    expect(body).toHaveProperty('has_pet', false);
+    // defaultValues の rank はそのまま送信される
+    expect(body).toHaveProperty('rank', 'SILVER');
+    // 空文字フィールドは toCustomerRequest で undefined に落ちる
+    expect(body).toHaveProperty('phone_number', undefined);
+    // camelCase キーが混入しないこと
+    expect(body).not.toHaveProperty('phoneNumber');
+    expect(body).not.toHaveProperty('hasPet');
+    expect(body).not.toHaveProperty('lineId');
+  });
+
+  it('編集時の has_pet:true が controlled チェックボックスに反映されること', () => {
+    render(<CustomerForm initialData={{ name: '太郎', has_pet: true }} onSubmit={jest.fn()} />);
+
+    expect(screen.getByRole('checkbox')).toBeChecked();
+    // ラベル文字クリックでトグルできること（label→control の関連付け維持）
+    fireEvent.click(screen.getByText('ペットあり'));
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+  });
+});

--- a/frontend/src/_pages/store-customers/ui/CustomerCreatePage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerCreatePage.tsx
@@ -30,8 +30,8 @@ export default function CustomerCreatePage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">新規顧客登録</h1>
-        <p className="text-sm text-gray-500 mt-1">新しい顧客情報を入力してください。</p>
+        <h1 className="text-2xl font-bold text-foreground">新規顧客登録</h1>
+        <p className="text-sm text-muted-foreground mt-1">新しい顧客情報を入力してください。</p>
       </div>
       <CustomerForm onSubmit={handleSubmit} isSubmitting={isSubmitting} />
     </div>

--- a/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
@@ -7,6 +7,7 @@ import { CustomerResponse, customerApi } from '@/entities/customer';
 import { Order, orderApi } from '@/entities/order';
 import { toast } from 'react-hot-toast';
 import { storePath } from '@/shared/lib';
+import { Card, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/shared/ui';
 
 /** 顧客編集ページ（プロフィール編集 + 注文履歴） */
 export default function CustomerEditPage() {
@@ -93,58 +94,40 @@ export default function CustomerEditPage() {
       />
 
       {/* 注文履歴 */}
-      <div className="bg-white shadow-sm border border-gray-200 rounded-lg overflow-hidden">
-        <div className="px-6 py-4 border-b border-gray-200 bg-gray-50">
-          <h3 className="text-lg font-medium text-gray-900">注文履歴</h3>
+      <Card className="py-0 overflow-hidden">
+        <div className="border-b bg-muted/50 px-6 py-4">
+          <h3 className="text-lg font-medium text-foreground">注文履歴</h3>
         </div>
         {orders.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">注文履歴がありません</div>
+          <div className="p-8 text-center text-muted-foreground">注文履歴がありません</div>
         ) : (
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  営業日
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  キャスト
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  コース
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  使用ポイント
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  ステータス
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>営業日</TableHead>
+                <TableHead>キャスト</TableHead>
+                <TableHead>コース</TableHead>
+                <TableHead>使用ポイント</TableHead>
+                <TableHead>ステータス</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
               {orders.map(order => (
-                <tr key={order.id} className="hover:bg-gray-50 transition-colors">
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    {order.business_date}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {order.cast_name || '-'}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <TableRow key={order.id}>
+                  <TableCell className="text-foreground">{order.business_date}</TableCell>
+                  <TableCell className="text-muted-foreground">{order.cast_name || '-'}</TableCell>
+                  <TableCell className="text-muted-foreground">
                     {order.course_minutes}分
                     {order.extension_minutes > 0 && ` (+延長${order.extension_minutes}分)`}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {order.used_points}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {order.status}
-                  </td>
-                </tr>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{order.used_points}</TableCell>
+                  <TableCell className="text-muted-foreground">{order.status}</TableCell>
+                </TableRow>
               ))}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         )}
-      </div>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
@@ -57,7 +57,7 @@ export default function CustomerEditPage() {
   };
 
   if (isLoading) {
-    return <div className="p-8 text-center text-gray-500">読み込み中...</div>;
+    return <div className="p-8 text-center text-muted-foreground">読み込み中...</div>;
   }
 
   if (!customer) return null;
@@ -66,10 +66,12 @@ export default function CustomerEditPage() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">顧客編集</h1>
-          <p className="text-sm text-gray-500 mt-1">「{customer.name}」の情報を編集します。</p>
+          <h1 className="text-2xl font-bold text-foreground">顧客編集</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            「{customer.name}」の情報を編集します。
+          </p>
         </div>
-        <div className="text-sm text-gray-600 bg-white px-4 py-2 rounded-md border border-gray-200">
+        <div className="text-sm text-muted-foreground bg-card px-4 py-2 rounded-md border border-border">
           保有ポイント: <span className="font-semibold">{customer.points ?? 0}</span>
         </div>
       </div>

--- a/frontend/src/_pages/store-customers/ui/CustomerForm.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerForm.tsx
@@ -3,6 +3,22 @@
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import { CustomerCreateRequest } from '@/entities/customer';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Checkbox,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  Input,
+  Label,
+  Textarea,
+} from '@/shared/ui';
 
 /** 顧客フォームのデータ型 */
 export interface CustomerFormData {
@@ -50,7 +66,7 @@ interface CustomerFormProps {
 /** 顧客登録・編集フォームコンポーネント */
 export function CustomerForm({ initialData, onSubmit, isSubmitting }: CustomerFormProps) {
   const router = useRouter();
-  const { register, handleSubmit } = useForm<CustomerFormData>({
+  const form = useForm<CustomerFormData>({
     defaultValues: {
       name: '',
       phone_number: '',
@@ -67,156 +83,118 @@ export function CustomerForm({ initialData, onSubmit, isSubmitting }: CustomerFo
       ...initialData,
     },
   });
+  const { register, handleSubmit, control } = form;
 
   return (
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className="space-y-8 bg-white p-8 rounded-xl shadow-sm border border-gray-100"
-    >
-      {/* 基本情報 */}
-      <section>
-        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
-          基本情報
-        </h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">名前 *</label>
-            <input
-              type="text"
-              {...register('name', { required: true })}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">区分</label>
-            <input
-              type="text"
-              {...register('classification')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">電話番号</label>
-            <input
-              type="tel"
-              {...register('phone_number')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">電話番号2</label>
-            <input
-              type="tel"
-              {...register('phone_number2')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">LINE ID</label>
-            <input
-              type="text"
-              {...register('line_id')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">ランク</label>
-            <input
-              type="text"
-              {...register('rank')}
-              placeholder="SILVER"
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-        </div>
-      </section>
+    <Form {...form}>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        {/* 基本情報 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>基本情報</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="grid gap-2">
+                <Label htmlFor="name">名前 *</Label>
+                <Input id="name" type="text" {...register('name', { required: true })} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="classification">区分</Label>
+                <Input id="classification" type="text" {...register('classification')} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="phone_number">電話番号</Label>
+                <Input id="phone_number" type="tel" {...register('phone_number')} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="phone_number2">電話番号2</Label>
+                <Input id="phone_number2" type="tel" {...register('phone_number2')} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="line_id">LINE ID</Label>
+                <Input id="line_id" type="text" {...register('line_id')} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="rank">ランク</Label>
+                <Input id="rank" type="text" placeholder="SILVER" {...register('rank')} />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
-      {/* 住所 */}
-      <section>
-        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
-          住所
-        </h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">住所</label>
-            <input
-              type="text"
-              {...register('address')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">建物名</label>
-            <input
-              type="text"
-              {...register('building_name')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">利用エリア</label>
-            <input
-              type="text"
-              {...register('usage_areas')}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div className="flex items-end pb-2">
-            <label className="inline-flex items-center text-sm font-medium text-gray-700">
-              <input
-                type="checkbox"
-                {...register('has_pet')}
-                className="mr-2 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+        {/* 住所 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>住所</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="grid gap-2">
+                <Label htmlFor="address">住所</Label>
+                <Input id="address" type="text" {...register('address')} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="building_name">建物名</Label>
+                <Input id="building_name" type="text" {...register('building_name')} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="usage_areas">利用エリア</Label>
+                <Input id="usage_areas" type="text" {...register('usage_areas')} />
+              </div>
+              <FormField
+                control={control}
+                name="has_pet"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-center gap-2 self-end pb-2">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={value => field.onChange(value === true)}
+                      />
+                    </FormControl>
+                    <FormLabel className="font-medium">ペットあり</FormLabel>
+                  </FormItem>
+                )}
               />
-              ペットあり
-            </label>
-          </div>
-        </div>
-      </section>
+            </div>
+          </CardContent>
+        </Card>
 
-      {/* NG 情報 */}
-      <section>
-        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
-          NG 情報
-        </h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">NG タイプ</label>
-            <input
-              type="text"
-              {...register('ng_type')}
-              placeholder="注意・禁止など"
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-        </div>
-        <div className="mt-4">
-          <label className="block text-sm font-medium text-gray-700 mb-1">NG 内容</label>
-          <textarea
-            {...register('ng_content')}
-            rows={3}
-            className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-          />
-        </div>
-      </section>
+        {/* NG 情報 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>NG 情報</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="grid gap-2">
+                <Label htmlFor="ng_type">NG タイプ</Label>
+                <Input
+                  id="ng_type"
+                  type="text"
+                  placeholder="注意・禁止など"
+                  {...register('ng_type')}
+                />
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="ng_content">NG 内容</Label>
+              <Textarea id="ng_content" rows={3} {...register('ng_content')} />
+            </div>
+          </CardContent>
+        </Card>
 
-      {/* ボタン */}
-      <div className="flex justify-end space-x-4 pt-6 border-t border-gray-100">
-        <button
-          type="button"
-          onClick={() => router.back()}
-          className="px-6 py-2.5 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors"
-        >
-          キャンセル
-        </button>
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="px-10 py-2.5 rounded-md bg-indigo-600 text-white font-semibold shadow-lg shadow-indigo-200 hover:bg-indigo-700 disabled:opacity-50 transition-all"
-        >
-          {isSubmitting ? '保存中...' : '保存する'}
-        </button>
-      </div>
-    </form>
+        {/* ボタン */}
+        <div className="flex justify-end gap-4">
+          <Button type="button" variant="outline" onClick={() => router.back()}>
+            キャンセル
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? '保存中...' : '保存する'}
+          </Button>
+        </div>
+      </form>
+    </Form>
   );
 }

--- a/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
@@ -12,6 +12,19 @@ import { useParams } from 'next/navigation';
 import { CustomerResponse, customerApi } from '@/entities/customer';
 import { toast } from 'react-hot-toast';
 import { storePath } from '@/shared/lib';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Input,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/ui';
 
 /** 顧客一覧ページ */
 export default function CustomersPage() {
@@ -77,161 +90,140 @@ export default function CustomersPage() {
           <h1 className="text-2xl font-bold text-gray-900">顧客管理</h1>
           <p className="text-sm text-gray-500 mt-1">顧客情報の登録・編集ができます。</p>
         </div>
-        <Link
-          href={storePath(storeId, '/customers/create')}
-          className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
-        >
-          <PlusIcon className="-ml-1 mr-2 h-5 w-5" />
-          新規顧客登録
-        </Link>
+        <Button asChild>
+          <Link href={storePath(storeId, '/customers/create')}>
+            <PlusIcon />
+            新規顧客登録
+          </Link>
+        </Button>
       </div>
 
       {/* 検索・絞り込みバー */}
-      <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200 flex flex-col md:flex-row md:items-center gap-4">
-        <div className="flex-1 relative">
-          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />
+      <Card>
+        <CardContent className="flex flex-col md:flex-row md:items-center gap-4">
+          <div className="flex-1 relative">
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <MagnifyingGlassIcon className="h-5 w-5 text-muted-foreground" />
+            </div>
+            <Input
+              type="text"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleSearch()}
+              className="pl-10"
+              placeholder="名前・電話番号・LINE ID で検索..."
+            />
           </div>
-          <input
+          <Input
             type="text"
-            value={search}
-            onChange={e => setSearch(e.target.value)}
+            value={rank}
+            onChange={e => setRank(e.target.value)}
             onKeyDown={e => e.key === 'Enter' && handleSearch()}
-            className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md leading-5 bg-white placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-            placeholder="名前・電話番号・LINE ID で検索..."
+            className="w-full md:w-32"
+            placeholder="ランク"
           />
-        </div>
-        <input
-          type="text"
-          value={rank}
-          onChange={e => setRank(e.target.value)}
-          onKeyDown={e => e.key === 'Enter' && handleSearch()}
-          className="w-full md:w-32 px-3 py-2 border border-gray-300 rounded-md leading-5 bg-white placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-          placeholder="ランク"
-        />
-        <input
-          type="text"
-          value={classification}
-          onChange={e => setClassification(e.target.value)}
-          onKeyDown={e => e.key === 'Enter' && handleSearch()}
-          className="w-full md:w-32 px-3 py-2 border border-gray-300 rounded-md leading-5 bg-white placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-          placeholder="区分"
-        />
-        <button
-          onClick={handleSearch}
-          className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
-        >
-          検索
-        </button>
-      </div>
+          <Input
+            type="text"
+            value={classification}
+            onChange={e => setClassification(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && handleSearch()}
+            className="w-full md:w-32"
+            placeholder="区分"
+          />
+          <Button variant="outline" onClick={handleSearch}>
+            検索
+          </Button>
+        </CardContent>
+      </Card>
 
       {/* テーブル */}
-      <div className="bg-white shadow-sm border border-gray-200 rounded-lg overflow-hidden">
+      <Card className="py-0 overflow-hidden">
         {isLoading ? (
-          <div className="p-8 text-center text-gray-500">読み込み中...</div>
+          <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
         ) : customers.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">顧客が登録されていません</div>
+          <div className="p-8 text-center text-muted-foreground">顧客が登録されていません</div>
         ) : (
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  名前
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  電話番号
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  LINE ID
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  ランク
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  区分
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  ポイント
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  NG
-                </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  アクション
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>名前</TableHead>
+                <TableHead>電話番号</TableHead>
+                <TableHead>LINE ID</TableHead>
+                <TableHead>ランク</TableHead>
+                <TableHead>区分</TableHead>
+                <TableHead>ポイント</TableHead>
+                <TableHead>NG</TableHead>
+                <TableHead className="text-right">アクション</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
               {customers.map(customer => (
-                <tr key={customer.id} className="hover:bg-gray-50 transition-colors">
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm font-medium text-gray-900">{customer.name}</div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <TableRow key={customer.id}>
+                  <TableCell className="font-medium text-foreground">{customer.name}</TableCell>
+                  <TableCell className="text-muted-foreground">
                     {customer.phone_number || '-'}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {customer.line_id || '-'}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {customer.rank || '-'}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{customer.line_id || '-'}</TableCell>
+                  <TableCell className="text-muted-foreground">{customer.rank || '-'}</TableCell>
+                  <TableCell className="text-muted-foreground">
                     {customer.classification || '-'}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {customer.points ?? 0}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{customer.points ?? 0}</TableCell>
+                  <TableCell>
                     {customer.ng_type ? (
-                      <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">
+                      <Badge
+                        variant="outline"
+                        className="border-transparent bg-red-100 text-red-800"
+                      >
                         {customer.ng_type}
-                      </span>
+                      </Badge>
                     ) : (
-                      <span className="text-sm text-gray-400">-</span>
+                      <span className="text-muted-foreground">-</span>
                     )}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-3">
-                    <Link
-                      href={storePath(storeId, `/customers/${customer.id}/edit`)}
-                      className="text-gray-400 hover:text-amber-600 inline-block"
-                    >
-                      <PencilSquareIcon className="h-5 w-5" />
-                    </Link>
-                    <button
-                      onClick={() => handleDelete(customer.id, customer.name)}
-                      className="text-gray-400 hover:text-red-600"
-                    >
-                      <TrashIcon className="h-5 w-5" />
-                    </button>
-                  </td>
-                </tr>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-1">
+                      <Button asChild variant="ghost" size="icon-sm">
+                        <Link href={storePath(storeId, `/customers/${customer.id}/edit`)}>
+                          <PencilSquareIcon />
+                        </Link>
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => handleDelete(customer.id, customer.name)}
+                      >
+                        <TrashIcon />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
               ))}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         )}
-      </div>
+      </Card>
 
       {/* ページネーション */}
       {totalPages > 1 && (
-        <div className="flex items-center justify-center space-x-4">
-          <button
+        <div className="flex items-center justify-center gap-4">
+          <Button
+            variant="outline"
             onClick={() => fetchCustomers(page - 1)}
             disabled={page <= 0 || isLoading}
-            className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
           >
             前へ
-          </button>
-          <span className="text-sm text-gray-600">
+          </Button>
+          <span className="text-sm text-muted-foreground">
             {page + 1} / {totalPages} ページ
           </span>
-          <button
+          <Button
+            variant="outline"
             onClick={() => fetchCustomers(page + 1)}
             disabled={page >= totalPages - 1 || isLoading}
-            className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
           >
             次へ
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
@@ -87,8 +87,8 @@ export default function CustomersPage() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">顧客管理</h1>
-          <p className="text-sm text-gray-500 mt-1">顧客情報の登録・編集ができます。</p>
+          <h1 className="text-2xl font-bold text-foreground">顧客管理</h1>
+          <p className="text-sm text-muted-foreground mt-1">顧客情報の登録・編集ができます。</p>
         </div>
         <Button asChild>
           <Link href={storePath(storeId, '/customers/create')}>
@@ -173,7 +173,7 @@ export default function CustomersPage() {
                     {customer.ng_type ? (
                       <Badge
                         variant="outline"
-                        className="border-transparent bg-red-100 text-red-800"
+                        className="border-transparent bg-destructive/10 text-destructive"
                       >
                         {customer.ng_type}
                       </Badge>


### PR DESCRIPTION
## 概要

shadcn/ui 移行(地図 #458)の restyle sweep 第2弾。`store-customers` スライスを shadcn プリミティブへ restyle する。**挙動完全維持**が原則で、API へ送るペイロードは restyle 前と一字も変えない。

パイロット #470(OrderForm)で確立したパターンをそのまま適用した:ネイティブ実体のコントロールは `{...register(name)}` を継続して shadcn `Input`/`Textarea` へ置換、Radix 制御コンポーネント(本票では Checkbox のみ)だけ `FormField` を使い、フォーム全体を `<Form {...form}>` で包む。本スライスに `<select>` は無いためセンチネル(`SELECT_NONE`)は不要で、`defaultValues` の追加も発生しない。

Closes #472

## 変更内容

- **CustomerForm.tsx** — Input / Textarea / Checkbox / Card / Button へ置換。`has_pet` のみ Radix `Checkbox` + `FormField`(`onCheckedChange={v => field.onChange(v === true)}` で boolean を維持)。他 12 フィールドは `register` 継続。`classification` / `rank` / `ng_type` は自由入力のまま(Select 化しない)。
- **CustomersPage.tsx** — 一覧を shadcn `Table` へ、検索バーを `Card` へ。NG 種別バッジは `Badge`。
- **CustomerEditPage.tsx** — 注文履歴テーブルを shadcn `Table` へ。
- **配色をセマンティックトークンへ統一** — 本 sweep の負の不変量「admin restyle に生パレットクラスを残さない」に沿って、`text-gray-900`→`text-foreground`、`text-gray-500/600`→`text-muted-foreground`、`bg-white`+`border-gray-200`→`bg-card`+`border-border`、NG バッジの `bg-red-100 text-red-800`→`bg-destructive/10 text-destructive`(従来の淡い赤の見た目を保つ)へ置換。ダークモード有効化票の作業を先送りしないための措置。
- **`__tests__/CustomersPage.test.tsx` 新規** — POST ボディの snake_case キー実在 + camelCase 混入の否定 + `has_pet:false` + 空文字→`undefined` 変換をアンカーする(ペイロード等価性の回帰検知)。

## 検証

- [x] `task -d frontend lint` exit 0(steiger 含む)
- [x] `task -d frontend test` exit 0(Jest 53 suites / 269 tests、うち新規 1 suite / 3 tests)
- [x] `task -d frontend build` exit 0(production build)
- [ ] `task test`(integration)/ `task e2e`: frontend 限定・API 契約無変更のため該当なし
- [x] ローカルで code-review 実施済み。blocking 1 件(`CustomerCreatePage.tsx` の生 gray クラス 2 行の取り残し)を指摘され修正済み。再レビュー観点の残りは指摘なし。

### 視覚確認(UI 変更時)

**要手動スモーク**: 顧客一覧・新規登録・編集の 3 画面。テーブルセルの余白が旧 `px-6 py-4` から shadcn 既定へ、検索バーが `Card`(py-6)へ変わるため、密度の変化が許容範囲かを一瞥で確認したい。

## 決定ログ

- **Select 化しない**:`classification` / `rank` / `ng_type` は現状フリーテキストで、選択肢を確定させるのは別議(値の正規化 = 挙動変更)。restyle の範囲外とした。
- **NG バッジは `bg-destructive/10 text-destructive`**:shadcn の `destructive` variant は塗りつぶしで従来の淡い赤より強い。セマンティック色 token(`--success`/`--warning`)は未定のため、既存の `--destructive` の淡色で代替した。token 確定時に整理する。
- **`ResizeObserver` スタブ**はテスト内ローカル(`Header.test.tsx` に既存前例あり)。共有 `setupTests.ts` への移設は、複数スライスが同時に必要とする段階でまとめて行う。

## 備考 / レビュー観点

- 最重点は**ペイロード等価性**。`toCustomerRequest` は無変更、`defaultValues` は master と同一、`has_pet` は boolean のまま。新規テストがこれをアンカーしている。
- push/PR まで実施。**マージは owner が手動**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
