### PR TITLE
fix(e2e): 播種キャスト名を Date.now() 接尾辞で一意化し中断 run の残骸と衝突しないようにする

### DIFF
--- a/e2e/steps/cast-custom-fields.steps.ts
+++ b/e2e/steps/cast-custom-fields.steps.ts
@@ -1,6 +1,7 @@
 import { expect, Page } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 import { PLATFORM_URL } from '../base-url';
+import { seededCastName } from './cast-detail-404.steps';
 import {
   STORE_HEADERS,
   deleteCast,
@@ -19,7 +20,8 @@ let createdFieldKey = '';
 let createdFieldLabel = '';
 // キャストの編集画面遷移時、一覧行の編集リンク（/store/{storeId}/casts/{id}/edit）から id を取り出して
 // 後続の公開詳細ページ遷移・After での削除に使う（作成ステップは cast-detail-404.steps.ts の
-// 既存 Given を再利用するため、その内部状態にはここから直接アクセスできない）。
+// 既存 Given を再利用する。名前は seededCastName() で解決済み一意名を受け取れるが、id は
+// 公開しておらず編集リンクから読み取る）。
 let currentCastId = '';
 let currentCastName = '';
 // ルート移設（#413）で店舗管理画面 URL に storeId が必須になった。ログイン着地先の
@@ -77,10 +79,12 @@ Then('フィールド一覧に {string} が表示される', async ({ page }, _l
 
 When(
   '{string} の編集画面で {string} に {string} と入力して保存する',
-  async ({ page }, castName: string, _fieldLabel: string, value: string) => {
-    currentCastName = castName;
+  async ({ page }, _castName: string, _fieldLabel: string, value: string) => {
+    // {string} のキャスト名は可読性のための基底名の表記。実際の照合は Given が播種した
+    // 解決済み一意名で行う（残骸の同基底名の行と衝突させない）。
+    currentCastName = seededCastName();
     await page.goto(`${PLATFORM_URL}/store/${storeId}/casts`);
-    const row = page.getByRole('row', { name: new RegExp(castName) });
+    const row = page.getByRole('row', { name: new RegExp(currentCastName) });
     await expect(row).toBeVisible({ timeout: 15000 });
     const editLink = row.locator('a[href$="/edit"]');
     const href = await editLink.getAttribute('href');

--- a/e2e/steps/cast-detail-404.steps.ts
+++ b/e2e/steps/cast-detail-404.steps.ts
@@ -10,11 +10,19 @@ const FOREIGN_CAST_ID = '00000000-0000-0000-0000-000000000000';
 let createdCastId = '';
 let createdCastName = '';
 
-Given('店舗 {string} にキャスト {string} を作成する', async ({ request }, _store: string, name: string) => {
+Given('店舗 {string} にキャスト {string} を作成する', async ({ request }, _store: string, baseName: string) => {
+  // 一意名で作成し、中断した過去 run の残骸との重複（strict モード違反）を避ける
+  //（platform-login.steps.ts と同じ手法）。{string} は可読性のための基底名の表記で、
+  // 後続ステップの照合は解決済みの createdCastName / seededCastName() を使う。
+  createdCastName = `${baseName}-${Date.now()}`;
   const token = await loginAsStoreAdmin(request);
-  createdCastId = await createCast(request, token, name);
-  createdCastName = name;
+  createdCastId = await createCast(request, token, createdCastName);
 });
+
+/** この Given で播種した cast の解決済み一意名。別 steps ファイル（cast-custom-fields）が参照する。 */
+export function seededCastName(): string {
+  return createdCastName;
+}
 
 Then('作成したキャストの詳細ページが表示される', async ({ page, $testInfo }) => {
   // fetchCasts は revalidate: 60 の ISR キャッシュのため、作成した cast が公開詳細に

--- a/e2e/steps/shift-public.steps.ts
+++ b/e2e/steps/shift-public.steps.ts
@@ -14,6 +14,10 @@ const yesterdayInTokyo = () =>
 
 let createdShiftIds: string[] = [];
 let createdCastIds: string[] = [];
+// 一意名で作成し、中断した過去 run の残骸との重複（strict モード違反）を避ける
+//（platform-login.steps.ts と同じ手法）。feature の {string} は可読性のための基底名の表記で、
+// 断言ステップはこの写像で解決済み一意名に引き当てる。
+let resolvedCastNames: Record<string, string> = {};
 
 Given(
   '店舗 {string} に出勤表検証用のシフトデータを準備する',
@@ -22,10 +26,14 @@ Given(
     const today = todayInTokyo();
     const yesterday = yesterdayInTokyo();
 
-    const castA = await createCast(request, token, 'E2E出勤A');
-    const castB = await createCast(request, token, 'E2E出勤B');
-    const castC = await createCast(request, token, 'E2E出勤C');
-    const castD = await createCast(request, token, 'E2E出勤D');
+    const suffix = Date.now();
+    resolvedCastNames = Object.fromEntries(
+      ['E2E出勤A', 'E2E出勤B', 'E2E出勤C', 'E2E出勤D'].map(base => [base, `${base}-${suffix}`])
+    );
+    const castA = await createCast(request, token, resolvedCastNames['E2E出勤A']);
+    const castB = await createCast(request, token, resolvedCastNames['E2E出勤B']);
+    const castC = await createCast(request, token, resolvedCastNames['E2E出勤C']);
+    const castD = await createCast(request, token, resolvedCastNames['E2E出勤D']);
     createdCastIds.push(castA, castB, castC, castD);
 
     const shiftA = await createShift(request, token, {
@@ -67,13 +75,17 @@ When('出勤表ページを開く', async ({ page }) => {
 Then(
   '出勤表にキャスト {string} と時間帯 {string} が表示される',
   async ({ page }, castName: string, timeRange: string) => {
-    await expect(page.getByRole('heading', { name: castName, exact: true })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: resolvedCastNames[castName], exact: true })
+    ).toBeVisible();
     await expect(page.getByText(timeRange)).toBeVisible();
   }
 );
 
 Then('出勤表にキャスト {string} が表示されない', async ({ page }, castName: string) => {
-  await expect(page.getByRole('heading', { name: castName, exact: true })).toHaveCount(0);
+  await expect(
+    page.getByRole('heading', { name: resolvedCastNames[castName], exact: true })
+  ).toHaveCount(0);
 });
 
 // 播種データを無条件で片付ける（テスト失敗・途中クラッシュでも実行）。
@@ -88,4 +100,5 @@ After(async ({ request }) => {
   }
   createdShiftIds = [];
   createdCastIds = [];
+  resolvedCastNames = {};
 });


### PR DESCRIPTION
## 概要

e2e の播種キャストが固定名だったため、After 清掃前に中断した run の残骸が共有 dev ストアに残ると、次回 run の行・見出し照合が複数要素に解決され strict モード違反で 2 シナリオが落ちていた（実際に発生し、API で残骸を手動削除して復旧した）。platform-login.steps.ts の既存手法に合わせ、作成時に `-${Date.now()}` で一意化する。

## 変更内容

- `cast-detail-404.steps.ts`: 共有 Given「店舗 {string} にキャスト {string} を作成する」で一意名を生成して播種し、解決済み名を `seededCastName()` として公開（cast-detail-404 / cast-custom-fields 両 feature が経由する唯一の播種点）
- `cast-custom-fields.steps.ts`: 行照合・見出し照合を feature の生引数ではなく `seededCastName()` の解決済み一意名で行う
- `shift-public.steps.ts`: E2E出勤A〜D を同一 suffix で一意化し、断言は `resolvedCastNames` 写像で解決済み名に引き当てる（同根因の全類掃討。cast-portal.steps.ts は既に一意化済みで対象外）
- feature ファイルは無変更（`{string}` 引数は可読性のための基底名の表記のまま。既存の `_label` 慣例と同じ扱い）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0（`task e2e` 内で実行）
- [x] `task e2e` exit 0（実行シナリオ: 全 19 件 pass。cast-detail-404 / cast-custom-fields / shift-public / platform-login を含む）
- [x] ローカルで code-review 実施済み（Standards / Spec 二軸、いずれも blocking なし）

## 決定ログ

- **一意化は Given 側・feature は不変**: フィールド key と同様に feature へ `{ts}` を書く案は、複数 steps ファイルがそれぞれ Date.now() を解決すると値が一致しないため不成立。既存の platform-login / staff-management の「作成時に解決し、以降は module 状態で照合」方式に統一した。
- **`seededCastName()` の export**: cast-custom-fields は別 steps ファイルの Given を再利用しており、解決済み名の受け渡しに accessor を公開した。suite が `workers: 1` 直列である（e2e/CLAUDE.md が明記）ことが安全性の前提。第三の消費者が現れたら store-api.ts への昇格を検討する。
- **id は従来どおり編集リンクから読む**: 今回の欠陥は名前照合のみで、id の受け渡しまで広げると差分が課題を超えるため見送り。

## 備考 / レビュー観点

- shift-public の時間帯断言 `getByText('20:00–02:00')` はページ全域照合のままで、残骸の**シフト**が同時間帯に見えている場合は依然衝突し得る（今回の欠陥はキャスト名で、シフト残骸は別クラス）。顕在化したら別途対処。
- 本修正で「中断 run が次回 run を汚染する」クラスは播種キャスト名について解消。過去の残骸 5 件は事前に API で清掃済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)