### PR TITLE
chore(frontend): アイコンライブラリを lucide-react に一本化する

### DIFF
--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -253,6 +253,13 @@ Each template owns a `templates/<key>/theme.css` that defines the same `--storef
 - **Admin UI**: system sans stack; Japanese text renders via the Noto Sans JP fallback. Weights: bold for headings and key figures, medium for emphasized inline text, regular otherwise. Key figures: 30px bold. Body/labels: 14px.
 - **Storefront default**: `'Noto Serif JP', 'Hiragino Mincho Pro', serif` with wide letter-spacing (`tracking-[0.25em]`-class values) for headings/nav; this serif-luxury voice is part of the template identity.
 
+## Icons
+
+- **One library: `lucide-react`.** Do not (re-)introduce `@heroicons/react` or any other icon set. `components.json`'s `iconLibrary` is what `shadcn add` consults when it generates a primitive, so the icons baked into vendored primitives are lucide; the application uses the same family so that icons sharing a screen share one stroke width and terminal style.
+- Import the `Icon`-suffixed aliases (`BellIcon`, not `Bell`) — the style the vendored primitives already use.
+- Keep the default `strokeWidth` (2px). Thinning an icon per call site re-creates the mixed-family look the single library exists to prevent.
+- The sidebar's `ICON_MAP` keys are the icon strings served by the menu API's seed data. They keep their heroicons-style names as a wire contract; only the mapped values point at lucide components.
+
 ## Spacing
 
 - Admin: content padding 24px (`p-6`); card padding ~25px (`p-6`); gap between cards 24px (`gap-6`); sidebar fixed 256px (`w-64`); header 64px (`h-16`); card radius `rounded-lg` (= `var(--radius)`, 0.5rem); subtle shadow (`shadow-sm`).
@@ -423,7 +430,7 @@ Everything else that still matches the grep — the unconverted slices, `widgets
 - **Vendored shadcn primitives** — `alert-dialog` / `button` / `card` / `dialog` / `select` / `form` / `table` / `badge` / `sheet` / `popover` / `command` / `skeleton` / `tabs` / `dropdown-menu` / `checkbox` / `switch` / `radio-group` / `input` / `label` / `textarea`. Kept exactly as generated; per-screen deviation goes in the consumer's `className`, never here.
 - **Kizuna-authored components** — `image-upload.tsx`, `auth-layout.tsx`, `theme-provider.tsx`, `confirm-dialog.tsx`. Hand-written, so they obey the token rules like any other admin file. `auth-layout.tsx` is the exception noted above: it belongs to the auth world.
 
-Tell them apart by the generator's fingerprint rather than by guessing. The one reliable single test is **`data-slot`**: all 20 vendored files carry it and none of the four hand-written ones do. The other markers are only suggestive — a `radix-ui` import is absent from 6 of the 20, and `cva` from 17 of the 20, so "some of these, not all" is the honest reading and neither is usable alone. The negative direction is what holds: the hand-written four carry none of the markers, and either import application code a generator would never emit (`@/shared/api`, `@heroicons/react`, `next-themes`) or, as `confirm-dialog.tsx` does, compose sibling primitives through relative imports where the generator emits the `@/shared/ui` alias. `git log --follow` settles any remaining doubt.
+Tell them apart by the generator's fingerprint rather than by guessing. The one reliable single test is **`data-slot`**: all 20 vendored files carry it and none of the four hand-written ones do. The other markers are only suggestive — a `radix-ui` import is absent from 6 of the 20, and `cva` from 17 of the 20, so "some of these, not all" is the honest reading and neither is usable alone. The negative direction is what holds: the hand-written four carry none of the markers, and either import application code a generator would never emit (`@/shared/api`, `react-hot-toast`, `next-themes`) or, as `confirm-dialog.tsx` does, compose sibling primitives through relative imports where the generator emits the `@/shared/ui` alias. `git log --follow` settles any remaining doubt.
 
 Editing a hand-written one is still a shared-file change, so it goes through the contract below rather than through a slice PR.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "kizuna",
       "version": "0.1.1",
       "dependencies": {
-        "@heroicons/react": "2.2.0",
         "axios": "1.18.1",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
@@ -1004,15 +1003,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
-    },
-    "node_modules/@heroicons/react": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
-      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">= 16 || ^19.0.0-rc"
-      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,6 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@heroicons/react": "2.2.0",
     "axios": "1.18.1",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/frontend/src/_pages/cast-portal/ui/CastPortalShell.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastPortalShell.tsx
@@ -3,11 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import {
-  CalendarDaysIcon,
-  ClipboardDocumentListIcon,
-  UserCircleIcon,
-} from '@heroicons/react/24/outline';
+import { CalendarDaysIcon, CircleUserRoundIcon, ClipboardListIcon } from 'lucide-react';
 import { platformAuthApi } from '@/entities/user';
 import { redirectToLogin } from '@/shared/lib';
 
@@ -17,8 +13,8 @@ interface CastPortalShellProps {
 
 const TABS = [
   { href: '/cast/schedule', label: 'スケジュール', icon: CalendarDaysIcon },
-  { href: '/cast/requests', label: '希望提出', icon: ClipboardDocumentListIcon },
-  { href: '/cast/account', label: 'アカウント', icon: UserCircleIcon },
+  { href: '/cast/requests', label: '希望提出', icon: ClipboardListIcon },
+  { href: '/cast/account', label: 'アカウント', icon: CircleUserRoundIcon },
 ] as const;
 
 /**

--- a/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
+++ b/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PlusIcon } from '@heroicons/react/24/outline';
+import { PlusIcon } from 'lucide-react';
 import { useState } from 'react';
 import {
   PlatformStaffResponse,

--- a/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
-import { ChevronLeftIcon, ChevronRightIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { ChevronLeftIcon, ChevronRightIcon, PlusIcon } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { Store, platformStoreApi } from '@/entities/store';
 import { PaginatedResponse } from '@/shared/api';

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PencilSquareIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { PlusIcon, SquarePenIcon, Trash2Icon } from 'lucide-react';
 import { useState } from 'react';
 import { CastFieldDefinitionResponse, castFieldDefinitionApi } from '@/entities/cast';
 import { useManagedList } from '@/shared/lib';
@@ -116,7 +116,7 @@ export default function CastFieldsPage() {
                           setEditing(definition);
                         }}
                       >
-                        <PencilSquareIcon />
+                        <SquarePenIcon />
                       </Button>
                       <Button
                         variant="ghost"
@@ -127,7 +127,7 @@ export default function CastFieldsPage() {
                         }}
                         aria-label="削除"
                       >
-                        <TrashIcon />
+                        <Trash2Icon />
                       </Button>
                     </div>
                   </TableCell>

--- a/frontend/src/_pages/store-casts/ui/CastsPage.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastsPage.tsx
@@ -3,13 +3,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
-import {
-  PlusIcon,
-  MagnifyingGlassIcon,
-  PencilSquareIcon,
-  TrashIcon,
-  Cog6ToothIcon,
-} from '@heroicons/react/24/outline';
+import { PlusIcon, SearchIcon, SquarePenIcon, Trash2Icon, SettingsIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { CastResponse, castApi, castInvitationStatusLabel } from '@/entities/cast';
 import { platformAuthApi } from '@/entities/user';
@@ -112,7 +106,7 @@ export default function CastListPage() {
             {canManageFieldDefs && (
               <Button asChild variant="outline">
                 <Link href={storePath(storeId, '/casts/fields')}>
-                  <Cog6ToothIcon />
+                  <SettingsIcon />
                   カスタムフィールド管理
                 </Link>
               </Button>
@@ -132,7 +126,7 @@ export default function CastListPage() {
         <CardContent className="flex flex-col md:flex-row md:items-center gap-4">
           <div className="flex-1 relative">
             <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              <MagnifyingGlassIcon className="h-5 w-5 text-muted-foreground" />
+              <SearchIcon className="h-5 w-5 text-muted-foreground" />
             </div>
             <Input
               type="text"
@@ -225,7 +219,7 @@ export default function CastListPage() {
                         )}
                         <Button asChild variant="ghost" size="icon-sm">
                           <Link href={storePath(storeId, `/casts/${cast.id}/edit`)}>
-                            <PencilSquareIcon />
+                            <SquarePenIcon />
                           </Link>
                         </Button>
                         <Button
@@ -233,7 +227,7 @@ export default function CastListPage() {
                           size="icon-sm"
                           onClick={() => setDeleteTarget(cast)}
                         >
-                          <TrashIcon />
+                          <Trash2Icon />
                         </Button>
                       </div>
                     </TableCell>

--- a/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import {
-  PlusIcon,
-  MagnifyingGlassIcon,
-  PencilSquareIcon,
-  TrashIcon,
-} from '@heroicons/react/24/outline';
+import { PlusIcon, SearchIcon, SquarePenIcon, Trash2Icon } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { CustomerResponse, customerApi } from '@/entities/customer';
@@ -106,7 +101,7 @@ export default function CustomersPage() {
         <CardContent className="flex flex-col md:flex-row md:items-center gap-4">
           <div className="flex-1 relative">
             <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              <MagnifyingGlassIcon className="h-5 w-5 text-muted-foreground" />
+              <SearchIcon className="h-5 w-5 text-muted-foreground" />
             </div>
             <Input
               type="text"
@@ -188,7 +183,7 @@ export default function CustomersPage() {
                     <div className="flex justify-end gap-1">
                       <Button asChild variant="ghost" size="icon-sm">
                         <Link href={storePath(storeId, `/customers/${customer.id}/edit`)}>
-                          <PencilSquareIcon />
+                          <SquarePenIcon />
                         </Link>
                       </Button>
                       <Button
@@ -196,7 +191,7 @@ export default function CustomersPage() {
                         size="icon-sm"
                         onClick={() => setDeleteTarget(customer)}
                       >
-                        <TrashIcon />
+                        <Trash2Icon />
                       </Button>
                     </div>
                   </TableCell>

--- a/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { PlusIcon, PencilSquareIcon } from '@heroicons/react/24/outline';
+import { PlusIcon, SquarePenIcon } from 'lucide-react';
 import { Order, orderApi } from '@/entities/order';
 import { storePath, useManagedList } from '@/shared/lib';
 import { PageHeader } from '@/widgets/page-header';
@@ -89,7 +89,7 @@ export default function OrderListPage() {
                     <div className="flex justify-end gap-1">
                       <Button asChild variant="ghost" size="icon-sm">
                         <Link href={storePath(storeId, `/orders/${order.id}/edit`)}>
-                          <PencilSquareIcon />
+                          <SquarePenIcon />
                         </Link>
                       </Button>
                     </div>

--- a/frontend/src/_pages/store-select/ui/StoreSelectPage.tsx
+++ b/frontend/src/_pages/store-select/ui/StoreSelectPage.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { BuildingStorefrontIcon } from '@heroicons/react/24/outline';
+import { StoreIcon } from 'lucide-react';
 import { useStoreContext } from '@/entities/user';
 import { replaceStoreIdInPath, setPlatformStore } from '@/shared/lib';
 import { Button, Card } from '@/shared/ui';
@@ -64,7 +64,7 @@ export default function StoreSelectPage() {
                   onClick={() => goTo(store.id)}
                   className="h-auto w-full justify-start gap-3 px-4 py-3 text-left"
                 >
-                  <BuildingStorefrontIcon className="size-5 text-muted-foreground" />
+                  <StoreIcon className="size-5 text-muted-foreground" />
                   {store.name}
                 </Button>
               ))}

--- a/frontend/src/_pages/store-shifts/ui/ShiftCalendar.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftCalendar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 import { ShiftResponse } from '@/entities/shift';
 import { Button } from '@/shared/ui';
 import { monthGrid, toDateStr } from '../lib/datetime';

--- a/frontend/src/_pages/store-shifts/ui/ShiftTimeline.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftTimeline.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PlusIcon } from '@heroicons/react/24/outline';
+import { PlusIcon } from 'lucide-react';
 import { CastResponse } from '@/entities/cast';
 import { ShiftResponse } from '@/entities/shift';
 import { Button } from '@/shared/ui';

--- a/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CalendarDaysIcon, ClockIcon, InboxIcon } from '@heroicons/react/24/outline';
+import { CalendarDaysIcon, ClockIcon, InboxIcon } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { CastResponse, castApi } from '@/entities/cast';

--- a/frontend/src/_pages/store-site/templates/_sections/CastSection.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/CastSection.tsx
@@ -3,7 +3,7 @@
 import { useRef } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 
 interface Cast {
   id: string;

--- a/frontend/src/shared/ui/image-upload.tsx
+++ b/frontend/src/shared/ui/image-upload.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef } from 'react';
 import Image from 'next/image';
-import { PhotoIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { ImageIcon, XIcon } from 'lucide-react';
 import { fileApi } from '@/shared/api';
 import { toast } from 'react-hot-toast';
 
@@ -79,12 +79,12 @@ export default function ImageUpload({
               }}
               className="absolute top-1 right-1 bg-destructive text-destructive-foreground rounded-full p-1 hover:bg-destructive/90"
             >
-              <XMarkIcon className="h-4 w-4" />
+              <XIcon className="h-4 w-4" />
             </button>
           </>
         ) : (
           <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
-            <PhotoIcon className="h-10 w-10 mb-2" />
+            <ImageIcon className="h-10 w-10 mb-2" />
             <span className="text-xs">{isUploading ? 'アップロード中...' : '写真を選択'}</span>
           </div>
         )}

--- a/frontend/src/widgets/header/ui/Header.tsx
+++ b/frontend/src/widgets/header/ui/Header.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/shared/ui';
-import { BellIcon, BuildingStorefrontIcon, UserCircleIcon } from '@heroicons/react/24/outline';
+import { BellIcon, CircleUserRoundIcon, StoreIcon } from 'lucide-react';
 import { ModeToggle } from './ModeToggle';
 
 export function Header() {
@@ -51,7 +51,7 @@ export function Header() {
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="outline" size="sm">
-                <BuildingStorefrontIcon className="size-5 shrink-0 text-muted-foreground" />
+                <StoreIcon className="size-5 shrink-0 text-muted-foreground" />
                 {/* 店名は 200 字まで許されるため、上限を置かないと行の固有幅に上界が無くなり、
                     シェルの下限幅では守れなくなる。 */}
                 <span className="max-w-40 truncate">{currentStoreName || '店舗を選択'}</span>
@@ -80,7 +80,7 @@ export function Header() {
                 aria-label="アカウントメニュー"
                 className="text-muted-foreground hover:text-primary-strong"
               >
-                <UserCircleIcon className="size-8" />
+                <CircleUserRoundIcon className="size-8" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" sideOffset={8} className="w-48">

--- a/frontend/src/widgets/header/ui/ModeToggle.tsx
+++ b/frontend/src/widgets/header/ui/ModeToggle.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from '@/shared/ui';
-import { MoonIcon, SunIcon } from '@heroicons/react/24/outline';
+import { MoonIcon, SunIcon } from 'lucide-react';
 
 export function ModeToggle() {
   // トリガーの絵柄は現在値を読まず dark: 変種、すなわち適用済みの .dark の有無だけで決める。

--- a/frontend/src/widgets/sidebar/ui/Sidebar.tsx
+++ b/frontend/src/widgets/sidebar/ui/Sidebar.tsx
@@ -5,25 +5,25 @@ import { usePathname } from 'next/navigation';
 import Cookies from 'js-cookie';
 import { useEffect, useState } from 'react';
 import {
-  HomeIcon,
-  BuildingOfficeIcon,
-  ClipboardDocumentListIcon,
-  PlusCircleIcon,
-  CurrencyYenIcon,
   BriefcaseIcon,
-  ChartBarIcon,
-  UserGroupIcon,
-  CogIcon,
-  AdjustmentsHorizontalIcon,
-  FaceSmileIcon,
+  BuildingIcon,
+  ChartColumnIcon,
+  CirclePlusIcon,
+  ClipboardListIcon,
   ClockIcon,
-  UsersIcon,
+  FileTextIcon,
+  HouseIcon,
+  ImageIcon,
+  JapaneseYenIcon,
+  KeyRoundIcon,
   MegaphoneIcon,
-  DocumentTextIcon,
-  PhotoIcon,
-  BuildingStorefrontIcon,
-  KeyIcon,
-} from '@heroicons/react/24/outline';
+  SettingsIcon,
+  SlidersHorizontalIcon,
+  SmileIcon,
+  StoreIcon,
+  UsersIcon,
+  UsersRoundIcon,
+} from 'lucide-react';
 import { menuApi, MenuVO } from '@/entities/menu';
 import {
   getPlatformConsole,
@@ -33,25 +33,27 @@ import {
   resolveStoreHref,
 } from '@/shared/lib';
 
+// キーはメニュー API（seed データ）が返す icon 文字列との wire 契約であり、
+// アイコンライブラリを差し替えてもキー側は変更しない。値のみ lucide の等価アイコンを指す。
 const ICON_MAP: { [key: string]: React.ForwardRefExoticComponent<any> } = {
-  HomeIcon,
-  BuildingOfficeIcon,
-  ClipboardDocumentListIcon,
-  PlusCircleIcon,
-  CurrencyYenIcon,
+  HomeIcon: HouseIcon,
+  BuildingOfficeIcon: BuildingIcon,
+  ClipboardDocumentListIcon: ClipboardListIcon,
+  PlusCircleIcon: CirclePlusIcon,
+  CurrencyYenIcon: JapaneseYenIcon,
   BriefcaseIcon,
-  ChartBarIcon,
-  UserGroupIcon,
-  CogIcon,
-  AdjustmentsHorizontalIcon,
-  FaceSmileIcon,
+  ChartBarIcon: ChartColumnIcon,
+  UserGroupIcon: UsersRoundIcon,
+  CogIcon: SettingsIcon,
+  AdjustmentsHorizontalIcon: SlidersHorizontalIcon,
+  FaceSmileIcon: SmileIcon,
   ClockIcon,
   UsersIcon,
   MegaphoneIcon,
-  DocumentTextIcon,
-  PhotoIcon,
-  BuildingStorefrontIcon,
-  KeyIcon,
+  DocumentTextIcon: FileTextIcon,
+  PhotoIcon: ImageIcon,
+  BuildingStorefrontIcon: StoreIcon,
+  KeyIcon: KeyRoundIcon,
 };
 
 export function Sidebar() {
@@ -88,7 +90,7 @@ export function Sidebar() {
           items: (section.items || []).map(item => ({
             name: item.name,
             href: item.path || '#',
-            icon: item.icon && ICON_MAP[item.icon] ? ICON_MAP[item.icon] : HomeIcon,
+            icon: item.icon && ICON_MAP[item.icon] ? ICON_MAP[item.icon] : HouseIcon,
           })),
         }));
 
@@ -108,7 +110,7 @@ export function Sidebar() {
               {
                 name: 'ダッシュボード',
                 href: isStore ? '/store/dashboard' : '/platform/dashboard',
-                icon: HomeIcon,
+                icon: HouseIcon,
               },
             ],
           },


### PR DESCRIPTION
## 概要

shadcn/ui 移行(#458)の産物として同居していた二つのアイコンライブラリを lucide-react に一本化し、`@heroicons/react` を撤去した。アプリ 16 ファイルの import を書き換え、vendored primitive は一切触っていない。

Closes #503

## 変更内容

- アプリコード 16 ファイルの heroicons import を lucide-react の **Icon 接尾辞エイリアス**（primitive と同じ流儀）へ書き換え。同名アイコンは import 元の差し替えのみ、改名を伴うものは造型最近傍の等価物へ写像（`XMarkIcon→XIcon` / `MagnifyingGlassIcon→SearchIcon` / `BuildingStorefrontIcon→StoreIcon` / `PencilSquareIcon→SquarePenIcon` / `TrashIcon→Trash2Icon` / `UserCircleIcon→CircleUserRoundIcon` / `KeyIcon→KeyRoundIcon` / `PhotoIcon→ImageIcon` ほか）
- `CogIcon`(Sidebar) と `Cog6ToothIcon`(CastsPage) は語義がいずれも「設定」のため `SettingsIcon` に統合
- **Sidebar の `ICON_MAP` はキーを一切変更していない**。キーはメニュー API（Liquibase seed）が返す icon 文字列との wire 契約であり、値のみ lucide コンポーネントへ差し替え（コメントで契約を明記）。このため既存テストの文字列モック（`icon: 'CogIcon'` 等）も無変更で通る
- `@heroicons/react` を package.json / package-lock.json から撤去
- `DESIGN.md` に `## Icons` 節を追加（lucide 一本化・Icon 接尾辞・strokeWidth デフォルト・ICON_MAP 契約）。あわせて手書きコンポーネント判別指紋の段落から heroicons の例示を撤去し `react-hot-toast` に置換（撤去後も記述が真であり続けるように）

## 検証

- [x] `task -d frontend lint` exit 0
- [x] `task -d frontend test` exit 0（Jest 72 suites / 425 tests）
- [x] `task build service=frontend` exit 0（buildx の陳旧キャッシュを検出したため `--no-cache-filter deps,builder` で再構築し、生成イメージの chunk に heroicons 0 件・lucide 含有を確認）
- [x] `task e2e` exit 0（実行シナリオ: 全 20 シナリオ、4.2 分で全通過）
- [ ] ローカルで code-review 未実施（機械的 rename のため省略可否はレビュアー判断に委ねる）
- 受け入れ基準の grep: `grep -rn "heroicons" src/ package.json` → 0 件

### 視覚確認（UI 変更時）

`task up` した実機をブラウザで確認済み（ライト/ダーク両モード）:

- Sidebar 6 項目がそれぞれ別個の lucide アイコンで描画（ICON_MAP の解決が正常で、フォールバック塌縮なし）
- Header の Bell / Sun⇄Moon / Store / CircleUserRound、店舗選択画面の Store
- キャスト管理の Settings・Plus・Search・行内 SquarePen/Trash2
- 出勤管理のタブ CalendarDays/Clock/Inbox とカレンダーの Chevron 対
- 線幅は全アイコン 2px で統一（heroicons 1.5px からの変化は意図どおり）

## 決定ログ

- **方向**: `components.json` の `iconLibrary` が参照する公式マッピング表（`/r/icons/index.json`）の対応は lucide/radix/tabler/hugeicons/phosphor/remixicon のみで **heroicons 非対応**と確認。issue 記載の分岐どおり lucide へ寄せた（vendored primitive の手当ては規約違反かつ `shadcn add` で戻るため不採用）
- **線幅**: lucide デフォルト 2px のまま。1.5px を指定すると primitive 内蔵アイコン（不可変・2px）との不一致が残存し、一本化の目的が果たせない
- **命名**: Icon 接尾辞エイリアス。primitive の現行流儀と一致し、大半のアイコンが import 元の差し替えだけで済む
- **トースト**: issue の対象外宣言どおり react-hot-toast には触れていない

## 備考 / レビュー観点

- `ICON_MAP` のキー維持が本 PR の唯一の非自明点。キーを改名すると seed データの icon 文字列が解決不能になり全項目が House にフォールバックする
- e2e はアイコン名に依存するセレクタを持たないため破損リスクは低い見込み（結果は追記する）
