### PR TITLE
feat(frontend): 削除確認を window.confirm から ConfirmDialog へ置き換える

### DIFF
--- a/e2e/steps/cast-custom-fields.steps.ts
+++ b/e2e/steps/cast-custom-fields.steps.ts
@@ -129,8 +129,11 @@ When('キャストカスタムフィールド管理画面で {string} を削除�
   await page.goto(`${PLATFORM_URL}/store/${storeId}/casts/fields`);
   const row = page.getByRole('row', { name: new RegExp(createdFieldLabel) });
   await expect(row).toBeVisible({ timeout: 15000 });
-  page.once('dialog', dialog => dialog.accept());
   await row.getByRole('button', { name: '削除', exact: true }).click();
+  await page
+    .getByRole('alertdialog')
+    .getByRole('button', { name: '削除する', exact: true })
+    .click();
   await expect(row).toHaveCount(0, { timeout: 15000 });
 });
 

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -283,6 +283,7 @@ Primitives come from `@/shared/ui` (the barrel over the vendored shadcn componen
 - **Form controls**: `Input` / `Textarea` / `Select` / `Checkbox` / `Switch` / `RadioGroup` / `Label`, wired per the form pattern below.
 - **Modal (centered dialog)**: `Dialog` (`DialogContent` / `DialogHeader` / `DialogTitle` / `DialogFooter`). Tall forms add `max-h-[calc(100vh-2rem)] overflow-y-auto` on the content so the modal scrolls internally instead of overflowing the viewport (precedent: `StaffCreateModal`). Precedent for the plain case: `ShiftFormModal`.
 - **Drawer (side-slide dialog)**: `Sheet` with `side="right"` for record-scoped edit forms opened from a list row. Never re-create a drawer by re-positioning `DialogContent`.
+- **Confirm dialog (destructive confirmation)**: `ConfirmDialog` — controlled `open` + `title` (optionally `description`), with a destructive action button (`confirmLabel`, default 削除する) and a キャンセル cancel. Never call `window.confirm`, and never rebuild the pattern from `AlertDialog` parts in a page. Precedent: `CastFieldsPage`.
 - **Combobox (searchable select)**: `Popover` + `Command` (`CommandInput` / `CommandList` / `CommandEmpty` / `CommandItem`).
 - **Card section heading**: `CardTitle` renders a `<div>`, so wherever it stands for a section heading it must be written `<CardTitle role="heading" aria-level={N}>`. Without both attributes the section disappears from screen-reader heading navigation, and the loss is invisible in a rendered diff. The primitive stays pristine — it spreads `React.ComponentProps<'div'>`, so the consumer supplies them. (Where the card is genuinely not a section heading — a bare label on a stat card — leave it a `div` and do not add the role.)
   - **Pick `N` from the outline the page actually has, never from the tag the card replaced.** Levels must not skip: a card section directly under the page's `<h1>` is `aria-level={2}`, whatever the pre-shadcn markup used. Every admin page today is `<h1>` + card sections, so **2** is the level in practice; a nested sub-section inside such a card would be 3. Sibling headings written as real tags follow the same outline (`CustomerEditPage`'s 注文履歴 is an `<h2>`, not an `<h3>`).
@@ -393,7 +394,7 @@ This holds for `success`, `warning` and `destructive` — the three semantics wh
 
 ### Behavior preservation
 
-Submitted payloads, react-hook-form wiring and existing `confirm()` calls are preserved exactly. Anything that would change the payload — turning a free-text field into a `Select`, normalizing a value — is a separate issue, not part of a restyle.
+Submitted payloads, react-hook-form wiring and existing `ConfirmDialog` confirmation flows are preserved exactly. Anything that would change the payload — turning a free-text field into a `Select`, normalizing a value — is a separate issue, not part of a restyle.
 
 ### Negative invariant
 
@@ -422,10 +423,10 @@ Everything else that still matches the grep — the unconverted slices, `widgets
 
 `src/shared/ui` holds two kinds of file, and only one of them is frozen.
 
-- **Vendored shadcn primitives** — `button` / `card` / `dialog` / `select` / `form` / `table` / `badge` / `sheet` / `popover` / `command` / `skeleton` / `tabs` / `dropdown-menu` / `checkbox` / `switch` / `radio-group` / `input` / `label` / `textarea`. Kept exactly as generated; per-screen deviation goes in the consumer's `className`, never here.
-- **Kizuna-authored components** — `image-upload.tsx`, `auth-layout.tsx`, `theme-provider.tsx`. Hand-written, so they obey the token rules like any other admin file. `auth-layout.tsx` is the exception noted above: it belongs to the auth world.
+- **Vendored shadcn primitives** — `alert-dialog` / `button` / `card` / `dialog` / `select` / `form` / `table` / `badge` / `sheet` / `popover` / `command` / `skeleton` / `tabs` / `dropdown-menu` / `checkbox` / `switch` / `radio-group` / `input` / `label` / `textarea`. Kept exactly as generated; per-screen deviation goes in the consumer's `className`, never here.
+- **Kizuna-authored components** — `image-upload.tsx`, `auth-layout.tsx`, `theme-provider.tsx`, `confirm-dialog.tsx`. Hand-written, so they obey the token rules like any other admin file. `auth-layout.tsx` is the exception noted above: it belongs to the auth world.
 
-Tell them apart by the generator's fingerprint rather than by guessing. The one reliable single test is **`data-slot`**: all 19 vendored files carry it and none of the three hand-written ones do. The other markers are only suggestive — a `radix-ui` import is absent from 8 of the 19, and `cva` from 17 of the 19, so "some of these, not all" is the honest reading and neither is usable alone. The negative direction is what holds: the hand-written three carry none of the markers, and import application code a generator would never emit (`@/shared/api`, `@heroicons/react`, `next-themes`). `git log --follow` settles any remaining doubt — the hand-written files predate the shadcn adoption by months.
+Tell them apart by the generator's fingerprint rather than by guessing. The one reliable single test is **`data-slot`**: all 20 vendored files carry it and none of the four hand-written ones do. The other markers are only suggestive — a `radix-ui` import is absent from 6 of the 20, and `cva` from 17 of the 20, so "some of these, not all" is the honest reading and neither is usable alone. The negative direction is what holds: the hand-written four carry none of the markers, and either import application code a generator would never emit (`@/shared/api`, `@heroicons/react`, `next-themes`) or, as `confirm-dialog.tsx` does, compose sibling primitives through relative imports where the generator emits the `@/shared/ui` alias. `git log --follow` settles any remaining doubt.
 
 Editing a hand-written one is still a shared-file change, so it goes through the contract below rather than through a slice PR.
 

--- a/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
+++ b/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
@@ -129,24 +129,25 @@ describe('店舗管理 3 画面の挙動', () => {
     expect(screen.getByRole('button', { name: '前へ' })).toBeEnabled();
   });
 
-  it('削除は confirm で承諾されたときだけ実行されること', async () => {
+  it('削除は確認ダイアログで承諾されたときだけ実行されること', async () => {
     mockedApi.getList.mockResolvedValue(paginated([store({ id: '7', name: 'アルファ店' })]));
     mockedApi.delete.mockResolvedValue(undefined);
-    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
 
     render(<StoresPage />);
     fireEvent.click(await screen.findByRole('button', { name: '削除' }));
 
-    expect(confirmSpy).toHaveBeenCalledWith(
-      '店舗「アルファ店」を削除しますか？この操作は取り消せません。'
-    );
+    const dialog = await screen.findByRole('alertdialog');
+    expect(dialog).toHaveTextContent('店舗「アルファ店」を削除しますか？');
+    expect(dialog).toHaveTextContent('この操作は取り消せません。');
+
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument());
     expect(mockedApi.delete).not.toHaveBeenCalled();
 
-    confirmSpy.mockReturnValue(true);
     fireEvent.click(screen.getByRole('button', { name: '削除' }));
+    fireEvent.click(await screen.findByRole('button', { name: '削除する' }));
 
     await waitFor(() => expect(mockedApi.delete).toHaveBeenCalledWith('7'));
-    confirmSpy.mockRestore();
   });
 
   it('新規作成は name/domain/email を送信し一覧へ遷移すること', async () => {

--- a/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
@@ -5,7 +5,7 @@ import { ChevronLeftIcon, ChevronRightIcon, PlusIcon } from '@heroicons/react/24
 import { useRouter } from 'next/navigation';
 import { Store, platformStoreApi } from '@/entities/store';
 import { PaginatedResponse } from '@/shared/api';
-import { Badge, Button, Card, CardContent, Input } from '@/shared/ui';
+import { Badge, Button, Card, CardContent, ConfirmDialog, Input } from '@/shared/ui';
 import { PageHeader } from '@/widgets/page-header';
 import toast from 'react-hot-toast';
 
@@ -15,6 +15,7 @@ export default function StoresPage() {
   const [loadingStores, setLoadingStores] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
+  const [deleteTarget, setDeleteTarget] = useState<Store | null>(null);
 
   const loadStores = useCallback(async () => {
     setLoadingStores(true);
@@ -43,13 +44,10 @@ export default function StoresPage() {
     loadStores();
   };
 
-  const handleDeleteStore = async (id: string, name: string) => {
-    if (!confirm(`店舗「${name}」を削除しますか？この操作は取り消せません。`)) {
-      return;
-    }
-
+  const handleDeleteStore = async () => {
+    if (!deleteTarget) return;
     try {
-      await platformStoreApi.delete(id);
+      await platformStoreApi.delete(deleteTarget.id);
       toast.success('店舗を削除しました');
       loadStores();
     } catch (error) {
@@ -155,7 +153,7 @@ export default function StoresPage() {
                         <Button
                           variant="destructive"
                           size="sm"
-                          onClick={() => handleDeleteStore(store.id, store.name)}
+                          onClick={() => setDeleteTarget(store)}
                         >
                           削除
                         </Button>
@@ -267,6 +265,14 @@ export default function StoresPage() {
           </div>
         )}
       </Card>
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={deleteTarget ? `店舗「${deleteTarget.name}」を削除しますか？` : ''}
+        description="この操作は取り消せません。"
+        onConfirm={() => void handleDeleteStore()}
+        onClose={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }

--- a/frontend/src/_pages/store-cast-fields/__tests__/CastFieldsPage.test.tsx
+++ b/frontend/src/_pages/store-cast-fields/__tests__/CastFieldsPage.test.tsx
@@ -38,16 +38,10 @@ const definitions = [
 ] as CastFieldDefinitionResponse[];
 
 describe('カスタムフィールド定義の管理ページ', () => {
-  const originalConfirm = window.confirm;
-
   beforeEach(() => {
     jest.clearAllMocks();
     mockedApi.list.mockResolvedValue(definitions);
     mockedApi.delete.mockResolvedValue(undefined as never);
-  });
-
-  afterEach(() => {
-    window.confirm = originalConfirm;
   });
 
   it('一覧の key・label・公開設定・表示順を表示する', async () => {
@@ -60,22 +54,26 @@ describe('カスタムフィールド定義の管理ページ', () => {
   });
 
   it('削除は確認ダイアログを label 付きで出し、キャンセルされたら削除 API を呼ばない', async () => {
-    window.confirm = jest.fn(() => false);
     render(<CastFieldsPage />);
     await screen.findByText('blood_type');
 
     fireEvent.click(screen.getAllByRole('button', { name: '削除' })[0]);
 
-    expect(window.confirm).toHaveBeenCalledWith('「血液型」を削除しますか？');
+    const dialog = await screen.findByRole('alertdialog');
+    expect(dialog).toHaveTextContent('「血液型」を削除しますか？');
+
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument());
     expect(mockedApi.delete).not.toHaveBeenCalled();
   });
 
   it('削除を承諾すると対象 id を削除し一覧を再取得する', async () => {
-    window.confirm = jest.fn(() => true);
     render(<CastFieldsPage />);
     await screen.findByText('blood_type');
 
     fireEvent.click(screen.getAllByRole('button', { name: '削除' })[1]);
+    fireEvent.click(await screen.findByRole('button', { name: '削除する' }));
 
     await waitFor(() => expect(mockedApi.delete).toHaveBeenCalledWith('def-2'));
     await waitFor(() => expect(mockedApi.list).toHaveBeenCalledTimes(2));
@@ -83,7 +81,6 @@ describe('カスタムフィールド定義の管理ページ', () => {
   });
 
   it('削除ボタンのクリックは行クリックへ伝播せず編集モーダルを開かない', async () => {
-    window.confirm = jest.fn(() => false);
     render(<CastFieldsPage />);
     await screen.findByText('blood_type');
 

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
@@ -9,6 +9,7 @@ import {
   Badge,
   Button,
   Card,
+  ConfirmDialog,
   Table,
   TableBody,
   TableCell,
@@ -32,11 +33,12 @@ export default function CastFieldsPage() {
   );
   const [createOpen, setCreateOpen] = useState(false);
   const [editing, setEditing] = useState<CastFieldDefinitionResponse | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<CastFieldDefinitionResponse | null>(null);
 
-  const handleDelete = async (id: string, label: string) => {
-    if (!confirm(`「${label}」を削除しますか？`)) return;
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
     try {
-      await castFieldDefinitionApi.delete(id);
+      await castFieldDefinitionApi.delete(deleteTarget.id);
       toast.success('フィールドを削除しました');
       void refetch();
     } catch {
@@ -121,7 +123,7 @@ export default function CastFieldsPage() {
                         size="icon-sm"
                         onClick={e => {
                           e.stopPropagation();
-                          void handleDelete(definition.id, definition.label);
+                          setDeleteTarget(definition);
                         }}
                         aria-label="削除"
                       >
@@ -146,6 +148,12 @@ export default function CastFieldsPage() {
         definition={editing}
         onClose={() => setEditing(null)}
         onUpdated={refetch}
+      />
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={deleteTarget ? `「${deleteTarget.label}」を削除しますか？` : ''}
+        onConfirm={() => void handleDelete()}
+        onClose={() => setDeleteTarget(null)}
       />
     </div>
   );

--- a/frontend/src/_pages/store-casts/ui/CastsPage.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastsPage.tsx
@@ -22,6 +22,7 @@ import {
   Button,
   Card,
   CardContent,
+  ConfirmDialog,
   Input,
   Table,
   TableBody,
@@ -37,6 +38,7 @@ export default function CastListPage() {
   const storeId = params.storeId as string;
   const [search, setSearch] = useState('');
   const [issuedInvitation, setIssuedInvitation] = useState<IssuedInvitation | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<CastResponse | null>(null);
   // 能力による UI 出し分け（強制はサーバ側 @PreAuthorize — ここは導線の表示制御のみ）
   const [canInvite, setCanInvite] = useState(false);
   const [canManageFieldDefs, setCanManageFieldDefs] = useState(false);
@@ -76,10 +78,10 @@ export default function CastListPage() {
   };
 
   /** キャストを削除する */
-  const handleDelete = async (id: string, name: string) => {
-    if (!confirm(`「${name}」を削除しますか？`)) return;
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
     try {
-      await castApi.delete(id);
+      await castApi.delete(deleteTarget.id);
       toast.success('キャストを削除しました');
       void refetch();
     } catch {
@@ -229,7 +231,7 @@ export default function CastListPage() {
                         <Button
                           variant="ghost"
                           size="icon-sm"
-                          onClick={() => handleDelete(cast.id, cast.name)}
+                          onClick={() => setDeleteTarget(cast)}
                         >
                           <TrashIcon />
                         </Button>
@@ -252,6 +254,12 @@ export default function CastListPage() {
         }
         expiresAt={issuedInvitation?.expiresAt ?? null}
         onClose={() => setIssuedInvitation(null)}
+      />
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={deleteTarget ? `「${deleteTarget.name}」を削除しますか？` : ''}
+        onConfirm={() => void handleDelete()}
+        onClose={() => setDeleteTarget(null)}
       />
     </div>
   );

--- a/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
@@ -18,6 +18,7 @@ import {
   Button,
   Card,
   CardContent,
+  ConfirmDialog,
   Input,
   Table,
   TableBody,
@@ -38,6 +39,7 @@ export default function CustomersPage() {
   const [classification, setClassification] = useState('');
   const [page, setPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
+  const [deleteTarget, setDeleteTarget] = useState<CustomerResponse | null>(null);
 
   const fetchCustomers = useCallback(
     async (pageNumber: number) => {
@@ -73,10 +75,10 @@ export default function CustomersPage() {
     fetchCustomers(0);
   };
 
-  const handleDelete = async (id: string, name: string) => {
-    if (!confirm(`「${name}」を削除しますか？`)) return;
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
     try {
-      await customerApi.delete(id);
+      await customerApi.delete(deleteTarget.id);
       toast.success('顧客を削除しました');
       fetchCustomers(page);
     } catch {
@@ -192,7 +194,7 @@ export default function CustomersPage() {
                       <Button
                         variant="ghost"
                         size="icon-sm"
-                        onClick={() => handleDelete(customer.id, customer.name)}
+                        onClick={() => setDeleteTarget(customer)}
                       >
                         <TrashIcon />
                       </Button>
@@ -227,6 +229,13 @@ export default function CustomersPage() {
           </Button>
         </div>
       )}
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={deleteTarget ? `「${deleteTarget.name}」を削除しますか？` : ''}
+        onConfirm={() => void handleDelete()}
+        onClose={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }

--- a/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { CastResponse } from '@/entities/cast';
 import { ShiftResponse, shiftApi } from '@/entities/shift';
 import {
   Button,
+  ConfirmDialog,
   Dialog,
   DialogContent,
   DialogTitle,
@@ -78,6 +79,7 @@ export function ShiftFormModal({
     control,
     formState: { isSubmitting },
   } = form;
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   useEffect(() => {
     if (!open) return;
@@ -125,7 +127,6 @@ export function ShiftFormModal({
 
   const handleDelete = async () => {
     if (!editing) return;
-    if (!confirm('このシフトを削除しますか？')) return;
     try {
       await shiftApi.delete(editing.id);
       toast.success('シフトを削除しました');
@@ -233,7 +234,7 @@ export function ShiftFormModal({
                   <Button
                     type="button"
                     variant="ghost"
-                    onClick={handleDelete}
+                    onClick={() => setConfirmOpen(true)}
                     className="text-destructive-strong"
                   >
                     削除
@@ -251,6 +252,12 @@ export function ShiftFormModal({
             </div>
           </form>
         </Form>
+        <ConfirmDialog
+          open={confirmOpen}
+          title="このシフトを削除しますか？"
+          onConfirm={() => void handleDelete()}
+          onClose={() => setConfirmOpen(false)}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/_pages/store-shifts/ui/__tests__/ShiftFormModal.test.tsx
+++ b/frontend/src/_pages/store-shifts/ui/__tests__/ShiftFormModal.test.tsx
@@ -246,18 +246,20 @@ describe('シフトフォームのセレクト配線と送信ペイロード', (
   });
 
   it('削除は確認を経て呼ばれ、取り消すと呼ばれないこと', async () => {
-    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
     const { onSaved } = renderModal({ editing: EDITING });
 
     fireEvent.click(screen.getByRole('button', { name: '削除' }));
-    expect(confirmSpy).toHaveBeenCalledWith('このシフトを削除しますか？');
+    const dialog = await screen.findByRole('alertdialog');
+    expect(dialog).toHaveTextContent('このシフトを削除しますか？');
+
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument());
     expect(mockedDelete).not.toHaveBeenCalled();
 
-    confirmSpy.mockReturnValue(true);
     fireEvent.click(screen.getByRole('button', { name: '削除' }));
+    fireEvent.click(await screen.findByRole('button', { name: '削除する' }));
 
     await waitFor(() => expect(mockedDelete).toHaveBeenCalledWith('shift-1'));
     await waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1));
-    confirmSpy.mockRestore();
   });
 });

--- a/frontend/src/shared/ui/alert-dialog.tsx
+++ b/frontend/src/shared/ui/alert-dialog.tsx
@@ -16,9 +16,7 @@ function AlertDialogTrigger({
   return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
 }
 
-function AlertDialogPortal({
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
   return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
 }
 

--- a/frontend/src/shared/ui/alert-dialog.tsx
+++ b/frontend/src/shared/ui/alert-dialog.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import * as React from 'react';
+import { AlertDialog as AlertDialogPrimitive } from 'radix-ui';
+
+import { cn } from '@/shared/lib/utils';
+import { buttonVariants } from '@/shared/ui/button';
+
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        'fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn('text-lg font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      data-slot="alert-dialog-action"
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      data-slot="alert-dialog-cancel"
+      className={cn(buttonVariants({ variant: 'outline' }), className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/frontend/src/shared/ui/confirm-dialog.tsx
+++ b/frontend/src/shared/ui/confirm-dialog.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './alert-dialog';
+import { buttonVariants } from './button';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  /** タイトルの下に出す補足。省略時はタイトルのみ。 */
+  description?: string;
+  /** 実行ボタンのラベル。 */
+  confirmLabel?: string;
+  /** 実行ボタン押下時。ダイアログは自動で閉じ、その後 onClose も呼ばれる。 */
+  onConfirm: () => void;
+  /** キャンセル・Esc・実行後の close で呼ばれる。ここで open を false に戻すこと。 */
+  onClose: () => void;
+}
+
+/** 破壊的操作の確認ダイアログ。 */
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = '削除する',
+  onConfirm,
+  onClose,
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={next => {
+        if (!next) onClose();
+      }}
+    >
+      <AlertDialogContent {...(description ? {} : { 'aria-describedby': undefined })}>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          {description && <AlertDialogDescription>{description}</AlertDialogDescription>}
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>キャンセル</AlertDialogCancel>
+          <AlertDialogAction
+            className={buttonVariants({ variant: 'destructive' })}
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -1,11 +1,13 @@
 export { default as ImageUpload } from './image-upload';
 export { default as AuthLayout } from './auth-layout';
 export { ThemeProvider } from './theme-provider';
+export * from './alert-dialog';
 export * from './button';
 export * from './badge';
 export * from './card';
 export * from './checkbox';
 export * from './command';
+export * from './confirm-dialog';
 export * from './dialog';
 export * from './dropdown-menu';
 export * from './form';


### PR DESCRIPTION
## 概要

ネイティブ `window.confirm` による削除確認（5 箇所）を、shared/ui に新設した AlertDialog（vendored shadcn プリミティブ）+ ConfirmDialog（手書き封装）へ置き換える。radix-ui 同梱のため依存追加なし。

## 変更内容

- `shared/ui/alert-dialog.tsx` 新設 — vendored shadcn AlertDialog（`radix-ui` 統一パッケージ使用、data-slot / cn / dialog.tsx と同じ class 語彙）
- `shared/ui/confirm-dialog.tsx` 新設 — `ConfirmDialog`（`open` / `title` / 任意 `description` / `confirmLabel`（既定 削除する）/ `onConfirm` / `onClose`、実行ボタンは destructive）
- 置き換え 5 箇所: `CastFieldsPage` / `CustomersPage` / `StoresPage` / `CastsPage` / `ShiftFormModal`（モーダル内から確認ダイアログを重ねる）。確認文言は従来どおり維持し、`StoresPage` の「この操作は取り消せません。」のみ description に分離
- テスト 3 ファイルを `window.confirm` モックからダイアログ実操作（`alertdialog` ロール + ボタンクリック）へ書き換え
- e2e `cast-custom-fields.steps.ts` を `page.once('dialog', accept)` から画面内「削除する」クリックへ変更
- `DESIGN.md` に Confirm dialog パターンを追記、shared/ui の vendored / 手書き台帳と指紋計数を更新（radix-ui / cva の計数は grep 実測値へ取り直し）

## 検証

- [x] `task lint service=frontend` exit 0（backend は無変更）
- [x] `task test service=frontend` exit 0（ローカル Jest 全量 70 suites / 399 tests も green）
- [x] `task build service=frontend` exit 0
- [x] `task e2e` 実行（実行シナリオ: 全 19）— **17 passed / 2 failed**。本 PR が変更した `cast-custom-fields` の 2 シナリオ（新ダイアログ経由の削除を含む）は green。失敗 2 件は `platform-login` の店舗切替で、`header [aria-haspopup]` セレクタが「唯一の aria-haspopup」前提のまま Header 側の変更（アカウントメニューの DropdownMenu 化等）で歧義になった master 既存の回帰。本 diff とは無関係のため別タスクとして切り出し済み
- [x] ローカルで code-review 実施済み（Standards / Spec の 2 軸。指摘のうち注釈の履歴叙述削除と DESIGN.md 計数の実測取り直しを反映済み）

### 視覚確認（UI 変更時）

実ブラウザ（Chrome）で顧客一覧の削除確認を実施: オーバーレイの暗転・タイトル・キャンセル / 赤の「削除する」ボタンの表示と、キャンセルで削除 API が呼ばれないことを確認。なお Playwright 同梱 Chromium は oklab 背景色を描画しない癖があり、スクリーンショット上はオーバーレイが暗転しない（既存 Dialog も同様、実ブラウザでは正常）。

## 決定ログ

- **AlertDialog は vendored、ConfirmDialog は手書き**: プリミティブは生成物のまま凍結し（DESIGN.md の運用どおり）、繰り返しパターンは手書きの薄い封装に集約。5 箇所が同型のため、ページごとに AlertDialog を組み立てる案は発散リスクで見送り
- **destructive 固定**: 現在の用途が全て削除確認のため、variant 汎用化はしない（必要になった時点で拡張）
- **`onClose` を close 経路の単一コールバックに**: キャンセル / Esc / 実行後 close のいずれも `onClose` に集約し、呼び出し側は state を null に戻すだけの冪等な実装にした
- **見送り**: 4 ページに残る `deleteTarget` state の定型を `useDeleteConfirm` フックへ括る案。現段階では抽象が先行しすぎると判断（レビューで必要と判断されれば追随可）

## 備考 / レビュー観点

- ConfirmDialog の `title` は close アニメーション中に一瞬空文字になる（`deleteTarget` クリア後）。実害のない既知の挙動
- e2e の platform-login 2 件失敗は master 由来の別件（上記）。修正タスクを別途起票済み