### PR TITLE
refactor(frontend): キャストポータルを shadcn/ui とトークン規格へ載せ替える

### DIFF
--- a/e2e/steps/cast-portal.steps.ts
+++ b/e2e/steps/cast-portal.steps.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 import {
   acceptCastInvitation,
@@ -18,6 +18,14 @@ const todayInTokyo = () =>
   new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Tokyo' }).format(new Date());
 
 const CAST_PASSWORD = 'pass12345';
+
+// 所属店舗セレクタはボタンで、選択肢は開いている間だけ描かれる。
+const storeSelect = (page: Page) => page.getByRole('combobox', { name: '店舗', exact: true });
+
+// セレクタへ店舗が流し込まれるまで待つ。未選択の間だけ data-placeholder が付くため、
+// その消失をもって「マウント時の非同期読み込みが解決した」と判定する。
+const expectStoreSelected = (page: Page) =>
+  expect(storeSelect(page)).not.toHaveAttribute('data-placeholder');
 
 // 播種した実体の id / 認証情報。CAST PlatformUser には削除 API が無いためタイムスタンプ付き
 // メールアドレスで隔離し残留を許容する（cast_id/shift_id/shift_request_id は明示削除 + FK CASCADE で片付ける）。
@@ -83,14 +91,13 @@ Then(
 
 When('希望提出タブを開く', async ({ page }) => {
   await page.locator('nav').getByRole('link', { name: '希望提出', exact: true }).click();
-  // 所属店舗セレクタの描画完了（マウント時の非同期読み込み）を待ってから後続の操作に入る。
-  await expect(page.getByLabel('店舗')).not.toHaveValue('');
+  await expectStoreSelected(page);
 });
 
 Then('希望提出タブを開き直す', async ({ page }) => {
   // 承認結果の反映には再取得が要る。同一ルートの再入場は remount しないため明示リロードする。
   await page.reload({ waitUntil: 'domcontentloaded' });
-  await expect(page.getByLabel('店舗')).not.toHaveValue('');
+  await expectStoreSelected(page);
 });
 
 When('スケジュールタブを開く', async ({ page }) => {
@@ -100,7 +107,8 @@ When('スケジュールタブを開く', async ({ page }) => {
 When(
   '店舗 {string}・開始 {string}・終了 {string}・備考 {string} で出勤希望を提出する',
   async ({ page }, storeName: string, startTime: string, endTime: string, note: string) => {
-    await page.getByLabel('店舗').selectOption({ label: storeName });
+    await storeSelect(page).click();
+    await page.getByRole('option', { name: storeName, exact: true }).click();
     // 勤務日は本日を明示指定する。フォーム既定の明日だと週末実行時に翌週へ落ち、
     // 承認後のスケジュール断言（当週ビュー）が曜日依存で失敗するため。
     await page.getByLabel('日付').fill(todayInTokyo());

--- a/frontend/src/_pages/cast-portal/ui/CastAccountPage.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastAccountPage.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { platformAuthApi, useAuth } from '@/entities/user';
+import { Button, Card, CardContent } from '@/shared/ui';
 
 /** アカウントタブ。表示名とログアウトのみの最小画面。 */
 export function CastAccountPage() {
@@ -25,17 +26,19 @@ export function CastAccountPage() {
 
   return (
     <div className="p-4">
-      <div className="rounded-[10px] border border-gray-200 bg-white p-6 shadow-sm">
-        <p className="text-xs font-medium uppercase tracking-wider text-gray-500">表示名</p>
-        <p className="mt-1 text-lg font-semibold text-gray-900">{displayName ?? '読み込み中...'}</p>
-        <button
-          type="button"
-          onClick={logout}
-          className="mt-6 w-full rounded-[10px] border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-        >
-          ログアウト
-        </button>
-      </div>
+      <Card>
+        <CardContent>
+          <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            表示名
+          </p>
+          <p className="mt-1 text-lg font-semibold text-foreground">
+            {displayName ?? '読み込み中...'}
+          </p>
+          <Button type="button" variant="outline" onClick={logout} className="mt-6 w-full">
+            ログアウト
+          </Button>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/_pages/cast-portal/ui/CastPortalShell.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastPortalShell.tsx
@@ -70,7 +70,7 @@ export function CastPortalShell({ children }: CastPortalShellProps) {
               key={tab.href}
               href={tab.href}
               aria-current={active ? 'page' : undefined}
-              className={`flex flex-1 flex-col items-center gap-1 py-2 text-xs font-medium ${
+              className={`flex flex-1 flex-col items-center gap-1 py-2 text-xs font-medium focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none ${
                 active
                   ? 'text-primary-strong'
                   : 'text-muted-foreground hover:bg-muted hover:text-foreground'

--- a/frontend/src/_pages/cast-portal/ui/CastPortalShell.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastPortalShell.tsx
@@ -52,16 +52,16 @@ export function CastPortalShell({ children }: CastPortalShellProps) {
 
   if (!authorized) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50">
-        <p className="text-sm text-gray-500">読み込み中...</p>
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <p className="text-sm text-muted-foreground">読み込み中...</p>
       </div>
     );
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-gray-50">
+    <div className="flex min-h-screen flex-col bg-background">
       <main className="flex-1 overflow-y-auto pb-16">{children}</main>
-      <nav className="fixed inset-x-0 bottom-0 z-10 flex border-t border-gray-200 bg-white">
+      <nav className="fixed inset-x-0 bottom-0 z-10 flex border-t bg-card">
         {TABS.map(tab => {
           const active = pathname === tab.href || pathname?.startsWith(`${tab.href}/`);
           const Icon = tab.icon;
@@ -70,8 +70,10 @@ export function CastPortalShell({ children }: CastPortalShellProps) {
               key={tab.href}
               href={tab.href}
               aria-current={active ? 'page' : undefined}
-              className={`flex flex-1 flex-col items-center gap-1 py-2 text-xs font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
-                active ? 'text-blue-600' : 'text-gray-600 hover:bg-gray-50'
+              className={`flex flex-1 flex-col items-center gap-1 py-2 text-xs font-medium ${
+                active
+                  ? 'text-primary-strong'
+                  : 'text-muted-foreground hover:bg-muted hover:text-foreground'
               }`}
             >
               <Icon className="h-6 w-6" />

--- a/frontend/src/_pages/cast-portal/ui/CastRequestsPage.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastRequestsPage.tsx
@@ -111,7 +111,6 @@ export function CastRequestsPage() {
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // 初期店舗の流し込みは選択肢が描画され終えた次のコミットで行う。Radix Select は

--- a/frontend/src/_pages/cast-portal/ui/CastRequestsPage.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastRequestsPage.tsx
@@ -9,6 +9,25 @@ import {
   ShiftRequestCreateRequest,
   shiftApi,
 } from '@/entities/shift';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from '@/shared/ui';
 import { toDateStr } from '../lib/week';
 
 interface RequestFormValues {
@@ -26,13 +45,10 @@ const STATUS_LABELS: Record<CastShiftRequestItem['status'], string> = {
 };
 
 const STATUS_PILL_CLASS: Record<CastShiftRequestItem['status'], string> = {
-  PENDING: 'bg-yellow-100 text-yellow-800',
-  APPROVED: 'bg-green-100 text-green-800',
-  DECLINED: 'bg-red-100 text-red-800',
+  PENDING: 'border-transparent bg-warning/10 text-warning-strong',
+  APPROVED: 'border-transparent bg-success/10 text-success-strong',
+  DECLINED: 'border-transparent bg-destructive/10 text-destructive-strong',
 };
-
-const inputClass =
-  'w-full rounded-md border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500';
 
 /** 本日の 'yyyy-MM-dd' を返す（過去日拒否の下限。当日の出勤希望は許容する）。 */
 function todayStr(): string {
@@ -62,13 +78,15 @@ export function CastRequestsPage() {
   const [history, setHistory] = useState<CastShiftRequestItem[] | null>(null);
   const [hasError, setHasError] = useState(false);
 
+  const form = useForm<RequestFormValues>({ defaultValues: defaultValues('') });
   const {
     register,
     handleSubmit,
     reset,
     setValue,
+    control,
     formState: { errors, isSubmitting },
-  } = useForm<RequestFormValues>({ defaultValues: defaultValues('') });
+  } = form;
 
   const loadHistory = () => {
     setHistory(null);
@@ -85,7 +103,6 @@ export function CastRequestsPage() {
       .then(res => {
         if (cancelled) return;
         setStores(res);
-        if (res[0]) setValue('store_id', String(res[0].store_id));
       })
       .catch(() => {
         if (!cancelled) setHasError(true);
@@ -96,6 +113,14 @@ export function CastRequestsPage() {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // 初期店舗の流し込みは選択肢が描画され終えた次のコミットで行う。Radix Select は
+  // form 内で隠し <select> を併走させており、選択肢が未登録のまま値だけ変わると
+  // その隠し要素が値を保持できず change を打ち返して選択を空へ巻き戻すため。
+  useEffect(() => {
+    const first = stores[0];
+    if (first) setValue('store_id', String(first.store_id));
+  }, [stores, setValue]);
 
   const submit = async (values: RequestFormValues) => {
     const payload: ShiftRequestCreateRequest = {
@@ -118,131 +143,122 @@ export function CastRequestsPage() {
   return (
     <div className="space-y-6 p-4">
       <div>
-        <h1 className="text-lg font-bold text-gray-900">希望提出</h1>
-        <p className="mt-1 text-xs text-gray-500">出勤したい店舗・日時を提出できます。</p>
+        <h1 className="text-lg font-bold text-foreground">希望提出</h1>
+        <p className="mt-1 text-xs text-muted-foreground">出勤したい店舗・日時を提出できます。</p>
       </div>
 
-      <form
-        onSubmit={handleSubmit(submit)}
-        className="space-y-4 rounded-[10px] border border-gray-200 bg-white p-4 shadow-sm"
-      >
-        <div>
-          <label htmlFor="request-store" className="mb-1 block text-sm font-medium text-gray-700">
-            店舗
-          </label>
-          <select
-            id="request-store"
-            {...register('store_id', { required: true })}
-            className={inputClass}
-          >
-            {stores.length === 0 && <option value="">所属店舗がありません</option>}
-            {stores.map(s => (
-              <option key={s.store_id} value={s.store_id}>
-                {s.store_name}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div>
-          <label
-            htmlFor="request-work-date"
-            className="mb-1 block text-sm font-medium text-gray-700"
-          >
-            日付
-          </label>
-          <input
-            id="request-work-date"
-            type="date"
-            {...register('work_date', {
-              required: true,
-              validate: v => v >= todayStr() || '本日以降の日付を指定してください',
-            })}
-            className={inputClass}
-          />
-          {errors.work_date && (
-            <p className="mt-1 text-xs text-red-600">{errors.work_date.message}</p>
-          )}
-        </div>
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label
-              htmlFor="request-start-time"
-              className="mb-1 block text-sm font-medium text-gray-700"
-            >
-              開始
-            </label>
-            <input
-              id="request-start-time"
-              type="time"
-              {...register('start_time', { required: true })}
-              className={inputClass}
-            />
-          </div>
-          <div>
-            <label
-              htmlFor="request-end-time"
-              className="mb-1 block text-sm font-medium text-gray-700"
-            >
-              終了
-            </label>
-            <input
-              id="request-end-time"
-              type="time"
-              {...register('end_time', { required: true })}
-              className={inputClass}
-            />
-          </div>
-        </div>
-        <div>
-          <label htmlFor="request-note" className="mb-1 block text-sm font-medium text-gray-700">
-            備考
-          </label>
-          <textarea
-            id="request-note"
-            {...register('note', {
-              maxLength: { value: 500, message: '備考は500文字以内で入力してください' },
-            })}
-            rows={3}
-            className={inputClass}
-          />
-          {errors.note && <p className="mt-1 text-xs text-red-600">{errors.note.message}</p>}
-        </div>
-        <button
-          type="submit"
-          disabled={isSubmitting || stores.length === 0}
-          className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-        >
-          {isSubmitting ? '提出中...' : '提出する'}
-        </button>
-      </form>
+      <Form {...form}>
+        <form onSubmit={handleSubmit(submit)}>
+          <Card>
+            <CardContent className="space-y-4">
+              <FormField
+                control={control}
+                name="store_id"
+                rules={{ required: true }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>店舗</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger className="w-full">
+                          {/* 所属店舗が無いときは選択肢自体が無く、値は空のままなので placeholder が出る。 */}
+                          <SelectValue placeholder="所属店舗がありません" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {stores.map(s => (
+                          <SelectItem key={s.store_id} value={String(s.store_id)}>
+                            {s.store_name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
+              />
+              <div className="grid gap-2">
+                <Label htmlFor="request-work-date">日付</Label>
+                <Input
+                  id="request-work-date"
+                  type="date"
+                  {...register('work_date', {
+                    required: true,
+                    validate: v => v >= todayStr() || '本日以降の日付を指定してください',
+                  })}
+                />
+                {errors.work_date && (
+                  <p className="text-xs text-destructive-strong">{errors.work_date.message}</p>
+                )}
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="grid gap-2">
+                  <Label htmlFor="request-start-time">開始</Label>
+                  <Input
+                    id="request-start-time"
+                    type="time"
+                    {...register('start_time', { required: true })}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="request-end-time">終了</Label>
+                  <Input
+                    id="request-end-time"
+                    type="time"
+                    {...register('end_time', { required: true })}
+                  />
+                </div>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="request-note">備考</Label>
+                <Textarea
+                  id="request-note"
+                  {...register('note', {
+                    maxLength: { value: 500, message: '備考は500文字以内で入力してください' },
+                  })}
+                  rows={3}
+                />
+                {errors.note && (
+                  <p className="text-xs text-destructive-strong">{errors.note.message}</p>
+                )}
+              </div>
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={isSubmitting || stores.length === 0}
+              >
+                {isSubmitting ? '提出中...' : '提出する'}
+              </Button>
+            </CardContent>
+          </Card>
+        </form>
+      </Form>
 
       <div>
-        <h2 className="mb-2 text-sm font-semibold text-gray-900">提出履歴</h2>
+        <h2 className="mb-2 text-sm font-semibold text-foreground">提出履歴</h2>
         {hasError ? (
-          <p className="text-sm text-red-600">履歴の取得に失敗しました</p>
+          <p className="text-sm text-destructive-strong">履歴の取得に失敗しました</p>
         ) : history === null ? (
-          <p className="text-sm text-gray-500">読み込み中...</p>
+          <p className="text-sm text-muted-foreground">読み込み中...</p>
         ) : history.length === 0 ? (
-          <p className="text-sm text-gray-500">提出履歴はありません</p>
+          <p className="text-sm text-muted-foreground">提出履歴はありません</p>
         ) : (
           <ul className="space-y-2">
             {history.map(item => (
-              <li
-                key={item.id}
-                className="rounded-[10px] border border-gray-200 bg-white p-3 shadow-sm"
-              >
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-gray-900">{item.store_name}</span>
-                  <span
-                    className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_PILL_CLASS[item.status]}`}
-                  >
-                    {STATUS_LABELS[item.status]}
-                  </span>
-                </div>
-                <p className="mt-1 text-xs text-gray-600">
-                  {item.work_date} {item.start_time.slice(0, 5)}–{item.end_time.slice(0, 5)}
-                </p>
-                {item.note && <p className="mt-1 text-xs text-gray-500">{item.note}</p>}
+              <li key={item.id}>
+                <Card className="py-3">
+                  <CardContent className="px-3">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-foreground">{item.store_name}</span>
+                      <Badge variant="outline" className={STATUS_PILL_CLASS[item.status]}>
+                        {STATUS_LABELS[item.status]}
+                      </Badge>
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {item.work_date} {item.start_time.slice(0, 5)}–{item.end_time.slice(0, 5)}
+                    </p>
+                    {item.note && <p className="mt-1 text-xs text-muted-foreground">{item.note}</p>}
+                  </CardContent>
+                </Card>
               </li>
             ))}
           </ul>

--- a/frontend/src/_pages/cast-portal/ui/CastSchedulePage.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastSchedulePage.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { CastScheduleItem, shiftApi } from '@/entities/shift';
+import { Badge, Button, Card, CardContent } from '@/shared/ui';
 import { groupByWorkDate } from '../lib/groupSchedule';
 import {
   formatEndTime,
@@ -60,55 +61,49 @@ export function CastSchedulePage() {
   return (
     <div className="p-4">
       <div className="mb-4 flex items-center justify-between">
-        <button
-          type="button"
-          onClick={() => shiftWeek(-7)}
-          className="rounded-[10px] border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-        >
+        <Button type="button" variant="outline" size="sm" onClick={() => shiftWeek(-7)}>
           前週
-        </button>
-        <p className="text-sm font-medium text-gray-900">{rangeLabel}</p>
-        <button
-          type="button"
-          onClick={() => shiftWeek(7)}
-          className="rounded-[10px] border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-        >
+        </Button>
+        <p className="text-sm font-medium text-foreground">{rangeLabel}</p>
+        <Button type="button" variant="outline" size="sm" onClick={() => shiftWeek(7)}>
           次週
-        </button>
+        </Button>
       </div>
 
       {hasError ? (
-        <p className="text-sm text-red-600">スケジュールの取得に失敗しました</p>
+        <p className="text-sm text-destructive-strong">スケジュールの取得に失敗しました</p>
       ) : items === null ? (
-        <p className="text-sm text-gray-500">読み込み中...</p>
+        <p className="text-sm text-muted-foreground">読み込み中...</p>
       ) : groups.length === 0 ? (
-        <p className="text-sm text-gray-500">今週の確定シフトはありません</p>
+        <p className="text-sm text-muted-foreground">今週の確定シフトはありません</p>
       ) : (
         <div className="space-y-3">
           {groups.map(group => (
-            <div
-              key={group.workDate}
-              className="rounded-[10px] border border-gray-200 bg-white p-4 shadow-sm"
-            >
-              <p className="mb-2 text-sm font-semibold text-gray-900">
-                {formatDateLabel(group.workDate)}
-              </p>
-              <ul className="space-y-2">
-                {group.items.map(item => (
-                  <li
-                    key={`${item.store_id}-${item.start_time}-${item.end_time}`}
-                    className="flex items-center justify-between text-sm text-gray-600"
-                  >
-                    <span className="rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-600">
-                      {item.store_name}
-                    </span>
-                    <span>
-                      {formatTime(item.start_time)}–{formatEndTime(item.end_time)}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </div>
+            <Card key={group.workDate} className="py-4">
+              <CardContent className="px-4">
+                <p className="mb-2 text-sm font-semibold text-foreground">
+                  {formatDateLabel(group.workDate)}
+                </p>
+                <ul className="space-y-2">
+                  {group.items.map(item => (
+                    <li
+                      key={`${item.store_id}-${item.start_time}-${item.end_time}`}
+                      className="flex items-center justify-between text-sm text-muted-foreground"
+                    >
+                      <Badge
+                        variant="outline"
+                        className="border-transparent bg-primary/10 text-primary-strong"
+                      >
+                        {item.store_name}
+                      </Badge>
+                      <span>
+                        {formatTime(item.start_time)}–{formatEndTime(item.end_time)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
           ))}
         </div>
       )}

--- a/frontend/src/_pages/cast-portal/ui/__tests__/CastRequestsPage.test.tsx
+++ b/frontend/src/_pages/cast-portal/ui/__tests__/CastRequestsPage.test.tsx
@@ -19,6 +19,14 @@ const STORES = [
   { store_id: 2, store_name: '店舗B' },
 ];
 
+/**
+ * 所属店舗の読み込み完了を待つ。Radix Select は form 内で隠し native <select> を併走させ
+ * 同じ店舗名を選択中ラベルと option の二箇所に描くため、件数を問わない findAll で待つ。
+ */
+function waitStoresLoaded() {
+  return screen.findAllByText('店舗A');
+}
+
 describe('CastRequestsPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -30,6 +38,8 @@ describe('CastRequestsPage', () => {
     render(<CastRequestsPage />);
 
     await waitFor(() => expect(mockedMyStores).toHaveBeenCalledTimes(1));
+    // Radix Select の選択肢は開いている間だけ描画される。
+    fireEvent.keyDown(await screen.findByRole('combobox', { name: '店舗' }), { key: 'ArrowDown' });
     expect(await screen.findByRole('option', { name: '店舗A' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: '店舗B' })).toBeInTheDocument();
   });
@@ -38,7 +48,7 @@ describe('CastRequestsPage', () => {
     render(<CastRequestsPage />);
     // 所属店セレクタの描画完了を待つ（マウント時の非同期読み込みが未解決のまま操作すると
     // store_id の初期値設定と競合するため、react-hook-form の値確定後に操作する）。
-    await screen.findByRole('option', { name: '店舗A' });
+    await waitStoresLoaded();
 
     fireEvent.change(screen.getByLabelText('日付'), { target: { value: '2000-01-01' } });
     fireEvent.click(screen.getByRole('button', { name: '提出する' }));
@@ -50,7 +60,7 @@ describe('CastRequestsPage', () => {
   it('本日の日付は許容され提出されること', async () => {
     mockedSubmit.mockResolvedValue({ id: 'sr1', status: 'PENDING' });
     render(<CastRequestsPage />);
-    await screen.findByRole('option', { name: '店舗A' });
+    await waitStoresLoaded();
 
     const d = new Date();
     const today = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
@@ -65,7 +75,7 @@ describe('CastRequestsPage', () => {
 
   it('備考が501文字だと検証エラーを表示し、提出しないこと', async () => {
     render(<CastRequestsPage />);
-    await screen.findByRole('option', { name: '店舗A' });
+    await waitStoresLoaded();
 
     fireEvent.change(screen.getByLabelText('備考'), { target: { value: 'あ'.repeat(501) } });
     fireEvent.click(screen.getByRole('button', { name: '提出する' }));

--- a/frontend/src/_pages/cast-portal/ui/__tests__/CastRequestsPayload.test.tsx
+++ b/frontend/src/_pages/cast-portal/ui/__tests__/CastRequestsPayload.test.tsx
@@ -1,0 +1,164 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { CastRequestsPage } from '../CastRequestsPage';
+import { shiftApi } from '@/entities/shift';
+
+jest.mock('@/entities/shift', () => ({
+  shiftApi: {
+    myStores: jest.fn(),
+    myShiftRequests: jest.fn(),
+    submitShiftRequest: jest.fn(),
+  },
+}));
+
+const mockedMyStores = shiftApi.myStores as jest.Mock;
+const mockedMyShiftRequests = shiftApi.myShiftRequests as jest.Mock;
+const mockedSubmit = shiftApi.submitShiftRequest as jest.Mock;
+
+const STORES = [
+  { store_id: 1, store_name: '店舗A' },
+  { store_id: 2, store_name: '店舗B' },
+];
+
+/** 提出フォームの初期日付（明日）をローカルタイム基準で組み立てる。 */
+function tomorrowStr(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+    d.getDate()
+  ).padStart(2, '0')}`;
+}
+
+/**
+ * 店舗セレクタ。native <select> と Radix Select のどちらでも role=combobox かつ
+ * アクセシブル名「店舗」で引けるため、DOM 形状の差だけを吸収して操作の意味は同一に保つ。
+ */
+function storeCombobox(): Promise<HTMLElement> {
+  return screen.findByRole('combobox', { name: '店舗' });
+}
+
+/** 店舗を選ぶ。native は値変更、Radix はキーボードで開いて項目クリック。 */
+async function pickStore(name: string, value: string) {
+  const combobox = await storeCombobox();
+  if (combobox instanceof HTMLSelectElement) {
+    fireEvent.change(combobox, { target: { value } });
+    return;
+  }
+  fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+  fireEvent.click(await screen.findByRole('option', { name }));
+}
+
+/** セレクタが今どの店舗を表示しているか。閉じた状態でのみ呼ぶこと。 */
+async function selectedStoreLabel(): Promise<string> {
+  const combobox = await storeCombobox();
+  if (combobox instanceof HTMLSelectElement) {
+    return combobox.options[combobox.selectedIndex]?.textContent ?? '';
+  }
+  return combobox.textContent ?? '';
+}
+
+function submitForm() {
+  fireEvent.click(screen.getByRole('button', { name: '提出する' }));
+}
+
+describe('出勤希望フォームの店舗セレクト配線と送信ペイロード', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedMyStores.mockResolvedValue(STORES);
+    mockedMyShiftRequests.mockResolvedValue([]);
+    mockedSubmit.mockResolvedValue({ id: 'sr1', status: 'PENDING' });
+  });
+
+  it('未操作の既定値がキー集合ごとそのまま送られること', async () => {
+    render(<CastRequestsPage />);
+    await screen.findByText('店舗A');
+
+    submitForm();
+
+    await waitFor(() => expect(mockedSubmit).toHaveBeenCalledTimes(1));
+    const body = mockedSubmit.mock.calls[0][0];
+    // note のキーは値が undefined でも残る。toStrictEqual はキーの欠落を検出する。
+    expect(body).toStrictEqual({
+      store_id: 1,
+      work_date: tomorrowStr(),
+      start_time: '18:00:00',
+      end_time: '23:00:00',
+      note: undefined,
+    });
+    expect(typeof body.store_id).toBe('number');
+  });
+
+  it('店舗を切り替えると選んだ店舗 ID が数値で送られること', async () => {
+    render(<CastRequestsPage />);
+    await screen.findByText('店舗A');
+
+    await pickStore('店舗B', '2');
+    submitForm();
+
+    await waitFor(() => expect(mockedSubmit).toHaveBeenCalledTimes(1));
+    expect(mockedSubmit.mock.calls[0][0].store_id).toBe(2);
+  });
+
+  it('セレクタの表示が選択中の店舗に追従すること', async () => {
+    render(<CastRequestsPage />);
+    await screen.findByText('店舗A');
+    expect(await selectedStoreLabel()).toBe('店舗A');
+
+    await pickStore('店舗B', '2');
+
+    await waitFor(async () => expect(await selectedStoreLabel()).toBe('店舗B'));
+  });
+
+  it('備考は入力された文字列がそのまま載ること', async () => {
+    render(<CastRequestsPage />);
+    await screen.findByText('店舗A');
+
+    fireEvent.change(screen.getByLabelText('備考'), { target: { value: '遅れます' } });
+    submitForm();
+
+    await waitFor(() => expect(mockedSubmit).toHaveBeenCalledTimes(1));
+    expect(mockedSubmit.mock.calls[0][0].note).toBe('遅れます');
+  });
+
+  it('提出後は選択店舗を保ったまま日時だけ既定へ戻ること', async () => {
+    render(<CastRequestsPage />);
+    await screen.findByText('店舗A');
+
+    await pickStore('店舗B', '2');
+    fireEvent.change(screen.getByLabelText('開始'), { target: { value: '20:00' } });
+    submitForm();
+
+    await waitFor(() => expect(mockedSubmit).toHaveBeenCalledTimes(1));
+    expect(mockedSubmit.mock.calls[0][0]).toMatchObject({
+      store_id: 2,
+      start_time: '20:00:00',
+    });
+
+    await waitFor(() => expect(screen.getByLabelText('開始')).toHaveValue('18:00'));
+    expect(await selectedStoreLabel()).toBe('店舗B');
+
+    submitForm();
+
+    await waitFor(() => expect(mockedSubmit).toHaveBeenCalledTimes(2));
+    expect(mockedSubmit.mock.calls[1][0]).toStrictEqual({
+      store_id: 2,
+      work_date: tomorrowStr(),
+      start_time: '18:00:00',
+      end_time: '23:00:00',
+      note: undefined,
+    });
+  });
+
+  it('所属店舗が無いときは案内を出し提出させないこと', async () => {
+    mockedMyStores.mockResolvedValue([]);
+    render(<CastRequestsPage />);
+    await waitFor(() => expect(mockedMyStores).toHaveBeenCalledTimes(1));
+
+    expect(await screen.findByText('所属店舗がありません')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '提出する' })).toBeDisabled();
+
+    submitForm();
+
+    await waitFor(() => expect(mockedMyShiftRequests).toHaveBeenCalledTimes(1));
+    expect(mockedSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/_pages/cast-portal/ui/__tests__/CastRequestsPayload.test.tsx
+++ b/frontend/src/_pages/cast-portal/ui/__tests__/CastRequestsPayload.test.tsx
@@ -36,6 +36,14 @@ function storeCombobox(): Promise<HTMLElement> {
   return screen.findByRole('combobox', { name: '店舗' });
 }
 
+/**
+ * 所属店舗の読み込み完了を待つ。Radix Select は form 内で隠し native <select> を併走させ
+ * 同じ店舗名を選択中ラベルと option の二箇所に描くため、件数を問わない findAll で待つ。
+ */
+function waitStoresLoaded() {
+  return screen.findAllByText('店舗A');
+}
+
 /** 店舗を選ぶ。native は値変更、Radix はキーボードで開いて項目クリック。 */
 async function pickStore(name: string, value: string) {
   const combobox = await storeCombobox();
@@ -70,7 +78,7 @@ describe('出勤希望フォームの店舗セレクト配線と送信ペイロ�
 
   it('未操作の既定値がキー集合ごとそのまま送られること', async () => {
     render(<CastRequestsPage />);
-    await screen.findByText('店舗A');
+    await waitStoresLoaded();
 
     submitForm();
 
@@ -89,7 +97,7 @@ describe('出勤希望フォームの店舗セレクト配線と送信ペイロ�
 
   it('店舗を切り替えると選んだ店舗 ID が数値で送られること', async () => {
     render(<CastRequestsPage />);
-    await screen.findByText('店舗A');
+    await waitStoresLoaded();
 
     await pickStore('店舗B', '2');
     submitForm();
@@ -100,7 +108,7 @@ describe('出勤希望フォームの店舗セレクト配線と送信ペイロ�
 
   it('セレクタの表示が選択中の店舗に追従すること', async () => {
     render(<CastRequestsPage />);
-    await screen.findByText('店舗A');
+    await waitStoresLoaded();
     expect(await selectedStoreLabel()).toBe('店舗A');
 
     await pickStore('店舗B', '2');
@@ -110,7 +118,7 @@ describe('出勤希望フォームの店舗セレクト配線と送信ペイロ�
 
   it('備考は入力された文字列がそのまま載ること', async () => {
     render(<CastRequestsPage />);
-    await screen.findByText('店舗A');
+    await waitStoresLoaded();
 
     fireEvent.change(screen.getByLabelText('備考'), { target: { value: '遅れます' } });
     submitForm();
@@ -121,7 +129,7 @@ describe('出勤希望フォームの店舗セレクト配線と送信ペイロ�
 
   it('提出後は選択店舗を保ったまま日時だけ既定へ戻ること', async () => {
     render(<CastRequestsPage />);
-    await screen.findByText('店舗A');
+    await waitStoresLoaded();
 
     await pickStore('店舗B', '2');
     fireEvent.change(screen.getByLabelText('開始'), { target: { value: '20:00' } });


### PR DESCRIPTION
## 概要

キャストポータル（外殻 / 希望提出 / スケジュール / アカウント）を shadcn/ui プリミティブとトークン規格へ載せ替える。挙動は維持し、生パレットを全廃する。

Closes #486

**合流順**: #491（DESIGN.md）を先に合流させてください。

## 変更内容

- 希望提出フォームを `Form` / `FormField` / `Select` / `Input` / `Textarea` へ載せ替え
- **Radix Select が初期値を空へ巻き戻す不具合を修正**（下記「決定ログ」）
- 外殻・スケジュール・アカウント・提出履歴バッジをトークンへ変換
- 下タブのフォーカス表示をトークンのリングで描く。プリミティブを使わない素の `Link` のため、手書きリングを落とすと UA 既定へ退化してしまう
- **e2e の店舗セレクタ操作を Radix の形へ合わせる**（下記）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（69 suites / 390 tests。三連 PR を統合した作業ツリーで実行）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（19 シナリオ全件。**キャストポータルのシナリオが本 PR の e2e 書き換えを実際に通っている**）
- [x] ローカルで code-review 実施済み

**等価性の証明**: HEAD のテスト本文を master 実装へ戻して再実行し 40/40 緑、restyle 実装でも 40/40 緑。

**アンカーの待ち合わせだけ書き換えた**（assertion は 1 行も触っていない）。Radix Select は form 内に隠しネイティブ `select` を併走させ、同じ店舗名を選択中ラベルと option の二箇所に描くため、`findByText` が multiple で throw する。件数を問わない `findAllByText` へ替えた。

### e2e の同時修正が必要だった理由

`selectOption` と `toHaveValue` はどちらも input/textarea/select にしか使えず、Radix のトリガー（`button[role=combobox]`）に対しては静的に確実に失敗する。**e2e は CI で走らないため、どのゲートも捕捉しない。** 全 4 ベースライン（master / 485 / 486 / 487）に対して e2e 隣接性の監査を行い、破断は本 PR の 3 箇所のみであることを確認した（master・485・487 は安全。Sheet 化・DropdownMenu 化・Table 化はいずれも e2e が依存する到達可能名と label 関連を保っている）。

待ち合わせは `not.toHaveValue('')` の忠実な写像として、未選択の間だけ付く `data-placeholder` の消失で判定する。`not.toHaveText('所属店舗がありません')` は瞬時の空文字でも満たされ競合を招くため採らなかった。

### 視覚確認（UI 変更時）

キャストポータルはキャスト用アカウントを要し、e2e のキャストは毎回生成される一時アカウントのため、**ブラウザでの目視は行えていない**。挙動は上記 e2e シナリオが実ブラウザで通っている。

外殻の `<main>` に `relative` が無い点は、#483 の二重スクロールバーと同型に見えるため実機で機構を検証した。コンソール側で `relative` を外すと `scrollHeight` が 906 → 1846 へ増え、隠し select の文書座標下端 1846 と一致する（復元で 906 に戻る）。増加は `main` が内部スクロールしている（2592 vs 842）ことが条件で、キャストポータルは `min-h-screen` により `main` が内部スクロールしないため成立しない。よって `relative` は追加していない。

## 決定ログ

**初期店舗の流し込みを `stores` 依存の効果へ移した**。`stores` と `store_id` を同一コミットで更新すると、隠し `select` にまだ `option` が登録されておらず代入が失敗し、空文字が書き戻されて選択が消える（`field.value` が `'' → '1' → ''` と遷移するのを実測）。選択肢が描画され終えた次のコミットで `setValue` する。送信ペイロードと可視挙動は不変。**この遅延を元へ戻すと 2 ファイルにまたがる 5 件のテストが赤になる。**

**番兵（`SELECT_NONE`）は置かない**。master の `<option value="">所属店舗がありません</option>` は `stores.length===0` のときだけ描かれる案内で、その状態では提出ボタンが disabled のため、ユーザーが選べる「未選択」項目は存在しない。`SelectValue` の placeholder が忠実な写像であり、番兵を置くと master が一度も提供していない選択可能な空項目を新設することになる。

**`rules={{ required: true }}` はテストで証明されていない**（削除しても 0 件赤）。提出ボタンが `stores.length===0` で disabled のため、`store_id` が空になり得る唯一の状態で発火しない。master の `register('store_id', { required: true })` も同様に未証明であり、等価性のため残置した。本 PR が作った穴ではない。

## 備考 / レビュー観点

- `text-destructive-strong` を `bg-background` の上に置く箇所がある。明モードでは `--background` ≡ `--card` のため既存行がそのまま適用でき、暗モードは 6.88（#491 で行列へ追補）
- `waitStoresLoaded` が 2 テストファイルに重複している。共有化は共有ファイルに触れるため並列 PR 契約により見送った

🤖 Generated with [Claude Code](https://claude.com/claude-code)