### PR TITLE
refactor(frontend): 出勤管理画面を shadcn/ui とトークン規格へ載せ替える

### DIFF
--- a/frontend/src/_pages/store-shifts/ui/ShiftCalendar.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftCalendar.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import { ShiftResponse } from '@/entities/shift';
+import { Button } from '@/shared/ui';
 import { monthGrid, toDateStr } from '../lib/datetime';
 
 interface ShiftCalendarProps {
@@ -36,35 +37,42 @@ export function ShiftCalendar({
   const title = `${month.getFullYear()}年${month.getMonth() + 1}月`;
 
   return (
-    <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
-      <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4">
-        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+    <div className="overflow-hidden rounded-lg border bg-card shadow-sm">
+      <div className="flex items-center justify-between border-b px-6 py-4">
+        <h2 className="text-lg font-semibold text-foreground">{title}</h2>
         <div className="flex items-center gap-1">
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="icon-sm"
             onClick={onPrevMonth}
             aria-label="前の月"
-            className="rounded-md p-2 text-gray-500 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
-            <ChevronLeftIcon className="h-5 w-5" />
-          </button>
-          <button
+            <ChevronLeftIcon />
+          </Button>
+          <Button
             type="button"
+            variant="ghost"
+            size="icon-sm"
             onClick={onNextMonth}
             aria-label="次の月"
-            className="rounded-md p-2 text-gray-500 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
-            <ChevronRightIcon className="h-5 w-5" />
-          </button>
+            <ChevronRightIcon />
+          </Button>
         </div>
       </div>
 
-      <div className="grid grid-cols-7 border-b border-gray-200 bg-gray-50">
+      {/* 曜日帯は地の塗りを持たない: 週末色と平日の注記色はいずれもカード面でのみ既定のコントラストを満たす。 */}
+      <div className="grid grid-cols-7 border-b">
         {WEEKDAYS.map((w, i) => (
           <div
             key={w}
             className={`px-2 py-2 text-center text-xs font-medium ${
-              i === 0 ? 'text-red-500' : i === 6 ? 'text-blue-500' : 'text-gray-500'
+              i === 0
+                ? 'text-destructive'
+                : i === 6
+                  ? 'text-primary-strong'
+                  : 'text-muted-foreground'
             }`}
           >
             {w}
@@ -83,35 +91,34 @@ export function ShiftCalendar({
               type="button"
               key={ds}
               onClick={() => onSelectDate(ds)}
-              className={`h-24 border-b border-r border-gray-100 p-2 text-left align-top transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500 ${
-                inMonth ? 'bg-white' : 'bg-gray-50'
-              }`}
+              className="group h-24 border-b border-r p-2 text-left align-top transition-colors hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary"
             >
+              {/* 当月外はホバーの色地に載るため、注記色のままだと沈む。ホバー時だけ本文色へ上げる。 */}
               <span
                 className={`text-sm ${
                   isToday
-                    ? 'flex h-6 w-6 items-center justify-center rounded-full bg-blue-600 font-semibold text-white'
+                    ? 'flex h-6 w-6 items-center justify-center rounded-full bg-primary font-semibold text-primary-foreground'
                     : inMonth
-                      ? 'text-gray-900'
-                      : 'text-gray-400'
+                      ? 'text-foreground'
+                      : 'text-muted-foreground group-hover:text-foreground'
                 }`}
               >
                 {date.getDate()}
               </span>
               {agg && (
                 <div className="mt-1 space-y-1">
-                  <span className="inline-flex items-center rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-600">
+                  <span className="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary-strong">
                     {agg.total}名
                   </span>
-                  <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[10px] text-gray-500">
+                  <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[10px] text-muted-foreground group-hover:text-foreground">
                     <span className="inline-flex items-center gap-0.5">
-                      <span className="inline-block h-1.5 w-1.5 rounded-full bg-green-500" />
+                      <span className="inline-block h-1.5 w-1.5 rounded-full bg-success" />
                       確定
                       {agg.confirmed}
                     </span>
                     {tentative > 0 && (
                       <span className="inline-flex items-center gap-0.5">
-                        <span className="inline-block h-1.5 w-1.5 rounded-full bg-yellow-400" />
+                        <span className="inline-block h-1.5 w-1.5 rounded-full bg-warning" />
                         未確定
                         {tentative}
                       </span>

--- a/frontend/src/_pages/store-shifts/ui/ShiftCalendar.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftCalendar.tsx
@@ -107,7 +107,9 @@ export function ShiftCalendar({
               </span>
               {agg && (
                 <div className="mt-1 space-y-1">
-                  <span className="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary-strong">
+                  {/* ホバー時はチップ自身の淡色地が同色の地に重なり、primary 系の文字色では
+                      コントラストが 4.5 を割る。重なる間だけ本文色へ上げる。 */}
+                  <span className="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary-strong group-hover:text-foreground">
                     {agg.total}名
                   </span>
                   <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[10px] text-muted-foreground group-hover:text-foreground">

--- a/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
@@ -5,7 +5,24 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { CastResponse } from '@/entities/cast';
 import { ShiftResponse, shiftApi } from '@/entities/shift';
-import { Dialog, DialogContent, DialogTitle } from '@/shared/ui';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/ui';
 
 interface ShiftFormValues {
   cast_id: string;
@@ -32,8 +49,9 @@ const STATUS_OPTIONS = [
   { value: 'CONFIRMED', label: '確定' },
 ];
 
-const inputClass =
-  'w-full rounded-md border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500';
+// Radix Select は value="" を許容しないため、キャスト未登録の案内項目に与える番兵値。
+// onValueChange で '' に戻すことで、フォームが持つ値は従来どおり空文字になる。
+const SELECT_NONE = '__none__';
 
 /** シフトの追加・編集モーダル。 */
 export function ShiftFormModal({
@@ -44,12 +62,22 @@ export function ShiftFormModal({
   defaultDate,
   onSaved,
 }: ShiftFormModalProps) {
+  const form = useForm<ShiftFormValues>({
+    defaultValues: {
+      cast_id: '',
+      work_date: '',
+      start_time: '',
+      end_time: '',
+      status: 'TENTATIVE',
+    },
+  });
   const {
     register,
     handleSubmit,
     reset,
+    control,
     formState: { isSubmitting },
-  } = useForm<ShiftFormValues>();
+  } = form;
 
   useEffect(() => {
     if (!open) return;
@@ -118,92 +146,111 @@ export function ShiftFormModal({
       <DialogContent
         showCloseButton={false}
         aria-describedby={undefined}
-        className="gap-0 rounded-[10px] border-gray-200 p-0 sm:max-w-md"
+        className="gap-0 rounded-[10px] p-0 sm:max-w-md"
       >
-        <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
+        <DialogTitle className="border-b px-6 py-4">
           {editing ? 'シフトを編集' : 'シフトを追加'}
         </DialogTitle>
-        <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
-          <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700">キャスト</label>
-            <select {...register('cast_id', { required: true })} className={inputClass}>
-              {casts.length === 0 && <option value="">キャストが未登録です</option>}
-              {casts.map(c => (
-                <option key={c.id} value={c.id}>
-                  {c.name}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700">日付</label>
-            <input
-              type="date"
-              {...register('work_date', { required: true })}
-              className={inputClass}
-            />
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">開始</label>
-              <input
-                type="time"
-                {...register('start_time', { required: true })}
-                className={inputClass}
-              />
-            </div>
-            <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">終了</label>
-              <input
-                type="time"
-                {...register('end_time', { required: true })}
-                className={inputClass}
-              />
-            </div>
-          </div>
-          <p className="text-xs text-gray-500">
-            終了が開始以前のときは翌日にまたがる勤務として扱います。
-          </p>
-          <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700">ステータス</label>
-            <select {...register('status')} className={inputClass}>
-              {STATUS_OPTIONS.map(o => (
-                <option key={o.value} value={o.value}>
-                  {o.label}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="flex items-center justify-between border-t border-gray-200 pt-4">
-            <div>
-              {editing && (
-                <button
-                  type="button"
-                  onClick={handleDelete}
-                  className="rounded text-sm font-medium text-red-600 hover:text-red-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                >
-                  削除
-                </button>
+        <Form {...form}>
+          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
+            <FormField
+              control={control}
+              name="cast_id"
+              rules={{ required: true }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>キャスト</FormLabel>
+                  <Select
+                    value={field.value ? field.value : SELECT_NONE}
+                    onValueChange={v => field.onChange(v === SELECT_NONE ? '' : v)}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {casts.length === 0 && (
+                        <SelectItem value={SELECT_NONE}>キャストが未登録です</SelectItem>
+                      )}
+                      {casts.map(c => (
+                        <SelectItem key={c.id} value={c.id}>
+                          {c.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FormItem>
               )}
+            />
+            <div className="grid gap-2">
+              <Label htmlFor="work_date">日付</Label>
+              <Input id="work_date" type="date" {...register('work_date', { required: true })} />
             </div>
-            <div className="flex gap-3">
-              <button
-                type="button"
-                onClick={onClose}
-                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              >
-                キャンセル
-              </button>
-              <button
-                type="submit"
-                disabled={isSubmitting}
-                className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-              >
-                {isSubmitting ? '保存中...' : '保存する'}
-              </button>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="start_time">開始</Label>
+                <Input
+                  id="start_time"
+                  type="time"
+                  {...register('start_time', { required: true })}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="end_time">終了</Label>
+                <Input id="end_time" type="time" {...register('end_time', { required: true })} />
+              </div>
             </div>
-          </div>
-        </form>
+            <p className="text-xs text-muted-foreground">
+              終了が開始以前のときは翌日にまたがる勤務として扱います。
+            </p>
+            <FormField
+              control={control}
+              name="status"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>ステータス</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {STATUS_OPTIONS.map(o => (
+                        <SelectItem key={o.value} value={o.value}>
+                          {o.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FormItem>
+              )}
+            />
+            <div className="flex items-center justify-between border-t pt-4">
+              <div>
+                {editing && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={handleDelete}
+                    className="text-destructive-strong"
+                  >
+                    削除
+                  </Button>
+                )}
+              </div>
+              <div className="flex gap-3">
+                <Button type="button" variant="outline" onClick={onClose}>
+                  キャンセル
+                </Button>
+                <Button type="submit" disabled={isSubmitting}>
+                  {isSubmitting ? '保存中...' : '保存する'}
+                </Button>
+              </div>
+            </div>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/_pages/store-shifts/ui/ShiftRequestInbox.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftRequestInbox.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { CastResponse } from '@/entities/cast';
 import { StoreShiftRequestItem, shiftApi } from '@/entities/shift';
+import { Button } from '@/shared/ui';
 
 interface ShiftRequestInboxProps {
   casts: CastResponse[];
@@ -60,10 +61,10 @@ export function ShiftRequestInbox({ casts, onApproved }: ShiftRequestInboxProps)
   };
 
   if (loading) {
-    return <p className="text-sm text-gray-500">読み込み中...</p>;
+    return <p className="text-sm text-muted-foreground">読み込み中...</p>;
   }
   if (requests.length === 0) {
-    return <p className="text-sm text-gray-500">受付中の出勤希望はありません</p>;
+    return <p className="text-sm text-muted-foreground">受付中の出勤希望はありません</p>;
   }
 
   return (
@@ -71,32 +72,33 @@ export function ShiftRequestInbox({ casts, onApproved }: ShiftRequestInboxProps)
       {requests.map(request => (
         <li
           key={request.id}
-          className="flex items-center justify-between rounded-[10px] border border-gray-200 bg-white p-4 shadow-sm"
+          className="flex items-center justify-between rounded-[10px] border bg-card p-4 shadow-sm"
         >
           <div>
-            <p className="text-sm font-medium text-gray-900">{castName(request.cast_id)}</p>
-            <p className="text-sm text-gray-600">
+            <p className="text-sm font-medium text-foreground">{castName(request.cast_id)}</p>
+            <p className="text-sm text-muted-foreground">
               {request.work_date} {request.start_time.slice(0, 5)}–{request.end_time.slice(0, 5)}
             </p>
-            {request.note && <p className="mt-1 text-xs text-gray-500">{request.note}</p>}
+            {request.note && <p className="mt-1 text-xs text-muted-foreground">{request.note}</p>}
           </div>
           <div className="flex gap-2">
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="sm"
               onClick={() => decline(request.id)}
               disabled={processingId === request.id}
-              className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
             >
               辞退
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
+              size="sm"
               onClick={() => approve(request.id)}
               disabled={processingId === request.id}
-              className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
             >
               承認
-            </button>
+            </Button>
           </div>
         </li>
       ))}

--- a/frontend/src/_pages/store-shifts/ui/ShiftTimeline.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftTimeline.tsx
@@ -3,6 +3,7 @@
 import { PlusIcon } from '@heroicons/react/24/outline';
 import { CastResponse } from '@/entities/cast';
 import { ShiftResponse } from '@/entities/shift';
+import { Button } from '@/shared/ui';
 import { shiftSpan, toDateStr } from '../lib/datetime';
 
 interface ShiftTimelineProps {
@@ -61,37 +62,34 @@ export function ShiftTimeline({
   const rowIds = Array.from(new Set(shifts.map(s => s.cast_id)));
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
-      <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4">
-        <h2 className="text-lg font-semibold text-gray-900">{date} の出勤</h2>
-        <button
-          type="button"
-          onClick={onAddShift}
-          className="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-        >
-          <PlusIcon className="h-5 w-5" />
+    <div className="rounded-lg border bg-card shadow-sm">
+      <div className="flex items-center justify-between border-b px-6 py-4">
+        <h2 className="text-lg font-semibold text-foreground">{date} の出勤</h2>
+        <Button type="button" onClick={onAddShift}>
+          <PlusIcon />
           シフト追加
-        </button>
+        </Button>
       </div>
 
       {loading ? (
-        <div className="p-8 text-center text-gray-500">読み込み中...</div>
+        <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
       ) : !hasShifts ? (
         <div className="p-12 text-center">
-          <p className="text-gray-500">この日のシフトはまだありません。</p>
-          <button
+          <p className="text-muted-foreground">この日のシフトはまだありません。</p>
+          <Button
             type="button"
+            variant="link"
             onClick={onAddShift}
-            className="mt-3 text-sm font-medium text-blue-600 hover:text-blue-700"
+            className="mt-3 h-auto p-0 text-sm font-medium text-primary-strong"
           >
             シフトを追加する
-          </button>
+          </Button>
         </div>
       ) : (
         <div className="space-y-4 p-6">
           {/* 同時出勤数カバレッジ */}
           <div>
-            <div className="mb-1 flex items-center justify-between text-xs text-gray-500">
+            <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
               <span>同時出勤数</span>
               <span>ピーク {peak}名</span>
             </div>
@@ -99,7 +97,7 @@ export function ShiftTimeline({
               {coverage.map(c => (
                 <div
                   key={c.at}
-                  className="flex-1 rounded-t bg-blue-500/80"
+                  className="flex-1 rounded-t bg-primary-strong"
                   style={{ height: `${(c.count / peak) * 100}%` }}
                   title={`${hourLabel(c.at)} ${c.count}名`}
                 />
@@ -113,7 +111,7 @@ export function ShiftTimeline({
               {hourMarks.map(m => (
                 <span
                   key={m}
-                  className="absolute -translate-x-1/2 text-[10px] text-gray-400"
+                  className="absolute -translate-x-1/2 text-[10px] text-muted-foreground"
                   style={{ left: `${pct(m)}%` }}
                 >
                   {hourLabel(m)}
@@ -128,15 +126,15 @@ export function ShiftTimeline({
                 return (
                   <div key={castId} className="flex items-center">
                     <div
-                      className={`${LABEL_COL} shrink-0 truncate pr-2 text-sm font-medium text-gray-700`}
+                      className={`${LABEL_COL} shrink-0 truncate pr-2 text-sm font-medium text-foreground`}
                     >
                       {castName(castId)}
                     </div>
-                    <div className="relative h-9 flex-1 rounded bg-gray-50">
+                    <div className="relative h-9 flex-1 rounded bg-muted">
                       {hourMarks.map(m => (
                         <div
                           key={m}
-                          className="absolute top-0 h-full border-l border-gray-100"
+                          className="absolute top-0 h-full border-l"
                           style={{ left: `${pct(m)}%` }}
                         />
                       ))}
@@ -150,8 +148,8 @@ export function ShiftTimeline({
                             onClick={() => onEditShift(s)}
                             className={`absolute top-1 flex h-7 items-center overflow-hidden rounded px-2 text-xs font-medium shadow-sm ${
                               confirmed
-                                ? 'bg-green-500 text-white hover:bg-green-600'
-                                : 'bg-yellow-400 text-yellow-900 hover:bg-yellow-500'
+                                ? 'bg-success text-success-foreground hover:bg-success/90'
+                                : 'bg-warning text-warning-foreground hover:bg-warning/90'
                             }`}
                             style={{
                               left: `${pct(start)}%`,
@@ -175,10 +173,10 @@ export function ShiftTimeline({
             {showNow && (
               <div className="pointer-events-none absolute inset-y-0 right-0 left-28">
                 <div
-                  className="absolute top-0 bottom-0 w-px bg-red-500"
+                  className="absolute top-0 bottom-0 w-px bg-destructive"
                   style={{ left: `${pct(nowMin)}%` }}
                 >
-                  <span className="absolute -top-0.5 -translate-x-1/2 rounded bg-red-500 px-1 text-[9px] font-medium text-white">
+                  <span className="absolute -top-0.5 -translate-x-1/2 rounded bg-destructive px-1 text-[9px] font-medium text-destructive-foreground">
                     現在
                   </span>
                 </div>

--- a/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
@@ -93,20 +93,23 @@ export default function ShiftsPage() {
     setTab(TIMELINE_TAB);
   };
 
+  // 既定・ホバーの文字色はプリミティブに任せ、選択中だけをプライマリの下線と文字色で示す。
   const tabTriggerClass =
-    'h-auto flex-none rounded-none border-0 border-b-2 border-transparent px-1 py-3 text-sm font-medium text-gray-500 shadow-none after:hidden hover:text-gray-700 data-[state=active]:border-blue-600 data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:shadow-none';
+    'h-auto flex-none rounded-none border-0 border-b-2 border-transparent px-1 py-3 text-sm font-medium shadow-none after:hidden data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary-strong data-[state=active]:shadow-none';
 
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">出勤管理</h1>
-        <p className="mt-1 text-sm text-gray-500">キャストの出勤シフトを登録・確認できます。</p>
+        <h1 className="text-2xl font-bold text-foreground">出勤管理</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          キャストの出勤シフトを登録・確認できます。
+        </p>
       </div>
 
       <Tabs value={tab} onValueChange={setTab} className="gap-0">
         <TabsList
           variant="line"
-          className="h-auto w-full justify-start gap-6 rounded-none border-b border-gray-200 p-0"
+          className="h-auto w-full justify-start gap-6 rounded-none border-b p-0"
         >
           <TabsTrigger value={CALENDAR_TAB} className={tabTriggerClass}>
             <span className="inline-flex items-center gap-1.5">

--- a/frontend/src/_pages/store-shifts/ui/__tests__/ShiftFormModal.test.tsx
+++ b/frontend/src/_pages/store-shifts/ui/__tests__/ShiftFormModal.test.tsx
@@ -1,0 +1,250 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { ShiftFormModal } from '../ShiftFormModal';
+import { CastResponse } from '@/entities/cast';
+import { ShiftResponse, shiftApi } from '@/entities/shift';
+
+jest.mock('@/entities/shift', () => ({
+  shiftApi: {
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock('react-hot-toast', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockedCreate = shiftApi.create as jest.Mock;
+const mockedUpdate = shiftApi.update as jest.Mock;
+const mockedDelete = shiftApi.delete as jest.Mock;
+
+const cast = (id: string, name: string): CastResponse => ({
+  id,
+  name,
+  status: 'ACTIVE',
+  invitation_status: 'NOT_INVITED',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+});
+
+const CASTS = [cast('cast-1', 'キャストA'), cast('cast-2', 'キャストB')];
+
+const EDITING: ShiftResponse = {
+  id: 'shift-1',
+  cast_id: 'cast-2',
+  work_date: '2026-08-02',
+  start_time: '19:30:00',
+  end_time: '01:00:00',
+  status: 'CONFIRMED',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+/** モーダル内のセレクトは上から キャスト・ステータス の順に並ぶ。 */
+const CAST_SELECT = 0;
+const STATUS_SELECT = 1;
+
+function renderModal(props: Partial<React.ComponentProps<typeof ShiftFormModal>> = {}) {
+  const onClose = jest.fn();
+  const onSaved = jest.fn();
+  const view = render(
+    <ShiftFormModal
+      open
+      onClose={onClose}
+      casts={CASTS}
+      editing={null}
+      defaultDate="2026-08-01"
+      onSaved={onSaved}
+      {...props}
+    />
+  );
+  return { ...view, onClose, onSaved };
+}
+
+function selectAt(index: number) {
+  return screen.getAllByRole('combobox')[index];
+}
+
+/**
+ * 選択中の項目の表示文言。素の select は選択済み option、Radix はトリガの内容。
+ */
+function selectedLabel(index: number) {
+  const el = selectAt(index);
+  if (el.tagName === 'SELECT') {
+    return (el as HTMLSelectElement).selectedOptions[0]?.textContent ?? '';
+  }
+  return el.textContent ?? '';
+}
+
+/**
+ * 表示文言で項目を選ぶ。素の select は change、Radix はキーボードで開いてクリックする
+ * （ポインタ系 API は jsdom に無いため開く経路はキーボードに限る）。
+ */
+async function pickOption(index: number, optionName: string) {
+  const el = selectAt(index);
+  if (el.tagName === 'SELECT') {
+    const option = within(el).getByRole('option', { name: optionName }) as HTMLOptionElement;
+    fireEvent.change(el, { target: { value: option.value } });
+    return;
+  }
+  fireEvent.keyDown(el, { key: 'ArrowDown' });
+  fireEvent.click(await screen.findByRole('option', { name: optionName }));
+}
+
+function submit() {
+  fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+}
+
+describe('シフトフォームのセレクト配線と送信ペイロード', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCreate.mockResolvedValue({});
+    mockedUpdate.mockResolvedValue({});
+    mockedDelete.mockResolvedValue(undefined);
+  });
+
+  it('新規作成の既定値が先頭キャスト・未確定・秒付き時刻で送られること', async () => {
+    renderModal();
+
+    submit();
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    const payload = mockedCreate.mock.calls[0][0];
+    expect(payload).toEqual({
+      cast_id: 'cast-1',
+      work_date: '2026-08-01',
+      start_time: '18:00:00',
+      end_time: '23:00:00',
+      status: 'TENTATIVE',
+    });
+    // キー集合そのものが移行で増減しないことを固定する
+    expect(Object.keys(payload).sort()).toEqual([
+      'cast_id',
+      'end_time',
+      'start_time',
+      'status',
+      'work_date',
+    ]);
+  });
+
+  it('新規作成時に先頭キャストと未確定が表示されること', async () => {
+    renderModal();
+
+    await waitFor(() => expect(selectedLabel(CAST_SELECT)).toBe('キャストA'));
+    expect(selectedLabel(STATUS_SELECT)).toBe('未確定');
+  });
+
+  it('キャストを選び直すと選んだ ID が送られること', async () => {
+    renderModal();
+
+    await pickOption(CAST_SELECT, 'キャストB');
+    submit();
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    expect(mockedCreate.mock.calls[0][0].cast_id).toBe('cast-2');
+  });
+
+  it('ステータスを確定へ変えると CONFIRMED が送られること', async () => {
+    renderModal();
+
+    await pickOption(STATUS_SELECT, '確定');
+    submit();
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    expect(mockedCreate.mock.calls[0][0].status).toBe('CONFIRMED');
+  });
+
+  it('編集時は既存のキャストとステータスが表示されること', async () => {
+    renderModal({ editing: EDITING });
+
+    await waitFor(() => expect(selectedLabel(CAST_SELECT)).toBe('キャストB'));
+    expect(selectedLabel(STATUS_SELECT)).toBe('確定');
+  });
+
+  it('編集を未変更で保存すると既存値がそのまま更新に送られること', async () => {
+    const { onSaved, onClose } = renderModal({ editing: EDITING });
+
+    await waitFor(() => expect(selectedLabel(CAST_SELECT)).toBe('キャストB'));
+    submit();
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(1));
+    expect(mockedUpdate).toHaveBeenCalledWith('shift-1', {
+      cast_id: 'cast-2',
+      work_date: '2026-08-02',
+      start_time: '19:30:00',
+      end_time: '01:00:00',
+      status: 'CONFIRMED',
+    });
+    expect(mockedCreate).not.toHaveBeenCalled();
+    await waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('編集でステータスを未確定へ戻すと TENTATIVE が送られること', async () => {
+    renderModal({ editing: EDITING });
+
+    await waitFor(() => expect(selectedLabel(STATUS_SELECT)).toBe('確定'));
+    await pickOption(STATUS_SELECT, '未確定');
+    submit();
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(1));
+    expect(mockedUpdate.mock.calls[0][1].status).toBe('TENTATIVE');
+  });
+
+  it('編集で別のキャストへ付け替えると新しい ID が送られること', async () => {
+    renderModal({ editing: EDITING });
+
+    await waitFor(() => expect(selectedLabel(CAST_SELECT)).toBe('キャストB'));
+    await pickOption(CAST_SELECT, 'キャストA');
+    submit();
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(1));
+    expect(mockedUpdate.mock.calls[0][1].cast_id).toBe('cast-1');
+  });
+
+  it('一覧に無いキャストを編集しても別のキャストが表示されないこと', async () => {
+    renderModal({ editing: { ...EDITING, cast_id: 'cast-ghost' } });
+
+    // ステータスの反映を待つことで初期化が済んだ状態を確かめてから空表示を見る
+    await waitFor(() => expect(selectedLabel(STATUS_SELECT)).toBe('確定'));
+    expect(selectedLabel(CAST_SELECT)).toBe('');
+  });
+
+  it('キャストが未登録のときは未登録の案内が表示され、保存しても送信されないこと', async () => {
+    const { onSaved } = renderModal({ casts: [] });
+
+    await waitFor(() => expect(selectedLabel(CAST_SELECT)).toBe('キャストが未登録です'));
+    await act(async () => submit());
+
+    expect(mockedCreate).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it('キャストが未登録のときに案内項目を選び直しても送信されないこと', async () => {
+    const { onSaved } = renderModal({ casts: [] });
+
+    await waitFor(() => expect(selectedLabel(CAST_SELECT)).toBe('キャストが未登録です'));
+    await pickOption(CAST_SELECT, 'キャストが未登録です');
+    await act(async () => submit());
+
+    expect(mockedCreate).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it('削除は確認を経て呼ばれ、取り消すと呼ばれないこと', async () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+    const { onSaved } = renderModal({ editing: EDITING });
+
+    fireEvent.click(screen.getByRole('button', { name: '削除' }));
+    expect(confirmSpy).toHaveBeenCalledWith('このシフトを削除しますか？');
+    expect(mockedDelete).not.toHaveBeenCalled();
+
+    confirmSpy.mockReturnValue(true);
+    fireEvent.click(screen.getByRole('button', { name: '削除' }));
+
+    await waitFor(() => expect(mockedDelete).toHaveBeenCalledWith('shift-1'));
+    await waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1));
+    confirmSpy.mockRestore();
+  });
+});

--- a/frontend/src/_pages/store-shifts/ui/__tests__/ShiftFormModal.test.tsx
+++ b/frontend/src/_pages/store-shifts/ui/__tests__/ShiftFormModal.test.tsx
@@ -232,6 +232,19 @@ describe('シフトフォームのセレクト配線と送信ペイロード', (
     expect(onSaved).not.toHaveBeenCalled();
   });
 
+  // キャスト取得が失敗しても既存シフトは描けるため、未登録の案内項目と編集値が同時に存在しうる。
+  // このときだけ案内項目は「選択されていない項目」になり、選ぶと値が空へ戻って送信が止まる。
+  it('キャストが未登録のまま編集を開き案内項目を選ぶと送信されないこと', async () => {
+    const { onSaved } = renderModal({ casts: [], editing: EDITING });
+
+    await pickOption(CAST_SELECT, 'キャストが未登録です');
+    await act(async () => submit());
+
+    expect(mockedUpdate).not.toHaveBeenCalled();
+    expect(mockedCreate).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
   it('削除は確認を経て呼ばれ、取り消すと呼ばれないこと', async () => {
     const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
     const { onSaved } = renderModal({ editing: EDITING });

--- a/frontend/src/_pages/store-shifts/ui/__tests__/ShiftsPage.test.tsx
+++ b/frontend/src/_pages/store-shifts/ui/__tests__/ShiftsPage.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ShiftsPage from '../ShiftsPage';
+import { castApi } from '@/entities/cast';
+import { shiftApi } from '@/entities/shift';
+import { toDateStr } from '../../lib/datetime';
+
+jest.mock('@/entities/cast', () => ({
+  castApi: { list: jest.fn() },
+}));
+
+jest.mock('@/entities/shift', () => ({
+  shiftApi: {
+    list: jest.fn(),
+    listShiftRequests: jest.fn(),
+    approveShiftRequest: jest.fn(),
+    declineShiftRequest: jest.fn(),
+  },
+}));
+
+jest.mock('react-hot-toast', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockedCastList = castApi.list as jest.Mock;
+const mockedShiftList = shiftApi.list as jest.Mock;
+
+/** 月グリッドの先頭 6 セル・末尾 14 セルにしか他月は現れないため、15 日は常に当月で一意。 */
+const DAY_IN_MONTH = 15;
+
+describe('ShiftsPage のタブ遷移', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCastList.mockResolvedValue({ content: [] });
+    mockedShiftList.mockResolvedValue([]);
+  });
+
+  it('カレンダーの日付をクリックするとタイムラインタブへ切り替わり、その日を表示すること', async () => {
+    render(<ShiftsPage />);
+
+    const day = await screen.findByRole('button', { name: String(DAY_IN_MONTH) });
+    fireEvent.click(day);
+
+    const now = new Date();
+    const expected = toDateStr(new Date(now.getFullYear(), now.getMonth(), DAY_IN_MONTH));
+
+    await waitFor(() =>
+      expect(screen.getByRole('tab', { name: 'タイムライン' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    );
+    expect(screen.getByRole('tab', { name: 'カレンダー' })).toHaveAttribute(
+      'aria-selected',
+      'false'
+    );
+    expect(await screen.findByText(`${expected} の出勤`)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

出勤管理スライス（カレンダー / タイムライン / 希望受信箱 / シフトフォーム）を shadcn/ui プリミティブとトークン規格へ載せ替える。挙動は維持し、色は生パレットを全廃する。

Closes #485

**合流順**: #491（DESIGN.md）を先に合流させてください。本 PR が書く配色の一部は #491 で行列へ追補されます。

## 変更内容

- `ShiftFormModal` を `Form` / `FormField` / `Select` / `Input` へ載せ替え。Radix の `SelectItem` は空文字を許さないため、未登録案内の項目に番兵を置き、送信前に空文字へ戻す
- カレンダー・タイムライン・希望受信箱・ページ外枠をトークンへ変換
- 日セルのホバー時、人数チップが同色の淡色地に重なってコントラストが 3.97 まで落ちる問題を修正（重なる間だけ本文色へ上げる）
- 曜日帯と当月外セルの地の塗りを落とした。`bg-muted` の上に注記色を置く組み合わせは DESIGN.md が 4.39 の不合格と明記しているため、塗りを外して週末色をカード面の認証済み行へ戻す

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（69 suites / 390 tests。三連 PR を統合した作業ツリーで実行）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（19 シナリオ全件。出勤管理に直接触れる e2e は無いが、全件を回して回帰が無いことを確認）
- [x] ローカルで code-review 実施済み

**等価性の証明**: アンカーテストを restyle 前の実装に対して先に緑にしてから restyle した。HEAD のテスト本文を master 実装へ戻して再実行し 18/18 緑、restyle 実装でも 18/18 緑。アンカーコミット `798ba94` の中身は 1 バイトも変更していない。

**配線の証明**（削除して赤くなるか）: `cast_id` の value/onValueChange 除去 → 8 件赤、`status` の同 → 5 件赤、番兵変換の除去 → 1 件赤。最後の 1 件は本 PR で追加したテスト（`9be64b5`、純増 13 行）が守っている。既存アンカーだけでは番兵が漏れる改変を検知できなかった — 案内項目が最初から選択済みで、Radix は同値の選択で `onValueChange` を発火しないため。到達経路は `castApi.list` 失敗時（`casts=[]` かつ `editing` 付きでモーダルを開く）に実在する。

### 視覚確認（UI 変更時）

統合ビルドを起動し実機で確認。

- カレンダー: 日セルのホバー時、地色とチップ地が重なった状態で**チップ文字が本文色へ切り替わることを実測で確認**（修正前 3.97 → 修正後は近黒）
- タイムライン: バー対軌道 **2.93**、バー内文字 **6.18**、バー対白地 **3.22** を実機で実測（DESIGN.md 記載値と一致）
- 全画面で `document.scrollHeight` == `window.innerHeight`、二重スクロールバー無し

## 決定ログ

**タイムラインのバー対軌道は明示免除**（明 2.92 / 2.90 で 3:1 未達）。バー内の時刻文字が 6.18:1 で同じ情報を冗長に担い、`shadow-sm` もあり、restyle 前（green-500 on gray-50）も同様に未達で回帰ではない。所有者裁定済み。軌道を `bg-background` + `border` へ戻す案は、明モードで `--background` が `--card` と同一のため軌道がカード面へ融けることから見送った。#491 に「この画面限りの免除、新しい面へは継承しない」として記録済み。

**Calendar / Timeline では `Card` プリミティブを使わない**。端まで詰めたグリッドであり、`Card` の `py-6 gap-6 rounded-xl` を打ち消すのはプリミティブの再記述に等しい。`bg-card` + 素の `border` に留めた。

**一覧に無い `cast_id` を編集した場合の挙動が変わる**。master はネイティブ select が値を空へ丸め `required` が送信を止めていた。restyle 後は不明 ID を保持して `update` へ送るため参照が保たれる。成員判定の実装は挙動追加でありスコープ外と判断した。追加テスト（206 行目）で現行語義を文書化している。

## 備考 / レビュー観点

- `rounded-[10px]` が 2 箇所 master のまま残る。DESIGN.md の `rounded-lg` と不一致だが、無関係な変更を避けた
- 凡例ドットは隣接文字と情報が完全に冗長なため装飾免除（#491 に記録）

🤖 Generated with [Claude Code](https://claude.com/claude-code)