### PR TITLE
chore: sweep 中に見つかった小さな負債をまとめて片付ける

### DIFF
--- a/e2e/steps/platform-login.steps.ts
+++ b/e2e/steps/platform-login.steps.ts
@@ -20,9 +20,11 @@ function castsUrl(page: Page): string {
   return `${PLATFORM_URL}/store/${currentStoreId(page)}/casts`;
 }
 
-// Header の店舗切替ドロップダウンは唯一の aria-haspopup 要素。
-// アカウントメニューは group-hover の素の要素で aria-haspopup を持たないため一意に特定できる。
-const storeSwitchToggle = (page: Page): Locator => page.locator('header [aria-haspopup]');
+// Header のドロップダウン（表示モード・店舗切替・アカウントメニュー）はいずれも aria-haspopup を
+// 持つ。うち店舗切替だけはアクセシブル名が現在店舗名（動的値）で aria-label を持たないため、
+// その欠如で一意に特定する。
+const storeSwitchToggle = (page: Page): Locator =>
+  page.locator('header button[aria-haspopup]:not([aria-label])');
 
 // 播種したキャストの id / 一意名。scenario 2 の Given でのみ設定し、断言と後始末で共有する。
 let createdCastId = '';
@@ -31,7 +33,8 @@ let createdCastName = '';
 /** 店舗切替ドロップダウンを開いた状態にし、開いたメニュー要素を返す（既に開いていれば再クリックしない）。 */
 async function openStoreSwitch(page: Page): Promise<Locator> {
   const toggle = storeSwitchToggle(page);
-  // stores() の取得完了までボタンは disabled。有効化＝一覧ロード済みを待ってから開く。
+  // stores() の取得完了までトグルは描画されない。toBeEnabled は出現も併せて待つため、
+  // これで一覧ロード済みを待ってから開くことになる。
   await expect(toggle).toBeEnabled();
   const menu = page.getByRole('menu');
   if ((await menu.count()) === 0) {

--- a/e2e/steps/store-settings.steps.ts
+++ b/e2e/steps/store-settings.steps.ts
@@ -5,11 +5,8 @@ import { getStoreConfig, loginAsStoreAdmin, loginViaUiAndEnterStore, setCustomTe
 
 const { Given, When, Then, After } = createBdd();
 
-// StoreProfileForm.tsx の模版テキスト欄は <label> と <textarea> が id/htmlFor で
-// 紐付いていない（隣接する兄弟要素）ため getByLabel は使えず、隣接セレクタで特定する。
 const ACCESS_NOTE_LABEL = 'アクセス補足（店舗情報ページに表示）';
-const accessNoteTextarea = (page: Page) =>
-  page.locator(`label:text-is("${ACCESS_NOTE_LABEL}") + textarea`);
+const accessNoteTextarea = (page: Page) => page.getByLabel(ACCESS_NOTE_LABEL, { exact: true });
 
 let originalCustomTexts: Record<string, string> | null = null;
 // 退避ステップが実際に成功したかの哨兵。退避前にシナリオが失敗した場合、

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -95,6 +95,7 @@ Ratios are WCAG relative-luminance figures computed from the oklch values in `gl
 | `text-primary-strong` on `bg-accent` (ghost hover)               | 4.78      | 5.65      | 4.5  |
 | `border-primary` / `ring-primary` vs `bg-card` / `bg-background` | 5.26      | 3.37      | 3    |
 | `bg-destructive/90` hover fill + its icon                        | 4.32      | 5.64      | 3    |
+| `border-muted-foreground` dropzone edge vs `bg-card`             | 4.83      | 6.74      | 3    |
 
 Every prescribed combination clears its bar in both modes, so **no size or weight condition is attached to any of them**.
 
@@ -105,6 +106,8 @@ A few of the newer rows need a note, since each answers a question that came up 
 - The `bg-destructive/90` row is the hover state of a solid destructive fill, as the vendored `Button` destructive variant emits it. Its 10% transparency means the figure depends on what sits behind; the values here are the **worst case over any backdrop**, which the small alpha keeps close to the opaque `bg-destructive` row. It carries an icon, not text, hence the 3:1 bar. The `bg-success/90` / `bg-warning/90` rows follow the same worst-case convention for the hover state of the solid timeline bars; these carry the bar's own time text, hence 4.5, and over their actual `bg-muted` track they measure 6.82 / 6.89 in light (9.41 / 9.75 in dark).
 - The two `on bg-background` rows cover text drawn on the page shell outside a card — the timeline view's selected tab (`text-primary-strong`) and page-level error copy (`text-destructive-strong`). In light mode `--background` is identical to `--card`, so only the dark figures differ from the `on bg-card` rows.
 - The `bg-destructive` marker row is the timeline's current-time line where it crosses the `bg-muted` track (its crossing of the card gaps is the `vs bg-card` row above).
+- The `border-muted-foreground` row is the image-upload dropzone's dashed edge. A dropzone's boundary is the only cue to where dropping works, so it is a meaningful graphic bound by 3:1 — the decorative exemption that covers `border-border` separators does not extend to it, and `border-border` itself sits at 1.27 / 1.33. Against `bg-background` the same edge measures 4.83 / 7.56, so the row's `bg-card` figures are the binding worst case.
+- The success toast (`ToastProvider`) is the `bg-success` + `text-success-foreground` row: react-hot-toast takes inline styles, so the pairing is written as `var(--success)` / `var(--success-foreground)` rather than classes, and follows the mode the same way.
 
 Three of these recipes exist in this form only because the matrix caught them failing: `text-primary` on a dark surface (3.37), solid destructive with a near-white foreground in dark (2.77), and category chips coloured with `text-chart-*`, where three of the five hues fall below 3:1 against their own tint in one mode or the other (as low as 1.62). Where a fix changed appearance it is noted with the recipe.
 
@@ -219,14 +222,7 @@ The `chart-*` tokens are category hues with **no `-foreground` pair** and no con
 
 Pick whichever hue keeps sibling categories distinct — with the hue confined to a 10% tint, that choice can no longer create a contrast problem.
 
-##### Sidebar facts: dormant `--sidebar-*` tokens and the no-op `custom-scrollbar`
-
-`widgets/sidebar/ui/Sidebar.tsx` is now an ordinary admin surface — `bg-card` behind the Sidebar nav item recipe from Components, with no raw palette classes left. Two adjacent facts are recorded so nobody re-derives them:
-
-- The `--sidebar-*` token family in `globals.css` (exposed as `bg-sidebar` etc. through `@theme inline`) has **no consumer**: the sidebar restyle used the generic tokens instead. Do not reach for these tokens in new markup; whether to delete the family is a `globals.css` shared-file decision, not a slice PR.
-- The `custom-scrollbar` class (on the sidebar scroll area and the two console `app/` layout shells) is defined **nowhere** — no stylesheet or config declares it, so it is a no-op. Do not copy it into new markup; removing the three usages is a code cleanup outside any restyle PR.
-
-One-off domain colors (now marker, weekend, coverage bar, category chips) intentionally reuse existing tokens instead of gaining dedicated ones: a token with a single consumer is dead weight.
+One-off domain colors (now marker, weekend, coverage bar, category chips) intentionally reuse existing tokens instead of gaining dedicated ones: a token with a single consumer is dead weight. The same policy is why `globals.css` carries no `--sidebar-*` family: the sidebar is an ordinary admin surface (`bg-card` behind the Sidebar nav item recipe from Components) built from the generic tokens.
 
 ### Public storefront (three templates)
 
@@ -285,6 +281,7 @@ Primitives come from `@/shared/ui` (the barrel over the vendored shadcn componen
 - **Drawer (side-slide dialog)**: `Sheet` with `side="right"` for record-scoped edit forms opened from a list row. Never re-create a drawer by re-positioning `DialogContent`.
 - **Confirm dialog (destructive confirmation)**: `ConfirmDialog` — controlled `open` + `title` (optionally `description`), with a destructive action button (`confirmLabel`, default 削除する) and a キャンセル cancel. Never call `window.confirm`, and never rebuild the pattern from `AlertDialog` parts in a page. Precedent: `CastFieldsPage`.
 - **Combobox (searchable select)**: `Popover` + `Command` (`CommandInput` / `CommandList` / `CommandEmpty` / `CommandItem`).
+- **Destructive menu item**: do not use the vendored `DropdownMenuItem`'s own `variant="destructive"` — it keeps the default red as the text over its tinted focus fill (`text-destructive` on `bg-destructive/10`), which measures **3.99 in light mode** (dark passes at 4.58 over its `/20` fill). Spell the colours out on the consumer instead: `className="text-destructive-strong focus:bg-destructive/10 focus:text-destructive-strong"` — certified by the `bg-destructive/10` + `text-destructive-strong` row (8.42 / 5.39). The primitive itself stays as generated; this rule binds the call sites. Precedent: the logout item in `widgets/header`.
 - **Card section heading**: `CardTitle` renders a `<div>`, so wherever it stands for a section heading it must be written `<CardTitle role="heading" aria-level={N}>`. Without both attributes the section disappears from screen-reader heading navigation, and the loss is invisible in a rendered diff. The primitive stays pristine — it spreads `React.ComponentProps<'div'>`, so the consumer supplies them. (Where the card is genuinely not a section heading — a bare label on a stat card — leave it a `div` and do not add the role.)
   - **Pick `N` from the outline the page actually has, never from the tag the card replaced.** Levels must not skip: a card section directly under the page's `<h1>` is `aria-level={2}`, whatever the pre-shadcn markup used. Every admin page today is `<h1>` + card sections, so **2** is the level in practice; a nested sub-section inside such a card would be 3. Sibling headings written as real tags follow the same outline (`CustomerEditPage`'s 注文履歴 is an `<h2>`, not an `<h3>`).
 - **Table**: shadcn `Table` inside a `Card`. Precedent: `CustomersPage`.

--- a/frontend/src/_app/providers/ui/ToastProvider.tsx
+++ b/frontend/src/_app/providers/ui/ToastProvider.tsx
@@ -19,7 +19,9 @@ export function ToastProvider() {
         },
         success: {
           duration: 2500,
-          style: { background: '#16a34a' }, // green-600
+          // react-hot-toast はインライン style しか受けないため、success トークンは
+          // CSS 変数で参照する（bg-success + text-success-foreground、6.18/11.20 — 両モード AA 達成）。
+          style: { background: 'var(--success)', color: 'var(--success-foreground)' },
         },
         error: {
           duration: 5000,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -39,14 +39,6 @@
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.546 0.245 262.881);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.967 0.001 286.375);
-  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
-  --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.705 0.015 286.067);
 }
 
 .dark {
@@ -82,14 +74,6 @@
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.21 0.006 285.885);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.546 0.245 262.881);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.274 0.006 286.033);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.552 0.016 285.938);
 }
 
 @theme inline {
@@ -129,14 +113,6 @@
   --color-chart-3: var(--chart-3);
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
 }
 
 @layer base {

--- a/frontend/src/app/platform/(console)/layout.tsx
+++ b/frontend/src/app/platform/(console)/layout.tsx
@@ -23,7 +23,7 @@ export default function PlatformLayout({ children }: { children: React.ReactNode
           {/* Main Content Area */}
           {/* relative: 絶対配置の子（Radix Select が描画するフォーム互換用の隠し select 等）の
               包含ブロックをこのスクロール領域に閉じ込め、ページ全体が伸びるのを防ぐ */}
-          <main className="relative flex-1 overflow-y-auto p-8 custom-scrollbar">
+          <main className="relative flex-1 overflow-y-auto p-8">
             <div className="max-w-7xl mx-auto">{children}</div>
           </main>
         </div>

--- a/frontend/src/app/store/layout.tsx
+++ b/frontend/src/app/store/layout.tsx
@@ -23,7 +23,7 @@ export default function StoreLayout({ children }: { children: React.ReactNode })
           {/* Main Content Area */}
           {/* relative: 絶対配置の子（Radix Select が描画するフォーム互換用の隠し select 等）の
               包含ブロックをこのスクロール領域に閉じ込め、ページ全体が伸びるのを防ぐ */}
-          <main className="relative flex-1 overflow-y-auto p-8 custom-scrollbar">
+          <main className="relative flex-1 overflow-y-auto p-8">
             <div className="max-w-7xl mx-auto">{children}</div>
           </main>
         </div>

--- a/frontend/src/shared/ui/image-upload.tsx
+++ b/frontend/src/shared/ui/image-upload.tsx
@@ -62,8 +62,10 @@ export default function ImageUpload({
 
   return (
     <div className="space-y-2">
+      {/* ドロップ可能域の境界はその機能を示す唯一の手掛かりなので装飾免除にならず 3:1 を要する。
+          既定の border-border は 1.27/1.33 でほぼ不可視のため muted-foreground を明示する。 */}
       <div
-        className={`relative border-2 border-dashed rounded-lg overflow-hidden cursor-pointer hover:border-primary transition-colors ${className}`}
+        className={`relative border-2 border-dashed border-muted-foreground rounded-lg overflow-hidden cursor-pointer hover:border-primary transition-colors ${className}`}
         onClick={() => inputRef.current?.click()}
       >
         {displayUrl ? (

--- a/frontend/src/widgets/sidebar/ui/Sidebar.tsx
+++ b/frontend/src/widgets/sidebar/ui/Sidebar.tsx
@@ -126,7 +126,7 @@ export function Sidebar() {
           {role === 'store' ? 'STORE' : 'PLATFORM'}
         </span>
       </div>
-      <div className="p-4 overflow-y-auto h-[calc(100vh-4rem)] custom-scrollbar">
+      <div className="p-4 overflow-y-auto h-[calc(100vh-4rem)]">
         <nav className="space-y-8">
           {navigation.map(section => (
             <div key={section.name}>


### PR DESCRIPTION
## 概要

shadcn sweep（#458）中に見つかった小さな負債 5 節（#498）の一括処理。コントラスト不達 2 箇所の修正、DESIGN.md への規則追補、無意味な定義・注記の削除を実装し、残り 2 節は調査の結果「対応不要」と判断した（決定ログ参照）。

Closes #498

## 変更内容

- **成功トースト**（`ToastProvider`）: 白文字 + `#16a34a`（3.30:1）→ `var(--success)` + `var(--success-foreground)`（**6.18 / 11.20**、行列既存行）。react-hot-toast はインライン style しか受けないため CSS 変数で token を参照し両モード追従
- **ImageUpload ドロップ域**: 既定の `border-border`（1.27/1.33 でほぼ不可視）→ `border-muted-foreground` を明示（**4.83 / 6.74** vs card、暗モード vs background は 7.56）。行列へ行追加
- **DESIGN.md**: 上記行列 1 行＋トースト注記に加え、「淡色地では `DropdownMenuItem variant=\"destructive\"` を使わず `-strong` を明示する」規則を Components へ追補（明モード focus 実測 **3.99** < 4.5、処方は Header 既成の 8.42/5.39 認証行）。既存使用箇所の遵守は grep 確認済み
- **削除**: 定義がどこにも無い `custom-scrollbar`（両コンソール shell + Sidebar の 3 箇所）、全仓ゼロ消費の `--sidebar-*` トークン一族（`:root`/`.dark`/`@theme` 計 24 行、削除前に消費ゼロを再 grep）、DESIGN.md の該当 Sidebar facts 小節を収斂
- **e2e**: 失効注記 2 件を実態へ訂正。`store-settings.steps.ts` は label/textarea が紐付け済み（1f776cf）のため隣接セレクタごと `getByLabel` へ置換。`platform-login.steps.ts` の店舗切替セレクタは Radix 移行（#469）で `header [aria-haspopup]` が 3 要素に増え **master で strict violation 必発**だったため、aria-label 欠如で一意化（同根因の master 既存回帰の修正）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（unit + coverage ゲート、integration も別途 exit 0）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全 19 本 — 修正前は platform-login の店舗切替 2 本が master 由来の selector 崩壊で fail、修正後 19/19）
- [x] ローカルで code-review 実施済み（Standards/Spec 二軸、hard violation 0）

### 視覚確認（UI 変更時）

worktree ビルドのイメージで起栈し、明・暗両モードで実機確認済み:

- ドロップ域: 両モードで破線が明瞭に視認可能（computed style で `muted-foreground` の適用を確認）
- 成功トースト: 明 = success 緑地 + 近黒文字、暗 = 明るい緑地 + 近黒文字（computed style 実測でモード追従を確認）

コントラスト計算は DESIGN.md 記載の校正手順 2 段階（black/white=21.00・`#767676`/white=4.54、既存行列 3 行の再現）を全て通過した計算機で実施。

## 決定ログ

- **4 節（e2e 生成スタッフの残留）は票面から落とした**。スタッフに DELETE API が存在せず（`PlatformStaffController` は GET/POST/PUT のみ）、テストの後片付けのためだけにドメイン API を新設するのは不釣り合い。実害は一覧が伸びることのみで、氏名のタイムスタンプ一意化により strict violation は起きない
- **5 節（redis 永続化）は前提が失真しており無変更**。`redis-data` named volume は #190（2026-07-03）から dev/release/example の全 compose に存在し `--appendonly yes` 済み。さらにログイン状態は JWT cookie（クライアント側、1h 失効）であり redis 非依存（redis はブラックリストとキャッシュのみ）。検収の「`task up` 2 連発でログイン維持」は実測済み: 同一トークンで 2 回目の `task up` 後も `/platform/me` が 200。再ログインが必要になる真因はトークンの 1 時間失効
- **票面の「実測 4.16」は 3.99 で記載**。校正済み計算機（既存行列の全対照行を正確に再現）では 3.99。DESIGN.md の規約「計算機と表が食い違ったら表が正」に基づき、表と整合する計算機の値を採用。どちらでも 4.5 不達という結論は不変
- **隣接セレクタ→`getByLabel`**: 失効注記を消すだけでは「紐付いているのに隣接セレクタ」という無根拠コードが残るため、レビュー指摘に従い置換（e2e 再実行で 19/19 緑を確認）

## 備考 / レビュー観点

- トーストの error / default は生 hex のままだが両モードとも AA 合格（4.83 / 14.68）のため本票では触っていない（票面の指摘は success のみ）
- `:not([aria-label])` による店舗切替の特定は、header に aria-label 無しのドロップダウンが増えると壊れる — その不変量はコメントに明記済み
- 別セッションで起票済みだった platform-login セレクタ修正チップ（task_de179632）は本 PR で解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)