### PR TITLE
refactor(frontend): 残りの管理画面を shadcn/ui とトークン規格へ一括で載せ替える

### DIFF
--- a/e2e/steps/staff-management.steps.ts
+++ b/e2e/steps/staff-management.steps.ts
@@ -13,11 +13,6 @@ const STAFF_URL = `${PLATFORM_URL}/platform/staff`;
 let createdStaffName = '';
 let createdStaffEmail = '';
 
-// Modal/Drawer の Dialog ルート要素は子要素がすべて fixed 配置のため自身は 0x0 サイズになり、
-// role=dialog を直接 toBeVisible/toBeHidden で判定すると常に「非表示」扱いになる（DESIGN.md の
-// Modal/Drawer 仕様どおりの構造。ShiftFormModal と同型）。開閉判定は実サイズを持つ見出し
-// （DialogTitle）で行う。
-
 When('スタッフ管理画面を開く', async ({ page }) => {
   await page.goto(STAFF_URL, { waitUntil: 'domcontentloaded' });
   await expect(page.getByRole('button', { name: 'スタッフを追加', exact: true })).toBeVisible();

--- a/frontend/src/_pages/store-cast-fields/__tests__/CastFieldCreateModal.test.tsx
+++ b/frontend/src/_pages/store-cast-fields/__tests__/CastFieldCreateModal.test.tsx
@@ -52,3 +52,66 @@ describe('カスタムフィールド定義の新規作成モーダルは予約�
     expect(mockedApi.create.mock.calls[0][0]).toMatchObject({ key: 'constructors' });
   });
 });
+
+describe('カスタムフィールド定義の新規作成モーダルの送信ペイロード', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApi.create.mockResolvedValue({} as never);
+  });
+
+  it('閉じているときは何も描画しない', () => {
+    render(<CastFieldCreateModal open={false} onClose={jest.fn()} onCreated={jest.fn()} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('key・label・公開設定の3項目だけを送ること', async () => {
+    render(<CastFieldCreateModal open onClose={jest.fn()} onCreated={jest.fn()} />);
+
+    fireEvent.change(screen.getByLabelText('key'), { target: { value: 'blood_type' } });
+    fireEvent.change(screen.getByLabelText('label'), { target: { value: '血液型' } });
+    fireEvent.click(screen.getByRole('button', { name: '追加する' }));
+
+    await waitFor(() => expect(mockedApi.create).toHaveBeenCalledTimes(1));
+    expect(mockedApi.create.mock.calls[0][0]).toEqual({
+      key: 'blood_type',
+      label: '血液型',
+      is_public: false,
+    });
+  });
+
+  it('公開チェックは真偽値で送られること', async () => {
+    render(<CastFieldCreateModal open onClose={jest.fn()} onCreated={jest.fn()} />);
+
+    fireEvent.change(screen.getByLabelText('key'), { target: { value: 'blood_type' } });
+    fireEvent.change(screen.getByLabelText('label'), { target: { value: '血液型' } });
+    fireEvent.click(screen.getByLabelText('公開する(公開詳細ページに表示)'));
+    fireEvent.click(screen.getByRole('button', { name: '追加する' }));
+
+    await waitFor(() => expect(mockedApi.create).toHaveBeenCalledTimes(1));
+    expect(mockedApi.create.mock.calls[0][0].is_public).toBe(true);
+  });
+
+  it('作成成功で onCreated と onClose を呼ぶこと', async () => {
+    const onClose = jest.fn();
+    const onCreated = jest.fn();
+    render(<CastFieldCreateModal open onClose={onClose} onCreated={onCreated} />);
+
+    fireEvent.change(screen.getByLabelText('key'), { target: { value: 'blood_type' } });
+    fireEvent.change(screen.getByLabelText('label'), { target: { value: '血液型' } });
+    fireEvent.click(screen.getByRole('button', { name: '追加する' }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledTimes(1));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('キャンセルは作成せず閉じること', () => {
+    const onClose = jest.fn();
+    render(<CastFieldCreateModal open onClose={onClose} onCreated={jest.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockedApi.create).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/_pages/store-cast-fields/__tests__/CastFieldEditModal.test.tsx
+++ b/frontend/src/_pages/store-cast-fields/__tests__/CastFieldEditModal.test.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
+import type { CastFieldDefinitionResponse } from '@/entities/cast';
+import { castFieldDefinitionApi } from '@/entities/cast';
+import { CastFieldEditModal } from '../ui/CastFieldEditModal';
+
+jest.mock('@/entities/cast', () => ({
+  castFieldDefinitionApi: { update: jest.fn() },
+}));
+
+jest.mock('react-hot-toast', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockedApi = castFieldDefinitionApi as jest.Mocked<typeof castFieldDefinitionApi>;
+
+const definition = (
+  override: Partial<CastFieldDefinitionResponse> = {}
+): CastFieldDefinitionResponse =>
+  ({
+    id: 'def-1',
+    key: 'blood_type',
+    label: '血液型',
+    display_order: 3,
+    is_public: false,
+    ...override,
+  }) as CastFieldDefinitionResponse;
+
+describe('カスタムフィールド定義の編集モーダル', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApi.update.mockResolvedValue({} as never);
+  });
+
+  it('編集対象が null なら開いていても描画しない', () => {
+    render(
+      <CastFieldEditModal open definition={null} onClose={jest.fn()} onUpdated={jest.fn()} />
+    );
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('key は編集できず表示のみとする', () => {
+    render(
+      <CastFieldEditModal
+        open
+        definition={definition()}
+        onClose={jest.fn()}
+        onUpdated={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('blood_type')).toBeInTheDocument();
+    expect(screen.queryByLabelText('key')).not.toBeInTheDocument();
+  });
+
+  it('既存値がフォームへ初期表示される', () => {
+    render(
+      <CastFieldEditModal
+        open
+        definition={definition()}
+        onClose={jest.fn()}
+        onUpdated={jest.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('label')).toHaveValue('血液型');
+    expect(screen.getByLabelText('表示順')).toHaveValue(3);
+  });
+
+  it('表示順は数値型のまま更新 API へ送られる', async () => {
+    render(
+      <CastFieldEditModal
+        open
+        definition={definition()}
+        onClose={jest.fn()}
+        onUpdated={jest.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('表示順'), { target: { value: '12' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(mockedApi.update).toHaveBeenCalledTimes(1));
+    expect(mockedApi.update.mock.calls[0][0]).toBe('def-1');
+    const body = mockedApi.update.mock.calls[0][1];
+    expect(body).toEqual({ label: '血液型', display_order: 12, is_public: false });
+    expect(typeof body.display_order).toBe('number');
+  });
+
+  it('公開チェックは真偽値で送られる', async () => {
+    render(
+      <CastFieldEditModal
+        open
+        definition={definition()}
+        onClose={jest.fn()}
+        onUpdated={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('公開する(公開詳細ページに表示)'));
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(mockedApi.update).toHaveBeenCalledTimes(1));
+    const body = mockedApi.update.mock.calls[0][1];
+    expect(body.is_public).toBe(true);
+  });
+
+  it('label が空なら更新 API を呼ばない', async () => {
+    render(
+      <CastFieldEditModal
+        open
+        definition={definition()}
+        onClose={jest.fn()}
+        onUpdated={jest.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('label'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: '保存する' })).toBeEnabled());
+    expect(mockedApi.update).not.toHaveBeenCalled();
+  });
+
+  it('更新成功で onUpdated と onClose を呼ぶ', async () => {
+    const onClose = jest.fn();
+    const onUpdated = jest.fn();
+    render(
+      <CastFieldEditModal open definition={definition()} onClose={onClose} onUpdated={onUpdated} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(onUpdated).toHaveBeenCalledTimes(1));
+    expect(toast.success).toHaveBeenCalledWith('フィールドを更新しました');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('キャンセルは更新せず閉じる', () => {
+    const onClose = jest.fn();
+    render(
+      <CastFieldEditModal
+        open
+        definition={definition()}
+        onClose={onClose}
+        onUpdated={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockedApi.update).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/_pages/store-cast-fields/__tests__/CastFieldEditModal.test.tsx
+++ b/frontend/src/_pages/store-cast-fields/__tests__/CastFieldEditModal.test.tsx
@@ -33,9 +33,7 @@ describe('カスタムフィールド定義の編集モーダル', () => {
   });
 
   it('編集対象が null なら開いていても描画しない', () => {
-    render(
-      <CastFieldEditModal open definition={null} onClose={jest.fn()} onUpdated={jest.fn()} />
-    );
+    render(<CastFieldEditModal open definition={null} onClose={jest.fn()} onUpdated={jest.fn()} />);
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
@@ -140,12 +138,7 @@ describe('カスタムフィールド定義の編集モーダル', () => {
   it('キャンセルは更新せず閉じる', () => {
     const onClose = jest.fn();
     render(
-      <CastFieldEditModal
-        open
-        definition={definition()}
-        onClose={onClose}
-        onUpdated={jest.fn()}
-      />
+      <CastFieldEditModal open definition={definition()} onClose={onClose} onUpdated={jest.fn()} />
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));

--- a/frontend/src/_pages/store-cast-fields/__tests__/CastFieldsPage.test.tsx
+++ b/frontend/src/_pages/store-cast-fields/__tests__/CastFieldsPage.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
+import type { CastFieldDefinitionResponse } from '@/entities/cast';
+import { castFieldDefinitionApi } from '@/entities/cast';
+import CastFieldsPage from '../ui/CastFieldsPage';
+
+jest.mock('@/entities/cast', () => ({
+  castFieldDefinitionApi: {
+    list: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock('react-hot-toast', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockedApi = castFieldDefinitionApi as jest.Mocked<typeof castFieldDefinitionApi>;
+const mockedToast = toast as jest.Mocked<typeof toast>;
+
+const definitions = [
+  {
+    id: 'def-1',
+    key: 'blood_type',
+    label: '血液型',
+    display_order: 1,
+    is_public: true,
+  },
+  {
+    id: 'def-2',
+    key: 'hobby',
+    label: '趣味',
+    display_order: 2,
+    is_public: false,
+  },
+] as CastFieldDefinitionResponse[];
+
+describe('カスタムフィールド定義の管理ページ', () => {
+  const originalConfirm = window.confirm;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApi.list.mockResolvedValue(definitions);
+    mockedApi.delete.mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    window.confirm = originalConfirm;
+  });
+
+  it('一覧の key・label・公開設定・表示順を表示する', async () => {
+    render(<CastFieldsPage />);
+
+    expect(await screen.findByText('blood_type')).toBeInTheDocument();
+    expect(screen.getByText('趣味')).toBeInTheDocument();
+    expect(screen.getByText('公開')).toBeInTheDocument();
+    expect(screen.getByText('非公開')).toBeInTheDocument();
+  });
+
+  it('削除は確認ダイアログを label 付きで出し、キャンセルされたら削除 API を呼ばない', async () => {
+    window.confirm = jest.fn(() => false);
+    render(<CastFieldsPage />);
+    await screen.findByText('blood_type');
+
+    fireEvent.click(screen.getAllByRole('button', { name: '削除' })[0]);
+
+    expect(window.confirm).toHaveBeenCalledWith('「血液型」を削除しますか？');
+    expect(mockedApi.delete).not.toHaveBeenCalled();
+  });
+
+  it('削除を承諾すると対象 id を削除し一覧を再取得する', async () => {
+    window.confirm = jest.fn(() => true);
+    render(<CastFieldsPage />);
+    await screen.findByText('blood_type');
+
+    fireEvent.click(screen.getAllByRole('button', { name: '削除' })[1]);
+
+    await waitFor(() => expect(mockedApi.delete).toHaveBeenCalledWith('def-2'));
+    await waitFor(() => expect(mockedApi.list).toHaveBeenCalledTimes(2));
+    expect(mockedToast.success).toHaveBeenCalledWith('フィールドを削除しました');
+  });
+
+  it('削除ボタンのクリックは行クリックへ伝播せず編集モーダルを開かない', async () => {
+    window.confirm = jest.fn(() => false);
+    render(<CastFieldsPage />);
+    await screen.findByText('blood_type');
+
+    fireEvent.click(screen.getAllByRole('button', { name: '削除' })[0]);
+
+    expect(screen.queryByText('フィールドを編集')).not.toBeInTheDocument();
+  });
+
+  it('行クリックで対象定義の編集モーダルが開く', async () => {
+    render(<CastFieldsPage />);
+
+    fireEvent.click(await screen.findByText('hobby'));
+
+    expect(await screen.findByText('フィールドを編集')).toBeInTheDocument();
+    expect(screen.getByLabelText('label')).toHaveValue('趣味');
+  });
+
+  it('フィールドを追加ボタンで作成モーダルが開く', async () => {
+    render(<CastFieldsPage />);
+    await screen.findByText('blood_type');
+
+    fireEvent.click(screen.getByRole('button', { name: 'フィールドを追加' }));
+
+    expect(await screen.findByText('フィールドを追加', { selector: 'h2' })).toBeInTheDocument();
+  });
+
+  it('定義が0件なら未登録メッセージを表示する', async () => {
+    mockedApi.list.mockResolvedValue([]);
+    render(<CastFieldsPage />);
+
+    expect(await screen.findByText('フィールドが登録されていません')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldCreateModal.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldCreateModal.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { CastFieldDefinitionCreateRequest, castFieldDefinitionApi } from '@/entities/cast';
 import { getApiErrorMessage } from '@/shared/lib';
-import { Dialog, DialogContent, DialogTitle } from '@/shared/ui';
+import { Button, Dialog, DialogContent, DialogTitle, Input, Label } from '@/shared/ui';
 
 interface CastFieldCreateModalProps {
   open: boolean;
@@ -19,9 +19,6 @@ interface CastFieldCreateFormValues {
   label: string;
   is_public: boolean;
 }
-
-const inputClass =
-  'w-full rounded-md border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500';
 
 /** カスタムフィールド定義の新規作成モーダル(key・label・公開設定)。 */
 export function CastFieldCreateModal({ open, onClose, onCreated }: CastFieldCreateModalProps) {
@@ -63,17 +60,15 @@ export function CastFieldCreateModal({ open, onClose, onCreated }: CastFieldCrea
       <DialogContent
         showCloseButton={false}
         aria-describedby={undefined}
-        className="gap-0 rounded-[10px] border-gray-200 p-0 sm:max-w-md"
+        className="gap-0 rounded-[10px] p-0 sm:max-w-md"
       >
-        <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
+        <DialogTitle className="border-b px-6 py-4 text-lg font-semibold text-foreground">
           フィールドを追加
         </DialogTitle>
         <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
-          <div>
-            <label htmlFor="field-key" className="mb-1 block text-sm font-medium text-gray-700">
-              key
-            </label>
-            <input
+          <div className="grid gap-1">
+            <Label htmlFor="field-key">key</Label>
+            <Input
               id="field-key"
               type="text"
               {...register('key', {
@@ -83,46 +78,26 @@ export function CastFieldCreateModal({ open, onClose, onCreated }: CastFieldCrea
                 // 編集フォームの描画をクラッシュさせるため作成時に拒否する。
                 pattern: /^(?!constructor$|prototype$)[a-z][a-z0-9_]*$/,
               })}
-              className={inputClass}
             />
-            <p className="mt-1 text-xs text-gray-500">
+            <p className="text-xs text-muted-foreground">
               英小文字で始まり、英小文字・数字・アンダースコアのみ使用できます(作成後は変更できません)
             </p>
           </div>
-          <div>
-            <label htmlFor="field-label" className="mb-1 block text-sm font-medium text-gray-700">
-              label
-            </label>
-            <input
-              id="field-label"
-              type="text"
-              {...register('label', { required: true })}
-              className={inputClass}
-            />
+          <div className="grid gap-1">
+            <Label htmlFor="field-label">label</Label>
+            <Input id="field-label" type="text" {...register('label', { required: true })} />
           </div>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
-            <input
-              type="checkbox"
-              {...register('is_public')}
-              className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-            />
+          <Label className="font-normal">
+            <input type="checkbox" {...register('is_public')} />
             公開する(公開詳細ページに表示)
-          </label>
-          <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
+          </Label>
+          <div className="flex justify-end gap-3 border-t pt-4">
+            <Button type="button" variant="outline" onClick={onClose}>
               キャンセル
-            </button>
-            <button
-              type="submit"
-              disabled={isSubmitting}
-              className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
               {isSubmitting ? '追加中...' : '追加する'}
-            </button>
+            </Button>
           </div>
         </form>
       </DialogContent>

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldEditModal.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldEditModal.tsx
@@ -9,7 +9,7 @@ import {
   castFieldDefinitionApi,
 } from '@/entities/cast';
 import { getApiErrorMessage } from '@/shared/lib';
-import { Dialog, DialogContent, DialogTitle } from '@/shared/ui';
+import { Button, Dialog, DialogContent, DialogTitle, Input, Label } from '@/shared/ui';
 
 interface CastFieldEditModalProps {
   open: boolean;
@@ -25,9 +25,6 @@ interface CastFieldEditFormValues {
   display_order: number;
   is_public: boolean;
 }
-
-const inputClass =
-  'w-full rounded-md border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500';
 
 /** カスタムフィールド定義の編集モーダル(label・表示順・公開設定のみ、key は不変のため編集不可)。 */
 export function CastFieldEditModal({
@@ -79,67 +76,39 @@ export function CastFieldEditModal({
       <DialogContent
         showCloseButton={false}
         aria-describedby={undefined}
-        className="gap-0 rounded-[10px] border-gray-200 p-0 sm:max-w-md"
+        className="gap-0 rounded-[10px] p-0 sm:max-w-md"
       >
-        <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
+        <DialogTitle className="border-b px-6 py-4 text-lg font-semibold text-foreground">
           フィールドを編集
         </DialogTitle>
         <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
           <div>
-            <span className="mb-1 block text-sm font-medium text-gray-700">key</span>
-            <p className="text-sm text-gray-500">{definition?.key}</p>
+            <span className="mb-1 block text-sm font-medium text-foreground">key</span>
+            <p className="text-sm text-muted-foreground">{definition?.key}</p>
           </div>
-          <div>
-            <label
-              htmlFor="field-edit-label"
-              className="mb-1 block text-sm font-medium text-gray-700"
-            >
-              label
-            </label>
-            <input
-              id="field-edit-label"
-              type="text"
-              {...register('label', { required: true })}
-              className={inputClass}
-            />
+          <div className="grid gap-1">
+            <Label htmlFor="field-edit-label">label</Label>
+            <Input id="field-edit-label" type="text" {...register('label', { required: true })} />
           </div>
-          <div>
-            <label
-              htmlFor="field-edit-display-order"
-              className="mb-1 block text-sm font-medium text-gray-700"
-            >
-              表示順
-            </label>
-            <input
+          <div className="grid gap-1">
+            <Label htmlFor="field-edit-display-order">表示順</Label>
+            <Input
               id="field-edit-display-order"
               type="number"
               {...register('display_order', { valueAsNumber: true, required: true })}
-              className={inputClass}
             />
           </div>
-          <label className="flex items-center gap-2 text-sm text-gray-700">
-            <input
-              type="checkbox"
-              {...register('is_public')}
-              className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-            />
+          <Label className="font-normal">
+            <input type="checkbox" {...register('is_public')} />
             公開する(公開詳細ページに表示)
-          </label>
-          <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
+          </Label>
+          <div className="flex justify-end gap-3 border-t pt-4">
+            <Button type="button" variant="outline" onClick={onClose}>
               キャンセル
-            </button>
-            <button
-              type="submit"
-              disabled={isSubmitting}
-              className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
               {isSubmitting ? '保存中...' : '保存する'}
-            </button>
+            </Button>
           </div>
         </form>
       </DialogContent>

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
@@ -4,6 +4,17 @@ import { PencilSquareIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/outli
 import { useState } from 'react';
 import { CastFieldDefinitionResponse, castFieldDefinitionApi } from '@/entities/cast';
 import { useManagedList } from '@/shared/lib';
+import {
+  Badge,
+  Button,
+  Card,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/ui';
 import { toast } from 'react-hot-toast';
 import { CastFieldCreateModal } from './CastFieldCreateModal';
 import { CastFieldEditModal } from './CastFieldEditModal';
@@ -36,100 +47,95 @@ export default function CastFieldsPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">カスタムフィールド管理</h1>
-          <p className="mt-1 text-sm text-gray-500">
+          <h1 className="text-2xl font-bold text-foreground">カスタムフィールド管理</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
             キャストの追加プロフィール項目を定義します。公開設定した項目は公開詳細ページに表示されます。
           </p>
         </div>
-        <button
-          onClick={() => setCreateOpen(true)}
-          className="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-        >
-          <PlusIcon className="h-5 w-5" />
+        <Button onClick={() => setCreateOpen(true)}>
+          <PlusIcon />
           フィールドを追加
-        </button>
+        </Button>
       </div>
 
-      <div className="overflow-hidden rounded-[10px] border border-gray-200 bg-white shadow-sm">
+      <Card className="overflow-hidden py-0">
         {isLoading ? (
-          <div className="p-8 text-center text-gray-500">読み込み中...</div>
+          <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
         ) : definitions.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">フィールドが登録されていません</div>
+          <div className="p-8 text-center text-muted-foreground">
+            フィールドが登録されていません
+          </div>
         ) : (
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  key
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  label
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  公開設定
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  表示順
-                </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  アクション
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>key</TableHead>
+                <TableHead>label</TableHead>
+                <TableHead>公開設定</TableHead>
+                <TableHead>表示順</TableHead>
+                <TableHead className="text-right">アクション</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
               {definitions.map(definition => (
-                <tr
+                <TableRow
                   key={definition.id}
-                  className="cursor-pointer hover:bg-gray-50"
+                  className="cursor-pointer"
                   onClick={() => setEditing(definition)}
                 >
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                    {definition.key}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {definition.label}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <span
-                      className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                        definition.is_public
-                          ? 'bg-green-100 text-green-800'
-                          : 'bg-gray-100 text-gray-800'
-                      }`}
-                    >
-                      {definition.is_public ? '公開' : '非公開'}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <TableCell className="font-medium text-foreground">{definition.key}</TableCell>
+                  <TableCell className="text-muted-foreground">{definition.label}</TableCell>
+                  <TableCell>
+                    {definition.is_public ? (
+                      <Badge
+                        variant="outline"
+                        className="border-transparent bg-success/10 text-success-strong"
+                      >
+                        公開
+                      </Badge>
+                    ) : (
+                      <Badge
+                        variant="outline"
+                        className="border-transparent bg-muted text-foreground"
+                      >
+                        非公開
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
                     {definition.display_order}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-3">
-                    <button
-                      onClick={e => {
-                        e.stopPropagation();
-                        setEditing(definition);
-                      }}
-                      className="text-gray-400 hover:text-amber-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
-                    >
-                      <PencilSquareIcon className="h-5 w-5" />
-                    </button>
-                    <button
-                      onClick={e => {
-                        e.stopPropagation();
-                        void handleDelete(definition.id, definition.label);
-                      }}
-                      aria-label="削除"
-                      className="text-gray-400 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
-                    >
-                      <TrashIcon className="h-5 w-5" />
-                    </button>
-                  </td>
-                </tr>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={e => {
+                          e.stopPropagation();
+                          setEditing(definition);
+                        }}
+                      >
+                        <PencilSquareIcon />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={e => {
+                          e.stopPropagation();
+                          void handleDelete(definition.id, definition.label);
+                        }}
+                        aria-label="削除"
+                      >
+                        <TrashIcon />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
               ))}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         )}
-      </div>
+      </Card>
 
       <CastFieldCreateModal
         open={createOpen}

--- a/frontend/src/_pages/store-dashboard/ui/DashboardPage.tsx
+++ b/frontend/src/_pages/store-dashboard/ui/DashboardPage.tsx
@@ -1,22 +1,32 @@
 'use client';
 
+import { Card, CardDescription, CardHeader, CardTitle } from '@/shared/ui';
+
 export default function StoreDashboard() {
   return (
-    <div className="min-h-screen bg-white flex flex-col items-center justify-center">
-      <div className="max-w-2xl w-full px-6 py-10 rounded-lg shadow-lg bg-gray-50">
-        <h1 className="text-3xl font-bold text-indigo-700 mb-4 text-center">店舗ダッシュボード</h1>
-        <p className="text-lg text-gray-700 text-center mb-6">ようこそ、someone さん！</p>
+    <div className="min-h-screen bg-background flex flex-col items-center justify-center">
+      <div className="max-w-2xl w-full px-6 py-10 rounded-lg shadow-lg bg-card">
+        <h1 className="text-3xl font-bold text-foreground mb-4 text-center">店舗ダッシュボード</h1>
+        <p className="text-lg text-foreground text-center mb-6">ようこそ、someone さん！</p>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="bg-white rounded-lg shadow p-6">
-            <h2 className="text-xl font-semibold text-indigo-600 mb-2">コンテンツ管理</h2>
-            <p className="text-gray-600 text-sm">記事やページの作成・編集・公開ができます。</p>
-          </div>
-          <div className="bg-white rounded-lg shadow p-6">
-            <h2 className="text-xl font-semibold text-indigo-600 mb-2">ユーザー管理</h2>
-            <p className="text-gray-600 text-sm">店舗内のユーザーの追加・権限設定ができます。</p>
-          </div>
+          <Card>
+            <CardHeader>
+              <CardTitle role="heading" aria-level={2} className="text-xl">
+                コンテンツ管理
+              </CardTitle>
+              <CardDescription>記事やページの作成・編集・公開ができます。</CardDescription>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle role="heading" aria-level={2} className="text-xl">
+                ユーザー管理
+              </CardTitle>
+              <CardDescription>店舗内のユーザーの追加・権限設定ができます。</CardDescription>
+            </CardHeader>
+          </Card>
         </div>
-        <div className="mt-8 text-center text-gray-400 text-xs">Powered by Kizuna</div>
+        <div className="mt-8 text-center text-muted-foreground text-xs">Powered by Kizuna</div>
       </div>
     </div>
   );

--- a/frontend/src/_pages/store-orders/__tests__/OrderFormPayload.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrderFormPayload.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { OrderForm, OrderFormData } from '../ui/OrderForm';
+import { castApi } from '@/entities/cast';
 import { orderApi } from '@/entities/order';
 
 jest.mock('@/entities/order', () => ({
@@ -128,5 +129,70 @@ describe('オーダーフォームのセレクト配線と送信ペイロード'
     const body = await submitAndGetBody(onSubmit);
 
     expect(body.discountName).toBe('');
+  });
+});
+
+describe('オーダーフォームのキャスト候補リストの選択配線', () => {
+  const mockedCastApi = castApi as jest.Mocked<typeof castApi>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockedOrderApi.listReceptionists.mockResolvedValue([]);
+    mockedCastApi.list.mockResolvedValue({
+      content: [{ id: 'cast-1', name: '花子' }],
+      total_pages: 1,
+      total_elements: 1,
+      size: 10,
+      number: 0,
+    } as never);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  /** 入力→デバウンス経過→候補描画までを進める。 */
+  const openSuggestions = async () => {
+    fireEvent.change(screen.getByRole('combobox', { name: 'キャスト' }), {
+      target: { value: '花' },
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+  };
+
+  it('候補を選ぶと castId がその id で送られること', async () => {
+    const onSubmit = jest.fn<void, [OrderFormData]>();
+    render(<OrderForm onSubmit={onSubmit} isSubmitting={false} />);
+
+    await openSuggestions();
+    fireEvent.click(screen.getByRole('option', { name: /花子/ }));
+
+    expect(screen.getByRole('combobox', { name: 'キャスト' })).toHaveValue('花子');
+    fireEvent.click(screen.getByRole('button', { name: '登録する' }));
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0].castId).toBe('cast-1');
+  });
+
+  it('候補選択後に名前を打ち直すと castId は空へ戻ること', async () => {
+    const onSubmit = jest.fn<void, [OrderFormData]>();
+    render(<OrderForm onSubmit={onSubmit} isSubmitting={false} />);
+
+    await openSuggestions();
+    fireEvent.click(screen.getByRole('option', { name: /花子/ }));
+    fireEvent.change(screen.getByRole('combobox', { name: 'キャスト' }), {
+      target: { value: '別の人' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '登録する' }));
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0].castId).toBe('');
   });
 });

--- a/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
@@ -61,6 +61,82 @@ describe('店側オーダー画面と API JSON（snake_case）の整合', () => 
     expect(screen.getByText('60 分')).toBeInTheDocument();
   });
 
+  it('一覧の遷移リンクは店舗スコープのパスを指すこと', async () => {
+    mockedOrderApi.list.mockResolvedValue({
+      content: [
+        {
+          id: '7',
+          business_date: '2026-07-03',
+          customer_name: '山田太郎',
+          cast_name: '花子',
+          course_minutes: 60,
+          extension_minutes: 0,
+          option_codes: [],
+          manual_discount: 0,
+          used_points: 0,
+          manual_grant_points: 0,
+          status: 'CREATED',
+        },
+      ],
+      total_pages: 1,
+      total_elements: 1,
+      size: 100,
+      number: 0,
+    } as never);
+
+    render(<OrderListPage />);
+    await screen.findByText('2026-07-03');
+
+    expect(screen.getByRole('link', { name: /新規オーダー登録/ })).toHaveAttribute(
+      'href',
+      '/store/1/orders/create'
+    );
+    const links = screen.getAllByRole('link');
+    expect(links.map(link => link.getAttribute('href'))).toContain('/store/1/orders/7/edit');
+  });
+
+  it('キャスト未指名はフリー表記になること', async () => {
+    mockedOrderApi.list.mockResolvedValue({
+      content: [
+        {
+          id: '8',
+          business_date: '2026-07-04',
+          customer_name: '鈴木花子',
+          cast_name: null,
+          course_minutes: 90,
+          extension_minutes: 0,
+          option_codes: [],
+          manual_discount: 0,
+          used_points: 0,
+          manual_grant_points: 0,
+          status: 'CREATED',
+        },
+      ],
+      total_pages: 1,
+      total_elements: 1,
+      size: 100,
+      number: 0,
+    } as never);
+
+    render(<OrderListPage />);
+
+    expect(await screen.findByText('フリー')).toBeInTheDocument();
+  });
+
+  it('オーダーが0件なら不在メッセージを表示すること', async () => {
+    mockedOrderApi.list.mockResolvedValue({
+      content: [],
+      total_pages: 0,
+      total_elements: 0,
+      size: 100,
+      number: 0,
+    } as never);
+
+    render(<OrderListPage />);
+
+    expect(await screen.findByText('オーダーがありません')).toBeInTheDocument();
+  });
+
   it('新規登録はバックエンドの DTO に合わせ snake_case キーで POST すること', async () => {
     mockedOrderApi.create.mockResolvedValue({} as never);
 

--- a/frontend/src/_pages/store-orders/ui/OrderCreatePage.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderCreatePage.tsx
@@ -62,8 +62,8 @@ export default function CreateOrderPage() {
   return (
     <div className="max-w-4xl mx-auto">
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">新規オーダー登録</h1>
-        <p className="text-sm text-gray-500 mt-1">新しい注文情報を入力してください。</p>
+        <h1 className="text-2xl font-bold text-foreground">新規オーダー登録</h1>
+        <p className="text-sm text-muted-foreground mt-1">新しい注文情報を入力してください。</p>
       </div>
 
       <OrderForm onSubmit={handleSubmit} isSubmitting={isSubmitting} />

--- a/frontend/src/_pages/store-orders/ui/OrderEditPage.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderEditPage.tsx
@@ -37,8 +37,10 @@ export default function EditOrderPage() {
   return (
     <div className="max-w-4xl mx-auto">
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">オーダー編集</h1>
-        <p className="text-sm text-gray-500 mt-1">オーダー ID: {params.id} の情報を編集します。</p>
+        <h1 className="text-2xl font-bold text-foreground">オーダー編集</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          オーダー ID: {params.id} の情報を編集します。
+        </p>
       </div>
 
       <OrderForm

--- a/frontend/src/_pages/store-orders/ui/OrderForm.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderForm.tsx
@@ -343,7 +343,7 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
                             <button
                               type="button"
                               onClick={() => handleCastSelect(cast)}
-                              className="flex w-full items-center justify-between px-4 py-2 text-left text-sm text-foreground hover:bg-blue-50"
+                              className="flex w-full items-center justify-between px-4 py-2 text-left text-sm text-foreground hover:bg-primary/10"
                               role="option"
                             >
                               <span className="font-medium">{cast.name}</span>

--- a/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
@@ -5,6 +5,17 @@ import { useParams } from 'next/navigation';
 import { PlusIcon, PencilSquareIcon } from '@heroicons/react/24/outline';
 import { Order, orderApi } from '@/entities/order';
 import { storePath, useManagedList } from '@/shared/lib';
+import {
+  Badge,
+  Button,
+  Card,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/ui';
 
 export default function OrderListPage() {
   const params = useParams();
@@ -18,90 +29,76 @@ export default function OrderListPage() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">オーダー一覧</h1>
-          <p className="text-sm text-gray-500 mt-1">当日の注文状況を確認・管理できます。</p>
+          <h1 className="text-2xl font-bold text-foreground">オーダー一覧</h1>
+          <p className="text-sm text-muted-foreground mt-1">当日の注文状況を確認・管理できます。</p>
         </div>
-        <Link
-          href={storePath(storeId, '/orders/create')}
-          className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
-        >
-          <PlusIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
-          新規オーダー登録
-        </Link>
+        <Button asChild>
+          <Link href={storePath(storeId, '/orders/create')}>
+            <PlusIcon aria-hidden="true" />
+            新規オーダー登録
+          </Link>
+        </Button>
       </div>
 
       {/* Orders Table */}
-      <div className="bg-white shadow-sm border border-gray-200 rounded-lg overflow-hidden">
+      <Card className="overflow-hidden py-0">
         {isLoading ? (
-          <div className="p-8 text-center text-gray-500">読み込み中...</div>
+          <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
         ) : orders.length === 0 ? (
-          <div className="p-8 text-center text-gray-500">オーダーがありません</div>
+          <div className="p-8 text-center text-muted-foreground">オーダーがありません</div>
         ) : (
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  営業日
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  お客様名
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  女の子名
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  コース
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  ステータス
-                </th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  アクション
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>営業日</TableHead>
+                <TableHead>お客様名</TableHead>
+                <TableHead>女の子名</TableHead>
+                <TableHead>コース</TableHead>
+                <TableHead>ステータス</TableHead>
+                <TableHead className="text-right">アクション</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
               {orders.map(order => (
-                <tr key={order.id} className="hover:bg-gray-50 transition-colors">
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm text-gray-500">{order.business_date}</div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm text-gray-900">{order.customer_name || '-'}</div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <span
-                      className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
+                <TableRow key={order.id}>
+                  <TableCell className="text-muted-foreground">{order.business_date}</TableCell>
+                  <TableCell className="text-foreground">{order.customer_name || '-'}</TableCell>
+                  <TableCell>
+                    <Badge
+                      variant="outline"
+                      className={
                         !order.cast_name || order.cast_name === 'フリー'
-                          ? 'bg-gray-100 text-gray-800'
-                          : 'bg-pink-100 text-pink-800'
-                      }`}
+                          ? 'border-transparent bg-muted text-foreground'
+                          : 'border-transparent bg-chart-5/10 text-foreground'
+                      }
                     >
                       {order.cast_name || 'フリー'}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {order.course_minutes} 分
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-                      {order.status}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-3">
-                    <Link
-                      href={storePath(storeId, `/orders/${order.id}/edit`)}
-                      className="text-gray-400 hover:text-amber-600 inline-block"
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{order.course_minutes} 分</TableCell>
+                  <TableCell>
+                    <Badge
+                      variant="outline"
+                      className="border-transparent bg-success/10 text-success-strong"
                     >
-                      <PencilSquareIcon className="h-5 w-5" />
-                    </Link>
-                  </td>
-                </tr>
+                      {order.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-1">
+                      <Button asChild variant="ghost" size="icon-sm">
+                        <Link href={storePath(storeId, `/orders/${order.id}/edit`)}>
+                          <PencilSquareIcon />
+                        </Link>
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
               ))}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         )}
-      </div>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/_pages/store-select/ui/StoreSelectPage.tsx
+++ b/frontend/src/_pages/store-select/ui/StoreSelectPage.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { BuildingStorefrontIcon } from '@heroicons/react/24/outline';
 import { useStoreContext } from '@/entities/user';
 import { replaceStoreIdInPath, setPlatformStore } from '@/shared/lib';
+import { Button, Card } from '@/shared/ui';
 
 /** クエリ next（店舗スコープの遷移先テンプレート）を読む。無ければダッシュボード。 */
 function resolveNext(): string {
@@ -41,35 +42,36 @@ export default function StoreSelectPage() {
   if (stores === null || stores.length === 1) {
     return (
       <div className="mx-auto max-w-md">
-        <p className="text-sm text-gray-500">読み込み中...</p>
+        <p className="text-sm text-muted-foreground">読み込み中...</p>
       </div>
     );
   }
 
   return (
     <div className="mx-auto max-w-md">
-      <div className="rounded-[10px] border border-gray-200 bg-white p-6 shadow-sm">
-        <h1 className="text-2xl font-bold text-gray-900">店舗を選択</h1>
+      <Card className="gap-0 p-6">
+        <h1 className="text-2xl font-bold text-foreground">店舗を選択</h1>
         {stores.length === 0 ? (
-          <p className="mt-4 text-sm text-gray-600">アクセス可能な店舗がありません</p>
+          <p className="mt-4 text-sm text-muted-foreground">アクセス可能な店舗がありません</p>
         ) : (
           <>
-            <p className="mt-1 text-sm text-gray-500">業務を行う店舗を選んでください。</p>
+            <p className="mt-1 text-sm text-muted-foreground">業務を行う店舗を選んでください。</p>
             <div className="mt-6 space-y-2">
               {stores.map(store => (
-                <button
+                <Button
                   key={store.id}
+                  variant="outline"
                   onClick={() => goTo(store.id)}
-                  className="flex w-full items-center gap-3 rounded-[10px] border border-gray-200 px-4 py-3 text-left text-sm font-medium text-gray-900 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50"
+                  className="h-auto w-full justify-start gap-3 px-4 py-3 text-left"
                 >
-                  <BuildingStorefrontIcon className="h-5 w-5 text-gray-400" />
+                  <BuildingStorefrontIcon className="size-5 text-muted-foreground" />
                   {store.name}
-                </button>
+                </Button>
               ))}
             </div>
           </>
         )}
-      </div>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/app/platform/(console)/layout.tsx
+++ b/frontend/src/app/platform/(console)/layout.tsx
@@ -7,7 +7,7 @@ import { Header } from '@/widgets/header';
 export default function PlatformLayout({ children }: { children: React.ReactNode }) {
   return (
     <StoreContextProvider>
-      <div className="flex h-screen bg-gray-50 overflow-hidden">
+      <div className="flex h-screen bg-background overflow-hidden">
         {/* Sidebar Component */}
         <Sidebar />
 

--- a/frontend/src/app/store/layout.tsx
+++ b/frontend/src/app/store/layout.tsx
@@ -7,7 +7,7 @@ import { Header } from '@/widgets/header';
 export default function StoreLayout({ children }: { children: React.ReactNode }) {
   return (
     <StoreContextProvider>
-      <div className="flex h-screen bg-gray-50 overflow-hidden">
+      <div className="flex h-screen bg-background overflow-hidden">
         {/* Sidebar Component */}
         <Sidebar />
 

--- a/frontend/src/features/cast-invitation/ui/InvitationButton.tsx
+++ b/frontend/src/features/cast-invitation/ui/InvitationButton.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { CastInvitationStatus, castApi } from '@/entities/cast';
 import { getApiErrorMessage } from '@/shared/lib';
+import { Button } from '@/shared/ui';
 
 export interface IssuedInvitation {
   token: string;
@@ -40,13 +41,15 @@ export function InvitationButton({ castId, status, onIssued }: InvitationButtonP
   };
 
   return (
-    <button
+    <Button
       type="button"
+      variant="ghost"
+      size="sm"
       onClick={handleIssue}
       disabled={issuing}
-      className="rounded text-blue-600 hover:text-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      className="text-primary-strong"
     >
       {status === 'INVITED' ? '再発行' : '招待を発行'}
-    </button>
+    </Button>
   );
 }

--- a/frontend/src/features/cast-invitation/ui/InvitationModal.tsx
+++ b/frontend/src/features/cast-invitation/ui/InvitationModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { toast } from 'react-hot-toast';
-import { Dialog, DialogContent, DialogTitle } from '@/shared/ui';
+import { Button, Dialog, DialogContent, DialogTitle, Input, Label } from '@/shared/ui';
 
 interface InvitationModalProps {
   open: boolean;
@@ -33,50 +33,37 @@ export function InvitationModal({ open, link, expiresAt, onClose }: InvitationMo
       <DialogContent
         showCloseButton={false}
         aria-describedby={undefined}
-        className="gap-0 rounded-[10px] border-gray-200 p-0 sm:max-w-md"
+        className="gap-0 rounded-[10px] p-0 sm:max-w-md"
       >
-        <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
+        <DialogTitle className="border-b px-6 py-4 text-lg font-semibold text-foreground">
           招待リンクを発行しました
         </DialogTitle>
         <div className="space-y-4 px-6 py-5">
-          <div>
-            <label
-              htmlFor="cast-invitation-link"
-              className="mb-1 block text-sm font-medium text-gray-700"
-            >
-              招待リンク
-            </label>
-            <input
+          <div className="grid gap-1">
+            <Label htmlFor="cast-invitation-link">招待リンク</Label>
+            <Input
               id="cast-invitation-link"
               type="text"
               readOnly
               value={link}
-              className="w-full rounded-md border-gray-300 bg-gray-50 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500"
+              className="bg-muted"
             />
           </div>
           {expiresAt && (
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-muted-foreground">
               有効期限: {new Date(expiresAt).toLocaleString('ja-JP')}
             </p>
           )}
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-muted-foreground">
             既に他店舗のキャストとして登録済みの場合、既存アカウントでログインして受諾すると本店舗の権限が追加されます。
           </p>
-          <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
+          <div className="flex justify-end gap-3 border-t pt-4">
+            <Button type="button" variant="outline" onClick={onClose}>
               閉じる
-            </button>
-            <button
-              type="button"
-              onClick={handleCopy}
-              className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
+            </Button>
+            <Button type="button" onClick={handleCopy}>
               コピー
-            </button>
+            </Button>
           </div>
         </div>
       </DialogContent>

--- a/frontend/src/features/cast-invitation/ui/__tests__/InvitationButton.test.tsx
+++ b/frontend/src/features/cast-invitation/ui/__tests__/InvitationButton.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
+import { castApi } from '@/entities/cast';
+import { InvitationButton } from '../InvitationButton';
+
+jest.mock('@/entities/cast', () => ({
+  castApi: { issueInvitation: jest.fn() },
+}));
+
+jest.mock('react-hot-toast', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockedCastApi = castApi as jest.Mocked<typeof castApi>;
+const mockedToast = toast as jest.Mocked<typeof toast>;
+
+describe('キャスト招待の行内発行ボタン', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCastApi.issueInvitation.mockResolvedValue({
+      token: 'tok-1',
+      expires_at: '2026-07-31T15:00:00Z',
+    } as never);
+  });
+
+  it('連携済みなら何も描画しない', () => {
+    const { container } = render(
+      <InvitationButton castId="c1" status="LINKED" onIssued={jest.fn()} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('未招待は「招待を発行」、招待中は「再発行」と表示する', () => {
+    const { rerender } = render(
+      <InvitationButton castId="c1" status="NOT_INVITED" onIssued={jest.fn()} />
+    );
+
+    expect(screen.getByRole('button', { name: '招待を発行' })).toBeInTheDocument();
+
+    rerender(<InvitationButton castId="c1" status="INVITED" onIssued={jest.fn()} />);
+
+    expect(screen.getByRole('button', { name: '再発行' })).toBeInTheDocument();
+  });
+
+  it('発行成功で token と有効期限を親へ渡す', async () => {
+    const onIssued = jest.fn();
+    render(<InvitationButton castId="c1" status="NOT_INVITED" onIssued={onIssued} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '招待を発行' }));
+
+    await waitFor(() => expect(mockedCastApi.issueInvitation).toHaveBeenCalledWith('c1'));
+    expect(onIssued).toHaveBeenCalledWith({
+      token: 'tok-1',
+      expiresAt: '2026-07-31T15:00:00Z',
+    });
+  });
+
+  it('発行失敗は親へ通知せず失敗トーストを出す', async () => {
+    mockedCastApi.issueInvitation.mockRejectedValue(new Error('boom'));
+    const onIssued = jest.fn();
+    render(<InvitationButton castId="c1" status="NOT_INVITED" onIssued={onIssued} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '招待を発行' }));
+
+    await waitFor(() => expect(mockedToast.error).toHaveBeenCalledWith('招待の発行に失敗しました'));
+    expect(onIssued).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/cast-invitation/ui/__tests__/InvitationModal.test.tsx
+++ b/frontend/src/features/cast-invitation/ui/__tests__/InvitationModal.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
+import { InvitationModal } from '../InvitationModal';
+
+jest.mock('react-hot-toast', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockedToast = toast as jest.Mocked<typeof toast>;
+const writeText = jest.fn();
+
+const LINK = 'https://store.example.com/cast/invite/abc';
+
+describe('キャスト招待リンクのモーダル', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  it('閉じているときは何も描画しない', () => {
+    render(<InvitationModal open={false} link={LINK} expiresAt={null} onClose={jest.fn()} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('招待リンクは読み取り専用の入力欄へそのまま表示する', () => {
+    render(<InvitationModal open link={LINK} expiresAt={null} onClose={jest.fn()} />);
+
+    const input = screen.getByLabelText('招待リンク') as HTMLInputElement;
+    expect(input.value).toBe(LINK);
+    expect(input).toHaveAttribute('readonly');
+  });
+
+  it('コピーはクリップボードへ招待リンクを書き込む', async () => {
+    render(<InvitationModal open link={LINK} expiresAt={null} onClose={jest.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'コピー' }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(LINK));
+    expect(mockedToast.success).toHaveBeenCalledWith('リンクをコピーしました');
+  });
+
+  it('コピー失敗は失敗トーストを出す', async () => {
+    writeText.mockRejectedValue(new Error('denied'));
+    render(<InvitationModal open link={LINK} expiresAt={null} onClose={jest.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'コピー' }));
+
+    await waitFor(() =>
+      expect(mockedToast.error).toHaveBeenCalledWith('リンクのコピーに失敗しました')
+    );
+  });
+
+  it('有効期限があれば日本語ロケールで表示し、無ければ表示しない', () => {
+    const { rerender } = render(
+      <InvitationModal open link={LINK} expiresAt="2026-07-31T15:00:00Z" onClose={jest.fn()} />
+    );
+
+    expect(screen.getByText(/有効期限:/)).toBeInTheDocument();
+
+    rerender(<InvitationModal open link={LINK} expiresAt={null} onClose={jest.fn()} />);
+
+    expect(screen.queryByText(/有効期限:/)).not.toBeInTheDocument();
+  });
+
+  it('閉じるは onClose を呼ぶ', () => {
+    const onClose = jest.fn();
+    render(<InvitationModal open link={LINK} expiresAt={null} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/staff-management/ui/BundlePicker.tsx
+++ b/frontend/src/features/staff-management/ui/BundlePicker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { CapabilityBundleResponse } from '@/entities/user';
+import { Label } from '@/shared/ui';
 
 interface BundlePickerProps {
   bundles: CapabilityBundleResponse[];
@@ -22,25 +23,26 @@ export function BundlePicker({ bundles, isLoading, bundleIds, onChange }: Bundle
 
   return (
     <div>
-      <span className="mb-1 block text-sm font-medium text-gray-700">権限束</span>
-      <div className="space-y-1 rounded-md border border-gray-200 p-3">
+      <span className="mb-1 block text-sm font-medium text-foreground">権限束</span>
+      <div className="space-y-1 rounded-md border p-3">
         {isLoading ? (
-          <p className="text-sm text-gray-500">読み込み中...</p>
+          <p className="text-sm text-muted-foreground">読み込み中...</p>
         ) : (
           bundles.map(bundle => (
-            <label key={bundle.id} className="flex items-center gap-2 text-sm text-gray-700">
+            <Label key={bundle.id} className="font-normal">
               <input
                 type="checkbox"
                 checked={bundleIds.includes(bundle.id)}
                 onChange={() => toggle(bundle.id)}
-                className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
               />
               {bundle.name}
-            </label>
+            </Label>
           ))
         )}
       </div>
-      <p className="mt-1 text-xs text-gray-500">1 つ以上を選択してください（兼務は複数選択）。</p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        1 つ以上を選択してください（兼務は複数選択）。
+      </p>
     </div>
   );
 }

--- a/frontend/src/features/staff-management/ui/SettlementScopePicker.tsx
+++ b/frontend/src/features/staff-management/ui/SettlementScopePicker.tsx
@@ -2,6 +2,7 @@
 
 import { PlatformStore, PlatformStoreScopeType, platformAuthApi } from '@/entities/user';
 import { useManagedList } from '@/shared/lib';
+import { Label } from '@/shared/ui';
 
 interface SettlementScopePickerProps {
   scopeType: PlatformStoreScopeType | null;
@@ -32,53 +33,49 @@ export function SettlementScopePicker({
 
   return (
     <div>
-      <span className="mb-1 block text-sm font-medium text-gray-700">精算範囲（任意）</span>
+      <span className="mb-1 block text-sm font-medium text-foreground">精算範囲（任意）</span>
       <div className="space-y-2">
-        <label className="flex items-center gap-2 text-sm text-gray-700">
+        <Label className="font-normal">
           <input
             type="radio"
             name="settlement-scope-type"
             checked={scopeType === null}
             onChange={() => onChange({ scopeType: null, storeIds: [] })}
-            className="border-gray-300 text-blue-600 focus:ring-blue-500"
           />
           なし
-        </label>
-        <label className="flex items-center gap-2 text-sm text-gray-700">
+        </Label>
+        <Label className="font-normal">
           <input
             type="radio"
             name="settlement-scope-type"
             checked={scopeType === 'ALL_STORES'}
             onChange={() => onChange({ scopeType: 'ALL_STORES', storeIds: [] })}
-            className="border-gray-300 text-blue-600 focus:ring-blue-500"
           />
           全店舗
-        </label>
-        <label className="flex items-center gap-2 text-sm text-gray-700">
+        </Label>
+        <Label className="font-normal">
           <input
             type="radio"
             name="settlement-scope-type"
             checked={scopeType === 'SPECIFIC_STORES'}
             onChange={() => onChange({ scopeType: 'SPECIFIC_STORES', storeIds })}
-            className="border-gray-300 text-blue-600 focus:ring-blue-500"
           />
           指定店舗
-        </label>
+        </Label>
         {scopeType === 'SPECIFIC_STORES' && (
-          <div className="ml-6 space-y-1 rounded-md border border-gray-200 p-3">
+          <div className="ml-6 space-y-1 rounded-md border p-3">
             {isLoading ? (
-              <p className="text-sm text-gray-500">読み込み中...</p>
+              <p className="text-sm text-muted-foreground">読み込み中...</p>
             ) : (
               stores.map(store => (
-                <label key={store.id} className="flex items-center gap-2 text-sm text-gray-700">
+                <Label key={store.id} className="font-normal">
                   <input
                     type="checkbox"
                     checked={storeIds.includes(store.id)}
                     onChange={() => toggleStore(store.id)}
-                    className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                   />
                   {store.name}
-                </label>
+                </Label>
               ))
             )}
           </div>

--- a/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
+++ b/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
@@ -9,7 +9,7 @@ import {
   platformStaffApi,
 } from '@/entities/user';
 import { getApiErrorMessage, useManagedList } from '@/shared/lib';
-import { Dialog, DialogContent, DialogTitle } from '@/shared/ui';
+import { Button, Dialog, DialogContent, DialogTitle, Input, Label } from '@/shared/ui';
 import { BundlePicker } from './BundlePicker';
 import { SettlementScopePicker } from './SettlementScopePicker';
 import { StoreSetPicker } from './StoreSetPicker';
@@ -26,9 +26,6 @@ interface StaffCreateFormValues {
   password: string;
   display_name: string;
 }
-
-const inputClass =
-  'w-full rounded-md border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500';
 
 /** スタッフの新規作成モーダル（メール・初期パスワード・氏名・権限束・担当店舗・任意の精算範囲）。 */
 export function StaffCreateModal({ open, onClose, onCreated }: StaffCreateModalProps) {
@@ -92,49 +89,30 @@ export function StaffCreateModal({ open, onClose, onCreated }: StaffCreateModalP
       <DialogContent
         showCloseButton={false}
         aria-describedby={undefined}
-        className="max-h-[calc(100vh-2rem)] gap-0 overflow-y-auto rounded-[10px] border-gray-200 p-0 sm:max-w-md"
+        className="max-h-[calc(100vh-2rem)] gap-0 overflow-y-auto rounded-[10px] p-0 sm:max-w-md"
       >
-        <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
+        <DialogTitle className="border-b px-6 py-4 text-lg font-semibold text-foreground">
           スタッフを追加
         </DialogTitle>
         <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
-          <div>
-            <label htmlFor="staff-email" className="mb-1 block text-sm font-medium text-gray-700">
-              メールアドレス
-            </label>
-            <input
-              id="staff-email"
-              type="email"
-              {...register('email', { required: true })}
-              className={inputClass}
-            />
+          <div className="grid gap-1">
+            <Label htmlFor="staff-email">メールアドレス</Label>
+            <Input id="staff-email" type="email" {...register('email', { required: true })} />
           </div>
-          <div>
-            <label
-              htmlFor="staff-password"
-              className="mb-1 block text-sm font-medium text-gray-700"
-            >
-              初期パスワード
-            </label>
-            <input
+          <div className="grid gap-1">
+            <Label htmlFor="staff-password">初期パスワード</Label>
+            <Input
               id="staff-password"
               type="password"
               {...register('password', { required: true })}
-              className={inputClass}
             />
           </div>
-          <div>
-            <label
-              htmlFor="staff-display-name"
-              className="mb-1 block text-sm font-medium text-gray-700"
-            >
-              氏名
-            </label>
-            <input
+          <div className="grid gap-1">
+            <Label htmlFor="staff-display-name">氏名</Label>
+            <Input
               id="staff-display-name"
               type="text"
               {...register('display_name', { required: true })}
-              className={inputClass}
             />
           </div>
           <BundlePicker
@@ -159,21 +137,13 @@ export function StaffCreateModal({ open, onClose, onCreated }: StaffCreateModalP
               setSettlementStoreIds(next.storeIds);
             }}
           />
-          <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
+          <div className="flex justify-end gap-3 border-t pt-4">
+            <Button type="button" variant="outline" onClick={onClose}>
               キャンセル
-            </button>
-            <button
-              type="submit"
-              disabled={isSubmitting}
-              className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
               {isSubmitting ? '追加中...' : '追加する'}
-            </button>
+            </Button>
           </div>
         </form>
       </DialogContent>

--- a/frontend/src/features/staff-management/ui/StaffEditDrawer.tsx
+++ b/frontend/src/features/staff-management/ui/StaffEditDrawer.tsx
@@ -12,7 +12,7 @@ import {
   platformStaffApi,
 } from '@/entities/user';
 import { getApiErrorMessage, useManagedList } from '@/shared/lib';
-import { Dialog, DialogContent, DialogTitle } from '@/shared/ui';
+import { Button, Label, Sheet, SheetContent, SheetTitle } from '@/shared/ui';
 import { bundleSetLabel } from '../lib/bundleSetLabel';
 import { storeSetLabel } from '../lib/storeSetLabel';
 import { BundlePicker } from './BundlePicker';
@@ -116,20 +116,21 @@ export function StaffEditDrawer({ open, onClose, staff, onUpdated }: StaffEditDr
   };
 
   return (
-    <Dialog
+    <Sheet
       open={open && staff !== null}
       onOpenChange={next => {
         if (!next) onClose();
       }}
     >
-      <DialogContent
+      <SheetContent
+        side="right"
         showCloseButton={false}
         aria-describedby={undefined}
-        className="inset-y-0 top-0 right-0 left-auto flex h-full max-w-md translate-x-0 translate-y-0 flex-col gap-0 overflow-y-auto rounded-none border-y-0 border-r-0 border-l border-gray-200 p-0 sm:max-w-md"
+        className="w-full gap-0 overflow-y-auto p-0 sm:max-w-md"
       >
-        <DialogTitle className="border-b border-gray-200 px-6 py-4 text-lg font-semibold text-gray-900">
+        <SheetTitle className="border-b px-6 py-4 text-lg">
           {staff?.display_name} の権限を編集
-        </DialogTitle>
+        </SheetTitle>
         <div className="flex-1 space-y-4 px-6 py-5">
           <BundlePicker
             bundles={bundles}
@@ -154,46 +155,44 @@ export function StaffEditDrawer({ open, onClose, staff, onUpdated }: StaffEditDr
             }}
           />
           <div>
-            <span className="mb-1 block text-sm font-medium text-gray-700">状態</span>
+            <span className="mb-1 block text-sm font-medium text-foreground">状態</span>
             <div className="flex items-center gap-4">
-              <label className="flex items-center gap-2 text-sm text-gray-700">
+              <Label className="font-normal">
                 <input
                   type="radio"
                   name="staff-enabled"
                   checked={enabled}
                   onChange={() => setEnabled(true)}
-                  className="border-gray-300 text-blue-600 focus:ring-blue-500"
                 />
                 有効
-              </label>
-              <label className="flex items-center gap-2 text-sm text-gray-700">
+              </Label>
+              <Label className="font-normal">
                 <input
                   type="radio"
                   name="staff-enabled"
                   checked={!enabled}
                   onChange={() => setEnabled(false)}
-                  className="border-gray-300 text-blue-600 focus:ring-blue-500"
                 />
                 停止
-              </label>
+              </Label>
             </div>
-            <p className="mt-1 text-xs text-gray-500">
+            <p className="mt-1 text-xs text-muted-foreground">
               停止してもアカウントは削除されず、過去の操作記録は保持されます。
             </p>
           </div>
           <div>
-            <p className="mb-1 text-sm font-medium text-gray-700">この設定の結果</p>
-            <p className="rounded-md bg-blue-50 p-3 text-sm text-blue-800">{summary}</p>
+            <p className="mb-1 text-sm font-medium text-foreground">この設定の結果</p>
+            <p className="rounded-md bg-primary/10 p-3 text-sm text-primary-strong">{summary}</p>
           </div>
           <div>
-            <p className="mb-1 text-sm font-medium text-gray-700">付与履歴</p>
+            <p className="mb-1 text-sm font-medium text-foreground">付与履歴</p>
             {history.length === 0 ? (
-              <p className="text-sm text-gray-500">履歴はありません</p>
+              <p className="text-sm text-muted-foreground">履歴はありません</p>
             ) : (
-              <ul className="space-y-1 rounded-md border border-gray-200 p-3">
+              <ul className="space-y-1 rounded-md border p-3">
                 {history.map(entry => (
-                  <li key={entry.id} className="text-xs text-gray-600">
-                    <span className="font-medium text-gray-900">
+                  <li key={entry.id} className="text-xs text-muted-foreground">
+                    <span className="font-medium text-foreground">
                       {GRANT_ACTION_LABELS[entry.action] ?? entry.action}
                     </span>
                     {' — '}
@@ -204,24 +203,15 @@ export function StaffEditDrawer({ open, onClose, staff, onUpdated }: StaffEditDr
             )}
           </div>
         </div>
-        <div className="flex justify-end gap-3 border-t border-gray-200 px-6 py-4">
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-          >
+        <div className="flex justify-end gap-3 border-t px-6 py-4">
+          <Button type="button" variant="outline" onClick={onClose}>
             キャンセル
-          </button>
-          <button
-            type="button"
-            onClick={submit}
-            disabled={isSubmitting}
-            className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-          >
+          </Button>
+          <Button type="button" onClick={submit} disabled={isSubmitting}>
             {isSubmitting ? '保存中...' : '保存する'}
-          </button>
+          </Button>
         </div>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/frontend/src/features/staff-management/ui/StoreSetPicker.tsx
+++ b/frontend/src/features/staff-management/ui/StoreSetPicker.tsx
@@ -2,6 +2,7 @@
 
 import { PlatformStore, PlatformStoreScopeType, platformAuthApi } from '@/entities/user';
 import { useManagedList } from '@/shared/lib';
+import { Label } from '@/shared/ui';
 
 interface StoreSetPickerProps {
   storeScopeType: PlatformStoreScopeType;
@@ -25,43 +26,40 @@ export function StoreSetPicker({ storeScopeType, storeIds, onChange }: StoreSetP
 
   return (
     <div>
-      <span className="mb-1 block text-sm font-medium text-gray-700">担当店舗</span>
+      <span className="mb-1 block text-sm font-medium text-foreground">担当店舗</span>
       <div className="space-y-2">
-        <label className="flex items-center gap-2 text-sm text-gray-700">
+        <Label className="font-normal">
           <input
             type="radio"
             name="store-scope-type"
             checked={storeScopeType === 'ALL_STORES'}
             onChange={() => onChange({ storeScopeType: 'ALL_STORES', storeIds: [] })}
-            className="border-gray-300 text-blue-600 focus:ring-blue-500"
           />
           全店舗
-        </label>
-        <label className="flex items-center gap-2 text-sm text-gray-700">
+        </Label>
+        <Label className="font-normal">
           <input
             type="radio"
             name="store-scope-type"
             checked={storeScopeType === 'SPECIFIC_STORES'}
             onChange={() => onChange({ storeScopeType: 'SPECIFIC_STORES', storeIds })}
-            className="border-gray-300 text-blue-600 focus:ring-blue-500"
           />
           個別店舗
-        </label>
+        </Label>
         {storeScopeType === 'SPECIFIC_STORES' && (
-          <div className="ml-6 space-y-1 rounded-md border border-gray-200 p-3">
+          <div className="ml-6 space-y-1 rounded-md border p-3">
             {isLoading ? (
-              <p className="text-sm text-gray-500">読み込み中...</p>
+              <p className="text-sm text-muted-foreground">読み込み中...</p>
             ) : (
               stores.map(store => (
-                <label key={store.id} className="flex items-center gap-2 text-sm text-gray-700">
+                <Label key={store.id} className="font-normal">
                   <input
                     type="checkbox"
                     checked={storeIds.includes(store.id)}
                     onChange={() => toggleStore(store.id)}
-                    className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                   />
                   {store.name}
-                </label>
+                </Label>
               ))
             )}
           </div>

--- a/frontend/src/features/staff-management/ui/__tests__/StaffCreateModal.test.tsx
+++ b/frontend/src/features/staff-management/ui/__tests__/StaffCreateModal.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
+import { platformAuthApi, platformStaffApi } from '@/entities/user';
+import { StaffCreateModal } from '../StaffCreateModal';
+
+jest.mock('@/entities/user', () => ({
+  platformAuthApi: { stores: jest.fn() },
+  platformStaffApi: { bundles: jest.fn(), create: jest.fn() },
+}));
+
+jest.mock('react-hot-toast', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockedAuthApi = platformAuthApi as jest.Mocked<typeof platformAuthApi>;
+const mockedStaffApi = platformStaffApi as jest.Mocked<typeof platformStaffApi>;
+const mockedToast = toast as jest.Mocked<typeof toast>;
+
+const fillBasics = () => {
+  fireEvent.change(screen.getByLabelText('メールアドレス'), {
+    target: { value: 'new@example.com' },
+  });
+  fireEvent.change(screen.getByLabelText('初期パスワード'), { target: { value: 'secret' } });
+  fireEvent.change(screen.getByLabelText('氏名'), { target: { value: '佐藤次郎' } });
+};
+
+describe('スタッフ新規作成モーダル', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAuthApi.stores.mockResolvedValue([{ id: 9, name: '店舗A' }]);
+    mockedStaffApi.bundles.mockResolvedValue([
+      { id: 3, name: '店長' },
+      { id: 4, name: '経理' },
+    ]);
+    mockedStaffApi.create.mockResolvedValue({} as never);
+  });
+
+  it('閉じているときは何も描画しない', () => {
+    render(<StaffCreateModal open={false} onClose={jest.fn()} onCreated={jest.fn()} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('入力値と選択状態を snake_case のまま作成 API へ送る', async () => {
+    render(<StaffCreateModal open onClose={jest.fn()} onCreated={jest.fn()} />);
+    await screen.findByLabelText('店長');
+
+    fillBasics();
+    fireEvent.click(screen.getByLabelText('店長'));
+    fireEvent.click(screen.getByRole('button', { name: '追加する' }));
+
+    await waitFor(() => expect(mockedStaffApi.create).toHaveBeenCalledTimes(1));
+    expect(mockedStaffApi.create.mock.calls[0][0]).toEqual({
+      email: 'new@example.com',
+      password: 'secret',
+      display_name: '佐藤次郎',
+      bundle_ids: [3],
+      store_scope_type: 'ALL_STORES',
+      store_ids: [],
+      settlement_scope_type: null,
+      settlement_store_ids: [],
+    });
+  });
+
+  it('個別店舗を選ぶと店舗集合が SPECIFIC_STORES と店舗 id で送られる', async () => {
+    render(<StaffCreateModal open onClose={jest.fn()} onCreated={jest.fn()} />);
+    await screen.findByLabelText('店長');
+
+    fillBasics();
+    fireEvent.click(screen.getByLabelText('店長'));
+    fireEvent.click(screen.getByLabelText('個別店舗'));
+    fireEvent.click(await screen.findByLabelText('店舗A'));
+    fireEvent.click(screen.getByRole('button', { name: '追加する' }));
+
+    await waitFor(() => expect(mockedStaffApi.create).toHaveBeenCalledTimes(1));
+    expect(mockedStaffApi.create.mock.calls[0][0]).toMatchObject({
+      store_scope_type: 'SPECIFIC_STORES',
+      store_ids: [9],
+    });
+  });
+
+  it('精算範囲は指定店舗を選ぶと scope と店舗 id が載る', async () => {
+    render(<StaffCreateModal open onClose={jest.fn()} onCreated={jest.fn()} />);
+    await screen.findByLabelText('店長');
+
+    fillBasics();
+    fireEvent.click(screen.getByLabelText('店長'));
+    fireEvent.click(screen.getByLabelText('指定店舗'));
+    const storeCheckboxes = await screen.findAllByLabelText('店舗A');
+    fireEvent.click(storeCheckboxes[storeCheckboxes.length - 1]);
+    fireEvent.click(screen.getByRole('button', { name: '追加する' }));
+
+    await waitFor(() => expect(mockedStaffApi.create).toHaveBeenCalledTimes(1));
+    expect(mockedStaffApi.create.mock.calls[0][0]).toMatchObject({
+      settlement_scope_type: 'SPECIFIC_STORES',
+      settlement_store_ids: [9],
+    });
+  });
+
+  it('権限束が未選択なら作成 API を呼ばず警告する', async () => {
+    render(<StaffCreateModal open onClose={jest.fn()} onCreated={jest.fn()} />);
+    await screen.findByLabelText('店長');
+
+    fillBasics();
+    fireEvent.click(screen.getByRole('button', { name: '追加する' }));
+
+    await waitFor(() =>
+      expect(mockedToast.error).toHaveBeenCalledWith('権限束を 1 つ以上選択してください')
+    );
+    expect(mockedStaffApi.create).not.toHaveBeenCalled();
+  });
+
+  it('必須項目が空なら作成 API を呼ばない', async () => {
+    render(<StaffCreateModal open onClose={jest.fn()} onCreated={jest.fn()} />);
+    await screen.findByLabelText('店長');
+
+    fireEvent.click(screen.getByLabelText('店長'));
+    fireEvent.click(screen.getByRole('button', { name: '追加する' }));
+
+    await waitFor(() => expect(mockedStaffApi.bundles).toHaveBeenCalled());
+    expect(mockedStaffApi.create).not.toHaveBeenCalled();
+  });
+
+  it('作成成功で onCreated と onClose を呼ぶ', async () => {
+    const onClose = jest.fn();
+    const onCreated = jest.fn();
+    render(<StaffCreateModal open onClose={onClose} onCreated={onCreated} />);
+    await screen.findByLabelText('店長');
+
+    fillBasics();
+    fireEvent.click(screen.getByLabelText('店長'));
+    fireEvent.click(screen.getByRole('button', { name: '追加する' }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledTimes(1));
+    expect(mockedToast.success).toHaveBeenCalledWith('スタッフを追加しました');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('キャンセルは作成せず閉じる', async () => {
+    const onClose = jest.fn();
+    render(<StaffCreateModal open onClose={onClose} onCreated={jest.fn()} />);
+    await screen.findByLabelText('店長');
+
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockedStaffApi.create).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/staff-management/ui/__tests__/StaffCreateModal.test.tsx
+++ b/frontend/src/features/staff-management/ui/__tests__/StaffCreateModal.test.tsx
@@ -29,8 +29,8 @@ describe('スタッフ新規作成モーダル', () => {
     jest.clearAllMocks();
     mockedAuthApi.stores.mockResolvedValue([{ id: 9, name: '店舗A' }]);
     mockedStaffApi.bundles.mockResolvedValue([
-      { id: 3, name: '店長' },
-      { id: 4, name: '経理' },
+      { id: 3, name: '店長', capabilities: [] },
+      { id: 4, name: '経理', capabilities: [] },
     ]);
     mockedStaffApi.create.mockResolvedValue({} as never);
   });

--- a/frontend/src/features/staff-management/ui/__tests__/StaffEditDrawer.test.tsx
+++ b/frontend/src/features/staff-management/ui/__tests__/StaffEditDrawer.test.tsx
@@ -45,8 +45,8 @@ describe('スタッフ授権編集ドロワー', () => {
     jest.clearAllMocks();
     mockedAuthApi.stores.mockResolvedValue([]);
     mockedStaffApi.bundles.mockResolvedValue([
-      { id: 3, name: '店長' },
-      { id: 4, name: '経理' },
+      { id: 3, name: '店長', capabilities: [] },
+      { id: 4, name: '経理', capabilities: [] },
     ]);
     mockedStaffApi.grantHistory.mockResolvedValue([]);
     mockedStaffApi.update.mockResolvedValue({} as never);

--- a/frontend/src/features/staff-management/ui/__tests__/StaffEditDrawer.test.tsx
+++ b/frontend/src/features/staff-management/ui/__tests__/StaffEditDrawer.test.tsx
@@ -35,13 +35,7 @@ const renderDrawer = (props: Partial<React.ComponentProps<typeof StaffEditDrawer
   const onClose = jest.fn();
   const onUpdated = jest.fn();
   render(
-    <StaffEditDrawer
-      open
-      staff={staff()}
-      onClose={onClose}
-      onUpdated={onUpdated}
-      {...props}
-    />
+    <StaffEditDrawer open staff={staff()} onClose={onClose} onUpdated={onUpdated} {...props} />
   );
   return { onClose, onUpdated };
 };

--- a/frontend/src/features/staff-management/ui/__tests__/StaffEditDrawer.test.tsx
+++ b/frontend/src/features/staff-management/ui/__tests__/StaffEditDrawer.test.tsx
@@ -1,0 +1,203 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
+import type { PlatformStaffResponse } from '@/entities/user';
+import { platformAuthApi, platformStaffApi } from '@/entities/user';
+import { StaffEditDrawer } from '../StaffEditDrawer';
+
+jest.mock('@/entities/user', () => ({
+  platformAuthApi: { stores: jest.fn() },
+  platformStaffApi: { bundles: jest.fn(), grantHistory: jest.fn(), update: jest.fn() },
+}));
+
+jest.mock('react-hot-toast', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockedAuthApi = platformAuthApi as jest.Mocked<typeof platformAuthApi>;
+const mockedStaffApi = platformStaffApi as jest.Mocked<typeof platformStaffApi>;
+const mockedToast = toast as jest.Mocked<typeof toast>;
+
+const staff = (override: Partial<PlatformStaffResponse> = {}): PlatformStaffResponse => ({
+  id: 42,
+  email: 'staff@example.com',
+  display_name: '山田太郎',
+  enabled: true,
+  bundles: [{ id: 3, name: '店長' }],
+  store_scope_type: 'ALL_STORES',
+  store_ids: [],
+  settlement_scope_type: null,
+  settlement_store_ids: [],
+  version: 7,
+  ...override,
+});
+
+const renderDrawer = (props: Partial<React.ComponentProps<typeof StaffEditDrawer>> = {}) => {
+  const onClose = jest.fn();
+  const onUpdated = jest.fn();
+  render(
+    <StaffEditDrawer
+      open
+      staff={staff()}
+      onClose={onClose}
+      onUpdated={onUpdated}
+      {...props}
+    />
+  );
+  return { onClose, onUpdated };
+};
+
+describe('スタッフ授権編集ドロワー', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAuthApi.stores.mockResolvedValue([]);
+    mockedStaffApi.bundles.mockResolvedValue([
+      { id: 3, name: '店長' },
+      { id: 4, name: '経理' },
+    ]);
+    mockedStaffApi.grantHistory.mockResolvedValue([]);
+    mockedStaffApi.update.mockResolvedValue({} as never);
+  });
+
+  it('閉じているときは何も描画しない', () => {
+    renderDrawer({ open: false });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('編集対象が null のときは開いていても描画しない', () => {
+    renderDrawer({ staff: null });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('開くと対象スタッフ名の見出しを表示する', async () => {
+    renderDrawer();
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('山田太郎 の権限を編集')).toBeInTheDocument();
+  });
+
+  it('保存は楽観ロックの version を含む現在値をそのまま送信する', async () => {
+    renderDrawer();
+    await screen.findByRole('dialog');
+
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(mockedStaffApi.update).toHaveBeenCalledTimes(1));
+    expect(mockedStaffApi.update.mock.calls[0][0]).toBe(42);
+    expect(mockedStaffApi.update.mock.calls[0][1]).toEqual({
+      bundle_ids: [3],
+      store_scope_type: 'ALL_STORES',
+      store_ids: [],
+      settlement_scope_type: null,
+      settlement_store_ids: [],
+      enabled: true,
+      version: 7,
+    });
+  });
+
+  it('状態を停止へ切り替えると enabled=false で送信する', async () => {
+    renderDrawer();
+    await screen.findByRole('dialog');
+
+    fireEvent.click(screen.getByLabelText('停止'));
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(mockedStaffApi.update).toHaveBeenCalledTimes(1));
+    expect(mockedStaffApi.update.mock.calls[0][1]).toMatchObject({ enabled: false });
+  });
+
+  it('権限束の選択を全て外すと更新 API を呼ばず警告する', async () => {
+    renderDrawer({ staff: staff({ bundles: [] }) });
+    await screen.findByRole('dialog');
+
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() =>
+      expect(mockedToast.error).toHaveBeenCalledWith('権限束を 1 つ以上選択してください')
+    );
+    expect(mockedStaffApi.update).not.toHaveBeenCalled();
+  });
+
+  it('保存成功で完了トーストを出し onUpdated と onClose を呼ぶ', async () => {
+    const { onClose, onUpdated } = renderDrawer();
+    await screen.findByRole('dialog');
+
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(onUpdated).toHaveBeenCalledTimes(1));
+    expect(mockedToast.success).toHaveBeenCalledWith('権限を更新しました');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('409 は固定文言で警告し一覧を再取得したままドロワーを閉じない', async () => {
+    mockedStaffApi.update.mockRejectedValue({ response: { status: 409 } });
+    const { onClose, onUpdated } = renderDrawer();
+    await screen.findByRole('dialog');
+
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() =>
+      expect(mockedToast.error).toHaveBeenCalledWith(
+        '他の管理者が更新しました。最新の内容を確認してください'
+      )
+    );
+    expect(onUpdated).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('409 以外の失敗は onUpdated を呼ばない', async () => {
+    mockedStaffApi.update.mockRejectedValue({ response: { status: 400 } });
+    const { onClose, onUpdated } = renderDrawer();
+    await screen.findByRole('dialog');
+
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(mockedToast.error).toHaveBeenCalled());
+    expect(mockedToast.error).not.toHaveBeenCalledWith(
+      '他の管理者が更新しました。最新の内容を確認してください'
+    );
+    expect(onUpdated).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('キャンセルは更新せず閉じる', async () => {
+    const { onClose } = renderDrawer();
+    await screen.findByRole('dialog');
+
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockedStaffApi.update).not.toHaveBeenCalled();
+  });
+
+  it('Escape で閉じる', async () => {
+    const { onClose } = renderDrawer();
+    await screen.findByRole('dialog');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+
+  it('付与履歴が空なら不在メッセージを表示する', async () => {
+    renderDrawer();
+
+    expect(await screen.findByText('履歴はありません')).toBeInTheDocument();
+  });
+
+  it('付与履歴があれば操作種別を日本語ラベルで表示する', async () => {
+    mockedStaffApi.grantHistory.mockResolvedValue([
+      {
+        id: 1,
+        action: 'GRANT',
+        actor_email: 'admin@example.com',
+        created_at: '2026-07-01T00:00:00Z',
+      },
+    ] as never);
+    renderDrawer();
+
+    expect(await screen.findByText('付与')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/widgets/header/ui/Header.tsx
+++ b/frontend/src/widgets/header/ui/Header.tsx
@@ -65,26 +65,31 @@ export function Header() {
             <p className="text-sm font-semibold text-foreground">管理者</p>
             <p className="text-xs text-muted-foreground">Platform Admin</p>
           </div>
-          <div className="relative group">
-            {' '}
-            <button className="flex items-center focus:outline-none">
-              <UserCircleIcon className="h-8 w-8 text-muted-foreground group-hover:text-primary-strong transition-colors" />
-            </button>
-            <div className="absolute right-0 mt-2 w-48 bg-card rounded-md shadow-lg py-1 border hidden group-hover:block transition-all duration-200 opacity-0 group-hover:opacity-100 scale-95 group-hover:scale-100 origin-top-right">
-              <Link
-                href={accountHref}
-                className="block w-full text-left px-4 py-2 text-sm text-foreground hover:bg-muted"
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="アカウントメニュー"
+                className="text-muted-foreground hover:text-primary-strong"
               >
-                アカウント設定
-              </Link>
-              <button
-                onClick={logout}
-                className="block w-full text-left px-4 py-2 text-sm text-destructive-strong hover:bg-destructive/10"
+                <UserCircleIcon className="size-8" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" sideOffset={8} className="w-48">
+              <DropdownMenuItem asChild>
+                <Link href={accountHref}>アカウント設定</Link>
+              </DropdownMenuItem>
+              {/* 原語の destructive 変種は淡色地の上で既定の赤を使い明モードで 4.5 を割るため、
+                  文字は -strong 側を指定する。 */}
+              <DropdownMenuItem
+                onSelect={logout}
+                className="text-destructive-strong focus:bg-destructive/10 focus:text-destructive-strong"
               >
                 ログアウト
-              </button>
-            </div>
-          </div>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
     </header>

--- a/frontend/src/widgets/header/ui/Header.tsx
+++ b/frontend/src/widgets/header/ui/Header.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useAuth, useStoreContext } from '@/entities/user';
 import { isStoreDomain, storePath } from '@/shared/lib';
 import {
+  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -29,31 +30,29 @@ export function Header() {
       : '/platform/settings/account';
 
   return (
-    <header className="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-8 sticky top-0 z-20">
+    <header className="h-16 bg-card border-b flex items-center justify-between px-8 sticky top-0 z-20">
       <div className="flex items-center">
-        <h2 className="text-lg font-medium text-gray-800">管理パネル</h2>
+        <h2 className="text-lg font-medium text-foreground">管理パネル</h2>
       </div>
 
       <div className="flex items-center space-x-6">
-        <button className="text-gray-400 hover:text-gray-600 transition-colors">
-          <BellIcon className="h-6 w-6" />
-        </button>
+        <Button variant="ghost" size="icon" className="text-muted-foreground">
+          <BellIcon className="size-6" />
+        </Button>
 
-        <div className="h-8 w-px bg-gray-200" />
+        <div className="h-8 w-px bg-border" />
 
         {stores && stores.length > 0 && (
           <DropdownMenu>
-            <DropdownMenuTrigger className="flex items-center gap-2 rounded-md border border-gray-200 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500">
-              <BuildingStorefrontIcon className="h-5 w-5 text-gray-400" />
-              <span>{currentStoreName || '店舗を選択'}</span>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm">
+                <BuildingStorefrontIcon className="size-5 text-muted-foreground" />
+                <span>{currentStoreName || '店舗を選択'}</span>
+              </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" sideOffset={8} className="w-56">
               {stores.map(store => (
-                <DropdownMenuItem
-                  key={store.id}
-                  onSelect={() => switchStore(store.id)}
-                  className="px-4 py-2 text-sm text-gray-700"
-                >
+                <DropdownMenuItem key={store.id} onSelect={() => switchStore(store.id)}>
                   {store.name}
                 </DropdownMenuItem>
               ))}
@@ -63,24 +62,24 @@ export function Header() {
 
         <div className="flex items-center space-x-4">
           <div className="text-right hidden sm:block">
-            <p className="text-sm font-semibold text-gray-900">管理者</p>
-            <p className="text-xs text-gray-500">Platform Admin</p>
+            <p className="text-sm font-semibold text-foreground">管理者</p>
+            <p className="text-xs text-muted-foreground">Platform Admin</p>
           </div>
           <div className="relative group">
             {' '}
             <button className="flex items-center focus:outline-none">
-              <UserCircleIcon className="h-8 w-8 text-gray-400 group-hover:text-indigo-500 transition-colors" />
+              <UserCircleIcon className="h-8 w-8 text-muted-foreground group-hover:text-primary-strong transition-colors" />
             </button>
-            <div className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 border border-gray-100 hidden group-hover:block transition-all duration-200 opacity-0 group-hover:opacity-100 scale-95 group-hover:scale-100 origin-top-right">
+            <div className="absolute right-0 mt-2 w-48 bg-card rounded-md shadow-lg py-1 border hidden group-hover:block transition-all duration-200 opacity-0 group-hover:opacity-100 scale-95 group-hover:scale-100 origin-top-right">
               <Link
                 href={accountHref}
-                className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                className="block w-full text-left px-4 py-2 text-sm text-foreground hover:bg-muted"
               >
                 アカウント設定
               </Link>
               <button
                 onClick={logout}
-                className="block w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-red-50"
+                className="block w-full text-left px-4 py-2 text-sm text-destructive-strong hover:bg-destructive/10"
               >
                 ログアウト
               </button>

--- a/frontend/src/widgets/header/ui/__tests__/Header.test.tsx
+++ b/frontend/src/widgets/header/ui/__tests__/Header.test.tsx
@@ -7,10 +7,15 @@ import type { PlatformStore } from '@/entities/user';
 // 現在店舗・授権店舗・切替は店舗コンテキストが担い、その全ケースは StoreContext.test.tsx で検証する。
 // ここでは context 出力（stores / currentStoreId）に対する Header 自身の表示条件・ラベル・
 // accountHref・切替クリックの委譲を検証する。
-jest.mock('@/entities/user', () => ({
-  useAuth: () => ({ logout: jest.fn() }),
-  useStoreContext: jest.fn(),
-}));
+jest.mock('@/entities/user', () => {
+  const logout = jest.fn();
+  return {
+    // フックを介さず参照できるよう、同じ実体をテスト向けにも公開する。
+    __logout: logout,
+    useAuth: () => ({ logout }),
+    useStoreContext: jest.fn(),
+  };
+});
 
 jest.mock('@/shared/lib', () => ({
   ...jest.requireActual('@/shared/lib'),
@@ -20,6 +25,7 @@ jest.mock('@/shared/lib', () => ({
 const mockedUseStoreContext = useStoreContext as jest.MockedFunction<typeof useStoreContext>;
 const mockedIsStoreDomain = isStoreDomain as jest.MockedFunction<typeof isStoreDomain>;
 const mockSwitchStore = jest.fn();
+const mockedLogout = (jest.requireMock('@/entities/user') as { __logout: jest.Mock }).__logout;
 
 function withContext(stores: PlatformStore[] | null, currentStoreId?: string) {
   mockedUseStoreContext.mockReturnValue({
@@ -80,28 +86,45 @@ describe('Header 店舗切替の常設化（店舗コンテキスト集約）', 
     expect(mockSwitchStore).toHaveBeenCalledWith(2);
   });
 
-  it('店舗別ドメイン経由ではアカウント設定リンクが currentStoreId を含む店舗ルートを指す', () => {
+  // アカウントメニューの中身は開いている間だけ描かれる。
+  function openAccountMenu() {
+    fireEvent.keyDown(screen.getByRole('button', { name: 'アカウントメニュー' }), { key: 'Enter' });
+  }
+
+  it('店舗別ドメイン経由ではアカウント設定リンクが currentStoreId を含む店舗ルートを指す', async () => {
     mockedIsStoreDomain.mockReturnValue(true);
     withContext([], '2');
 
     render(<Header />);
+    openAccountMenu();
 
-    expect(screen.getByRole('link', { name: 'アカウント設定' })).toHaveAttribute(
+    expect(await screen.findByRole('menuitem', { name: 'アカウント設定' })).toHaveAttribute(
       'href',
       '/store/2/settings/account'
     );
   });
 
-  it('店舗別ドメイン経由でも currentStoreId が未確定ならアカウント設定リンクは platform 側へ fallback する', () => {
+  it('店舗別ドメイン経由でも currentStoreId が未確定ならアカウント設定リンクは platform 側へ fallback する', async () => {
     mockedIsStoreDomain.mockReturnValue(true);
     withContext([], undefined);
 
     render(<Header />);
+    openAccountMenu();
 
-    expect(screen.getByRole('link', { name: 'アカウント設定' })).toHaveAttribute(
+    expect(await screen.findByRole('menuitem', { name: 'アカウント設定' })).toHaveAttribute(
       'href',
       '/platform/settings/account'
     );
+  });
+
+  it('ログアウトはアカウントメニューから選べる', async () => {
+    withContext([], '1');
+
+    render(<Header />);
+    openAccountMenu();
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'ログアウト' }));
+
+    expect(mockedLogout).toHaveBeenCalledTimes(1);
   });
 
   it('currentStoreId が変化するとラベルが新しい店舗名へ追随する', () => {


### PR DESCRIPTION
## 概要

sweep の残り 19 ファイル（store-dashboard / store-orders / store-cast-fields / store-select / staff-management / cast-invitation / widgets-header / 両コンソールのシェル）をトークン規格へ載せ替える。

Closes #487

**合流順**: #491（DESIGN.md）を先に合流させてください。

## 変更内容

- 上記スライスをトークンとプリミティブへ変換（構造変更は `StaffEditDrawer` の `Sheet` 化のみ）
- 両コンソールのシェルを `bg-gray-50` → `bg-background` へ（下記「決定ログ」）
- ヘッダーの店舗切替を `DropdownMenuTrigger asChild` + `Button` へ
- **アカウントメニューを到達可能なドロップダウンへ置き換える**（下記）
- 権限束モックが実型（`CapabilityBundleResponse`）を満たしておらず tsc が赤だったのを修正
- 実体を失った e2e の注記を削除（Dialog/Sheet の content 自身が寸法を持つため「ルート要素が 0x0」という前提は成立しない）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（69 suites / 390 tests。三連 PR を統合した作業ツリーで実行）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（19 シナリオ全件。**スタッフ管理 2 シナリオが Sheet 化後の編集ドロワーを実ブラウザで通っている**）
- [x] ローカルで code-review 実施済み

`npx tsc --noEmit` は本 PR で 5 件 → 1 件へ。残る 1 件（`shared/api/__tests__/file.test.ts` の axios adapter キャスト）は master 既存で本 PR の対象外。

検収 grep は 0 件。なお票面に載せた `_pages/platform-select` は**実在しないパス**（platform 側に独立した選択ルートは無い）で、そのまま grep に含めると exit 2 になります。

### 視覚確認（UI 変更時）

統合ビルドを起動し実機で確認。コンテナのイメージ ID がビルド直後のものと一致することを確認したうえで観察している。

- **シェルが全面純白**（下記「決定ログ」）。サイドバー / ヘッダー / 本文の背景を実測するといずれも `lab(100 0 0)`
- スタッフ編集ドロワー（Sheet）: 右からスライドイン、幅 448px（従来幅を維持）、× ボタン無し、`role=dialog` + `aria-labelledby`、フォーカスがドロワー内に閉じ込められること、文書が伸びないことを実測
- スタッフ一覧・カスタムフィールド管理・作成モーダル・オーダー一覧を目視。モーダルは Escape で閉じ、`body` のスクロールロックが解放されることを確認
- 全画面で `document.scrollHeight` == `window.innerHeight`

## 決定ログ

**シェルの `bg-background` 化で領域の区切りが 1px の境界線だけになる**。`--background` と `--card` はいずれも `oklch(1 0 0)` のため、サイドバー・ヘッダー・本文がすべて純白になる。写像表どおりの帰結として採用し、`globals.css` は一切触っていない。所有者へ提示済みで「単調だが当面これで進める」との判断を得た。トーンを付けたい場合は token 値の設計（共有ファイル）として別途扱う。

**アカウントメニューを `DropdownMenu` へ置き換えた（挙動変更）**。従来はトリガーとメニューの間に `mt-2` の余白があり、ホバーで開く方式ではカーソルがその隙間を通る間に `group-hover` が切れてメニューが消え、**ログアウトを押せなかった**。キーボードからも到達できない。master にも同じ構造があり本 PR が作った問題ではないが、同じファイルを触る本 PR で直すのが最も衝突が少ない。隣の店舗切替と同じプリミティブへ揃えたため、開き方はホバーからクリックへ変わる。

その際、プリミティブの `variant="destructive"` は使わなかった。淡色地（`bg-destructive/10`）の上で既定の赤を使うため**明モードのコントラストが実測 4.16 と 4.5 を割る**（`-strong` は 10.03）。文字色を明示指定し、理由をコードに注記した。これは vendored プリミティブ自体の問題であり、共有ファイルの扱いとして別票が要る。

**ネイティブの checkbox / radio は維持**。`@tailwindcss/forms` は package.json / postcss / globals.css のいずれにも存在しないため、落とした `text-blue-600` / `border-gray-300` / `focus:ring-blue-500` はネイティブ控件の上で元から無効で、見た目は変わらない。Radix 化するとアンカーの包みラベル紐付けが切れ、同一モーダル内で同じ店舗名を描く 2 つのピッカーが id 重複で壊れる。

**`stopPropagation()` の 1 箇所は削除しても赤くならないが逐語温存した**。行の `onClick` と編集ボタンの `onClick` は同一クロージャの `setEditing` を呼ぶため、状態遷移・レンダリング回数・フォーカス・DOM 終態のいずれでも区別できない（外延的に冗長であって未証明ではない）。対照として削除ボタン側の `stopPropagation()` は除去すると赤くなる。

## 備考 / レビュー観点

- 既存テスト 2 件のクエリを変更した。`DropdownMenu` の中身は開いている間だけ描かれるため、メニューを開く操作を足した。**assertion は変更していない**。併せてログアウト配線を守るテストを 1 件追加（削除すると赤になることを確認済み）
- スタッフ一覧に e2e が生成したスタッフが数十件残留している。e2e 側の後片付けの話で本 PR の対象外だが、別票の候補

🤖 Generated with [Claude Code](https://claude.com/claude-code)