### PR TITLE
refactor(frontend): 一覧ページの外殻を規格化し PageHeader へ抽出する

### DIFF
--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -311,7 +311,7 @@ The heading block is a component, not a class string to copy, because a document
 </div>
 ```
 
-`description` and `actions` are optional; `actions` takes one `Button` or several, and the wrapper spaces them, so a page never writes a wrapper of its own. **A list page carries no heading class string** — if a `text-2xl` appears under `_pages/`, the shell was re-derived instead of composed.
+`description` and `actions` are optional; `actions` takes one `Button` or several, and the wrapper spaces them, so a page never writes a wrapper of its own. **A list page carries no heading class string of its own** — a `text-2xl` surviving in a list page file means the shell was re-derived rather than composed. (Form and settings pages still write their own `<h1 className="text-2xl font-bold text-foreground">`; unifying those shells is a separate question and `PageHeader` is deliberately not claimed for them yet.)
 
 Four consequences that are easy to get wrong:
 

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -288,6 +288,38 @@ Hover / focus / disabled states come from the primitives. Only hand-write a stat
 
 A bare interactive element does not inherit the primitives' focus ring, so it hand-writes one: `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary`. `ring-primary` is certified against `bg-card` / `bg-background` by the matrix row above (5.26 / 3.37) — and against nothing else, so an element on a muted or tinted fill moves its ring to a certified surface or stays with the primitive. Add `ring-inset` where an overflow container would clip an outer ring (a calendar cell inside a framed grid).
 
+### List page shell
+
+Every admin list page is assembled from the same four parts. **The strings below are the specification, not an illustration — write them verbatim.** They are spelled out rather than delegated to "follow the precedent" because a precedent is re-derived independently by every parallel branch, and independent re-derivations do not converge: the parts this document states as strings come out identical across slices, the parts it leaves to a reference do not.
+
+| Part          | Markup                                                                                 |
+| ------------- | -------------------------------------------------------------------------------------- |
+| Outer         | `<div className="space-y-6">`                                                          |
+| Heading block | `<PageHeader title description actions />` from `@/widgets/page-header`                |
+| Search card   | `<Card>` > `<CardContent className="flex flex-col md:flex-row md:items-center gap-4">` |
+| Table card    | `<Card className="py-0 overflow-hidden">`                                              |
+
+The heading block is a component, not a class string to copy, because a documented rule can be departed from and a component cannot. `PageHeader` renders exactly:
+
+```tsx
+<div className="flex items-center justify-between">
+  <div>
+    <h1 className="text-2xl font-bold text-foreground">{title}</h1>
+    {description && <p className="text-sm text-muted-foreground mt-1">{description}</p>}
+  </div>
+  {actions && <div className="flex items-center gap-3">{actions}</div>}
+</div>
+```
+
+`description` and `actions` are optional; `actions` takes one `Button` or several, and the wrapper spaces them, so a page never writes a wrapper of its own. **A list page carries no heading class string** — if a `text-2xl` appears under `_pages/`, the shell was re-derived instead of composed.
+
+Four consequences that are easy to get wrong:
+
+- **The page heading is `text-2xl` at every breakpoint.** No `sm:text-3xl` step, no `font-semibold` variant.
+- **The console layout already supplies `p-8` and `max-w-7xl mx-auto`** (`app/platform/(console)/layout.tsx`, `app/store/layout.tsx`), so a list page adds no padding, width cap or `min-h-screen` of its own — and no navigation bar: the sidebar and header own logout, store switching and cross-page navigation.
+- **The primary action keeps its element type.** A page that opens a modal passes a plain `Button`; only a page that navigates passes `Button asChild` wrapping a `Link`. The two differ in ARIA role (`button` vs `link`), and the Playwright steps under `e2e/steps/` select by role — swapping one for the other breaks them silently, since e2e does not run in CI.
+- **Where the search must submit on Enter, the `<form>` wraps the `Card`**, so `CardContent` still carries the exact string above (precedent: `StoresPage`). Pages without a form put the search behind `onKeyDown` instead (precedent: `CustomersPage`).
+
 ## Admin restyle rules (shadcn sweep)
 
 Rules for converting a remaining admin slice to the primitives + token vocabulary. Slices are converted independently and in parallel, so these are contracts, not suggestions.

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -292,6 +292,8 @@ A bare interactive element does not inherit the primitives' focus ring, so it ha
 
 Every admin list page is assembled from the same four parts. **The strings below are the specification, not an illustration — write them verbatim.** They are spelled out rather than delegated to "follow the precedent" because a precedent is re-derived independently by every parallel branch, and independent re-derivations do not converge: the parts this document states as strings come out identical across slices, the parts it leaves to a reference do not.
 
+The section binds the six record-list pages that compose `PageHeader` today — `store-customers` / `store-casts` / `store-orders` / `platform-staff` / `platform-stores` / `store-cast-fields`. Every other admin page still writes its own heading markup: the form pages, the two settings consoles, `store-shifts` and `store-select`. Widening `PageHeader` to those is a separate question and **is not authority to convert one in passing** — but it is equally not a licence to leave a page from the list above unconverted.
+
 | Part          | Markup                                                                                 |
 | ------------- | -------------------------------------------------------------------------------------- |
 | Outer         | `<div className="space-y-6">`                                                          |
@@ -311,7 +313,7 @@ The heading block is a component, not a class string to copy, because a document
 </div>
 ```
 
-`description` and `actions` are optional; `actions` takes one `Button` or several, and the wrapper spaces them, so a page never writes a wrapper of its own. **A list page carries no heading class string of its own** — a `text-2xl` surviving in a list page file means the shell was re-derived rather than composed. (Form and settings pages still write their own `<h1 className="text-2xl font-bold text-foreground">`; unifying those shells is a separate question and `PageHeader` is deliberately not claimed for them yet.)
+`description` and `actions` are optional; `actions` takes one `Button` or several, and the wrapper spaces them, so a page never writes a wrapper of its own. **A list page carries no heading class string of its own** — a `text-2xl` surviving in one of the six files above means the shell was re-derived rather than composed.
 
 Four consequences that are easy to get wrong:
 

--- a/frontend/src/_pages/platform-staff/__tests__/StaffPage.test.tsx
+++ b/frontend/src/_pages/platform-staff/__tests__/StaffPage.test.tsx
@@ -100,10 +100,12 @@ describe('スタッフ一覧ページの外殻', () => {
   });
 
   it('見出し（h1）・副題を備え、主アクションが button ロールのままであること', async () => {
-    render(<StaffPage />);
+    const { container } = render(<StaffPage />);
     await screen.findByText('スタッフが登録されていません');
 
     expect(screen.getByRole('heading', { level: 1, name: 'スタッフ管理' })).toBeInTheDocument();
+    // 外殻の class 文字列は DESIGN.md が規格として定めた面そのもの。
+    expect(container.firstElementChild).toHaveClass('space-y-6');
     expect(
       screen.getByText('権限束・担当店舗・精算範囲の付与と編集ができます。')
     ).toBeInTheDocument();

--- a/frontend/src/_pages/platform-staff/__tests__/StaffPage.test.tsx
+++ b/frontend/src/_pages/platform-staff/__tests__/StaffPage.test.tsx
@@ -91,3 +91,23 @@ describe('スタッフ一覧ページ', () => {
     expect(screen.getByText('作成モーダル表示中')).toBeInTheDocument();
   });
 });
+
+describe('スタッフ一覧ページの外殻', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAuthApi.stores.mockResolvedValue([]);
+    mockedStaffApi.list.mockResolvedValue([]);
+  });
+
+  it('見出し（h1）・副題を備え、主アクションが button ロールのままであること', async () => {
+    render(<StaffPage />);
+    await screen.findByText('スタッフが登録されていません');
+
+    expect(screen.getByRole('heading', { level: 1, name: 'スタッフ管理' })).toBeInTheDocument();
+    expect(
+      screen.getByText('権限束・担当店舗・精算範囲の付与と編集ができます。')
+    ).toBeInTheDocument();
+    // e2e（staff-management）は button ロールで取得するため、リンク化してはならない
+    expect(screen.getByRole('button', { name: 'スタッフを追加' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
+++ b/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
@@ -15,6 +15,7 @@ import {
   storeSetLabel,
 } from '@/features/staff-management';
 import { useManagedList } from '@/shared/lib';
+import { PageHeader } from '@/widgets/page-header';
 import {
   Badge,
   Button,
@@ -49,18 +50,16 @@ export default function StaffPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">スタッフ管理</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            権限束・担当店舗・精算範囲の付与と編集ができます。
-          </p>
-        </div>
-        <Button onClick={() => setCreateOpen(true)}>
-          <PlusIcon />
-          スタッフを追加
-        </Button>
-      </div>
+      <PageHeader
+        title="スタッフ管理"
+        description="権限束・担当店舗・精算範囲の付与と編集ができます。"
+        actions={
+          <Button onClick={() => setCreateOpen(true)}>
+            <PlusIcon />
+            スタッフを追加
+          </Button>
+        }
+      />
 
       <Card className="py-0 overflow-hidden">
         {isLoading ? (

--- a/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
+++ b/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
@@ -212,3 +212,22 @@ describe('店舗管理 3 画面の挙動', () => {
     await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/platform/stores'));
   });
 });
+
+describe('店舗一覧ページの外殻', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApi.getList.mockResolvedValue(paginated([store({ id: '1', name: 'アルファ店' })]));
+  });
+
+  it('見出し・副題を備え、主アクションが button ロールのまま作成画面へ遷移すること', async () => {
+    render(<StoresPage />);
+    await screen.findByText('アルファ店');
+
+    // 見出しレベルは他の一覧ページに揃えて h2→h1 へ変える予定のため、ここでは level を断言しない
+    expect(screen.getByRole('heading', { name: '店舗一覧' })).toBeInTheDocument();
+    expect(screen.getByText('システム内の全ての店舗を管理します')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '店舗を追加' }));
+    expect(mockPush).toHaveBeenCalledWith('/platform/stores/create');
+  });
+});

--- a/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
+++ b/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
@@ -220,11 +220,12 @@ describe('店舗一覧ページの外殻', () => {
   });
 
   it('見出し・副題を備え、主アクションが button ロールのまま作成画面へ遷移すること', async () => {
-    render(<StoresPage />);
+    const { container } = render(<StoresPage />);
     await screen.findByText('アルファ店');
 
-    // 見出しレベルは他の一覧ページに揃えて h2→h1 へ変える予定のため、ここでは level を断言しない
-    expect(screen.getByRole('heading', { name: '店舗一覧' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: '店舗一覧' })).toBeInTheDocument();
+    // 外殻の class 文字列は DESIGN.md が規格として定めた面そのもの。
+    expect(container.firstElementChild).toHaveClass('space-y-6');
     expect(screen.getByText('システム内の全ての店舗を管理します')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: '店舗を追加' }));

--- a/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
+++ b/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
@@ -230,4 +230,35 @@ describe('店舗一覧ページの外殻', () => {
     fireEvent.click(screen.getByRole('button', { name: '店舗を追加' }));
     expect(mockPush).toHaveBeenCalledWith('/platform/stores/create');
   });
+
+  // 検索語の変更だけでも取得は走るため、送信そのものを捉えるには「現在ページが 1 に戻る」
+  // という送信ハンドラ固有の副作用を見る必要がある（form が無くなるとここだけが赤くなる）。
+  it('検索の送信は現在ページを 1 へ戻すこと', async () => {
+    mockedApi.getList.mockResolvedValue(
+      paginated([store({ id: '1', name: 'アルファ店' })], { last_page: 3, to: 10, total: 25 })
+    );
+
+    render(<StoresPage />);
+    await screen.findByText('アルファ店');
+
+    fireEvent.click(screen.getByRole('button', { name: '2' }));
+    await waitFor(() =>
+      expect(mockedApi.getList).toHaveBeenLastCalledWith({
+        page: 2,
+        per_page: 10,
+        search: undefined,
+      })
+    );
+
+    fireEvent.change(screen.getByLabelText('店舗を検索'), { target: { value: 'アルファ' } });
+    fireEvent.click(screen.getByRole('button', { name: '検索' }));
+
+    await waitFor(() =>
+      expect(mockedApi.getList).toHaveBeenLastCalledWith({
+        page: 1,
+        per_page: 10,
+        search: 'アルファ',
+      })
+    );
+  });
 });

--- a/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
@@ -2,15 +2,14 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { ChevronLeftIcon, ChevronRightIcon, PlusIcon } from '@heroicons/react/24/outline';
-import { useAuth } from '@/entities/user';
 import { useRouter } from 'next/navigation';
 import { Store, platformStoreApi } from '@/entities/store';
 import { PaginatedResponse } from '@/shared/api';
 import { Badge, Button, Card, CardContent, Input } from '@/shared/ui';
+import { PageHeader } from '@/widgets/page-header';
 import toast from 'react-hot-toast';
 
 export default function StoresPage() {
-  const { logout } = useAuth();
   const router = useRouter();
   const [stores, setStores] = useState<PaginatedResponse<Store> | null>(null);
   const [loadingStores, setLoadingStores] = useState(true);
@@ -59,255 +58,215 @@ export default function StoresPage() {
   };
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* ナビゲーションバー */}
-      <nav className="bg-card shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between h-16">
-            <div className="flex items-center space-x-4">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="text-primary-strong"
-                onClick={() => router.push('/')}
-              >
-                ← ダッシュボードへ戻る
-              </Button>
-              <h1 className="text-xl font-semibold text-foreground">店舗管理</h1>
-            </div>
-            <div className="flex items-center space-x-4">
-              <span className="text-sm text-muted-foreground">ようこそ、someone さん</span>
-              <Button variant="ghost" size="sm" onClick={logout}>
-                ログアウト
-              </Button>
-            </div>
-          </div>
-        </div>
-      </nav>
+    <div className="space-y-6">
+      <PageHeader
+        title="店舗一覧"
+        description="システム内の全ての店舗を管理します"
+        actions={
+          <Button onClick={() => router.push('/platform/stores/create')}>
+            <PlusIcon />
+            店舗を追加
+          </Button>
+        }
+      />
 
-      {/* 主要内容 */}
-      <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-        <div className="px-4 py-6 sm:px-0">
-          {/* ページヘッダー */}
-          <div className="md:flex md:items-center md:justify-between mb-6">
-            <div className="flex-1 min-w-0">
-              <h2 className="text-2xl font-bold leading-7 text-foreground sm:text-3xl sm:truncate">
-                店舗一覧
-              </h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                システム内の全ての店舗を管理します
-              </p>
+      {/* 検索フォーム。Enter での送信を残すため form がカードを包む */}
+      <form onSubmit={handleSearch}>
+        <Card>
+          <CardContent className="flex flex-col md:flex-row md:items-center gap-4">
+            <div className="w-full md:max-w-xs">
+              <label htmlFor="search" className="sr-only">
+                店舗を検索
+              </label>
+              <Input
+                type="text"
+                name="search"
+                id="search"
+                value={searchTerm}
+                onChange={e => setSearchTerm(e.target.value)}
+                placeholder="店舗名またはドメインで検索..."
+              />
             </div>
-            <div className="mt-4 flex md:mt-0 md:ml-4">
+            <Button type="submit">検索</Button>
+            {searchTerm && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setSearchTerm('');
+                  setCurrentPage(1);
+                }}
+              >
+                クリア
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      </form>
+
+      {/* 店舗一覧 */}
+      <Card className="py-0 overflow-hidden">
+        {loadingStores ? (
+          <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
+        ) : stores && stores.data.length > 0 ? (
+          <>
+            <ul className="divide-y">
+              {stores.data.map(store => (
+                <li key={store.id} className="px-4 py-4">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center min-w-0 flex-1">
+                      <div className="flex-shrink-0">
+                        <div className="h-12 w-12 rounded-full bg-primary/10 flex items-center justify-center">
+                          <span className="text-lg font-medium text-primary-strong">
+                            {store.name.charAt(0).toUpperCase()}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="ml-4 min-w-0 flex-1">
+                        <div className="flex items-center">
+                          <p className="text-lg font-medium text-foreground truncate">
+                            {store.name}
+                          </p>
+                          <Badge
+                            variant="outline"
+                            className={`ml-2 border-transparent ${
+                              store.is_active
+                                ? 'bg-success/10 text-success-strong'
+                                : 'bg-destructive/10 text-destructive-strong'
+                            }`}
+                          >
+                            {store.is_active ? '有効' : '無効'}
+                          </Badge>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <span className="text-sm text-muted-foreground">
+                        {new Date(store.created_at).toLocaleDateString('ja-JP')}
+                      </span>
+                      <div className="flex space-x-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => router.push(`/platform/stores/${store.id}/edit`)}
+                        >
+                          編集
+                        </Button>
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => handleDeleteStore(store.id, store.name)}
+                        >
+                          削除
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+
+            {/* ページネーション */}
+            {stores.last_page > 1 && (
+              <div className="px-4 py-3 flex items-center justify-between border-t sm:px-6">
+                <div className="flex-1 flex justify-between sm:hidden">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setCurrentPage(currentPage - 1)}
+                    disabled={currentPage <= 1}
+                  >
+                    前へ
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="ml-3"
+                    onClick={() => setCurrentPage(currentPage + 1)}
+                    disabled={currentPage >= stores.last_page}
+                  >
+                    次へ
+                  </Button>
+                </div>
+                <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-sm text-muted-foreground">
+                      {stores.total} 件中 {stores.from}-{stores.to} を表示
+                    </p>
+                  </div>
+                  <div>
+                    <nav className="flex gap-1">
+                      <Button
+                        variant="outline"
+                        size="icon-sm"
+                        onClick={() => setCurrentPage(currentPage - 1)}
+                        disabled={currentPage <= 1}
+                      >
+                        <ChevronLeftIcon />
+                      </Button>
+
+                      {/* ページ番号ボタン */}
+                      {Array.from({ length: Math.min(5, stores.last_page) }, (_, i) => {
+                        const page = i + 1;
+                        return (
+                          <Button
+                            key={page}
+                            variant="outline"
+                            size="sm"
+                            className={
+                              page === currentPage
+                                ? 'border-primary bg-primary/10 text-primary-strong'
+                                : undefined
+                            }
+                            onClick={() => setCurrentPage(page)}
+                          >
+                            {page}
+                          </Button>
+                        );
+                      })}
+
+                      <Button
+                        variant="outline"
+                        size="icon-sm"
+                        onClick={() => setCurrentPage(currentPage + 1)}
+                        disabled={currentPage >= stores.last_page}
+                      >
+                        <ChevronRightIcon />
+                      </Button>
+                    </nav>
+                  </div>
+                </div>
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="px-4 py-12 text-center">
+            <svg
+              className="mx-auto h-12 w-12 text-muted-foreground"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+              />
+            </svg>
+            <h3 className="mt-2 text-sm font-medium text-foreground">店舗がありません</h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {searchTerm ? '該当する店舗が見つかりません' : '最初の店舗を作成しましょう'}
+            </p>
+            <div className="mt-6">
               <Button onClick={() => router.push('/platform/stores/create')}>
                 <PlusIcon />
                 店舗を追加
               </Button>
             </div>
           </div>
-
-          {/* 検索フォーム */}
-          <Card className="mb-6">
-            <CardContent>
-              <form
-                onSubmit={handleSearch}
-                className="flex flex-col gap-3 sm:flex-row sm:items-center"
-              >
-                <div className="w-full sm:max-w-xs">
-                  <label htmlFor="search" className="sr-only">
-                    店舗を検索
-                  </label>
-                  <Input
-                    type="text"
-                    name="search"
-                    id="search"
-                    value={searchTerm}
-                    onChange={e => setSearchTerm(e.target.value)}
-                    placeholder="店舗名またはドメインで検索..."
-                  />
-                </div>
-                <Button type="submit">検索</Button>
-                {searchTerm && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => {
-                      setSearchTerm('');
-                      setCurrentPage(1);
-                    }}
-                  >
-                    クリア
-                  </Button>
-                )}
-              </form>
-            </CardContent>
-          </Card>
-
-          {/* 店舗一覧 */}
-          <Card className="py-0 overflow-hidden">
-            {loadingStores ? (
-              <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
-            ) : stores && stores.data.length > 0 ? (
-              <>
-                <ul className="divide-y">
-                  {stores.data.map(store => (
-                    <li key={store.id} className="px-4 py-4">
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center min-w-0 flex-1">
-                          <div className="flex-shrink-0">
-                            <div className="h-12 w-12 rounded-full bg-primary/10 flex items-center justify-center">
-                              <span className="text-lg font-medium text-primary-strong">
-                                {store.name.charAt(0).toUpperCase()}
-                              </span>
-                            </div>
-                          </div>
-                          <div className="ml-4 min-w-0 flex-1">
-                            <div className="flex items-center">
-                              <p className="text-lg font-medium text-foreground truncate">
-                                {store.name}
-                              </p>
-                              <Badge
-                                variant="outline"
-                                className={`ml-2 border-transparent ${
-                                  store.is_active
-                                    ? 'bg-success/10 text-success-strong'
-                                    : 'bg-destructive/10 text-destructive-strong'
-                                }`}
-                              >
-                                {store.is_active ? '有効' : '無効'}
-                              </Badge>
-                            </div>
-                          </div>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                          <span className="text-sm text-muted-foreground">
-                            {new Date(store.created_at).toLocaleDateString('ja-JP')}
-                          </span>
-                          <div className="flex space-x-2">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => router.push(`/platform/stores/${store.id}/edit`)}
-                            >
-                              編集
-                            </Button>
-                            <Button
-                              variant="destructive"
-                              size="sm"
-                              onClick={() => handleDeleteStore(store.id, store.name)}
-                            >
-                              削除
-                            </Button>
-                          </div>
-                        </div>
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-
-                {/* ページネーション */}
-                {stores.last_page > 1 && (
-                  <div className="px-4 py-3 flex items-center justify-between border-t sm:px-6">
-                    <div className="flex-1 flex justify-between sm:hidden">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setCurrentPage(currentPage - 1)}
-                        disabled={currentPage <= 1}
-                      >
-                        前へ
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="ml-3"
-                        onClick={() => setCurrentPage(currentPage + 1)}
-                        disabled={currentPage >= stores.last_page}
-                      >
-                        次へ
-                      </Button>
-                    </div>
-                    <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
-                      <div>
-                        <p className="text-sm text-muted-foreground">
-                          {stores.total} 件中 {stores.from}-{stores.to} を表示
-                        </p>
-                      </div>
-                      <div>
-                        <nav className="flex gap-1">
-                          <Button
-                            variant="outline"
-                            size="icon-sm"
-                            onClick={() => setCurrentPage(currentPage - 1)}
-                            disabled={currentPage <= 1}
-                          >
-                            <ChevronLeftIcon />
-                          </Button>
-
-                          {/* ページ番号ボタン */}
-                          {Array.from({ length: Math.min(5, stores.last_page) }, (_, i) => {
-                            const page = i + 1;
-                            return (
-                              <Button
-                                key={page}
-                                variant="outline"
-                                size="sm"
-                                className={
-                                  page === currentPage
-                                    ? 'border-primary bg-primary/10 text-primary-strong'
-                                    : undefined
-                                }
-                                onClick={() => setCurrentPage(page)}
-                              >
-                                {page}
-                              </Button>
-                            );
-                          })}
-
-                          <Button
-                            variant="outline"
-                            size="icon-sm"
-                            onClick={() => setCurrentPage(currentPage + 1)}
-                            disabled={currentPage >= stores.last_page}
-                          >
-                            <ChevronRightIcon />
-                          </Button>
-                        </nav>
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </>
-            ) : (
-              <div className="px-4 py-12 text-center">
-                <svg
-                  className="mx-auto h-12 w-12 text-muted-foreground"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-                  />
-                </svg>
-                <h3 className="mt-2 text-sm font-medium text-foreground">店舗がありません</h3>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {searchTerm ? '該当する店舗が見つかりません' : '最初の店舗を作成しましょう'}
-                </p>
-                <div className="mt-6">
-                  <Button onClick={() => router.push('/platform/stores/create')}>
-                    <PlusIcon />
-                    店舗を追加
-                  </Button>
-                </div>
-              </div>
-            )}
-          </Card>
-        </div>
-      </div>
+        )}
+      </Card>
     </div>
   );
 }

--- a/frontend/src/_pages/store-cast-fields/__tests__/CastFieldsPage.test.tsx
+++ b/frontend/src/_pages/store-cast-fields/__tests__/CastFieldsPage.test.tsx
@@ -117,3 +117,26 @@ describe('カスタムフィールド定義の管理ページ', () => {
     expect(await screen.findByText('フィールドが登録されていません')).toBeInTheDocument();
   });
 });
+
+describe('カスタムフィールド管理ページの外殻', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApi.list.mockResolvedValue([]);
+  });
+
+  it('見出し（h1）・副題を備え、主アクションが button ロールのままであること', async () => {
+    render(<CastFieldsPage />);
+    await screen.findByText('フィールドが登録されていません');
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'カスタムフィールド管理' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'キャストの追加プロフィール項目を定義します。公開設定した項目は公開詳細ページに表示されます。'
+      )
+    ).toBeInTheDocument();
+    // e2e（cast-custom-fields）は button ロールで取得するため、リンク化してはならない
+    expect(screen.getByRole('button', { name: 'フィールドを追加' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/_pages/store-cast-fields/__tests__/CastFieldsPage.test.tsx
+++ b/frontend/src/_pages/store-cast-fields/__tests__/CastFieldsPage.test.tsx
@@ -125,12 +125,14 @@ describe('カスタムフィールド管理ページの外殻', () => {
   });
 
   it('見出し（h1）・副題を備え、主アクションが button ロールのままであること', async () => {
-    render(<CastFieldsPage />);
+    const { container } = render(<CastFieldsPage />);
     await screen.findByText('フィールドが登録されていません');
 
     expect(
       screen.getByRole('heading', { level: 1, name: 'カスタムフィールド管理' })
     ).toBeInTheDocument();
+    // 外殻の class 文字列は DESIGN.md が規格として定めた面そのもの。
+    expect(container.firstElementChild).toHaveClass('space-y-6');
     expect(
       screen.getByText(
         'キャストの追加プロフィール項目を定義します。公開設定した項目は公開詳細ページに表示されます。'

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
@@ -4,6 +4,7 @@ import { PencilSquareIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/outli
 import { useState } from 'react';
 import { CastFieldDefinitionResponse, castFieldDefinitionApi } from '@/entities/cast';
 import { useManagedList } from '@/shared/lib';
+import { PageHeader } from '@/widgets/page-header';
 import {
   Badge,
   Button,
@@ -45,18 +46,16 @@ export default function CastFieldsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">カスタムフィールド管理</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            キャストの追加プロフィール項目を定義します。公開設定した項目は公開詳細ページに表示されます。
-          </p>
-        </div>
-        <Button onClick={() => setCreateOpen(true)}>
-          <PlusIcon />
-          フィールドを追加
-        </Button>
-      </div>
+      <PageHeader
+        title="カスタムフィールド管理"
+        description="キャストの追加プロフィール項目を定義します。公開設定した項目は公開詳細ページに表示されます。"
+        actions={
+          <Button onClick={() => setCreateOpen(true)}>
+            <PlusIcon />
+            フィールドを追加
+          </Button>
+        }
+      />
 
       <Card className="overflow-hidden py-0">
         {isLoading ? (

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
@@ -57,7 +57,7 @@ export default function CastFieldsPage() {
         }
       />
 
-      <Card className="overflow-hidden py-0">
+      <Card className="py-0 overflow-hidden">
         {isLoading ? (
           <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
         ) : definitions.length === 0 ? (

--- a/frontend/src/_pages/store-casts/__tests__/CastsPage.test.tsx
+++ b/frontend/src/_pages/store-casts/__tests__/CastsPage.test.tsx
@@ -165,10 +165,12 @@ describe('キャスト一覧ページの外殻', () => {
   });
 
   it('見出し（h1）・副題・主アクションのリンク先を備えること', async () => {
-    render(<CastListPage />);
+    const { container } = render(<CastListPage />);
     await screen.findByText('キャストが登録されていません');
 
     expect(screen.getByRole('heading', { level: 1, name: 'キャスト管理' })).toBeInTheDocument();
+    // 外殻の class 文字列は DESIGN.md が規格として定めた面そのもの。
+    expect(container.firstElementChild).toHaveClass('space-y-6');
     expect(screen.getByText('キャスト情報の登録・編集ができます。')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '新規キャスト登録' })).toHaveAttribute(
       'href',

--- a/frontend/src/_pages/store-casts/__tests__/CastsPage.test.tsx
+++ b/frontend/src/_pages/store-casts/__tests__/CastsPage.test.tsx
@@ -156,3 +156,23 @@ describe('カスタムフィールド管理への入口リンクは CAST_FIELD_D
     expect(screen.queryByRole('link', { name: 'カスタムフィールド管理' })).not.toBeInTheDocument();
   });
 });
+
+describe('キャスト一覧ページの外殻', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCastApi.list.mockResolvedValue(toPage([]));
+    mockedMe.mockResolvedValue(meWith(['CAST_MANAGE']));
+  });
+
+  it('見出し（h1）・副題・主アクションのリンク先を備えること', async () => {
+    render(<CastListPage />);
+    await screen.findByText('キャストが登録されていません');
+
+    expect(screen.getByRole('heading', { level: 1, name: 'キャスト管理' })).toBeInTheDocument();
+    expect(screen.getByText('キャスト情報の登録・編集ができます。')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '新規キャスト登録' })).toHaveAttribute(
+      'href',
+      '/store/1/casts/create'
+    );
+  });
+});

--- a/frontend/src/_pages/store-casts/ui/CastsPage.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastsPage.tsx
@@ -15,6 +15,7 @@ import { CastResponse, castApi, castInvitationStatusLabel } from '@/entities/cas
 import { platformAuthApi } from '@/entities/user';
 import { InvitationButton, InvitationModal, IssuedInvitation } from '@/features/cast-invitation';
 import { storePath, useManagedList } from '@/shared/lib';
+import { PageHeader } from '@/widgets/page-header';
 import { toast } from 'react-hot-toast';
 import {
   Badge,
@@ -100,33 +101,33 @@ export default function CastListPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-center">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">キャスト管理</h1>
-          <p className="text-sm text-muted-foreground mt-1">キャスト情報の登録・編集ができます。</p>
-        </div>
-        <div className="flex items-center gap-3">
-          {/* 定義管理ページ（/store/casts/fields）への入口。定義CRUDは CAST_FIELD_DEF_MANAGE 能力限定。 */}
-          {canManageFieldDefs && (
-            <Button asChild variant="outline">
-              <Link href={storePath(storeId, '/casts/fields')}>
-                <Cog6ToothIcon />
-                カスタムフィールド管理
+      <PageHeader
+        title="キャスト管理"
+        description="キャスト情報の登録・編集ができます。"
+        actions={
+          <>
+            {/* 定義管理ページ（/store/casts/fields）への入口。定義CRUDは CAST_FIELD_DEF_MANAGE 能力限定。 */}
+            {canManageFieldDefs && (
+              <Button asChild variant="outline">
+                <Link href={storePath(storeId, '/casts/fields')}>
+                  <Cog6ToothIcon />
+                  カスタムフィールド管理
+                </Link>
+              </Button>
+            )}
+            <Button asChild>
+              <Link href={storePath(storeId, '/casts/create')}>
+                <PlusIcon />
+                新規キャスト登録
               </Link>
             </Button>
-          )}
-          <Button asChild>
-            <Link href={storePath(storeId, '/casts/create')}>
-              <PlusIcon />
-              新規キャスト登録
-            </Link>
-          </Button>
-        </div>
-      </div>
+          </>
+        }
+      />
 
       {/* 検索バー */}
       <Card>
-        <CardContent className="flex items-center gap-4">
+        <CardContent className="flex flex-col md:flex-row md:items-center gap-4">
           <div className="flex-1 relative">
             <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
               <MagnifyingGlassIcon className="h-5 w-5 text-muted-foreground" />

--- a/frontend/src/_pages/store-customers/__tests__/CustomersPage.test.tsx
+++ b/frontend/src/_pages/store-customers/__tests__/CustomersPage.test.tsx
@@ -99,10 +99,12 @@ describe('顧客一覧ページの外殻', () => {
   });
 
   it('見出し（h1）・副題・主アクションのリンク先を備えること', async () => {
-    render(<CustomersPage />);
+    const { container } = render(<CustomersPage />);
     await screen.findByText('顧客が登録されていません');
 
     expect(screen.getByRole('heading', { level: 1, name: '顧客管理' })).toBeInTheDocument();
+    // 外殻の class 文字列は DESIGN.md が規格として定めた面そのもの。
+    expect(container.firstElementChild).toHaveClass('space-y-6');
     expect(screen.getByText('顧客情報の登録・編集ができます。')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '新規顧客登録' })).toHaveAttribute(
       'href',

--- a/frontend/src/_pages/store-customers/__tests__/CustomersPage.test.tsx
+++ b/frontend/src/_pages/store-customers/__tests__/CustomersPage.test.tsx
@@ -85,3 +85,28 @@ describe('店側顧客画面と API JSON（snake_case）の整合', () => {
     expect(screen.getByRole('checkbox')).not.toBeChecked();
   });
 });
+
+describe('顧客一覧ページの外殻', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCustomerApi.list.mockResolvedValue({
+      content: [],
+      total_pages: 0,
+      total_elements: 0,
+      size: 20,
+      number: 0,
+    } as never);
+  });
+
+  it('見出し（h1）・副題・主アクションのリンク先を備えること', async () => {
+    render(<CustomersPage />);
+    await screen.findByText('顧客が登録されていません');
+
+    expect(screen.getByRole('heading', { level: 1, name: '顧客管理' })).toBeInTheDocument();
+    expect(screen.getByText('顧客情報の登録・編集ができます。')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '新規顧客登録' })).toHaveAttribute(
+      'href',
+      '/store/1/customers/create'
+    );
+  });
+});

--- a/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
@@ -12,6 +12,7 @@ import { useParams } from 'next/navigation';
 import { CustomerResponse, customerApi } from '@/entities/customer';
 import { toast } from 'react-hot-toast';
 import { storePath } from '@/shared/lib';
+import { PageHeader } from '@/widgets/page-header';
 import {
   Badge,
   Button,
@@ -85,18 +86,18 @@ export default function CustomersPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-center">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">顧客管理</h1>
-          <p className="text-sm text-muted-foreground mt-1">顧客情報の登録・編集ができます。</p>
-        </div>
-        <Button asChild>
-          <Link href={storePath(storeId, '/customers/create')}>
-            <PlusIcon />
-            新規顧客登録
-          </Link>
-        </Button>
-      </div>
+      <PageHeader
+        title="顧客管理"
+        description="顧客情報の登録・編集ができます。"
+        actions={
+          <Button asChild>
+            <Link href={storePath(storeId, '/customers/create')}>
+              <PlusIcon />
+              新規顧客登録
+            </Link>
+          </Button>
+        }
+      />
 
       {/* 検索・絞り込みバー */}
       <Card>

--- a/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
@@ -158,3 +158,29 @@ describe('店側オーダー画面と API JSON（snake_case）の整合', () => 
     expect(body).not.toHaveProperty('businessDate');
   });
 });
+
+describe('オーダー一覧ページの外殻', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedOrderApi.list.mockResolvedValue({
+      content: [],
+      total_pages: 0,
+      total_elements: 0,
+      size: 100,
+      number: 0,
+    } as never);
+  });
+
+  it('見出し（h1）・副題・主アクションのリンク先を備えること', async () => {
+    render(<OrderListPage />);
+    await screen.findByText('オーダーがありません');
+
+    // e2e（hybrid-console-access）は見出し名 'オーダー一覧' の完全一致で到達確認する
+    expect(screen.getByRole('heading', { level: 1, name: 'オーダー一覧' })).toBeInTheDocument();
+    expect(screen.getByText('当日の注文状況を確認・管理できます。')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '新規オーダー登録' })).toHaveAttribute(
+      'href',
+      '/store/1/orders/create'
+    );
+  });
+});

--- a/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
@@ -172,11 +172,13 @@ describe('オーダー一覧ページの外殻', () => {
   });
 
   it('見出し（h1）・副題・主アクションのリンク先を備えること', async () => {
-    render(<OrderListPage />);
+    const { container } = render(<OrderListPage />);
     await screen.findByText('オーダーがありません');
 
     // e2e（hybrid-console-access）は見出し名 'オーダー一覧' の完全一致で到達確認する
     expect(screen.getByRole('heading', { level: 1, name: 'オーダー一覧' })).toBeInTheDocument();
+    // 外殻の class 文字列は DESIGN.md が規格として定めた面そのもの。
+    expect(container.firstElementChild).toHaveClass('space-y-6');
     expect(screen.getByText('当日の注文状況を確認・管理できます。')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '新規オーダー登録' })).toHaveAttribute(
       'href',

--- a/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
@@ -42,7 +42,7 @@ export default function OrderListPage() {
       />
 
       {/* Orders Table */}
-      <Card className="overflow-hidden py-0">
+      <Card className="py-0 overflow-hidden">
         {isLoading ? (
           <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
         ) : orders.length === 0 ? (

--- a/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation';
 import { PlusIcon, PencilSquareIcon } from '@heroicons/react/24/outline';
 import { Order, orderApi } from '@/entities/order';
 import { storePath, useManagedList } from '@/shared/lib';
+import { PageHeader } from '@/widgets/page-header';
 import {
   Badge,
   Button,
@@ -27,18 +28,18 @@ export default function OrderListPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-center">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">オーダー一覧</h1>
-          <p className="text-sm text-muted-foreground mt-1">当日の注文状況を確認・管理できます。</p>
-        </div>
-        <Button asChild>
-          <Link href={storePath(storeId, '/orders/create')}>
-            <PlusIcon aria-hidden="true" />
-            新規オーダー登録
-          </Link>
-        </Button>
-      </div>
+      <PageHeader
+        title="オーダー一覧"
+        description="当日の注文状況を確認・管理できます。"
+        actions={
+          <Button asChild>
+            <Link href={storePath(storeId, '/orders/create')}>
+              <PlusIcon aria-hidden="true" />
+              新規オーダー登録
+            </Link>
+          </Button>
+        }
+      />
 
       {/* Orders Table */}
       <Card className="overflow-hidden py-0">

--- a/frontend/src/widgets/page-header/index.ts
+++ b/frontend/src/widgets/page-header/index.ts
@@ -1,0 +1,1 @@
+export { PageHeader } from './ui/PageHeader';

--- a/frontend/src/widgets/page-header/ui/PageHeader.tsx
+++ b/frontend/src/widgets/page-header/ui/PageHeader.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+
+type PageHeaderProps = {
+  /** ページの主見出し。各ページに 1 つだけ置かれる h1 になる。 */
+  title: string;
+  /** 見出しの下に添える補足。持たないページがあるため任意。 */
+  description?: string;
+  /** 見出し右側の主アクション。複数渡された場合も同じ間隔で並ぶ。 */
+  actions?: ReactNode;
+};
+
+/**
+ * 一覧ページ外殻の見出しブロック。
+ *
+ * class 文字列をここに封じ込めることで、ページ側が外殻を再導出できなくなる
+ * ——並行して改修される複数ページの余白と見出しサイズを揃える手段はこれのみ。
+ */
+export function PageHeader({ title, description, actions }: PageHeaderProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">{title}</h1>
+        {description && <p className="text-sm text-muted-foreground mt-1">{description}</p>}
+      </div>
+      {actions && <div className="flex items-center gap-3">{actions}</div>}
+    </div>
+  );
+}

--- a/frontend/src/widgets/page-header/ui/__tests__/PageHeader.test.tsx
+++ b/frontend/src/widgets/page-header/ui/__tests__/PageHeader.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { PageHeader } from '../PageHeader';
+
+// 6 つの一覧ページは title・description・actions を常に 3 つとも渡すため、
+// 任意引数を省いた場合の分岐はここでしか通らない。
+describe('PageHeader', () => {
+  it('見出しを h1 として描き、副題とアクションを並べること', () => {
+    render(
+      <PageHeader
+        title="顧客管理"
+        description="顧客情報の登録・編集ができます。"
+        actions={<button type="button">新規顧客登録</button>}
+      />
+    );
+
+    expect(screen.getByRole('heading', { level: 1, name: '顧客管理' })).toBeInTheDocument();
+    expect(screen.getByText('顧客情報の登録・編集ができます。')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '新規顧客登録' })).toBeInTheDocument();
+  });
+
+  it('副題とアクションが無ければ見出しだけを描くこと', () => {
+    const { container } = render(<PageHeader title="顧客管理" />);
+
+    expect(screen.getByRole('heading', { level: 1, name: '顧客管理' })).toBeInTheDocument();
+    expect(container.querySelector('p')).toBeNull();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

一覧 6 ページの外殻を規格へ揃え、見出しブロックを `widgets/page-header` へ抽出する。あわせて `DESIGN.md` に「List page shell」節を **class 文字列そのもの**で新設する。

Closes #489

## なぜ文書だけでは足りないか

並列 restyle の実測が根拠になっている。`DESIGN.md` が `Card className="py-0 overflow-hidden"` と**精確に規定した**テーブルカードは 4 ページとも完全に一致し、「先例を参照」としか書かなかった外殻は 4 ページとも食い違った。同じ文書・同じ実行者でこの差が出る。**規約文書は「従うことが期待される」に留まり、コンポーネントは「従わないことができない」を作る。**

## 変更内容

- `widgets/page-header` を新設（見出し + 副題 + 右側アクション）し、一覧 6 ページへ適用
- `DESIGN.md`「List page shell」節を class 文字列で新設。拘束する 6 ページを肯定形で名指しし、対象外（フォーム画面・設定・store-shifts・store-select）も明記
- 店舗一覧を他の 5 ページへ揃える（見出し `text-2xl sm:text-3xl` → `text-2xl`、外層 `space-y-6` 追加、ページ自前のナビ帯を削除）
- テーブルカードの class 並び順を規格へ統一（grep で機械的に同一性を確認できるようにするため）
- 外殻の class 文字列そのものを錨で固定（下記）

## 検証

- [x] `task -d frontend lint` exit 0（警告 15 件はすべて既存）
- [x] `task -d frontend test` exit 0（70 suite / 399 test）
- [x] `task -d frontend build` exit 0
- [ ] `task e2e` — **e2e は 1 バイトも変えておらず、破断しないことを静的に確認済み**（下記）
- [x] ローカルで code-review 実施済み

`npx tsc --noEmit` の残り 1 件は master 既存（`shared/api/__tests__/file.test.ts` の axios adapter キャスト）。

**等価性の証明**: 6 つの実装ファイルだけを master へ戻し、テストは HEAD のまま `npx jest src/_pages src/widgets` を実行して **186/186 緑**（新実装と同数）。

**配線の証明**（削除して赤くなるか）: `description` 除去 → 7 件赤 / `actions` 除去 → 11 件赤 / `<h1>` → `<div>` → 8 件赤 / 主アクションを `Button asChild + Link` 化 → 2 件赤 / 店舗検索の `<form>` 除去 → 1 件赤 / **外層の `space-y-6` 除去 → 1 件赤**。

最後の 1 件は当初 0 件赤（＝未証明）だった。「jsdom に配置計算が無いので原理的に証明できない」と一度は結論したが、これは誤り。`toHaveClass` が照合するのは class **属性文字列**であって配置計算ではなく、本 PR は `DESIGN.md` でこれらの文字列を規格そのものと定義している。規格文字列は断言できる面である。

**既存テストの穴も 1 つ塞いだ**: 店舗検索のテストは「検索語を変える → ボタンを押す → ペイロード確認」だったが、`loadStores` が `searchTerm` に依存し `useEffect` が再取得するため、**ボタンを押さなくても通っていた**。送信固有の副作用（現在ページが 1 に戻る）を見る錨に差し替えた。

### e2e 隣接性

一覧ページは e2e が実際に遷移して操作する画面のため、`e2e/steps/` を全数精査した。**破断なし**、根拠は以下。

| 参照元 | 根拠 |
|---|---|
| `staff-management` / `cast-custom-fields` の `getByRole('button', ...)` | 主アクションは素の `Button onClick` のまま。**リンク化しないことを錨で固定**（`Button asChild + Link` へ変えると 2 件赤） |
| `hybrid-console-access` の heading `オーダー一覧` exact | `<h1>` のまま、副題は兄弟 `<p>`。可訪問名は完全一致 |
| `sidebar-menus` | `aside` 内リンクと URL のみ判定 |
| 削除した店舗一覧のナビ帯 | 否定 grep で `ログアウト` / `ようこそ` / `ダッシュボードへ戻る` はいずれも e2e に 0 件 |

`DESIGN.md` に「primary action keeps its element type」を規格として明記し、この落とし穴を文書側にも残した。

### 視覚確認（UI 変更時）

統合ビルドを起動し、コンテナのイメージ ID がビルド直後のものと一致することを確認したうえで実測した。

| 実測項目 | 顧客管理 | オーダー一覧 | 店舗一覧 |
| --- | --- | --- | --- |
| `<h1>` サイズ / 太さ | 24px / 700 | 24px / 700 | 24px / 700 |
| `<h1>` の上端 | 96px | 96px | 96px |
| 見出しから最初のカードまで | 48px | 48px | 48px |
| 副題サイズ | 14px | 14px | 14px |
| 外層 class | `space-y-6` | `space-y-6` | `space-y-6` |

店舗一覧のタグが `H1` であること、自前ナビ帯の残留が無いことも確認済み。**オーナーが差異に気づいた組み合わせ（顧客管理 ↔ オーダー一覧）が実測で完全一致**している。

**実際に見た目が変わるのは 3 箇所**（いずれも意図した統一）:
1. 店舗一覧の見出しがデスクトップで 30px → 24px
2. 店舗一覧の上部から自前ナビ帯が消える
3. キャスト管理の検索バーが 768px 未満で縦積みになる（`sm:` → `md:` 統一）

## 決定ログ

**店舗一覧の自前ナビ帯（`← ダッシュボードへ戻る` / `ようこそ、someone さん` / `ログアウト`）を削除した。** 当該ルートは `app/platform/(console)/stores/` 配下で、console layout が既に Header（アカウントメニュー経由のログアウトを含む）・Sidebar・`p-8`・`max-w-7xl` を提供している。削ったのは**内容領域に重複していた二本目のナビ**であり、`ようこそ、someone さん` は誰に対しても同じ文字列を返す固定文言でユーザーデータではない。また受け入れ基準「外層 = `space-y-6`」は、ナビ帯と `min-h-screen` の入れ子を残したままでは達成できない。

**`PageHeader` の API は現在の 6 ページが必要とするものだけ**（見出し・任意の副題・任意のアクション）。将来のための引数は足していない。

## 備考 / レビュー観点

- `PageHeader` をフォーム画面（8 枚）や設定画面へ広げるかは本票の対象外。`DESIGN.md` に「6 ページを拘束する / ついで変換は不可」と明記した
- 店舗一覧の一覧本体は `<ul>` のまま（他 5 ページは `Table`）。テーブル化は外殻ではなく中身の話

🤖 Generated with [Claude Code](https://claude.com/claude-code)