### PR TITLE
refactor(frontend): store-casts スライスを shadcn プリミティブへ restyle する

### DIFF
--- a/frontend/src/_pages/store-casts/__tests__/CastPagesPayload.test.tsx
+++ b/frontend/src/_pages/store-casts/__tests__/CastPagesPayload.test.tsx
@@ -102,6 +102,8 @@ describe('キャスト登録・更新の送信ペイロード', () => {
     render(<CastEditPage />);
     const customField = (await screen.findByLabelText('血液型')) as HTMLInputElement;
     expect(customField.value).toBe('A');
+    // 取得値のステータスがセレクトに選択済みとして表示されること
+    expect(screen.getByRole('combobox', { name: 'ステータス' })).toHaveTextContent('無効');
 
     fireEvent.click(screen.getByRole('button', { name: '保存する' }));
 

--- a/frontend/src/_pages/store-casts/__tests__/CastPagesPayload.test.tsx
+++ b/frontend/src/_pages/store-casts/__tests__/CastPagesPayload.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CastCreatePage from '../ui/CastCreatePage';
+import CastEditPage from '../ui/CastEditPage';
+import { castApi, castFieldDefinitionApi } from '@/entities/cast';
+
+jest.mock('@/entities/cast', () => ({
+  castApi: {
+    create: jest.fn(),
+    get: jest.fn(),
+    update: jest.fn(),
+  },
+  castFieldDefinitionApi: {
+    list: jest.fn(),
+  },
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+  useParams: () => ({ storeId: '1', id: 'cast-1' }),
+}));
+
+const mockedCastApi = castApi as jest.Mocked<typeof castApi>;
+const mockedFieldApi = castFieldDefinitionApi as jest.Mocked<typeof castFieldDefinitionApi>;
+
+/** name 属性で入力欄を引く（register が付与するため、素の input でも Input プリミティブでも安定する）。 */
+const inputByName = (container: HTMLElement, name: string) =>
+  container.querySelector(`input[name="${name}"]`) as HTMLInputElement;
+
+describe('キャスト登録・更新の送信ペイロード', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('新規登録は未操作の既定値ごとバックエンドの DTO に合わせ snake_case キーで POST すること', async () => {
+    mockedCastApi.create.mockResolvedValue({} as never);
+
+    const { container } = render(<CastCreatePage />);
+    fireEvent.change(inputByName(container, 'name'), { target: { value: '花子' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(mockedCastApi.create).toHaveBeenCalledTimes(1));
+    const body = mockedCastApi.create.mock.calls[0][0] as unknown as Record<string, unknown>;
+    expect(body).toHaveProperty('name', '花子');
+    // ステータス未操作時の既定ペイロード
+    expect(body).toHaveProperty('status', 'ACTIVE');
+    expect(body).toHaveProperty('photo_url', '');
+    expect(body).toHaveProperty('introduction', '');
+    expect(body).toHaveProperty('display_order', 0);
+    // 未入力の数値は null → undefined に落ち、JSON からキーごと欠落する
+    expect(body).toHaveProperty('age', undefined);
+    expect(body).toHaveProperty('hip', undefined);
+    // camelCase キーが混入しないこと
+    expect(body).not.toHaveProperty('displayOrder');
+    expect(body).not.toHaveProperty('photoUrl');
+  });
+
+  it('入力後に空へ戻した数値は NaN のまま送信されること', async () => {
+    mockedCastApi.create.mockResolvedValue({} as never);
+
+    const { container } = render(<CastCreatePage />);
+    fireEvent.change(inputByName(container, 'name'), { target: { value: '花子' } });
+    fireEvent.change(inputByName(container, 'age'), { target: { value: '25' } });
+    fireEvent.change(inputByName(container, 'age'), { target: { value: '' } });
+    fireEvent.change(inputByName(container, 'height'), { target: { value: '160' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(mockedCastApi.create).toHaveBeenCalledTimes(1));
+    const body = mockedCastApi.create.mock.calls[0][0] as unknown as Record<string, unknown>;
+    // valueAsNumber の空文字は NaN。null ではないため ?? を素通りし、JSON 化の段で null になる
+    expect(Number.isNaN(body.age)).toBe(true);
+    expect(body).toHaveProperty('height', 160);
+  });
+
+  it('編集の無変更保存は取得値と同一のボディで PUT すること（custom_fields 含む）', async () => {
+    mockedCastApi.get.mockResolvedValue({
+      id: 'cast-1',
+      name: '花子',
+      status: 'INACTIVE',
+      photo_url: '',
+      introduction: '紹介',
+      age: 25,
+      height: 160,
+      display_order: 3,
+      custom_fields: { blood_type: 'A' },
+      invitation_status: 'NOT_INVITED',
+      created_at: '2026-07-01T00:00:00Z',
+      updated_at: '2026-07-01T00:00:00Z',
+    });
+    mockedCastApi.update.mockResolvedValue({} as never);
+    mockedFieldApi.list.mockResolvedValue([
+      {
+        id: 'def-blood_type',
+        key: 'blood_type',
+        label: '血液型',
+        display_order: 0,
+        is_public: false,
+        created_at: '2026-07-01T00:00:00Z',
+        updated_at: '2026-07-01T00:00:00Z',
+      },
+    ]);
+
+    render(<CastEditPage />);
+    const customField = (await screen.findByLabelText('血液型')) as HTMLInputElement;
+    expect(customField.value).toBe('A');
+
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(mockedCastApi.update).toHaveBeenCalledTimes(1));
+    expect(mockedCastApi.update.mock.calls[0][0]).toBe('cast-1');
+    const body = mockedCastApi.update.mock.calls[0][1] as unknown as Record<string, unknown>;
+    expect(body).toHaveProperty('name', '花子');
+    // プリフィルされたステータスが往復で変わらないこと
+    expect(body).toHaveProperty('status', 'INACTIVE');
+    expect(body).toHaveProperty('introduction', '紹介');
+    expect(body).toHaveProperty('age', 25);
+    expect(body).toHaveProperty('display_order', 3);
+    // 取得値に無い数値は undefined のままキーごと欠落する
+    expect(body).toHaveProperty('bust', undefined);
+    expect(body).toHaveProperty('custom_fields', { blood_type: 'A' });
+    expect(body).not.toHaveProperty('customFields');
+    expect(body).not.toHaveProperty('invitation_status');
+  });
+});

--- a/frontend/src/_pages/store-casts/ui/CastCreatePage.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastCreatePage.tsx
@@ -43,8 +43,8 @@ export default function CastCreatePage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">新規キャスト登録</h1>
-        <p className="text-sm text-gray-500 mt-1">新しいキャスト情報を入力してください。</p>
+        <h1 className="text-2xl font-bold text-foreground">新規キャスト登録</h1>
+        <p className="text-sm text-muted-foreground mt-1">新しいキャスト情報を入力してください。</p>
       </div>
       <CastForm onSubmit={handleSubmit} isSubmitting={isSubmitting} />
     </div>

--- a/frontend/src/_pages/store-casts/ui/CastEditPage.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastEditPage.tsx
@@ -59,7 +59,7 @@ export default function CastEditPage() {
   };
 
   if (isLoading) {
-    return <div className="p-8 text-center text-gray-500">読み込み中...</div>;
+    return <div className="p-8 text-center text-muted-foreground">読み込み中...</div>;
   }
 
   if (!cast) return null;
@@ -67,8 +67,8 @@ export default function CastEditPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">キャスト編集</h1>
-        <p className="text-sm text-gray-500 mt-1">「{cast.name}」の情報を編集します。</p>
+        <h1 className="text-2xl font-bold text-foreground">キャスト編集</h1>
+        <p className="text-sm text-muted-foreground mt-1">「{cast.name}」の情報を編集します。</p>
       </div>
       <CastForm
         initialData={{

--- a/frontend/src/_pages/store-casts/ui/CastForm.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastForm.tsx
@@ -3,7 +3,27 @@
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import { CastFieldDefinitionResponse, castFieldDefinitionApi } from '@/entities/cast';
-import { ImageUpload } from '@/shared/ui';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  ImageUpload,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from '@/shared/ui';
 import { useManagedList } from '@/shared/lib';
 
 /** キャストフォームのデータ型 */
@@ -41,7 +61,7 @@ export function CastForm({
   isSubmitting,
 }: CastFormProps) {
   const router = useRouter();
-  const { register, handleSubmit, setValue, watch } = useForm<CastFormData>({
+  const form = useForm<CastFormData>({
     defaultValues: {
       name: '',
       status: 'ACTIVE',
@@ -56,6 +76,7 @@ export function CastForm({
       ...initialData,
     },
   });
+  const { register, handleSubmit, setValue, watch, control } = form;
 
   const photoUrl = watch('photo_url');
 
@@ -69,178 +90,160 @@ export function CastForm({
     );
 
   return (
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className="space-y-8 bg-white p-8 rounded-xl shadow-sm border border-gray-100"
-    >
-      {/* 基本情報 */}
-      <section>
-        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
-          基本情報
-        </h3>
-        <div className="flex gap-8">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">写真</label>
-            <ImageUpload
-              value={photoUrl}
-              onChange={url => setValue('photo_url', url)}
-              bucket="public"
-            />
-          </div>
-          <div className="flex-1 space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">名前 *</label>
-              <input
-                type="text"
-                {...register('name', { required: true })}
-                className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">ステータス</label>
-              <select
-                {...register('status')}
-                className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-              >
-                <option value="ACTIVE">有効</option>
-                <option value="INACTIVE">無効</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">表示順</label>
-              <input
-                type="number"
-                {...register('display_order', { valueAsNumber: true })}
-                className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-              />
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* プロフィール */}
-      <section>
-        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
-          プロフィール
-        </h3>
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">年齢</label>
-            <input
-              type="number"
-              {...register('age', { valueAsNumber: true })}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">身長 (cm)</label>
-            <input
-              type="number"
-              {...register('height', { valueAsNumber: true })}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">バスト (cm)</label>
-            <input
-              type="number"
-              {...register('bust', { valueAsNumber: true })}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">ウエスト (cm)</label>
-            <input
-              type="number"
-              {...register('waist', { valueAsNumber: true })}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">ヒップ (cm)</label>
-            <input
-              type="number"
-              {...register('hip', { valueAsNumber: true })}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-        </div>
-      </section>
-
-      {/* 自己紹介 */}
-      <section>
-        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
-          自己紹介
-        </h3>
-        <textarea
-          {...register('introduction')}
-          rows={4}
-          className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-          placeholder="自己紹介を入力してください..."
-        />
-      </section>
-
-      {/* カスタムフィールド（編集時のみ。作成時はキャストがまだ無いため値を付与できない） */}
-      {isEdit && (
-        <section>
-          <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-blue-600 pl-3">
-            カスタムフィールド
-          </h3>
-          {isLoadingDefinitions ? (
-            <div className="p-6 text-center text-sm text-gray-500">読み込み中...</div>
-          ) : definitions.length === 0 ? (
-            <div className="p-6 bg-gray-50 rounded-lg border border-dashed border-gray-300 text-center text-gray-500 text-sm">
-              カスタムフィールドは登録されていません
-            </div>
-          ) : (
-            <div className="space-y-4">
-              {definitions.map(definition => (
-                <div key={definition.key}>
-                  <label
-                    htmlFor={`cast-custom-field-${definition.key}`}
-                    className="block text-sm font-medium text-gray-700 mb-1"
-                  >
-                    {definition.label}
-                  </label>
-                  <input
-                    id={`cast-custom-field-${definition.key}`}
-                    type="text"
-                    // 自身が所有するキーのみ初期値に採用する。プレーンオブジェクトの
-                    // ブラケットアクセスは 'constructor' 等の継承プロパティを拾うため hasOwn で防ぐ。
-                    defaultValue={
-                      existingCustomFields && Object.hasOwn(existingCustomFields, definition.key)
-                        ? existingCustomFields[definition.key]
-                        : ''
-                    }
-                    {...register(`custom_fields.${definition.key}`)}
-                    className="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+    <Form {...form}>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        {/* 基本情報 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>基本情報</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex gap-8">
+              <div className="grid gap-2">
+                <Label>写真</Label>
+                <ImageUpload
+                  value={photoUrl}
+                  onChange={url => setValue('photo_url', url)}
+                  bucket="public"
+                />
+              </div>
+              <div className="flex-1 space-y-4">
+                <div className="grid gap-2">
+                  <Label htmlFor="name">名前 *</Label>
+                  <Input id="name" type="text" {...register('name', { required: true })} />
+                </div>
+                <FormField
+                  control={control}
+                  name="status"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>ステータス</FormLabel>
+                      <Select value={field.value} onValueChange={field.onChange}>
+                        <FormControl>
+                          <SelectTrigger className="w-full">
+                            <SelectValue />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="ACTIVE">有効</SelectItem>
+                          <SelectItem value="INACTIVE">無効</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </FormItem>
+                  )}
+                />
+                <div className="grid gap-2">
+                  <Label htmlFor="display_order">表示順</Label>
+                  <Input
+                    id="display_order"
+                    type="number"
+                    {...register('display_order', { valueAsNumber: true })}
                   />
                 </div>
-              ))}
+              </div>
             </div>
-          )}
-        </section>
-      )}
+          </CardContent>
+        </Card>
 
-      {/* ボタン */}
-      <div className="flex justify-end space-x-4 pt-6 border-t border-gray-100">
-        <button
-          type="button"
-          onClick={() => router.back()}
-          className="px-6 py-2.5 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors"
-        >
-          キャンセル
-        </button>
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="px-10 py-2.5 rounded-md bg-indigo-600 text-white font-semibold shadow-lg shadow-indigo-200 hover:bg-indigo-700 disabled:opacity-50 transition-all"
-        >
-          {isSubmitting ? '保存中...' : '保存する'}
-        </button>
-      </div>
-    </form>
+        {/* プロフィール */}
+        <Card>
+          <CardHeader>
+            <CardTitle>プロフィール</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+              <div className="grid gap-2">
+                <Label htmlFor="age">年齢</Label>
+                <Input id="age" type="number" {...register('age', { valueAsNumber: true })} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="height">身長 (cm)</Label>
+                <Input id="height" type="number" {...register('height', { valueAsNumber: true })} />
+              </div>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div className="grid gap-2">
+                <Label htmlFor="bust">バスト (cm)</Label>
+                <Input id="bust" type="number" {...register('bust', { valueAsNumber: true })} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="waist">ウエスト (cm)</Label>
+                <Input id="waist" type="number" {...register('waist', { valueAsNumber: true })} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="hip">ヒップ (cm)</Label>
+                <Input id="hip" type="number" {...register('hip', { valueAsNumber: true })} />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* 自己紹介 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>自己紹介</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Textarea
+              id="introduction"
+              rows={4}
+              {...register('introduction')}
+              placeholder="自己紹介を入力してください..."
+            />
+          </CardContent>
+        </Card>
+
+        {/* カスタムフィールド（編集時のみ。作成時はキャストがまだ無いため値を付与できない） */}
+        {isEdit && (
+          <Card>
+            <CardHeader>
+              <CardTitle>カスタムフィールド</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {isLoadingDefinitions ? (
+                <div className="p-6 text-center text-sm text-muted-foreground">読み込み中...</div>
+              ) : definitions.length === 0 ? (
+                <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                  カスタムフィールドは登録されていません
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {definitions.map(definition => (
+                    <div key={definition.key} className="grid gap-2">
+                      <Label htmlFor={`cast-custom-field-${definition.key}`}>
+                        {definition.label}
+                      </Label>
+                      <Input
+                        id={`cast-custom-field-${definition.key}`}
+                        type="text"
+                        // 自身が所有するキーのみ初期値に採用する。プレーンオブジェクトの
+                        // ブラケットアクセスは 'constructor' 等の継承プロパティを拾うため hasOwn で防ぐ。
+                        defaultValue={
+                          existingCustomFields &&
+                          Object.hasOwn(existingCustomFields, definition.key)
+                            ? existingCustomFields[definition.key]
+                            : ''
+                        }
+                        {...register(`custom_fields.${definition.key}`)}
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* ボタン */}
+        <div className="flex justify-end gap-4">
+          <Button type="button" variant="outline" onClick={() => router.back()}>
+            キャンセル
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? '保存中...' : '保存する'}
+          </Button>
+        </div>
+      </form>
+    </Form>
   );
 }

--- a/frontend/src/_pages/store-casts/ui/CastForm.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastForm.tsx
@@ -95,7 +95,9 @@ export function CastForm({
         {/* 基本情報 */}
         <Card>
           <CardHeader>
-            <CardTitle>基本情報</CardTitle>
+            <CardTitle role="heading" aria-level={3}>
+              基本情報
+            </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="flex gap-8">
@@ -148,7 +150,9 @@ export function CastForm({
         {/* プロフィール */}
         <Card>
           <CardHeader>
-            <CardTitle>プロフィール</CardTitle>
+            <CardTitle role="heading" aria-level={3}>
+              プロフィール
+            </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
@@ -181,7 +185,9 @@ export function CastForm({
         {/* 自己紹介 */}
         <Card>
           <CardHeader>
-            <CardTitle>自己紹介</CardTitle>
+            <CardTitle role="heading" aria-level={3}>
+              自己紹介
+            </CardTitle>
           </CardHeader>
           <CardContent>
             <Textarea
@@ -197,7 +203,9 @@ export function CastForm({
         {isEdit && (
           <Card>
             <CardHeader>
-              <CardTitle>カスタムフィールド</CardTitle>
+              <CardTitle role="heading" aria-level={3}>
+                カスタムフィールド
+              </CardTitle>
             </CardHeader>
             <CardContent>
               {isLoadingDefinitions ? (

--- a/frontend/src/_pages/store-casts/ui/CastsPage.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastsPage.tsx
@@ -16,6 +16,19 @@ import { platformAuthApi } from '@/entities/user';
 import { InvitationButton, InvitationModal, IssuedInvitation } from '@/features/cast-invitation';
 import { storePath, useManagedList } from '@/shared/lib';
 import { toast } from 'react-hot-toast';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Input,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/ui';
 
 /** キャスト一覧ページ */
 export default function CastListPage() {
@@ -73,15 +86,15 @@ export default function CastListPage() {
     }
   };
 
-  /** ステータスの表示ラベルと色を返す */
+  /** ステータスの表示ラベルと配色を返す */
   const statusLabel = (status: string) => {
     switch (status) {
       case 'ACTIVE':
-        return { text: '有効', color: 'bg-green-100 text-green-800' };
+        return { text: '有効', color: 'bg-success/10 text-success-strong' };
       case 'INACTIVE':
-        return { text: '無効', color: 'bg-gray-100 text-gray-800' };
+        return { text: '無効', color: 'bg-muted text-foreground' };
       default:
-        return { text: status, color: 'bg-gray-100 text-gray-800' };
+        return { text: status, color: 'bg-muted text-foreground' };
     }
   };
 
@@ -89,97 +102,78 @@ export default function CastListPage() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">キャスト管理</h1>
-          <p className="text-sm text-gray-500 mt-1">キャスト情報の登録・編集ができます。</p>
+          <h1 className="text-2xl font-bold text-foreground">キャスト管理</h1>
+          <p className="text-sm text-muted-foreground mt-1">キャスト情報の登録・編集ができます。</p>
         </div>
         <div className="flex items-center gap-3">
           {/* 定義管理ページ（/store/casts/fields）への入口。定義CRUDは CAST_FIELD_DEF_MANAGE 能力限定。 */}
           {canManageFieldDefs && (
-            <Link
-              href={storePath(storeId, '/casts/fields')}
-              className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
-              <Cog6ToothIcon className="-ml-1 mr-2 h-5 w-5" />
-              カスタムフィールド管理
-            </Link>
+            <Button asChild variant="outline">
+              <Link href={storePath(storeId, '/casts/fields')}>
+                <Cog6ToothIcon />
+                カスタムフィールド管理
+              </Link>
+            </Button>
           )}
-          <Link
-            href={storePath(storeId, '/casts/create')}
-            className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
-          >
-            <PlusIcon className="-ml-1 mr-2 h-5 w-5" />
-            新規キャスト登録
-          </Link>
+          <Button asChild>
+            <Link href={storePath(storeId, '/casts/create')}>
+              <PlusIcon />
+              新規キャスト登録
+            </Link>
+          </Button>
         </div>
       </div>
 
       {/* 検索バー */}
-      <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200 flex items-center space-x-4">
-        <div className="flex-1 relative">
-          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />
+      <Card>
+        <CardContent className="flex items-center gap-4">
+          <div className="flex-1 relative">
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <MagnifyingGlassIcon className="h-5 w-5 text-muted-foreground" />
+            </div>
+            <Input
+              type="text"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleSearch()}
+              className="pl-10"
+              placeholder="名前で検索..."
+            />
           </div>
-          <input
-            type="text"
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && handleSearch()}
-            className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md leading-5 bg-white placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-            placeholder="名前で検索..."
-          />
-        </div>
-        <button
-          onClick={handleSearch}
-          className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
-        >
-          検索
-        </button>
-      </div>
+          <Button variant="outline" onClick={handleSearch}>
+            検索
+          </Button>
+        </CardContent>
+      </Card>
 
       {/* テーブル */}
-      <div className="bg-white shadow-sm border border-gray-200 rounded-lg overflow-hidden">
+      <Card className="py-0 overflow-hidden">
         {isLoading ? (
-          <div className="p-8 text-center text-gray-500">読み込み中...</div>
+          <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
         ) : casts.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">キャストが登録されていません</div>
+          <div className="p-8 text-center text-muted-foreground">キャストが登録されていません</div>
         ) : (
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  写真
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  名前
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  年齢
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  スリーサイズ
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  表示順
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  ステータス
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  招待状態
-                </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  アクション
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>写真</TableHead>
+                <TableHead>名前</TableHead>
+                <TableHead>年齢</TableHead>
+                <TableHead>スリーサイズ</TableHead>
+                <TableHead>表示順</TableHead>
+                <TableHead>ステータス</TableHead>
+                <TableHead>招待状態</TableHead>
+                <TableHead className="text-right">アクション</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
               {casts.map(cast => {
                 const status = statusLabel(cast.status);
                 const invitation = castInvitationStatusLabel(cast.invitation_status);
                 return (
-                  <tr key={cast.id} className="hover:bg-gray-50 transition-colors">
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="h-12 w-10 rounded overflow-hidden bg-gray-100 relative">
+                  <TableRow key={cast.id}>
+                    <TableCell>
+                      <div className="h-12 w-10 rounded overflow-hidden bg-muted relative">
                         {cast.photo_url ? (
                           <Image
                             src={cast.photo_url}
@@ -189,68 +183,64 @@ export default function CastListPage() {
                             sizes="40px"
                           />
                         ) : (
-                          <div className="flex items-center justify-center h-full text-gray-300 text-xs">
+                          <div className="flex items-center justify-center h-full text-foreground text-xs">
                             No
                           </div>
                         )}
                       </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm font-medium text-gray-900">{cast.name}</div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    </TableCell>
+                    <TableCell className="font-medium text-foreground">{cast.name}</TableCell>
+                    <TableCell className="text-muted-foreground">
                       {cast.age ? `${cast.age}歳` : '-'}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
                       {cast.bust && cast.waist && cast.hip
                         ? `B${cast.bust} W${cast.waist} H${cast.hip}`
                         : '-'}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
                       {cast.display_order ?? 0}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span
-                        className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${status.color}`}
-                      >
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className={`border-transparent ${status.color}`}>
                         {status.text}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span
-                        className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${invitation.color}`}
-                      >
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className={`border-transparent ${invitation.color}`}>
                         {invitation.text}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-3">
-                      {canInvite && (
-                        <InvitationButton
-                          castId={cast.id}
-                          status={cast.invitation_status}
-                          onIssued={handleIssued}
-                        />
-                      )}
-                      <Link
-                        href={storePath(storeId, `/casts/${cast.id}/edit`)}
-                        className="text-gray-400 hover:text-amber-600 inline-block"
-                      >
-                        <PencilSquareIcon className="h-5 w-5" />
-                      </Link>
-                      <button
-                        onClick={() => handleDelete(cast.id, cast.name)}
-                        className="text-gray-400 hover:text-red-600"
-                      >
-                        <TrashIcon className="h-5 w-5" />
-                      </button>
-                    </td>
-                  </tr>
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        {canInvite && (
+                          <InvitationButton
+                            castId={cast.id}
+                            status={cast.invitation_status}
+                            onIssued={handleIssued}
+                          />
+                        )}
+                        <Button asChild variant="ghost" size="icon-sm">
+                          <Link href={storePath(storeId, `/casts/${cast.id}/edit`)}>
+                            <PencilSquareIcon />
+                          </Link>
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={() => handleDelete(cast.id, cast.name)}
+                        >
+                          <TrashIcon />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
                 );
               })}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         )}
-      </div>
+      </Card>
 
       <InvitationModal
         open={issuedInvitation !== null}

--- a/frontend/src/entities/cast/__tests__/invitationStatusLabel.test.ts
+++ b/frontend/src/entities/cast/__tests__/invitationStatusLabel.test.ts
@@ -4,28 +4,28 @@ describe('castInvitationStatusLabel', () => {
   it('NOT_INVITED は「未招待」を返すこと', () => {
     expect(castInvitationStatusLabel('NOT_INVITED')).toEqual({
       text: '未招待',
-      color: 'bg-gray-100 text-gray-800',
+      color: 'bg-muted text-foreground',
     });
   });
 
   it('INVITED は「招待中」を返すこと', () => {
     expect(castInvitationStatusLabel('INVITED')).toEqual({
       text: '招待中',
-      color: 'bg-blue-100 text-blue-800',
+      color: 'bg-primary/10 text-primary-strong',
     });
   });
 
   it('EXPIRED は「期限切れ」を返すこと', () => {
     expect(castInvitationStatusLabel('EXPIRED')).toEqual({
       text: '期限切れ',
-      color: 'bg-red-100 text-red-800',
+      color: 'bg-destructive/10 text-destructive-strong',
     });
   });
 
   it('LINKED は「連携済み」を返すこと', () => {
     expect(castInvitationStatusLabel('LINKED')).toEqual({
       text: '連携済み',
-      color: 'bg-green-100 text-green-800',
+      color: 'bg-success/10 text-success-strong',
     });
   });
 });

--- a/frontend/src/entities/cast/model/invitationStatusLabel.ts
+++ b/frontend/src/entities/cast/model/invitationStatusLabel.ts
@@ -1,19 +1,19 @@
 import { CastInvitationStatus } from './types';
 
-/** 招待状態の表示ラベルと配色（DESIGN.md Status pill: *-100 bg + *-800 text）を返す。 */
+/** 招待状態の表示ラベルと配色（DESIGN.md Status pill の tint レシピ）を返す。 */
 export function castInvitationStatusLabel(status: CastInvitationStatus): {
   text: string;
   color: string;
 } {
   switch (status) {
     case 'LINKED':
-      return { text: '連携済み', color: 'bg-green-100 text-green-800' };
+      return { text: '連携済み', color: 'bg-success/10 text-success-strong' };
     case 'INVITED':
-      return { text: '招待中', color: 'bg-blue-100 text-blue-800' };
+      return { text: '招待中', color: 'bg-primary/10 text-primary-strong' };
     case 'EXPIRED':
-      return { text: '期限切れ', color: 'bg-red-100 text-red-800' };
+      return { text: '期限切れ', color: 'bg-destructive/10 text-destructive-strong' };
     case 'NOT_INVITED':
     default:
-      return { text: '未招待', color: 'bg-gray-100 text-gray-800' };
+      return { text: '未招待', color: 'bg-muted text-foreground' };
   }
 }


### PR DESCRIPTION
## 概要

shadcn/ui 移行(地図 #458)の restyle sweep、並列第 1 陣の 1 枚。基盤票 #474 で敷いた token・プリミティブ・`frontend/DESIGN.md` の写像表とコントラスト検算マトリクスに従って `store-casts` スライスを restyle する。**挙動完全維持**が原則で、API へ送るペイロードは restyle 前と一字も変えない。

Closes #477

## 等価性の証明(本 PR の主眼)

`useForm` + `<select>` を持つ高リスクスライスのため、**ペイロードアンカーテストを restyle 前に追加し、master 実装のまま green を確認してからコミット**した(コミット 1)。restyle 後も**同じテストを一切変更せず green**であることが等価性の機械的証明になる。

- コミット 1 → HEAD のテスト差分は **+2 行の純増のみ**(プリフィル表示の錨とそのコメント)。既存 assertion の変更・削除は**ゼロ**。
- ローカルレビューで、コミット 1 のテストを master 実装の一時 worktree で実行して green を再現し、証明チェーンが本物であることを独立に確認済み。

## 変更内容

- **`CastForm.tsx`** — Radix 化が必要な `<select>` は **`status` の 1 箇所だけ**。`defaultValues` に既に `status: 'ACTIVE'` があり「DOM 先頭 option を拾う」経路に依存していないため、**センチネル(`SELECT_NONE`)も型復元も `defaultValues` の追加補完も不要**だった。他の全フィールド(name / 数値 5 種 / display_order / introduction / カスタムフィールド動的欄)は `{...register(name)}` を継続し `Input`/`Textarea` へ置換するのみ。4 セクションを `Card` 化。
- **`CastsPage.tsx`** — 一覧を shadcn `Table` へ、検索バーを `Card` へ、ステータス/招待状態のバッジを `Badge` + tint レシピへ。能力による出し分け(fail-closed)・検索・削除 `confirm()`・招待モーダル・遷移は逐語温存。
- **`CastCreatePage.tsx` / `CastEditPage.tsx`** — 見出しのトークン化のみ。`handleSubmit` の変換ロジックは一字も変えていない。
- **`_pages/store-casts/__tests__/CastPagesPayload.test.tsx` 新規** — 3 件。未操作時の既定ペイロード(`status:'ACTIVE'` 含む)/ 編集のプリフィル→無変更保存の往復(`status:'INACTIVE'` 保持・`custom_fields` 含む)/ 数値を入力後に空へ戻した際の NaN 経路。camelCase 混入の否定も含む。

### スライス外の変更(旗)

**`entities/cast/model/invitationStatusLabel.ts`(+ 同テスト)の配色を tint レシピへ更新した。** 招待状態バッジの色文字列はスライス内ではなくここにあり、スライス内 grep では検出されないため、放置すると一覧に生パレットが残り続ける。生産消費者は `CastsPage` ただ 1 つ(grep 実証・レビューでも独立確認)なので並列衝突リスクは無い。

## 検証

- [x] `task -d frontend lint` exit 0
- [x] `task -d frontend test` exit 0(Jest 54 suites / 272 tests)
- [x] `task -d frontend build` exit 0
- [x] 検収 grep(`DESIGN.md` の負の不変量)→ 対象ファイルでマッチゼロ
- [x] 共有ファイル差分ゼロ(`src/shared/ui/**`・`src/app/globals.css`・`setupTests.ts`・barrel・`DESIGN.md`・`features/cast-invitation`)
- [ ] `task test`(integration)/ `task e2e`: frontend 限定・API 契約無変更のため該当なし
- [x] ローカルで code-review 実施済み。blocking なし。should-fix 1 件(下記「残る無証明範囲」)。

### 視覚確認(UI 変更時)

**【必須】編集画面でステータスを「無効」→「有効」に変更して保存し、PUT ボディの `status` が `ACTIVE` に変わることを DevTools の Network で確認する。** 理由は下記のとおり、この経路だけ自動テストで塞げていない。

その他の確認項目:
- 編集画面を開いたときにステータスが**プリフィル表示**されるか(Radix 化の最大リスク点)
- 一覧のバッジ 2 系統(ステータス / 招待状態)の配色
- **写真なし行の「No」プレースホルダが以前より濃い**こと。`bg-muted` 上でマトリクスが許すテキストは `text-foreground` のみ(`text-muted-foreground` との組み合わせは DESIGN.md が 4.39 の不合格ペアと明記)のため、`text-gray-300` からの**測定済みの帰結**。許容可否の判断を仰ぐ
- 検索バーが狭い画面で窮屈にならないか

## 残る無証明範囲(正直な申告)

**`onValueChange={field.onChange}` の配線は自動テストでは未証明。** 3 テストはいずれも Select を操作しない経路(未操作既定値 / プリフィル無変更往復)なので、仮にこの配線が欠落しても全テストが green のままになる。上記の手動スモークが現時点で唯一の証明手段。

自動で塞ぐことを試みたが、**jsdom に `Element.prototype.scrollIntoView` が無いため不可能**だった。Radix Select は content のマウント時 effect で「選択済み項目をビューへスクロール」するため、`ArrowDown` / `Enter` / `Space` のどのキーで開いても同じ箇所で落ちる(開き方に依存しない)。`Header.test.tsx` の DropdownMenu が shim 無しで緑なのは、DropdownMenu にこの副作用が無いためで、precedent を転用できない。

**必要なシムは `Element.prototype.scrollIntoView = jest.fn();` の 1 行のみ**であることを実測済み(pointer capture 系 3 行は、キーボードで開く限り到達しないため不要)。`setupTests.ts` は並列 restyle 中の共有ファイルにつき本 PR では触らず、**シム追加と値変更経路テストは別票**に切り出す。

## 決定ログ

- **`getByText('無効')` ではなく `getByRole('combobox', { name: 'ステータス' })` + `toHaveTextContent`**:Radix は選択値をトリガの `SelectValue` span と、フォーム互換用の非表示 `<select>` の**両方**に描画するため `getByText` は 2 ノードにマッチして落ちる。実装ではなくクエリ側の問題なので、実装は触らずクエリを直した。
- **NaN 経路のテストを計画超過で 1 本追加**:数値を入力後に空へ戻すと `valueAsNumber` が NaN になる挙動は、当初ブラウザでの実ペイロード記録で証明する計画だったが、その手順を取りやめたため無証明になっていた。`NaN → null` の変換は axios の `JSON.stringify` で起きモック境界より下流なので、`Number.isNaN(body.age)` で assert している(`null` で書くと master で赤くなる)。
- **カスタムフィールドの空状態は `bg-muted` を使わない**:`bg-gray-50` の素直な写像先は `bg-muted` だが、その中の説明文が `text-muted-foreground` になり DESIGN.md が 4.39 の不合格と明記する組み合わせを踏む。面の塗りを外し dashed 枠のみ残した。
- **検索バーは `flex items-center gap-4`**:正本 `CustomersPage` は `flex-col md:flex-row` だが、こちらは子要素が 2 個(Input + ボタン)のため。master も単行だったので挙動は同等。

## 備考 / レビュー観点

- 最重点は**ペイロード等価性**。`defaultValues` は一切変更しておらず、`photo_url` の `setValue`/`watch` 経路とカスタムフィールドの `register`/`defaultValue`/hasOwn ガード/id 付与は逐語温存。
- **旗のみ・未変更**: `features/cast-invitation`(InvitationButton / InvitationModal)に生パレットが残存 — 別スライス・別票。
- push/PR まで実施。**マージは owner が手動**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
