### PR TITLE
refactor(frontend): サイドバーを DESIGN.md の浅色規格へ作り替える

### DIFF
--- a/frontend/src/widgets/sidebar/ui/Sidebar.tsx
+++ b/frontend/src/widgets/sidebar/ui/Sidebar.tsx
@@ -120,9 +120,9 @@ export function Sidebar() {
   }, []);
 
   return (
-    <aside className="w-64 bg-slate-800 text-white shrink-0 hidden md:block border-r border-slate-700">
-      <div className="h-16 flex items-center px-6 border-b border-slate-700">
-        <span className="text-xl font-bold tracking-wider text-indigo-400">
+    <aside className="w-64 bg-card shrink-0 hidden md:block border-r">
+      <div className="h-16 flex items-center px-6 border-b">
+        <span className="text-xl font-bold tracking-wider text-primary-strong">
           {role === 'store' ? 'STORE' : 'PLATFORM'}
         </span>
       </div>
@@ -130,7 +130,7 @@ export function Sidebar() {
         <nav className="space-y-8">
           {navigation.map(section => (
             <div key={section.name}>
-              <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-widest mb-4 px-3">
+              <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-widest mb-4 px-3">
                 {section.name}
               </h3>
               <ul className="space-y-1">
@@ -141,17 +141,22 @@ export function Sidebar() {
                     <li key={item.name}>
                       <Link
                         href={href}
-                        className={`flex items-center px-3 py-2.5 text-sm font-medium rounded-lg transition-all duration-200 group ${
+                        className={`relative flex items-center px-3 py-2.5 text-sm font-medium rounded-lg transition-colors duration-200 ${
                           isActive
-                            ? 'bg-indigo-600 text-white shadow-lg shadow-indigo-900/20'
-                            : 'text-slate-400 hover:bg-slate-700/50 hover:text-white'
+                            ? 'bg-primary/10 text-primary-strong'
+                            : 'text-muted-foreground hover:bg-muted hover:text-foreground'
                         }`}
                       >
-                        <item.icon
-                          className={`mr-3 h-5 w-5 shrink-0 ${
-                            isActive ? 'text-white' : 'text-slate-500 group-hover:text-slate-300'
-                          }`}
-                        />
+                        {/* 現在地を示す 2px のエッジバー。文字を持たないので
+                            リンクのアクセシブル名には寄与しない */}
+                        {isActive && (
+                          <span
+                            aria-hidden
+                            className="absolute inset-y-1 left-0 w-0.5 rounded-full bg-primary-strong"
+                          />
+                        )}
+                        {/* アイコンは currentColor を継承し、hover / 現在地でラベルと一緒に色が動く */}
+                        <item.icon className="mr-3 h-5 w-5 shrink-0" />
                         {item.name}
                       </Link>
                     </li>

--- a/frontend/src/widgets/sidebar/ui/__tests__/Sidebar.test.tsx
+++ b/frontend/src/widgets/sidebar/ui/__tests__/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import Cookies from 'js-cookie';
 import { Sidebar } from '../Sidebar';
 import { menuApi } from '@/entities/menu';
@@ -109,5 +109,70 @@ describe('Sidebar', () => {
       'href',
       '/store/select?next=%2Fstore%2Forders'
     );
+  });
+
+  // 現在地の項目だけが他と異なる見えを持つ、という関係だけを見る。
+  // 具体的なクラス名に依存しないので配色の作り替えを跨いでも意味が変わらない。
+  it('現在地の項目だけが他項目と異なる見えになる', async () => {
+    mockPathname = '/platform/stores';
+    (Cookies.get as jest.Mock).mockImplementation((key: string) =>
+      key === 'platform-role' ? 'platform' : undefined
+    );
+    mockedGetMenus.mockResolvedValue(menuWithStoreAndPlatform);
+
+    render(<Sidebar />);
+
+    const active = await screen.findByRole('link', { name: '店舗一覧' });
+    const inactive = screen.getByRole('link', { name: '受注一覧' });
+
+    expect(active.className).not.toBe(inactive.className);
+  });
+
+  it('現在地でない画面では全項目が同じ見えになる', async () => {
+    mockPathname = '/platform/dashboard';
+    (Cookies.get as jest.Mock).mockImplementation((key: string) =>
+      key === 'platform-role' ? 'platform' : undefined
+    );
+    mockedGetMenus.mockResolvedValue(menuWithStoreAndPlatform);
+
+    render(<Sidebar />);
+
+    const first = await screen.findByRole('link', { name: '受注一覧' });
+    const second = screen.getByRole('link', { name: '店舗一覧' });
+
+    expect(first.className).toBe(second.className);
+  });
+
+  // グループ見出しと配下項目の親子関係。折りたたみ機構は現状無く、
+  // 全項目が操作なしで見えていることが e2e の前提でもある。
+  it('グループ見出しの配下に当該グループの項目が展開されている', async () => {
+    (Cookies.get as jest.Mock).mockImplementation((key: string) =>
+      key === 'platform-role' ? 'platform' : undefined
+    );
+    mockedGetMenus.mockResolvedValue([
+      ...menuWithStoreAndPlatform,
+      { name: '設定', items: [{ name: '店舗情報', path: '/store/profile', icon: 'CogIcon' }] },
+    ]);
+
+    render(<Sidebar />);
+
+    const mainGroup = (await screen.findByText('メイン')).parentElement as HTMLElement;
+    const settingsGroup = screen.getByText('設定').parentElement as HTMLElement;
+
+    expect(within(mainGroup).getByRole('link', { name: '受注一覧' })).toBeVisible();
+    expect(within(mainGroup).getByRole('link', { name: '店舗一覧' })).toBeVisible();
+    expect(within(mainGroup).queryByRole('link', { name: '店舗情報' })).toBeNull();
+    expect(within(settingsGroup).getByRole('link', { name: '店舗情報' })).toBeVisible();
+  });
+
+  it('コンソール種別に応じた識別ラベルを掲げる', async () => {
+    (Cookies.get as jest.Mock).mockImplementation((key: string) =>
+      key === 'platform-role' ? 'store' : undefined
+    );
+
+    render(<Sidebar />);
+
+    expect(await screen.findByText('STORE')).toBeVisible();
+    expect(screen.queryByText('PLATFORM')).toBeNull();
   });
 });


### PR DESCRIPTION
## 概要

shadcn/ui 移行(地図 #458)の restyle sweep で、**サイドバーだけが未解決のまま残っていた**。現物は `bg-slate-800` の暗色レール(active は `bg-indigo-600`)で、`DESIGN.md` の「Sidebar nav item」規格が記述する**浅色**と矛盾しており、#476 で「機械的な slate → muted 写像は禁止、オーナー裁定へ委譲」と明記して先送りしていた。

**オーナー裁定(浅色へ寄せる)を受けて実装**する。クラスの機械的写像ではなく、DESIGN.md の規格そのものへ作り替えた。

Closes #488

## 変更内容

変更ファイルは **`Sidebar.tsx` と `Sidebar.test.tsx` の 2 つのみ**。

- 面 `bg-card`、ブランド字 `text-primary-strong`、非現在地 `text-muted-foreground`、hover は `bg-muted` + `text-foreground`、現在地は `bg-primary/10` + `text-primary-strong` + 左端 2px の `bg-primary-strong` エッジバー。
- **アイコンは色指定をやめ `currentColor` 継承**にした。DESIGN.md が Sidebar nav item にも帰する「hover は面と文字を一緒に返す」規則に従い、hover / 現在地でラベルと必ず同時に動く。これにより `group-hover` 系の別配色が不要になり、**新しい色の組み合わせが 1 つも生まれていない**。
- ジオメトリ(`px-3 py-2.5` = 40px 行、`h-5 w-5` = 20px アイコン、`text-sm` = 14px)は既に規格どおりだったため**触っていない**。差分は色とエッジバーだけ。

### トークン選択 — `--sidebar-*` ではなく汎用トークンを採った

票面は「既存の `--sidebar-*` を使う」と指示していたが、**DESIGN.md のハードルール(マトリクスに無い組み合わせを書かない)を優先**した。

`:root` の `--sidebar-foreground` / `-accent` / `-border` は `--foreground` / `--muted` / `--border` と**値が完全に同一**で、この族が実際に足すのは面そのものだけ。ところが `--sidebar: oklch(0.985 0 0)` と `--card: oklch(1 0 0)` が **light で異なる**(dark では同値)。つまり `bg-sidebar` はコントラストマトリクスに行の無い**未計測の面**になり、正当化には `DESIGN.md` への行追加が要る — 並列 PR 契約が禁じる共有ファイルである。

書いた組み合わせはすべて既存行で被覆されている(レビューで全行検算・追認済み):

| 箇所 | 組み合わせ | Light / Dark(必要値) |
|---|---|---|
| ブランド字 | `text-primary-strong` on `bg-card` | 5.26 / 6.72 (4.5) |
| 非現在地(字+アイコン) | `text-muted-foreground` on `bg-card` | 4.83 / 6.74 (4.5) |
| hover | `bg-muted` + `text-foreground` | 18.07 / 14.26 (4.5) |
| 現在地(字+アイコン) | `bg-primary/10` + `text-primary-strong` | 4.55 / 6.23 (4.5) |
| エッジバー | `bg-primary-strong` vs `bg-card` / vs 隣接ティント | 5.26 / 6.72、4.55 / 6.23 (3) |
| 罫線 | 素の `border-r` / `border-b` | 装飾扱いで明示除外 |

**4.39 の不合格ペア(`text-muted-foreground` on `bg-muted`)も回避している** — hover は面と文字を同時に返すため。

## 等価性の証明

アンカーテスト 4 本を **master 実装のまま green にしてから先行コミット**(既存 5 本は無改変、計 9/9)。restyle 後も**テストを 1 バイトも変えずに 9/9 green**。

現在地の判定は**クラス名リテラルではなく「現在地の項目の className が兄弟の非現在地項目と異なる」という関係**で押さえた。配色の作り替えを跨いで意味が保存され(本 PR 自身が実証)、かつ `isActive` 分岐を消せば必ず赤くなる。

### 「削除したら赤くなるか」実験(レビューで独立再現済み)

| 消した配線 | 結果 |
|---|---|
| `isActive ?` 三項(className) | **1 failed** — 現在地の視覚的区別が消えることを捕捉 |
| `resolveStoreHref(item.href, storeId)` → `item.href` | **3 failed** — href 解決 3 本すべて |
| `section.items` → 空 | **6 failed** — グループ展開含む |
| コンソール種別三項 → 固定値 | **1 failed** |
| **エッジバーのみ削除** | **9 passed(未証明)** |

**未証明を正直に申告する**: エッジバーは `aria-hidden` の純装飾で挙動を持たず、master に存在しないためアンカーを先行 green にできなかった。**目視確認だけが担保**。

## 検証

- [x] `task -d frontend lint` exit 0
- [x] `task -d frontend test` exit 0(60 suites / 313 tests)
- [x] `task -d frontend build` exit 0
- [x] 検収 grep(`widgets/sidebar` + `entities/menu`)→ マッチゼロ
- [x] 共有ファイル差分ゼロ(`shared/ui/**`・`globals.css`・`setupTests.ts`・barrel・`DESIGN.md`)
- [x] ローカルで code-review 実施済み。**blocking なし。**
- [ ] `task test`(integration)/ `task e2e`: frontend 限定・API 契約無変更のため該当なし

### 視覚確認(実施済み・実測値つき)

`task build service=frontend` + `task up` でイメージを差し替え、ブラウザで実測した:

- 現在地行 = `bg-primary/10` + `text-primary-strong`、**エッジバーは 2px × 32px**(行 40px に `inset-y-1` で上下 4px 内寄せ)の `bg-primary-strong`
- サイドバー面 = 純白 `lab(100 0 0)`、ヘッダーも純白、**1px の `border-r` で分離されており継ぎ目は視認できる**
- グループ見出し = 12px の `text-muted-foreground`、白面上で読める

**マージ前に見てほしい点**:

1. **エッジバーの上下端が 8px の角丸をわずかに超えて見える**(行に `overflow-hidden` を付けていないため)。視覚的には意図的な指示子として読める範囲だが、**全高バーの方が好みかを含めてご判断を**。
2. **サイドバー面が純白 `bg-card` になり、ヘッダーと同一の面色**になった。`--sidebar` の 98.5% オフホワイトではない。上記のとおりマトリクス上の理由による選択で、**この視覚的帰結は裁定の外側**なので追認をお願いしたい。
3. レールは `hidden md:block` なので **768px 以上**でのみ表示。**店舗コンソールとプラットフォームコンソールの両方**を確認(ブランド字が STORE / PLATFORM で変わる)。

## 決定ログ

- **`shadow-lg shadow-indigo-900/20` は丸ごと落とした。** 写像表の一般則は「ティントだけ落として素の elevation は残す」だが、同じ表がサイドバーを「do not map — 規格への rebuild」として適用対象から明示除外しており、その規格は影を規定していない。平坦な白レール上の nav 行に浮きの影が付くと読み違いになる。
- **フォーカスは master のままブラウザ既定のアウトライン。** `<a>` は素の要素で変更前後ともフォーカス用クラスがなく、トークン化は restyle の範囲を超え、master で green のアンカーも作れない。規格もフォーカス処遇を規定していない。
- `transition-all` → `transition-colors`(色だけを遷移させる意図の明示)。
- エッジバーは `aria-hidden` な空 `<span>`。文字を持たないので e2e の `getByRole('link', { name, exact: true })` のアクセシブル名に一切寄与しない(e2e ステップがこの厳密一致に依存しているため必須の配慮)。

## 備考 / 合流後に必要なフォロー(別票)

**本 PR が合流すると `DESIGN.md` の 4 箇所が偽になる**(並列 PR 契約により本 PR では直せないのが正しい挙動):

1. 写像表の `any slate-* (sidebar) → do not map — see below`
2. 「サイドバーの扱いは意図的に未裁定」節そのもの
3. Sidebar nav item 規格の太字注意書き「これは浅色サイドバーを記述しており出荷物はそうではない。裁定が済むまで適用するな」
4. pending 一覧の「サイドバーだけは追加でブロックされている」

あわせて同票で裁定したい既知の穴:

- **「Groups collapse with a chevron」は現在も偽**。master にグループ折りたたみ機構は存在せず(現物は `<h3>` + `<ul>`)、追加すれば「挙動不変」の受け入れ基準に反する。**実装するか文言を削るか**のオーナー裁定が要る。
- **フォーカス処遇が規格に無い**(上記)。
- **`--sidebar-*` 族が実質デッド**になった。削除するか、`--sidebar` を `--card` に合わせるか、マトリクスに行を足すか。
- `custom-scrollbar` はリポジトリ全体で CSS 定義が存在しない死クラス(master 由来、他 2 箇所でも使用)。

push/PR まで実施。**マージは owner が手動**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
