### PR TITLE
refactor: メニューアイコンの wire 名を lucide-react のエクスポート名に統一し CLAUDE.md 監査を補完する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Issues use `.github/ISSUE_TEMPLATE/` (feature / bug); PR bodies follow `.github/
 ## Do NOT introduce (unless explicitly requested)
 
 - A second HTTP client on the frontend — `axios` is the established client.
+- A second icon library — `lucide-react` is the icon set (`@heroicons/react` was removed; see `frontend/DESIGN.md`).
 - CSS-in-JS (styled-components / emotion) or UI kits that bypass the vendored shadcn/ui primitives (`frontend/src/shared/ui`, Radix-based) + Tailwind CSS.
 - Global state libraries (Redux / MobX / Zustand) — none is in use; forms use react-hook-form.
 - `logback` — log4j2 is the logging backend and logback is explicitly excluded in `backend/build.gradle`.

--- a/backend/src/main/resources/db/changelog/releases/v0.1.0/platform/04-menu.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.1.0/platform/04-menu.yaml
@@ -36,7 +36,7 @@ databaseChangeLog:
               - column:
                   name: icon
                   type: VARCHAR(50)
-                  remarks: アイコン名（heroicons）
+                  remarks: アイコン名（lucide-react のエクスポート名）
               - column:
                   name: permission
                   type: VARCHAR(100)

--- a/backend/src/main/resources/db/changelog/releases/v0.1.0/seed/02-menus.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.1.0/seed/02-menus.yaml
@@ -23,7 +23,7 @@ databaseChangeLog:
               - column: { name: parent_id, value: platform-main }
               - column: { name: label, value: ダッシュボード }
               - column: { name: path, value: /platform/dashboard }
-              - column: { name: icon, value: HomeIcon }
+              - column: { name: icon, value: HouseIcon }
               - column: { name: permission, value: PLATFORM_MENU_VIEW }
               - column: { name: sort_order, valueNumeric: 1 }
         - insert:
@@ -33,7 +33,7 @@ databaseChangeLog:
               - column: { name: parent_id, value: platform-main }
               - column: { name: label, value: 店舗一覧 }
               - column: { name: path, value: /platform/stores }
-              - column: { name: icon, value: BuildingOfficeIcon }
+              - column: { name: icon, value: BuildingIcon }
               - column: { name: permission, value: STORE_MANAGE }
               - column: { name: sort_order, valueNumeric: 2 }
         - insert:
@@ -60,7 +60,7 @@ databaseChangeLog:
               - column: { name: parent_id, value: platform-settings }
               - column: { name: label, value: システム設定 }
               - column: { name: path, value: /platform/settings }
-              - column: { name: icon, value: CogIcon }
+              - column: { name: icon, value: SettingsIcon }
               - column: { name: permission, value: SYSTEM_CONFIG_MANAGE }
               - column: { name: sort_order, valueNumeric: 1 }
         # --- 店舗コンソール ---
@@ -78,7 +78,7 @@ databaseChangeLog:
               - column: { name: parent_id, value: store-main }
               - column: { name: label, value: ダッシュボード }
               - column: { name: path, value: /store/dashboard }
-              - column: { name: icon, value: HomeIcon }
+              - column: { name: icon, value: HouseIcon }
               - column: { name: permission, value: STORE_MENU_VIEW }
               - column: { name: sort_order, valueNumeric: 1 }
         - insert:
@@ -95,7 +95,7 @@ databaseChangeLog:
               - column: { name: parent_id, value: store-ops }
               - column: { name: label, value: 予約・案件管理 }
               - column: { name: path, value: /store/orders }
-              - column: { name: icon, value: ClipboardDocumentListIcon }
+              - column: { name: icon, value: ClipboardListIcon }
               - column: { name: permission, value: ORDER_MANAGE }
               - column: { name: sort_order, valueNumeric: 1 }
         - insert:
@@ -112,7 +112,7 @@ databaseChangeLog:
               - column: { name: parent_id, value: store-hrm }
               - column: { name: label, value: キャスト管理 }
               - column: { name: path, value: /store/casts }
-              - column: { name: icon, value: FaceSmileIcon }
+              - column: { name: icon, value: SmileIcon }
               - column: { name: permission, value: CAST_MANAGE }
               - column: { name: sort_order, valueNumeric: 1 }
         - insert:
@@ -139,7 +139,7 @@ databaseChangeLog:
               - column: { name: parent_id, value: store-crm }
               - column: { name: label, value: 顧客一覧 }
               - column: { name: path, value: /store/customers }
-              - column: { name: icon, value: UserGroupIcon }
+              - column: { name: icon, value: UsersRoundIcon }
               - column: { name: permission, value: CUSTOMER_MANAGE }
               - column: { name: sort_order, valueNumeric: 1 }
         - insert:
@@ -156,6 +156,6 @@ databaseChangeLog:
               - column: { name: parent_id, value: store-settings }
               - column: { name: label, value: 店舗情報 }
               - column: { name: path, value: /store/settings/profile }
-              - column: { name: icon, value: BuildingStorefrontIcon }
+              - column: { name: icon, value: StoreIcon }
               - column: { name: permission, value: STORE_PROFILE_MANAGE }
               - column: { name: sort_order, valueNumeric: 1 }

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -20,7 +20,7 @@ frontend/src/
 ├── entities/     # Mirror of the backend domain modules:
 │                 #   store, user, menu, cast, customer, order, store-profile, system-config, shift
 │                 #   each slice = model (types) / api (requests) / index (public API)
-└── shared/       # api (apiClient, shared types), lib (navigation, config, proxy), ui (generic components)
+└── shared/       # api (apiClient, shared types), lib (navigation, config, proxy), ui (shadcn/ui barrel + hand-written generics)
 ```
 
 Outside the layers, at `src/` root: `styles/` (global CSS not owned by a slice), `proxy.ts` + `proxy.test.ts` (the Next proxy entry — Host-based store/platform dispatch, delegating to `shared/lib/proxy`), and `__tests__/` (cross-cutting invariant tests).
@@ -29,6 +29,7 @@ Outside the layers, at `src/` root: `styles/` (global CSS not owned by a slice),
 - **Layer dependencies point downward only**: app → _pages → widgets → features → entities → shared.
 - **Entities must not import each other**. Composition spanning multiple entities (e.g. store-site's storefrontService) is the page layer's responsibility.
 - **server-only modules** (those depending on next/headers, etc.) are not exported from the normal index but from a separate `index.server.ts` entry (e.g. serverClient in `shared/api/index.server.ts`).
+- **`shared/ui` is the shadcn/ui layer** (ADR 0004): import primitives through the `@/shared/ui` barrel. The vendored primitives are frozen — which files are vendored vs hand-written, and the restyle rules, live in [`DESIGN.md`](./DESIGN.md). This applies to _any_ change touching `shared/ui`, not only UI work.
 - **Public storefront templates live at `_pages/store-site/templates/<key>/<page>.tsx`** where `<page>` is one of `page` (TOP) / `casts` / `cast-detail` / `schedule` / `menu` / `about`:
   - This is the dynamic-import contract keyed by the cookie's templateKey (dispatched via `loadTemplatePage`, which falls back to the default template's same page for unknown keys), so do not change the path structure.
   - Top-level public routes under `app/(public)/` (`/casts`, `/schedule`, `/menu`, `/about`) are thin shells rendering `StoreSitePage`.

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -258,7 +258,7 @@ Each template owns a `templates/<key>/theme.css` that defines the same `--storef
 - **One library: `lucide-react`.** Do not (re-)introduce `@heroicons/react` or any other icon set. `components.json`'s `iconLibrary` is what `shadcn add` consults when it generates a primitive, so the icons baked into vendored primitives are lucide; the application uses the same family so that icons sharing a screen share one stroke width and terminal style.
 - Import the `Icon`-suffixed aliases (`BellIcon`, not `Bell`) — the style the vendored primitives already use.
 - Keep the default `strokeWidth` (2px). Thinning an icon per call site re-creates the mixed-family look the single library exists to prevent.
-- The sidebar's `ICON_MAP` keys are the icon strings served by the menu API's seed data. They keep their heroicons-style names as a wire contract; only the mapped values point at lucide components.
+- The sidebar's `ICON_MAP` keys are the icon strings served by the menu API's seed data. Keys are lucide-react export names verbatim (`HouseIcon`, `SettingsIcon`, …) — the map doubles as the allowlist of icons a menu row may reference, and an unknown key falls back to `HouseIcon`.
 
 ## Spacing
 

--- a/frontend/src/widgets/sidebar/ui/Sidebar.tsx
+++ b/frontend/src/widgets/sidebar/ui/Sidebar.tsx
@@ -33,27 +33,27 @@ import {
   resolveStoreHref,
 } from '@/shared/lib';
 
-// キーはメニュー API（seed データ）が返す icon 文字列との wire 契約であり、
-// アイコンライブラリを差し替えてもキー側は変更しない。値のみ lucide の等価アイコンを指す。
+// キーはメニュー API（seed データ）が返す icon 文字列との wire 契約。
+// lucide-react のエクスポート名をそのまま用い、メニューが参照してよいアイコンの許可リストを兼ねる。
 const ICON_MAP: { [key: string]: React.ForwardRefExoticComponent<any> } = {
-  HomeIcon: HouseIcon,
-  BuildingOfficeIcon: BuildingIcon,
-  ClipboardDocumentListIcon: ClipboardListIcon,
-  PlusCircleIcon: CirclePlusIcon,
-  CurrencyYenIcon: JapaneseYenIcon,
   BriefcaseIcon,
-  ChartBarIcon: ChartColumnIcon,
-  UserGroupIcon: UsersRoundIcon,
-  CogIcon: SettingsIcon,
-  AdjustmentsHorizontalIcon: SlidersHorizontalIcon,
-  FaceSmileIcon: SmileIcon,
+  BuildingIcon,
+  ChartColumnIcon,
+  CirclePlusIcon,
+  ClipboardListIcon,
   ClockIcon,
-  UsersIcon,
+  FileTextIcon,
+  HouseIcon,
+  ImageIcon,
+  JapaneseYenIcon,
+  KeyRoundIcon,
   MegaphoneIcon,
-  DocumentTextIcon: FileTextIcon,
-  PhotoIcon: ImageIcon,
-  BuildingStorefrontIcon: StoreIcon,
-  KeyIcon: KeyRoundIcon,
+  SettingsIcon,
+  SlidersHorizontalIcon,
+  SmileIcon,
+  StoreIcon,
+  UsersIcon,
+  UsersRoundIcon,
 };
 
 export function Sidebar() {

--- a/frontend/src/widgets/sidebar/ui/__tests__/Sidebar.test.tsx
+++ b/frontend/src/widgets/sidebar/ui/__tests__/Sidebar.test.tsx
@@ -21,8 +21,8 @@ const menuWithStoreAndPlatform = [
   {
     name: 'メイン',
     items: [
-      { name: '受注一覧', path: '/store/orders', icon: 'HomeIcon' },
-      { name: '店舗一覧', path: '/platform/stores', icon: 'HomeIcon' },
+      { name: '受注一覧', path: '/store/orders', icon: 'HouseIcon' },
+      { name: '店舗一覧', path: '/platform/stores', icon: 'HouseIcon' },
     ],
   },
 ];
@@ -151,7 +151,7 @@ describe('Sidebar', () => {
     );
     mockedGetMenus.mockResolvedValue([
       ...menuWithStoreAndPlatform,
-      { name: '設定', items: [{ name: '店舗情報', path: '/store/profile', icon: 'CogIcon' }] },
+      { name: '設定', items: [{ name: '店舗情報', path: '/store/profile', icon: 'SettingsIcon' }] },
     ]);
 
     render(<Sidebar />);


### PR DESCRIPTION
## 概要

CLAUDE.md 監査（claude-md-improver）の補完 2 点に加え、@heroicons/react 撤去（1454168）の残骸だったメニューアイコンの wire 文字列（seed の icon 値と Sidebar の ICON_MAP キー）を lucide-react のエクスポート名へ統一する。

## 変更内容

- **seed `02-menus.yaml`**: icon 値 8 件を lucide 名へ変更（HomeIcon→HouseIcon / BuildingOfficeIcon→BuildingIcon / CogIcon→SettingsIcon / ClipboardDocumentListIcon→ClipboardListIcon / FaceSmileIcon→SmileIcon / UserGroupIcon→UsersRoundIcon / BuildingStorefrontIcon→StoreIcon）。UsersIcon / ClockIcon は同名のため変更なし
- **`04-menu.yaml`**: icon 列の remarks を「アイコン名（heroicons）」→「アイコン名（lucide-react のエクスポート名）」
- **`Sidebar.tsx`**: ICON_MAP を旧名→lucide の変換表から lucide 名そのままの許可リスト（identity map）へ置き換え。テストデータも同期
- **`frontend/DESIGN.md`**: wire 契約の記述を「キー＝lucide エクスポート名。許可リストを兼ね、未知キーは HouseIcon にフォールバック」へ更新
- **CLAUDE.md 監査補完**: frontend/CLAUDE.md に shared/ui＝shadcn バレル層（vendored primitive 凍結）の規約を追記、ルート CLAUDE.md の Do NOT introduce に第二アイコンライブラリ禁止を追加

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task test-unit` / `task test-integration` を分割実行、いずれも exit 0。integration は使い捨て DB で全 changeset を再生し修正済み seed を検証）
- [x] `task build` exit 0
- [ ] `task e2e` — 未実行。適用済み changeset を直接修正したため共有 dev DB の再作成（下記）が先。e2e はアイコン文字列を参照しない（grep 確認済み）
- [ ] ローカルで code-review 実施済み

### 視覚確認（UI 変更時）

視覚差分なし。描画される lucide コンポーネントは従前と同一で、変わるのは wire 文字列とマップのキーのみ（Jest 9 件を含む全 425 件で確認）。

## 決定ログ

- **移行 changeset を作らず適用済み changeset を直接修正**: seed が未リリースであることを前提にした指示による。代替案の UPDATE changeset 追加（v0.5.0）は本番データが存在しない現状では純粋なノイズになるため見送り
- **ICON_MAP は identity の許可リストとして温存**: マップ自体を廃止して動的 import にする案は、メニューが参照可能なアイコンの明示的な境界（許可リスト）が失われるため見送り
- **キーは lucide のエクスポート名そのまま**（kebab 名ではなく）: マップが shorthand の identity になり、対応関係の検証が不要になる

## 備考 / レビュー観点

- **取り込み後、適用済みの既存 DB は checksum 検証で backend が起動失敗する**。`DROP DATABASE kizuna` + `CREATE DATABASE kizuna` で再作成して再適用すること（ボリューム削除はガードレール禁止のため不可）
- マージまでの間、旧コード（master）のフロントは新 DB に対して全アイコンが HouseIcon フォールバックになる（表示劣化のみ、機能影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)