### PR TITLE
fix(frontend): コンソールの二重スクロールバーを解消する

### DIFF
--- a/frontend/src/_pages/store-settings/ui/StoreProfileForm.tsx
+++ b/frontend/src/_pages/store-settings/ui/StoreProfileForm.tsx
@@ -496,7 +496,7 @@ export function StoreProfileForm({ initialData, onSubmit, isSubmitting }: StoreP
         </section>
 
         {/* Buttons */}
-        <div className="flex justify-end space-x-4 pt-6 border-t sticky bottom-0 bg-card/90 backdrop-blur-sm p-4 -mx-8 -mb-8 rounded-b-xl">
+        <div className="flex justify-end gap-4 pt-6 border-t">
           <Button type="submit" disabled={isSubmitting}>
             {isSubmitting ? '保存中...' : '設定を保存する'}
           </Button>

--- a/frontend/src/app/platform/(console)/layout.tsx
+++ b/frontend/src/app/platform/(console)/layout.tsx
@@ -17,7 +17,9 @@ export default function PlatformLayout({ children }: { children: React.ReactNode
           <Header />
 
           {/* Main Content Area */}
-          <main className="flex-1 overflow-y-auto p-8 custom-scrollbar">
+          {/* relative: 絶対配置の子（Radix Select が描画するフォーム互換用の隠し select 等）の
+              包含ブロックをこのスクロール領域に閉じ込め、ページ全体が伸びるのを防ぐ */}
+          <main className="relative flex-1 overflow-y-auto p-8 custom-scrollbar">
             <div className="max-w-7xl mx-auto">{children}</div>
           </main>
         </div>

--- a/frontend/src/app/store/layout.tsx
+++ b/frontend/src/app/store/layout.tsx
@@ -17,7 +17,9 @@ export default function StoreLayout({ children }: { children: React.ReactNode })
           <Header />
 
           {/* Main Content Area */}
-          <main className="flex-1 overflow-y-auto p-8 custom-scrollbar">
+          {/* relative: 絶対配置の子（Radix Select が描画するフォーム互換用の隠し select 等）の
+              包含ブロックをこのスクロール領域に閉じ込め、ページ全体が伸びるのを防ぐ */}
+          <main className="relative flex-1 overflow-y-auto p-8 custom-scrollbar">
             <div className="max-w-7xl mx-auto">{children}</div>
           </main>
         </div>


### PR DESCRIPTION
## 概要

管理コンソールで**スクロールバーが二重に出る**不具合を直す。ユーザー報告(店舗情報画面)を受けて実ブラウザで原因を特定した。

## 原因(実測で特定)

Radix `Select` は、フォーム互換のために `aria-hidden="true"` / `tabIndex=-1` / 高さ 1px の**隠しネイティブ `<select>` を絶対配置で描画する**。

コンソールのシェルは `<div class="flex h-screen overflow-hidden">` の中に `<main class="flex-1 overflow-y-auto">` があり、内側の `main` だけがスクロールする構造。ところが **`main` もその中のフォームも静的配置だった**ため、この隠し `<select>` の包含ブロックが初期包含ブロックまで遡ってしまう。**絶対配置要素は、包含ブロックの連鎖に入っていない祖先の `overflow: hidden` では切り取られない**ため、隠し `<select>` がシェルの外へ抜けて `document` を伸ばしていた。

結果として、内側 `main` のスクロールバーと外側 `document` のスクロールバーが同時に出ていた。

実測値(店舗情報画面、ビューポート 906px):

| | 修正前 | 修正後 |
| --- | --- | --- |
| `document.scrollHeight` | 1846 | **906**(= `clientHeight`) |
| ページ側のスクロール | あり(2 本目) | **なし** |
| `main` の内部スクロール | あり | あり(維持) |

隠し `<select>` の document 座標での底辺が 1846 で、`document.scrollHeight` と 1px も違わず一致していたことが決め手。

## 変更内容

`app/store/layout.tsx` と `app/platform/(console)/layout.tsx` の `<main>` に `relative` を追加し、絶対配置の子の包含ブロックをスクロール領域へ閉じ込める。

**ページ単位ではなくシェルで直した理由**: 発現は店舗情報画面だけだが、原因は「Radix Select を持つページ」に共通で、**発現条件は隠し `<select>` の静的位置がビューポート高を超えること**。オーダーフォームやキャストフォームも Radix Select を持っており、フォームが伸びれば同じ症状が出る潜在バグだった。シェルで直せばコンソール全体で塞がる。

## 検証

- [x] `task -d frontend lint` exit 0
- [x] `task -d frontend test` exit 0
- [x] `task -d frontend build` exit 0
- [x] **実ブラウザで修正前後を実測**(上表)。`task build service=frontend` + `task up` でイメージを差し替えたうえで確認
- [ ] `task test`(integration)/ `task e2e`: レイアウトのみの変更のため該当なし

### 視覚確認(UI 変更時)

店舗情報画面(`/store/{id}/settings/profile`)でスクロールバーが 1 本になり、ページ下部の余白が消えていることを確認済み(スクリーンショット取得)。プラットフォーム側コンソールも同じシェルなので併せて一瞥を推奨。

## 決定ログ

- **自動テストは追加していない。** jsdom はレイアウトを計算しない(`scrollHeight` / `getBoundingClientRect` が常に 0)ため、この不具合は Jest では再現も検知もできない。E2E(Playwright)なら理論上は可能だが、スクロールバーの本数を安定して判定する assertion は脆く、本修正は 2 ファイル 1 クラスの追加であるため見合わないと判断した。**検証はブラウザでの実測に依拠している**。
- `custom-scrollbar` クラスが 3 箇所で使われているが**どこにも定義が無い**ことに気づいた(scaffold 以前から一度も定義されていない)。本件とは無関係なので本 PR では触っていない。別途整理する。

---

## 追加変更: 保存ボタンの追従表示を廃止

**オーナー判断による。** 店舗情報フォームの保存ボタンだけが `sticky bottom-0` でスクロールに追従し、さらに `-mx-8 -mb-8` の負のマージンと `bg-card/90 backdrop-blur-sm` でカード枠を跨いで本文に重なっていた。他の管理フォーム（`OrderForm` / `CustomerForm` / `CastForm`）はいずれも **末尾に `flex justify-end gap-4` の通常配置**なので、そちらへ揃える。

```diff
-<div className="flex justify-end space-x-4 pt-6 border-t sticky bottom-0 bg-card/90 backdrop-blur-sm p-4 -mx-8 -mb-8 rounded-b-xl">
+<div className="flex justify-end gap-4 pt-6 border-t">
```

区切りの `border-t` は単一サーフェスのフォームなので残している。

なお、これにより DESIGN.md の「sticky footer は `bg-card/90`」という記述が消費者を失う。整理は sweep の収尾票（#482）側で行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
