### PR TITLE
refactor(frontend): store-settings スライスと password-change を shadcn へ restyle する

### DIFF
--- a/frontend/src/_pages/store-settings/__tests__/StoreProfileForm.test.tsx
+++ b/frontend/src/_pages/store-settings/__tests__/StoreProfileForm.test.tsx
@@ -26,9 +26,9 @@ function initialData(overrides: Partial<StoreProfileResponse> = {}): StoreProfil
     id: '1',
     template_key: 'default',
     mv_type: 'image',
-    logo_url: '',
-    banner_url: '',
-    mv_url: '',
+    logo_url: '/uploads/logo.png',
+    banner_url: '/uploads/banner.png',
+    mv_url: '/uploads/mv.png',
     description: '説明',
     catch_copy: '',
     address: '',
@@ -71,6 +71,10 @@ describe('店舗プロフィールフォームの送信ペイロード', () => {
     // 選択肢の先頭値（twitter）へ化けず、保存済みの platform と label が保たれること
     expect(body.sns_links).toEqual([{ platform: 'instagram', url: 'https://insta', label: '' }]);
     expect(body.partner_links).toEqual([]);
+    // 画像欄はアップロード済み URL を保持するだけで、無編集の送信でも値ごと往復すること
+    expect(body.logo_url).toBe('/uploads/logo.png');
+    expect(body.banner_url).toBe('/uploads/banner.png');
+    expect(body.mv_url).toBe('/uploads/mv.png');
   });
 
   it('既定値ではない mv_type が無編集の送信で保持されること', async () => {
@@ -118,5 +122,31 @@ describe('店舗プロフィールフォームの送信ペイロード', () => {
       url: 'https://new.test',
       label: '',
     });
+  });
+
+  it('保存済みのパートナー行がロゴ URL ごと無編集の送信で往復すること', async () => {
+    const partner = { name: '提携店', url: 'https://partner.test', logo_url: '/uploads/p.png' };
+    const { onSubmit } = renderForm(initialData({ partner_links: [partner] }));
+
+    const body = await submitAndGetBody(onSubmit);
+
+    expect(body.partner_links).toEqual([partner]);
+  });
+
+  it('パートナーリンクの追加行が既定値どおりのキーで送られること', async () => {
+    const { onSubmit } = renderForm(initialData());
+
+    fireEvent.click(screen.getAllByRole('button', { name: '+ 追加' })[1]);
+    fireEvent.change(screen.getByPlaceholderText('パートナー名'), { target: { value: '提携B' } });
+    const urlInputs = screen.getAllByPlaceholderText('https://...');
+    fireEvent.change(urlInputs[urlInputs.length - 1], {
+      target: { value: 'https://partner-b.test' },
+    });
+
+    const body = await submitAndGetBody(onSubmit);
+
+    expect(body.partner_links).toEqual([
+      { name: '提携B', url: 'https://partner-b.test', logo_url: '' },
+    ]);
   });
 });

--- a/frontend/src/_pages/store-settings/__tests__/StoreProfileForm.test.tsx
+++ b/frontend/src/_pages/store-settings/__tests__/StoreProfileForm.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { StoreProfileForm } from '../ui/StoreProfileForm';
+import type { StoreProfileResponse, StoreProfileUpdateRequest } from '@/entities/store-profile';
+
+// 送信ペイロードの形を固定する錨。プリミティブ置換で defaultValues や
+// フィールド配線が崩れると、この期待値が先に落ちる。
+const PAYLOAD_KEYS = [
+  'address',
+  'banner_url',
+  'business_hours',
+  'catch_copy',
+  'custom_texts',
+  'description',
+  'logo_url',
+  'mv_type',
+  'mv_url',
+  'partner_links',
+  'phone',
+  'pricing_description',
+  'sns_links',
+  'template_key',
+];
+
+function initialData(overrides: Partial<StoreProfileResponse> = {}): StoreProfileResponse {
+  return {
+    id: '1',
+    template_key: 'default',
+    mv_type: 'image',
+    logo_url: '',
+    banner_url: '',
+    mv_url: '',
+    description: '説明',
+    catch_copy: '',
+    address: '',
+    phone: '',
+    business_hours: '',
+    pricing_description: '',
+    custom_texts: { access_note: '既存メモ', modern_only_key: '他模版の値' },
+    sns_links: [{ platform: 'instagram', url: 'https://insta', label: '' }],
+    partner_links: [],
+    created_at: '',
+    updated_at: '',
+    ...overrides,
+  };
+}
+
+function renderForm(data: StoreProfileResponse) {
+  const onSubmit = jest.fn<Promise<void>, [StoreProfileUpdateRequest]>().mockResolvedValue();
+  const view = render(
+    <StoreProfileForm initialData={data} onSubmit={onSubmit} isSubmitting={false} />
+  );
+  return { ...view, onSubmit };
+}
+
+async function submitAndGetBody(onSubmit: jest.Mock) {
+  fireEvent.click(screen.getByRole('button', { name: '設定を保存する' }));
+  await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+  return onSubmit.mock.calls[0][0] as StoreProfileUpdateRequest;
+}
+
+describe('店舗プロフィールフォームの送信ペイロード', () => {
+  it('無編集の送信でも保存済みの全キーと値がそのまま送られること', async () => {
+    const { onSubmit } = renderForm(initialData());
+
+    const body = await submitAndGetBody(onSubmit);
+
+    expect(Object.keys(body).sort()).toEqual(PAYLOAD_KEYS);
+    expect(body.template_key).toBe('default');
+    expect(body.mv_type).toBe('image');
+    expect(body.description).toBe('説明');
+    // 選択肢の先頭値（twitter）へ化けず、保存済みの platform と label が保たれること
+    expect(body.sns_links).toEqual([{ platform: 'instagram', url: 'https://insta', label: '' }]);
+    expect(body.partner_links).toEqual([]);
+  });
+
+  it('既定値ではない mv_type が無編集の送信で保持されること', async () => {
+    const { onSubmit } = renderForm(initialData({ mv_type: 'video' }));
+
+    const body = await submitAndGetBody(onSubmit);
+
+    expect(body.mv_type).toBe('video');
+  });
+
+  it('模版テキストの編集後も現模版に無い custom_texts の key が保持されること', async () => {
+    const { container, onSubmit } = renderForm(initialData());
+
+    const slot = container.querySelector('[name="custom_texts.access_note"]');
+    expect(slot).not.toBeNull();
+    fireEvent.change(slot as HTMLTextAreaElement, { target: { value: '新値' } });
+
+    const body = await submitAndGetBody(onSubmit);
+
+    expect(body.custom_texts).toEqual({ access_note: '新値', modern_only_key: '他模版の値' });
+  });
+
+  it('テンプレートカードの選択が template_key に反映されること', async () => {
+    const { onSubmit } = renderForm(initialData());
+
+    fireEvent.click(screen.getByRole('radio', { name: /モダン/ }));
+
+    const body = await submitAndGetBody(onSubmit);
+
+    expect(body.template_key).toBe('modern');
+  });
+
+  it('SNS リンクの追加行が既定値どおりのキーで送られること', async () => {
+    const { onSubmit } = renderForm(initialData());
+
+    fireEvent.click(screen.getAllByRole('button', { name: '+ 追加' })[0]);
+    const urlInputs = screen.getAllByPlaceholderText('https://...');
+    fireEvent.change(urlInputs[urlInputs.length - 1], { target: { value: 'https://new.test' } });
+
+    const body = await submitAndGetBody(onSubmit);
+
+    expect(body.sns_links).toHaveLength(2);
+    expect(body.sns_links?.[1]).toEqual({
+      platform: 'twitter',
+      url: 'https://new.test',
+      label: '',
+    });
+  });
+});

--- a/frontend/src/_pages/store-settings/ui/AccountPage.tsx
+++ b/frontend/src/_pages/store-settings/ui/AccountPage.tsx
@@ -68,7 +68,9 @@ export default function AccountPage() {
       <form onSubmit={handleProfileSubmit}>
         <Card>
           <CardHeader>
-            <CardTitle>プロフィール</CardTitle>
+            <CardTitle role="heading" aria-level={3}>
+              プロフィール
+            </CardTitle>
           </CardHeader>
           <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="grid gap-2">

--- a/frontend/src/_pages/store-settings/ui/AccountPage.tsx
+++ b/frontend/src/_pages/store-settings/ui/AccountPage.tsx
@@ -4,6 +4,16 @@ import { useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { platformAuthApi } from '@/entities/user';
 import { PasswordChangeForm } from '@/features/password-change';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+} from '@/shared/ui';
 
 /** アカウント設定ページ（プロフィール + パスワード変更） */
 export default function AccountPage() {
@@ -42,57 +52,47 @@ export default function AccountPage() {
   };
 
   if (isLoading) {
-    return <div className="p-8 text-center text-gray-500">読み込み中...</div>;
+    return <div className="p-8 text-center text-muted-foreground">読み込み中...</div>;
   }
 
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">アカウント設定</h1>
-        <p className="text-sm text-gray-500 mt-1">自分のプロフィールとパスワードを管理します。</p>
+        <h1 className="text-2xl font-bold text-foreground">アカウント設定</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          自分のプロフィールとパスワードを管理します。
+        </p>
       </div>
 
       {/* プロフィール */}
-      <form
-        onSubmit={handleProfileSubmit}
-        className="bg-white p-8 rounded-xl shadow-sm border border-gray-100 space-y-6"
-      >
-        <h3 className="text-lg font-semibold text-gray-900 border-l-4 border-indigo-500 pl-3">
-          プロフィール
-        </h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              メールアドレス（ログインID）
-            </label>
-            <input
-              type="email"
-              value={email}
-              disabled
-              className="w-full rounded-md border-gray-300 bg-gray-50 text-gray-500 shadow-sm"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">ニックネーム *</label>
-            <input
-              type="text"
-              value={nickname}
-              onChange={e => setNickname(e.target.value)}
-              required
-              maxLength={150}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-        </div>
-        <div className="flex justify-end">
-          <button
-            type="submit"
-            disabled={isSubmitting}
-            className="px-10 py-2.5 rounded-md bg-indigo-600 text-white font-semibold shadow-lg shadow-indigo-200 hover:bg-indigo-700 disabled:opacity-50 transition-all"
-          >
-            {isSubmitting ? '保存中...' : '保存する'}
-          </button>
-        </div>
+      <form onSubmit={handleProfileSubmit}>
+        <Card>
+          <CardHeader>
+            <CardTitle>プロフィール</CardTitle>
+          </CardHeader>
+          <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="grid gap-2">
+              <Label htmlFor="account-email">メールアドレス（ログインID）</Label>
+              <Input id="account-email" type="email" value={email} disabled />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="account-nickname">ニックネーム *</Label>
+              <Input
+                id="account-nickname"
+                type="text"
+                value={nickname}
+                onChange={e => setNickname(e.target.value)}
+                required
+                maxLength={150}
+              />
+            </div>
+          </CardContent>
+          <CardFooter className="justify-end">
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? '保存中...' : '保存する'}
+            </Button>
+          </CardFooter>
+        </Card>
       </form>
 
       <PasswordChangeForm />

--- a/frontend/src/_pages/store-settings/ui/ProfilePage.tsx
+++ b/frontend/src/_pages/store-settings/ui/ProfilePage.tsx
@@ -45,7 +45,7 @@ export default function StoreProfilePage() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-100">
-        <div className="text-gray-500">読み込み中...</div>
+        <div className="text-muted-foreground">読み込み中...</div>
       </div>
     );
   }
@@ -53,7 +53,7 @@ export default function StoreProfilePage() {
   if (!config) {
     return (
       <div className="flex items-center justify-center min-h-100">
-        <div className="text-red-500">設定の読み込みに失敗しました</div>
+        <div className="text-destructive-strong">設定の読み込みに失敗しました</div>
       </div>
     );
   }
@@ -61,8 +61,8 @@ export default function StoreProfilePage() {
   return (
     <div className="max-w-4xl mx-auto">
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">店舗情報</h1>
-        <p className="text-sm text-gray-500 mt-1">店舗サイトの外観をカスタマイズします。</p>
+        <h1 className="text-2xl font-bold text-foreground">店舗情報</h1>
+        <p className="text-sm text-muted-foreground mt-1">店舗サイトの外観をカスタマイズします。</p>
       </div>
       <StoreProfileForm initialData={config} onSubmit={handleSubmit} isSubmitting={isSubmitting} />
     </div>

--- a/frontend/src/_pages/store-settings/ui/StoreProfileForm.tsx
+++ b/frontend/src/_pages/store-settings/ui/StoreProfileForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useForm, useFieldArray, Controller } from 'react-hook-form';
+import { useForm, useFieldArray } from 'react-hook-form';
 import {
   getAllTemplateMetas,
   getTemplateMeta,
@@ -9,7 +9,23 @@ import {
   StoreProfileResponse,
   StoreProfileUpdateRequest,
 } from '@/entities/store-profile';
-import { ImageUpload } from '@/shared/ui';
+import {
+  Button,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  ImageUpload,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from '@/shared/ui';
 
 interface StoreProfileFormData {
   template_key: string;
@@ -44,7 +60,7 @@ const SNS_PLATFORMS = [
 ];
 
 export function StoreProfileForm({ initialData, onSubmit, isSubmitting }: StoreProfileFormProps) {
-  const { register, control, handleSubmit, watch } = useForm<StoreProfileFormData>({
+  const form = useForm<StoreProfileFormData>({
     defaultValues: {
       template_key: initialData.template_key || 'default',
       logo_url: initialData.logo_url || '',
@@ -62,6 +78,7 @@ export function StoreProfileForm({ initialData, onSubmit, isSubmitting }: StoreP
       partner_links: initialData.partner_links || [],
     },
   });
+  const { register, control, handleSubmit, watch } = form;
 
   const templateKey = watch('template_key');
   const textSlots = getTemplateMeta(templateKey).textSlots;
@@ -93,384 +110,398 @@ export function StoreProfileForm({ initialData, onSubmit, isSubmitting }: StoreP
   };
 
   return (
-    <form
-      onSubmit={handleSubmit(handleFormSubmit)}
-      className="space-y-10 bg-white p-8 rounded-xl shadow-sm border border-gray-100"
-    >
-      {/* 1. 基本設定 */}
-      <section>
-        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
-          基本設定
-        </h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          <div className="col-span-2">
-            <label className="block text-sm font-medium text-gray-700 mb-2">テンプレート</label>
-            {/* サムネイル付き予覧カードで模版を選択。選択中の key は既存 watch で
-                模版テキスト欄の描画に連動する（追加配線は不要） */}
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {getAllTemplateMetas().map(meta => {
-                const selected = templateKey === meta.key;
-                return (
-                  <label
-                    key={meta.key}
-                    className={`block rounded-[10px] border p-3 cursor-pointer transition-colors has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-blue-500 ${
-                      selected
-                        ? 'border-blue-600 ring-2 ring-blue-600 bg-blue-50'
-                        : 'border-gray-200 hover:bg-gray-50'
-                    }`}
-                  >
-                    <input
-                      type="radio"
-                      value={meta.key}
-                      {...register('template_key')}
-                      className="sr-only"
-                    />
-                    {/* eslint-disable-next-line @next/next/no-img-element -- 静的サムネイル、最適化不要 */}
-                    <img
-                      src={meta.thumbnail}
-                      alt={meta.name}
-                      className="w-full rounded border border-gray-200"
-                    />
-                    <p
-                      className={`mt-2 text-sm font-medium ${
-                        selected ? 'text-blue-600' : 'text-gray-900'
+    <Form {...form}>
+      <form
+        onSubmit={handleSubmit(handleFormSubmit)}
+        className="space-y-10 bg-card text-card-foreground p-8 rounded-xl shadow-sm border"
+      >
+        {/* 1. 基本設定 */}
+        <section>
+          <h3 className="text-lg font-semibold text-foreground mb-6 border-l-4 border-primary pl-3">
+            基本設定
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            <div className="col-span-2 grid gap-2">
+              <Label>テンプレート</Label>
+              {/* サムネイル付き予覧カードで模版を選択。選択中の key は既存 watch で
+                  模版テキスト欄の描画に連動する（追加配線は不要） */}
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                {getAllTemplateMetas().map(meta => {
+                  const selected = templateKey === meta.key;
+                  return (
+                    <label
+                      key={meta.key}
+                      className={`block rounded-lg border p-3 cursor-pointer transition-colors has-[:focus-visible]:ring-2 ${
+                        selected
+                          ? 'border-primary ring-2 ring-primary bg-primary/10'
+                          : 'hover:bg-muted'
                       }`}
                     >
-                      {meta.name}
-                    </p>
-                    <p className="text-xs text-gray-500">{meta.description}</p>
-                  </label>
-                );
-              })}
+                      <input
+                        type="radio"
+                        value={meta.key}
+                        {...register('template_key')}
+                        className="sr-only"
+                      />
+                      {/* eslint-disable-next-line @next/next/no-img-element -- 静的サムネイル、最適化不要 */}
+                      <img src={meta.thumbnail} alt={meta.name} className="w-full rounded border" />
+                      <p
+                        className={`mt-2 text-sm font-medium ${
+                          selected ? 'text-primary-strong' : 'text-foreground'
+                        }`}
+                      >
+                        {meta.name}
+                      </p>
+                      <p className="text-xs text-muted-foreground">{meta.description}</p>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+            <div className="col-span-2 grid gap-2">
+              <Label htmlFor="description">店舗説明文</Label>
+              <Textarea
+                id="description"
+                rows={4}
+                placeholder="店舗の紹介文を入力してください..."
+                {...register('description')}
+              />
+            </div>
+            <div className="col-span-2 grid gap-2">
+              <Label htmlFor="catch_copy">キャッチコピー</Label>
+              <Textarea
+                id="catch_copy"
+                rows={2}
+                placeholder="トップページに大きく表示される一言を入力してください..."
+                {...register('catch_copy')}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="address">住所</Label>
+              <Input
+                id="address"
+                type="text"
+                placeholder="例: 東京都新宿区..."
+                {...register('address')}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="phone">電話番号</Label>
+              <Input id="phone" type="tel" placeholder="例: 03-1234-5678" {...register('phone')} />
+            </div>
+            <div className="col-span-2 grid gap-2">
+              <Label htmlFor="business_hours">営業時間</Label>
+              <Input
+                id="business_hours"
+                type="text"
+                placeholder="例: 10:00〜翌1:00（不定休）"
+                {...register('business_hours')}
+              />
+            </div>
+            <div className="col-span-2 grid gap-2">
+              <Label htmlFor="pricing_description">料金説明文</Label>
+              <p className="text-xs text-muted-foreground">
+                料金ページの本文です。改行はそのまま公開サイトに表示されます。
+              </p>
+              <Textarea
+                id="pricing_description"
+                rows={6}
+                placeholder={'例:\nセット料金 60分 5,000円\n指名料 1,000円\n延長 30分 2,500円'}
+                {...register('pricing_description')}
+              />
             </div>
           </div>
-          <div className="col-span-2">
-            <label className="block text-sm font-medium text-gray-700 mb-2">店舗説明文</label>
-            <textarea
-              {...register('description')}
-              rows={4}
-              placeholder="店舗の紹介文を入力してください..."
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div className="col-span-2">
-            <label className="block text-sm font-medium text-gray-700 mb-2">キャッチコピー</label>
-            <textarea
-              {...register('catch_copy')}
-              rows={2}
-              placeholder="トップページに大きく表示される一言を入力してください..."
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">住所</label>
-            <input
-              type="text"
-              {...register('address')}
-              placeholder="例: 東京都新宿区..."
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">電話番号</label>
-            <input
-              type="tel"
-              {...register('phone')}
-              placeholder="例: 03-1234-5678"
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div className="col-span-2">
-            <label className="block text-sm font-medium text-gray-700 mb-2">営業時間</label>
-            <input
-              type="text"
-              {...register('business_hours')}
-              placeholder="例: 10:00〜翌1:00（不定休）"
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
-          </div>
-          <div className="col-span-2">
-            <label className="block text-sm font-medium text-gray-700 mb-2">料金説明文</label>
-            <p className="text-xs text-gray-500 mb-2">
-              料金ページの本文です。改行はそのまま公開サイトに表示されます。
+        </section>
+
+        {/* 模版テキスト */}
+        <section>
+          <h3 className="text-lg font-semibold text-foreground mb-6 border-l-4 border-primary pl-3">
+            模版テキスト
+          </h3>
+          {textSlots.length === 0 ? (
+            <div className="p-6 rounded-lg border border-dashed text-center text-muted-foreground text-sm">
+              この模版に追加のテキスト項目はありません
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {textSlots.map(slot => (
+                <div key={slot.key} className="grid gap-2">
+                  <Label htmlFor={`custom_texts.${slot.key}`}>{slot.label}</Label>
+                  <Textarea
+                    id={`custom_texts.${slot.key}`}
+                    rows={3}
+                    {...register(`custom_texts.${slot.key}`)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* 2. ビジュアル設定 */}
+        <section>
+          <h3 className="text-lg font-semibold text-foreground mb-6 border-l-4 border-primary pl-3">
+            ビジュアル設定
+          </h3>
+
+          {/* ロゴ */}
+          <div className="mb-8 grid gap-2">
+            <Label>ロゴ画像</Label>
+            <p className="text-xs text-muted-foreground">
+              正方形の画像を推奨します（例: 200x200px）
             </p>
-            <textarea
-              {...register('pricing_description')}
-              rows={6}
-              placeholder={'例:\nセット料金 60分 5,000円\n指名料 1,000円\n延長 30分 2,500円'}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            />
+            <div className="flex items-start">
+              <FormField
+                control={control}
+                name="logo_url"
+                render={({ field: { value, onChange } }) => (
+                  <ImageUpload
+                    value={value}
+                    onChange={onChange}
+                    bucket="public"
+                    className="w-32 h-32" // Square
+                  />
+                )}
+              />
+            </div>
           </div>
-        </div>
-      </section>
 
-      {/* 模版テキスト */}
-      <section>
-        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
-          模版テキスト
-        </h3>
-        {textSlots.length === 0 ? (
-          <div className="p-6 bg-gray-50 rounded-lg border border-dashed border-gray-300 text-center text-gray-500 text-sm">
-            この模版に追加のテキスト項目はありません
-          </div>
-        ) : (
-          <div className="space-y-6">
-            {textSlots.map(slot => (
-              <div key={slot.key}>
-                <label className="block text-sm font-medium text-gray-700 mb-2">{slot.label}</label>
-                <textarea
-                  {...register(`custom_texts.${slot.key}`)}
-                  rows={3}
-                  className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                />
-              </div>
-            ))}
-          </div>
-        )}
-      </section>
-
-      {/* 2. ビジュアル設定 */}
-      <section>
-        <h3 className="text-lg font-semibold text-gray-900 mb-6 border-l-4 border-indigo-500 pl-3">
-          ビジュアル設定
-        </h3>
-
-        {/* ロゴ */}
-        <div className="mb-8">
-          <label className="block text-sm font-medium text-gray-700 mb-2">ロゴ画像</label>
-          <p className="text-xs text-gray-500 mb-3">正方形の画像を推奨します（例: 200x200px）</p>
-          <div className="flex items-start">
-            <Controller
+          {/* バナー */}
+          <div className="mb-8 grid gap-2">
+            <Label>バナー画像</Label>
+            <p className="text-xs text-muted-foreground">
+              横長の画像を推奨します（例: 1200x400px）
+            </p>
+            <FormField
               control={control}
-              name="logo_url"
+              name="banner_url"
               render={({ field: { value, onChange } }) => (
                 <ImageUpload
                   value={value}
                   onChange={onChange}
                   bucket="public"
-                  className="w-32 h-32" // Square
+                  className="w-full h-40 max-w-2xl" // Wide rectangle
                 />
               )}
             />
           </div>
-        </div>
 
-        {/* バナー */}
-        <div className="mb-8">
-          <label className="block text-sm font-medium text-gray-700 mb-2">バナー画像</label>
-          <p className="text-xs text-gray-500 mb-3">横長の画像を推奨します（例: 1200x400px）</p>
-          <Controller
-            control={control}
-            name="banner_url"
-            render={({ field: { value, onChange } }) => (
-              <ImageUpload
-                value={value}
-                onChange={onChange}
-                bucket="public"
-                className="w-full h-40 max-w-2xl" // Wide rectangle
+          {/* メインビジュアル (MV) */}
+          <div className="mb-8 grid gap-2">
+            <div className="flex justify-between items-center">
+              <Label>メインビジュアル (MV)</Label>
+              <FormField
+                control={control}
+                name="mv_type"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-center gap-2">
+                    <FormLabel className="text-muted-foreground font-normal">タイプ:</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger size="sm">
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="image">画像</SelectItem>
+                        <SelectItem value="video">動画</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
               />
-            )}
-          />
-        </div>
-
-        {/* メインビジュアル (MV) */}
-        <div className="mb-8">
-          <div className="flex justify-between items-center mb-2">
-            <label className="block text-sm font-medium text-gray-700">メインビジュアル (MV)</label>
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-600">タイプ:</span>
-              <select
-                {...register('mv_type')}
-                className="text-sm rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 py-1 pl-2 pr-8"
-              >
-                <option value="image">画像</option>
-                <option value="video">動画</option>
-              </select>
             </div>
+            <p className="text-xs text-muted-foreground">
+              サイトの顔となる大きな画像です（例: 1920x800px）
+            </p>
+            <FormField
+              control={control}
+              name="mv_url"
+              render={({ field: { value, onChange } }) => (
+                <ImageUpload
+                  value={value}
+                  onChange={onChange}
+                  bucket="public"
+                  className="w-full h-64" // Taller wide rectangle
+                />
+              )}
+            />
           </div>
-          <p className="text-xs text-gray-500 mb-3">
-            サイトの顔となる大きな画像です（例: 1920x800px）
-          </p>
-          <Controller
-            control={control}
-            name="mv_url"
-            render={({ field: { value, onChange } }) => (
-              <ImageUpload
-                value={value}
-                onChange={onChange}
-                bucket="public"
-                className="w-full h-64" // Taller wide rectangle
-              />
-            )}
-          />
-        </div>
-      </section>
+        </section>
 
-      {/* 3. SNSリンク */}
-      <section>
-        <div className="flex justify-between items-center mb-6">
-          <h3 className="text-lg font-semibold text-gray-900 border-l-4 border-indigo-500 pl-3">
-            SNS リンク
-          </h3>
-          <button
-            type="button"
-            onClick={() => appendSns({ platform: 'twitter', url: '', label: '' })}
-            className="px-4 py-2 text-sm bg-indigo-50 text-indigo-600 rounded-md hover:bg-indigo-100 transition-colors"
-          >
-            + 追加
-          </button>
-        </div>
-        <div className="space-y-4">
-          {snsFields.length === 0 ? (
-            <div className="p-6 bg-gray-50 rounded-lg border border-dashed border-gray-300 text-center text-gray-500 text-sm">
-              SNS リンクが登録されていません
-            </div>
-          ) : (
-            snsFields.map((field, index) => (
-              <div
-                key={field.id}
-                className="flex items-start gap-4 p-4 bg-gray-50 rounded-lg border border-gray-200"
-              >
-                <div className="flex-1 grid grid-cols-1 md:grid-cols-3 gap-4">
-                  <div>
-                    <label className="block text-xs font-medium text-gray-500 mb-1">
-                      プラットフォーム
-                    </label>
-                    <select
-                      {...register(`sns_links.${index}.platform`)}
-                      className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                    >
-                      {SNS_PLATFORMS.map(p => (
-                        <option key={p.value} value={p.value}>
-                          {p.label}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div className="md:col-span-2">
-                    <label className="block text-xs font-medium text-gray-500 mb-1">URL</label>
-                    <input
-                      type="url"
-                      {...register(`sns_links.${index}.url`)}
-                      placeholder="https://..."
-                      className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                    />
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => removeSns(index)}
-                  className="mt-6 p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-full transition-colors"
-                  aria-label="削除"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
+        {/* 3. SNSリンク */}
+        <section>
+          <div className="flex justify-between items-center mb-6">
+            <h3 className="text-lg font-semibold text-foreground border-l-4 border-primary pl-3">
+              SNS リンク
+            </h3>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => appendSns({ platform: 'twitter', url: '', label: '' })}
+            >
+              + 追加
+            </Button>
+          </div>
+          <div className="space-y-4">
+            {snsFields.length === 0 ? (
+              <div className="p-6 rounded-lg border border-dashed text-center text-muted-foreground text-sm">
+                SNS リンクが登録されていません
               </div>
-            ))
-          )}
-        </div>
-      </section>
-
-      {/* 4. パートナーリンク */}
-      <section>
-        <div className="flex justify-between items-center mb-6">
-          <h3 className="text-lg font-semibold text-gray-900 border-l-4 border-indigo-500 pl-3">
-            パートナーリンク
-          </h3>
-          <button
-            type="button"
-            onClick={() => appendPartner({ name: '', url: '', logo_url: '' })}
-            className="px-4 py-2 text-sm bg-indigo-50 text-indigo-600 rounded-md hover:bg-indigo-100 transition-colors"
-          >
-            + 追加
-          </button>
-        </div>
-        <div className="space-y-4">
-          {partnerFields.length === 0 ? (
-            <div className="p-6 bg-gray-50 rounded-lg border border-dashed border-gray-300 text-center text-gray-500 text-sm">
-              パートナーリンクが登録されていません
-            </div>
-          ) : (
-            partnerFields.map((field, index) => (
-              <div
-                key={field.id}
-                className="flex items-start gap-4 p-4 bg-gray-50 rounded-lg border border-gray-200"
-              >
-                <div className="flex-1 grid grid-cols-1 md:grid-cols-12 gap-4">
-                  <div className="md:col-span-4">
-                    <label className="block text-xs font-medium text-gray-500 mb-1">名前</label>
-                    <input
-                      type="text"
-                      {...register(`partner_links.${index}.name`)}
-                      placeholder="パートナー名"
-                      className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+            ) : (
+              snsFields.map((field, index) => (
+                <div key={field.id} className="flex items-start gap-4 p-4 rounded-lg border">
+                  <div className="flex-1 grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <FormField
+                      control={control}
+                      name={`sns_links.${index}.platform`}
+                      render={({ field: platformField }) => (
+                        <FormItem>
+                          <FormLabel>プラットフォーム</FormLabel>
+                          <Select
+                            value={platformField.value}
+                            onValueChange={platformField.onChange}
+                          >
+                            <FormControl>
+                              <SelectTrigger className="w-full">
+                                <SelectValue />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              {SNS_PLATFORMS.map(p => (
+                                <SelectItem key={p.value} value={p.value}>
+                                  {p.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </FormItem>
+                      )}
                     />
-                  </div>
-                  <div className="md:col-span-5">
-                    <label className="block text-xs font-medium text-gray-500 mb-1">URL</label>
-                    <input
-                      type="url"
-                      {...register(`partner_links.${index}.url`)}
-                      placeholder="https://..."
-                      className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                    />
-                  </div>
-                  <div className="md:col-span-3">
-                    <label className="block text-xs font-medium text-gray-500 mb-1">ロゴ</label>
-                    <div className="h-10">
-                      <Controller
-                        control={control}
-                        name={`partner_links.${index}.logo_url`}
-                        render={({ field: { value, onChange } }) => (
-                          <ImageUpload
-                            value={value}
-                            onChange={onChange}
-                            bucket="public"
-                            className="w-full h-10 border-gray-200"
-                          />
-                        )}
+                    <div className="md:col-span-2 grid gap-2">
+                      <Label htmlFor={`sns_links.${index}.url`}>URL</Label>
+                      <Input
+                        id={`sns_links.${index}.url`}
+                        type="url"
+                        placeholder="https://..."
+                        {...register(`sns_links.${index}.url`)}
                       />
                     </div>
                   </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={() => removeSns(index)}
+                    className="mt-6 text-muted-foreground hover:text-destructive"
+                    aria-label="削除"
+                  >
+                    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </Button>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => removePartner(index)}
-                  className="mt-6 p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-full transition-colors"
-                  aria-label="削除"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
-              </div>
-            ))
-          )}
-        </div>
-      </section>
+              ))
+            )}
+          </div>
+        </section>
 
-      {/* Buttons */}
-      <div className="flex justify-end space-x-4 pt-6 border-t border-gray-100 sticky bottom-0 bg-white/90 backdrop-blur-sm p-4 -mx-8 -mb-8 rounded-b-xl">
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="px-10 py-2.5 rounded-md bg-indigo-600 text-white font-semibold shadow-lg shadow-indigo-200 hover:bg-indigo-700 disabled:opacity-50 transition-all transform active:scale-95"
-        >
-          {isSubmitting ? '保存中...' : '設定を保存する'}
-        </button>
-      </div>
-    </form>
+        {/* 4. パートナーリンク */}
+        <section>
+          <div className="flex justify-between items-center mb-6">
+            <h3 className="text-lg font-semibold text-foreground border-l-4 border-primary pl-3">
+              パートナーリンク
+            </h3>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => appendPartner({ name: '', url: '', logo_url: '' })}
+            >
+              + 追加
+            </Button>
+          </div>
+          <div className="space-y-4">
+            {partnerFields.length === 0 ? (
+              <div className="p-6 rounded-lg border border-dashed text-center text-muted-foreground text-sm">
+                パートナーリンクが登録されていません
+              </div>
+            ) : (
+              partnerFields.map((field, index) => (
+                <div key={field.id} className="flex items-start gap-4 p-4 rounded-lg border">
+                  <div className="flex-1 grid grid-cols-1 md:grid-cols-12 gap-4">
+                    <div className="md:col-span-4 grid gap-2">
+                      <Label htmlFor={`partner_links.${index}.name`}>名前</Label>
+                      <Input
+                        id={`partner_links.${index}.name`}
+                        type="text"
+                        placeholder="パートナー名"
+                        {...register(`partner_links.${index}.name`)}
+                      />
+                    </div>
+                    <div className="md:col-span-5 grid gap-2">
+                      <Label htmlFor={`partner_links.${index}.url`}>URL</Label>
+                      <Input
+                        id={`partner_links.${index}.url`}
+                        type="url"
+                        placeholder="https://..."
+                        {...register(`partner_links.${index}.url`)}
+                      />
+                    </div>
+                    <div className="md:col-span-3 grid gap-2">
+                      <Label>ロゴ</Label>
+                      <div className="h-10">
+                        <FormField
+                          control={control}
+                          name={`partner_links.${index}.logo_url`}
+                          render={({ field: { value, onChange } }) => (
+                            <ImageUpload
+                              value={value}
+                              onChange={onChange}
+                              bucket="public"
+                              className="w-full h-10"
+                            />
+                          )}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={() => removePartner(index)}
+                    className="mt-6 text-muted-foreground hover:text-destructive"
+                    aria-label="削除"
+                  >
+                    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
+        </section>
+
+        {/* Buttons */}
+        <div className="flex justify-end space-x-4 pt-6 border-t sticky bottom-0 bg-card/90 backdrop-blur-sm p-4 -mx-8 -mb-8 rounded-b-xl">
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? '保存中...' : '設定を保存する'}
+          </Button>
+        </div>
+      </form>
+    </Form>
   );
 }

--- a/frontend/src/features/password-change/ui/PasswordChangeForm.tsx
+++ b/frontend/src/features/password-change/ui/PasswordChangeForm.tsx
@@ -52,7 +52,9 @@ export function PasswordChangeForm() {
     <form onSubmit={handleSubmit}>
       <Card>
         <CardHeader>
-          <CardTitle>パスワード変更</CardTitle>
+          <CardTitle role="heading" aria-level={3}>
+            パスワード変更
+          </CardTitle>
           <CardDescription>
             変更後は自動的にログアウトされ、新しいパスワードでの再ログインが必要です。
           </CardDescription>

--- a/frontend/src/features/password-change/ui/PasswordChangeForm.tsx
+++ b/frontend/src/features/password-change/ui/PasswordChangeForm.tsx
@@ -4,6 +4,17 @@ import { useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { platformAuthApi, useAuth } from '@/entities/user';
 import { getApiErrorMessage } from '@/shared/lib';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+} from '@/shared/ui';
 
 /** パスワード変更フォーム。成功するとトークンが失効するため、ログアウトして再ログインを促す。 */
 export function PasswordChangeForm() {
@@ -38,66 +49,57 @@ export function PasswordChangeForm() {
   };
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="bg-white p-8 rounded-xl shadow-sm border border-gray-100 space-y-6"
-    >
-      <h3 className="text-lg font-semibold text-gray-900 border-l-4 border-indigo-500 pl-3">
-        パスワード変更
-      </h3>
-      <p className="text-sm text-gray-500">
-        変更後は自動的にログアウトされ、新しいパスワードでの再ログインが必要です。
-      </p>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">現在のパスワード *</label>
-          <input
-            type="password"
-            value={currentPassword}
-            onChange={e => setCurrentPassword(e.target.value)}
-            required
-            autoComplete="current-password"
-            className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            新しいパスワード（8文字以上）*
-          </label>
-          <input
-            type="password"
-            value={newPassword}
-            onChange={e => setNewPassword(e.target.value)}
-            required
-            minLength={8}
-            autoComplete="new-password"
-            className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            新しいパスワード（確認）*
-          </label>
-          <input
-            type="password"
-            value={confirmPassword}
-            onChange={e => setConfirmPassword(e.target.value)}
-            required
-            minLength={8}
-            autoComplete="new-password"
-            className="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-          />
-        </div>
-      </div>
-      <div className="flex justify-end">
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="px-10 py-2.5 rounded-md bg-indigo-600 text-white font-semibold shadow-lg shadow-indigo-200 hover:bg-indigo-700 disabled:opacity-50 transition-all"
-        >
-          {isSubmitting ? '変更中...' : 'パスワードを変更する'}
-        </button>
-      </div>
+    <form onSubmit={handleSubmit}>
+      <Card>
+        <CardHeader>
+          <CardTitle>パスワード変更</CardTitle>
+          <CardDescription>
+            変更後は自動的にログアウトされ、新しいパスワードでの再ログインが必要です。
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div className="grid gap-2">
+            <Label htmlFor="current-password">現在のパスワード *</Label>
+            <Input
+              id="current-password"
+              type="password"
+              value={currentPassword}
+              onChange={e => setCurrentPassword(e.target.value)}
+              required
+              autoComplete="current-password"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="new-password">新しいパスワード（8文字以上）*</Label>
+            <Input
+              id="new-password"
+              type="password"
+              value={newPassword}
+              onChange={e => setNewPassword(e.target.value)}
+              required
+              minLength={8}
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="confirm-password">新しいパスワード（確認）*</Label>
+            <Input
+              id="confirm-password"
+              type="password"
+              value={confirmPassword}
+              onChange={e => setConfirmPassword(e.target.value)}
+              required
+              minLength={8}
+              autoComplete="new-password"
+            />
+          </div>
+        </CardContent>
+        <CardFooter className="justify-end">
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? '変更中...' : 'パスワードを変更する'}
+          </Button>
+        </CardFooter>
+      </Card>
     </form>
   );
 }

--- a/frontend/src/features/password-change/ui/__tests__/PasswordChangeForm.test.tsx
+++ b/frontend/src/features/password-change/ui/__tests__/PasswordChangeForm.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
+import { PasswordChangeForm } from '../PasswordChangeForm';
+import { platformAuthApi } from '@/entities/user';
+
+const mockLogout = jest.fn();
+
+jest.mock('react-hot-toast', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('@/entities/user', () => ({
+  platformAuthApi: { changePassword: jest.fn() },
+  useAuth: () => ({ logout: mockLogout }),
+}));
+
+const mockedChangePassword = platformAuthApi.changePassword as jest.Mock;
+const mockedToastError = toast.error as jest.Mock;
+
+/** autoComplete 属性でフィールドを特定する（ラベル関連付けの有無に依存しない）。 */
+function fields(container: HTMLElement) {
+  const newPasswords = container.querySelectorAll<HTMLInputElement>(
+    'input[autocomplete="new-password"]'
+  );
+  return {
+    current: container.querySelector<HTMLInputElement>('input[autocomplete="current-password"]')!,
+    next: newPasswords[0],
+    confirm: newPasswords[1],
+  };
+}
+
+describe('パスワード変更フォーム', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('入力が揃うと current_password / new_password のみで API を呼びログアウトすること', async () => {
+    mockedChangePassword.mockResolvedValue(undefined);
+    const { container } = render(<PasswordChangeForm />);
+    const { current, next, confirm } = fields(container);
+
+    fireEvent.change(current, { target: { value: 'oldpass123' } });
+    fireEvent.change(next, { target: { value: 'newpass123' } });
+    fireEvent.change(confirm, { target: { value: 'newpass123' } });
+    fireEvent.click(screen.getByRole('button', { name: 'パスワードを変更する' }));
+
+    await waitFor(() => expect(mockedChangePassword).toHaveBeenCalledTimes(1));
+    const body = mockedChangePassword.mock.calls[0][0] as Record<string, unknown>;
+    expect(Object.keys(body).sort()).toEqual(['current_password', 'new_password']);
+    expect(body).toEqual({ current_password: 'oldpass123', new_password: 'newpass123' });
+    await waitFor(() => expect(mockLogout).toHaveBeenCalledTimes(1));
+  });
+
+  it('確認用パスワードが一致しない場合は API を呼ばないこと', async () => {
+    const { container } = render(<PasswordChangeForm />);
+    const { current, next, confirm } = fields(container);
+
+    fireEvent.change(current, { target: { value: 'oldpass123' } });
+    fireEvent.change(next, { target: { value: 'newpass123' } });
+    fireEvent.change(confirm, { target: { value: 'other12345' } });
+    fireEvent.click(screen.getByRole('button', { name: 'パスワードを変更する' }));
+
+    await waitFor(() =>
+      expect(mockedToastError).toHaveBeenCalledWith('新しいパスワードが一致しません')
+    );
+    expect(mockedChangePassword).not.toHaveBeenCalled();
+    expect(mockLogout).not.toHaveBeenCalled();
+  });
+
+  it('ブラウザ側の入力制約（type / required / minLength）が維持されていること', () => {
+    const { container } = render(<PasswordChangeForm />);
+    const { current, next, confirm } = fields(container);
+
+    for (const input of [current, next, confirm]) {
+      expect(input.type).toBe('password');
+      expect(input.required).toBe(true);
+    }
+    expect(next.minLength).toBe(8);
+    expect(confirm.minLength).toBe(8);
+  });
+});


### PR DESCRIPTION
## 概要

shadcn/ui 移行(地図 #458)の restyle sweep、並列第 1 陣の 1 枚。基盤票 #474 で敷いた token・プリミティブ・`frontend/DESIGN.md` の写像表とコントラスト検算マトリクスに従って `store-settings` スライスと `features/password-change` を restyle する。**挙動完全維持**が原則で、API へ送るペイロードは restyle 前と一字も変えない。

`features/password-change` は 2 つのコンソール(`_pages/store-settings` と `_pages/platform-settings`)が host する共有ファイルのため、DESIGN.md の裁定により**本票の所有**。`_pages/platform-settings` 本体は並列で走る別票の担当で、本 PR では一切触っていない。

Closes #478

## 等価性の証明(本 PR の主眼)

`useForm` + `<select>` × 2 + **画像アップロード(multipart)** を持つ最高リスクのスライスのため、**ペイロードアンカーテストを restyle 前に追加し、master 実装のまま green を確認してからコミット**した(コミット 1)。restyle 後も**同じテストを一切変更せず green**であることが等価性の機械的証明になる。

- コミット 1 → restyle 完了時点のテスト差分は **空**(1 バイトも変わっていない)。
- 後述の追加コミット 4 でアンカーを増強した際も、**既存 assertion は 1 行も変更していない**(差分の削除 3 行は fixture の空文字列を非空 URL に置き換えたもののみ)。
- 増強後のテストが master 実装でも green であることを、`git show 9f7dbc4:...` で取り出した master 版を追跡外の一時ファイルに置いて実行し確認済み(実行後に削除、`git status` が空であることも確認)。

## 変更内容

- **`StoreProfileForm.tsx`** — 最大の発見は `defaultValues` が**全 14 キー補完済み**で、`mv_type` と `sns_links[i].platform` の `<select>` はどちらも空選択肢を持たず値が常に非空だったこと。よって**センチネル(`SELECT_NONE`)も型復元も `defaultValues` の追加補完も不要**。Select 化は 2 箇所のみ `FormField` + Radix Select、他は全て `{...register(name)}` を継続し `Input`/`Textarea` へ置換。画像 4 箇所の生 `Controller` は `FormField` へ置換(`ImageUpload` 本体と props は不変)。sticky footer の `-mx-8 -mb-8` が `p-8` に依存するため**単一サーフェスの form を維持**し Card 分割はしていない。
- **`AccountPage.tsx` / `ProfilePage.tsx`** — `Card` + `Input` + `Label` + `Button` 化。
- **`features/password-change/ui/PasswordChangeForm.tsx`** — 同上。`required` / `minLength` / `autoComplete` は維持。admin token のみを使うため platform 側 host でもそのまま成立する(host 側は素で描画するだけで Card ラップが無く、二重の面にはならないことをレビューで独立確認済み)。
- **テスト新規 2 ファイル・計 10 件** — `StoreProfileForm` 7 件 / `PasswordChangeForm` 3 件。

### アンカーが押さえている経路

無編集送信の**キー集合 14 件一致** / `sns_links[0].platform` が先頭 option `twitter` に化けず `label` キーも保持 / `mv_type: 'video'` の非デフォルト値保持 / `custom_texts` の他テンプレートキー(`modern_only_key`)のマージ / radio による `template_key` 選択 / SNS 行 append の既定値 / **非空の `logo_url`・`banner_url`・`mv_url` が値ごと往復** / **パートナー行が `logo_url` ごと往復** / パートナー append の既定値 / パスワードは `{current_password, new_password}` のみ + `logout` 呼び出し + 属性維持。

## 検証

- [x] `task -d frontend lint` exit 0
- [x] `task -d frontend test` exit 0(Jest 55 suites / 277 tests → アンカー増強後さらに +2 件)
- [x] `task -d frontend build` exit 0
- [x] 検収 grep(`DESIGN.md` の負の不変量)→ `_pages/store-settings` と `features/password-change` でマッチゼロ
- [x] 共有ファイル差分ゼロ(`src/shared/ui/**`・`src/app/globals.css`・`setupTests.ts`・barrel・`DESIGN.md`・`_pages/platform-settings`)
- [ ] `task test`(integration)/ `task e2e`: frontend 限定・API 契約無変更のため該当なし
- [x] ローカルで code-review 実施済み(初回 + 修正後)。blocking なし。should-fix 1 件は本 PR 内で対応済み。

### 視覚確認(UI 変更時)

**【必須】`/store/{id}/settings/profile` でロゴ・バナー・MV・パートナーロゴの画像アップロードと保存。** jsdom では multipart の実送信を検証できないため、**テストで直接叩けない唯一の経路**。

その他:
- sticky footer の半透明(`bg-card/90`)
- テンプレート選択カードの選択リング / ホバー / キーボードフォーカス
- `mv_type` と SNS プラットフォームの Select 開閉(jsdom では開閉を検証していない)
- SNS 行・パートナー行の追加と削除
- `/platform/settings/account` でパスワード変更フォームが正しく表示されること(別票が restyle する host 側との組み合わせ)

## 決定ログ

- **画像経路はフォーム値に影響しない**(コードによる根拠):`ImageUpload` は `File` をローカル state に閉じ込め、自ら `fileApi.upload(file, bucket)` を呼び、`onChange(response.url)` で**文字列 URL のみ**をフォームへ返す。`File` / `FormData` がフォーム state に到達する経路は存在しない。`FormField` は `Controller` をコンテキストで包むだけの薄いラッパーで `field.value/onChange` シグネチャは同一。`shared/api/file.ts`(`Content-Type: multipart/form-data` を明示する唯一の箇所)は**無変更**。
- **`getByLabelText` を使わない**:master 側に `htmlFor`/`id` の関連付けが無く、使うと master で必ず赤くなり「restyle 前後で同一のテスト」が成立しない。role / placeholder / `name` 属性 / `autocomplete` 属性で取得しており、`autocomplete` 経由の取得はそのまま属性維持の錨も兼ねる。
- **パートナー行は共有 fixture ではなく専用テストの override で与える**:共有 fixture に常設すると、既存テストが `getAllByPlaceholderText('https://...')` の**最後**の要素を新規 SNS 行として掴んでいるところへ、DOM 順(SNS → パートナー)でパートナーの URL 欄が割り込み赤くなる。既存テストのクエリを書き換えれば直るが、それは「前後同一」の証明価値を削る。override なら既存テストは一字も変わらず、カバレッジだけ増える。
- **空状態・行コンテナの `bg-gray-50` は写像せず削除**:`bg-muted` にすると中の説明文が `text-muted-foreground` になり、DESIGN.md が 4.39 の不合格と明記する組み合わせを踏む。
- **`h3` → `CardTitle` で見出しレベルが失われる**(`<h3>` → `<div data-slot="card-title">`)。`CustomerForm` に同じ前例があり既存スライスと一貫しているが、アンカーテストで検知できない唯一の挙動隣接変更。見出しアウトラインの後退は sweep 横断の負債として認識しており、本票単独では直さない。

## 備考 / レビュー観点

- **旗(本 PR 範囲外)**: `frontend/src/shared/ui/image-upload.tsx` に生パレットが残存(`border-gray-300` / `hover:border-indigo-400` / `bg-red-500` / `text-gray-400` / `bg-white/70` / `border-indigo-600`)。共有ファイルにつき本票では未修正、検収 grep のスコープ外。共有ファイル票への申し送り。
- **旗(DESIGN.md への追随が必要)**: 「Selectable preview card」レシピは非選択ホバー時に面を `bg-muted` にする一方、カード内の説明文は `text-muted-foreground` を指定しており、**ホバー中に 4.39 の不合格ペアが成立**する。レビューでさらに、**選択状態でも `bg-primary/10` の上に `text-muted-foreground` が乗り、これはマトリクスに行が無い未測定ペア**であることが判明。レシピは正本なので本 PR では逐語適用したまま。DESIGN.md 側の追随は別票へ。
- push/PR まで実施。**マージは owner が手動**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
