### PR TITLE
feat(frontend): 一覧ページ外殻の基盤 — PageResult 正規化と ListPage / useListPage の新設

### DIFF
--- a/frontend/src/__tests__/list-page-heading-parity.test.tsx
+++ b/frontend/src/__tests__/list-page-heading-parity.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import { PageHeader } from '@/widgets/page-header';
+import { ListPage } from '@/widgets/list-page';
+
+/**
+ * widgets/list-page/ui/ListPage.tsx は Steiger の同一レイヤー cross-slice import 禁止
+ * （fsd/forbidden-imports）のため widgets/page-header を import できず、見出し markup を
+ * 逐字複製している。正本が 2 つに分かれた状態であり、片方だけ class を直すと気付かず乖離する。
+ * このテストは両者の見出し block（外枠 div・タイトル div・h1・description p・actions
+ * wrapper div の class 文字列）が一致し続けることを機械的に固定する。
+ *
+ * widgets 同士を横断 import できるのは FSD の層構造に属さない src/__tests__ だけ
+ * （frontend/CLAUDE.md の「cross-cutting invariant tests」）。
+ */
+describe('ListPage の見出し markup と PageHeader の一致', () => {
+  const headingProps = {
+    title: '顧客管理',
+    description: '顧客情報の登録・編集ができます。',
+    actions: <button type="button">新規顧客登録</button>,
+  };
+
+  it('見出し block の class 文字列がすべて一致すること', () => {
+    const { unmount: unmountPageHeader } = render(<PageHeader {...headingProps} />);
+    const pageHeaderH1 = screen.getByRole('heading', { level: 1 });
+    const pageHeaderTitleBlock = pageHeaderH1.parentElement!;
+    const pageHeaderOuter = pageHeaderTitleBlock.parentElement!;
+    const pageHeaderDescription = screen.getByText(headingProps.description);
+    const pageHeaderActionsWrapper = screen.getByRole('button', {
+      name: '新規顧客登録',
+    }).parentElement!;
+
+    const snapshot = {
+      outer: pageHeaderOuter.className,
+      titleBlock: pageHeaderTitleBlock.className,
+      h1: pageHeaderH1.className,
+      description: pageHeaderDescription.className,
+      actionsWrapper: pageHeaderActionsWrapper.className,
+    };
+    unmountPageHeader();
+
+    render(
+      <ListPage
+        {...headingProps}
+        state={{
+          rows: ['a'],
+          page: 0,
+          pageCount: 1,
+          total: 1,
+          isLoading: false,
+          onPageChange: jest.fn(),
+        }}
+        emptyMessage="empty"
+      >
+        <div>table</div>
+      </ListPage>
+    );
+    const listPageH1 = screen.getByRole('heading', { level: 1 });
+    const listPageTitleBlock = listPageH1.parentElement!;
+    const listPageOuter = listPageTitleBlock.parentElement!;
+    const listPageDescription = screen.getByText(headingProps.description);
+    const listPageActionsWrapper = screen.getByRole('button', {
+      name: '新規顧客登録',
+    }).parentElement!;
+
+    expect(listPageOuter.className).toBe(snapshot.outer);
+    expect(listPageTitleBlock.className).toBe(snapshot.titleBlock);
+    expect(listPageH1.className).toBe(snapshot.h1);
+    expect(listPageDescription.className).toBe(snapshot.description);
+    expect(listPageActionsWrapper.className).toBe(snapshot.actionsWrapper);
+  });
+});

--- a/frontend/src/shared/api/__tests__/page.test.ts
+++ b/frontend/src/shared/api/__tests__/page.test.ts
@@ -1,0 +1,98 @@
+import {
+  Page,
+  PaginatedResponse,
+  fromLaravelPage,
+  fromSpringPage,
+  toLaravelPageParams,
+  toSpringPageParams,
+} from '@/shared/api';
+
+describe('fromSpringPage', () => {
+  it('0 起点の Spring Data Page をそのまま正規化する', () => {
+    const raw: Page<{ id: string }> = {
+      content: [{ id: 'a' }, { id: 'b' }],
+      total_pages: 5,
+      total_elements: 42,
+      size: 10,
+      number: 0,
+    };
+
+    expect(fromSpringPage(raw)).toEqual({
+      rows: [{ id: 'a' }, { id: 'b' }],
+      page: 0,
+      pageCount: 5,
+      total: 42,
+    });
+  });
+
+  it('途中ページの number をそのまま page として渡す', () => {
+    const raw: Page<{ id: string }> = {
+      content: [{ id: 'c' }],
+      total_pages: 5,
+      total_elements: 42,
+      size: 10,
+      number: 3,
+    };
+
+    expect(fromSpringPage(raw).page).toBe(3);
+  });
+});
+
+describe('fromLaravelPage', () => {
+  it('1 起点の current_page を 0 起点の page に変換する', () => {
+    const raw: PaginatedResponse<{ id: string }> = {
+      data: [{ id: 'a' }, { id: 'b' }],
+      current_page: 1,
+      from: 1,
+      last_page: 3,
+      per_page: 10,
+      to: 2,
+      total: 25,
+      first_page_url: '',
+      last_page_url: '',
+      next_page_url: null,
+      prev_page_url: null,
+    };
+
+    expect(fromLaravelPage(raw)).toEqual({
+      rows: [{ id: 'a' }, { id: 'b' }],
+      page: 0,
+      pageCount: 3,
+      total: 25,
+    });
+  });
+
+  it('途中ページの current_page から 1 を引いた値を page とする', () => {
+    const raw: PaginatedResponse<{ id: string }> = {
+      data: [{ id: 'c' }],
+      current_page: 3,
+      from: 21,
+      last_page: 3,
+      per_page: 10,
+      to: 25,
+      total: 25,
+      first_page_url: '',
+      last_page_url: '',
+      next_page_url: null,
+      prev_page_url: null,
+    };
+
+    expect(fromLaravelPage(raw).page).toBe(2);
+  });
+});
+
+describe('toSpringPageParams', () => {
+  it('0 起点の page をそのまま渡す', () => {
+    expect(toSpringPageParams(2, 20)).toEqual({ page: 2, size: 20 });
+  });
+});
+
+describe('toLaravelPageParams', () => {
+  it('0 起点の page を 1 起点の page / per_page に変換する', () => {
+    expect(toLaravelPageParams(0, 10)).toEqual({ page: 1, per_page: 10 });
+  });
+
+  it('途中ページも 1 を足した値になる', () => {
+    expect(toLaravelPageParams(2, 10)).toEqual({ page: 3, per_page: 10 });
+  });
+});

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -1,3 +1,5 @@
 export { default as apiClient } from './client';
 export { fileApi } from './file';
 export * from './types';
+export { fromLaravelPage, fromSpringPage, toLaravelPageParams, toSpringPageParams } from './page';
+export type { PageResult } from './page';

--- a/frontend/src/shared/api/page.ts
+++ b/frontend/src/shared/api/page.ts
@@ -1,0 +1,40 @@
+import { Page, PaginatedResponse } from './types';
+
+// 一覧ページ外殻が扱う正規化ページ型。page は 0 起点で統一する
+export interface PageResult<T> {
+  rows: T[];
+  page: number;
+  pageCount: number;
+  total: number;
+}
+
+export function fromSpringPage<T>(raw: Page<T>): PageResult<T> {
+  return {
+    rows: raw.content,
+    page: raw.number,
+    pageCount: raw.total_pages,
+    total: raw.total_elements,
+  };
+}
+
+export function fromLaravelPage<T>(raw: PaginatedResponse<T>): PageResult<T> {
+  return {
+    rows: raw.data,
+    page: raw.current_page - 1,
+    pageCount: raw.last_page,
+    total: raw.total,
+  };
+}
+
+// Spring Data の page クエリパラメータは 0 起点なのでそのまま渡せる
+export function toSpringPageParams(page: number, size: number): { page: number; size: number } {
+  return { page, size };
+}
+
+// /platform/stores の Laravel 風封筒は 1 起点
+export function toLaravelPageParams(
+  page: number,
+  size: number
+): { page: number; per_page: number } {
+  return { page: page + 1, per_page: size };
+}

--- a/frontend/src/shared/lib/__tests__/useListPage.test.tsx
+++ b/frontend/src/shared/lib/__tests__/useListPage.test.tsx
@@ -1,0 +1,108 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
+import { useListPage } from '@/shared/lib';
+import { PageResult } from '@/shared/api';
+
+jest.mock('react-hot-toast', () => ({
+  toast: { error: jest.fn() },
+}));
+
+const pageOf = (page: number, rows: string[] = ['a']): PageResult<string> => ({
+  rows,
+  page,
+  pageCount: 3,
+  total: 21,
+});
+
+describe('useListPage', () => {
+  it('マウント時に 0 ページ目を取得し pageResult と isLoading を管理する', async () => {
+    const fetcher = jest.fn(async (page: number) => pageOf(page, ['a', 'b']));
+    const { result } = renderHook(() => useListPage(fetcher, '取得失敗'));
+
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.rows).toEqual(['a', 'b']);
+    expect(result.current.page).toBe(0);
+    expect(fetcher).toHaveBeenCalledWith(0);
+  });
+
+  it('onPageChange は指定ページで再取得する', async () => {
+    const fetcher = jest.fn(async (page: number) => pageOf(page));
+    const { result } = renderHook(() => useListPage(fetcher, '取得失敗'));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.onPageChange(2);
+    });
+
+    expect(fetcher).toHaveBeenLastCalledWith(2);
+    expect(result.current.page).toBe(2);
+  });
+
+  it('search は現在ページに関わらず 0 ページ目へ戻して再取得する', async () => {
+    const fetcher = jest.fn(async (page: number) => pageOf(page));
+    const { result } = renderHook(() => useListPage(fetcher, '取得失敗'));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.onPageChange(2);
+    });
+    expect(result.current.page).toBe(2);
+
+    await act(async () => {
+      await result.current.search();
+    });
+
+    expect(fetcher).toHaveBeenLastCalledWith(0);
+    expect(result.current.page).toBe(0);
+  });
+
+  it('古いリクエストの遅延応答は新しい結果を上書きしない', async () => {
+    const resolvers: Array<(value: PageResult<string>) => void> = [];
+    const fetcher = jest.fn(
+      () => new Promise<PageResult<string>>(resolve => resolvers.push(resolve))
+    );
+    const { result } = renderHook(() => useListPage(fetcher, '取得失敗'));
+
+    act(() => {
+      void result.current.onPageChange(1);
+    });
+    await act(async () => {
+      resolvers[1](pageOf(1, ['newer']));
+    });
+    await act(async () => {
+      resolvers[0](pageOf(0, ['stale']));
+    });
+
+    expect(result.current.rows).toEqual(['newer']);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('アンマウント後に失敗したリクエストはトーストを出さない', async () => {
+    let rejectRequest!: (reason?: unknown) => void;
+    const fetcher = () =>
+      new Promise<PageResult<string>>((_, reject) => {
+        rejectRequest = reject;
+      });
+    const { unmount } = renderHook(() => useListPage(fetcher, '取得失敗'));
+
+    unmount();
+    await act(async () => {
+      rejectRequest(new Error('boom'));
+    });
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('失敗時はトーストを出し loading を解除する', async () => {
+    const { result } = renderHook(() =>
+      useListPage(async () => {
+        throw new Error('boom');
+      }, '取得失敗')
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(toast.error).toHaveBeenCalledWith('取得失敗');
+    expect(result.current.rows).toEqual([]);
+  });
+});

--- a/frontend/src/shared/lib/index.ts
+++ b/frontend/src/shared/lib/index.ts
@@ -2,6 +2,7 @@ export * from './config';
 export { default as redirectToLogin } from './navigation';
 export { getApiErrorMessage } from './apiError';
 export { useManagedList } from './useManagedList';
+export { useListPage } from './useListPage';
 export {
   clearPlatformSession,
   getPlatformConsole,

--- a/frontend/src/shared/lib/useListPage.ts
+++ b/frontend/src/shared/lib/useListPage.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { PageResult } from '@/shared/api';
+
+const EMPTY_PAGE: PageResult<never> = { rows: [], page: 0, pageCount: 0, total: 0 };
+
+/**
+ * ListPage 向けの取得ライフサイクル（page state・失敗トースト・順不同レスポンス守衛）。
+ * fetcher は毎レンダー最新のクロージャを参照するため、検索条件の state は useManagedList 同様に
+ * 呼び出し側がそのまま閉じ込めてよい。hook が持つのはページ番号（0 起点）だけ。
+ */
+export function useListPage<T>(
+  fetcher: (page: number) => Promise<PageResult<T>>,
+  errorMessage: string
+) {
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+  // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する
+  const requestIdRef = useRef(0);
+  const [pageResult, setPageResult] = useState<PageResult<T>>(EMPTY_PAGE);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const load = useCallback(
+    async (page: number) => {
+      const requestId = ++requestIdRef.current;
+      setIsLoading(true);
+      try {
+        const result = await fetcherRef.current(page);
+        if (requestId === requestIdRef.current) setPageResult(result);
+      } catch {
+        if (requestId === requestIdRef.current) toast.error(errorMessage);
+      } finally {
+        if (requestId === requestIdRef.current) setIsLoading(false);
+      }
+    },
+    [errorMessage]
+  );
+
+  useEffect(() => {
+    void load(0);
+    return () => {
+      // requestIdRef is a request counter, not a DOM ref.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      requestIdRef.current++;
+    };
+  }, [load]);
+
+  // 検索条件が変わったときの再取得は 1 ページ目に戻す
+  const search = useCallback(() => load(0), [load]);
+  const onPageChange = useCallback((page: number) => load(page), [load]);
+
+  return { ...pageResult, isLoading, search, onPageChange };
+}

--- a/frontend/src/shared/lib/useListPage.ts
+++ b/frontend/src/shared/lib/useListPage.ts
@@ -41,7 +41,7 @@ export function useListPage<T>(
   useEffect(() => {
     void load(0);
     return () => {
-      // requestIdRef is a request counter, not a DOM ref.
+      // requestIdRef はリクエストカウンタであり DOM ref ではない
       // eslint-disable-next-line react-hooks/exhaustive-deps
       requestIdRef.current++;
     };

--- a/frontend/src/shared/lib/useListPage.ts
+++ b/frontend/src/shared/lib/useListPage.ts
@@ -47,7 +47,10 @@ export function useListPage<T>(
     };
   }, [load]);
 
-  // 検索条件が変わったときの再取得は 1 ページ目に戻す
+  // 検索条件が変わったときの再取得は 1 ページ目に戻す。
+  // fetcher クロージャは直近のレンダーの値を参照するため、検索条件の state を更新した
+  // 同一ハンドラ内で続けて呼ぶと再レンダー前の古い条件で取得してしまう
+  // （useManagedList の refetch と同じ制約）。state 更新の反映後（次のレンダー以降）に呼ぶこと。
   const search = useCallback(() => load(0), [load]);
   const onPageChange = useCallback((page: number) => load(page), [load]);
 

--- a/frontend/src/widgets/list-page/index.ts
+++ b/frontend/src/widgets/list-page/index.ts
@@ -1,0 +1,2 @@
+export { ListPage } from './ui/ListPage';
+export type { ListPageSearch, ListPageState } from './ui/ListPage';

--- a/frontend/src/widgets/list-page/ui/ListPage.tsx
+++ b/frontend/src/widgets/list-page/ui/ListPage.tsx
@@ -62,6 +62,14 @@ export function ListPage({
   const from = isLastPage ? total - rows.length + 1 : page * rows.length + 1;
   const to = isLastPage ? total : from + rows.length - 1;
 
+  // 削除等で現在ページの rows が空になっても（total は残っていても）前ページへ戻れるよう、
+  // ページネーションは isEmpty 分岐の外側で常に描画する
+  const windowSize = Math.min(5, pageCount);
+  const windowStart = Math.max(
+    0,
+    Math.min(page - Math.floor(windowSize / 2), pageCount - windowSize)
+  );
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -89,80 +97,80 @@ export function ListPage({
         ) : isEmpty ? (
           <div className="p-8 text-center text-muted-foreground">{emptyMessage}</div>
         ) : (
-          <>
-            {children}
+          children
+        )}
 
-            {pageCount > 1 && (
-              <div className="px-4 py-3 flex items-center justify-between border-t sm:px-6">
-                <div className="flex-1 flex justify-between sm:hidden">
+        {!isLoading && pageCount > 1 && (
+          <div className="px-4 py-3 flex items-center justify-between border-t sm:px-6">
+            <div className="flex-1 flex justify-between sm:hidden">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onPageChange(page - 1)}
+                disabled={page <= 0}
+              >
+                前へ
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="ml-3"
+                onClick={() => onPageChange(page + 1)}
+                disabled={page >= pageCount - 1}
+              >
+                次へ
+              </Button>
+            </div>
+            <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  {rows.length > 0 ? `${total} 件中 ${from}-${to} を表示` : `${total} 件`}
+                </p>
+              </div>
+              <div>
+                <nav className="flex gap-1">
                   <Button
                     variant="outline"
-                    size="sm"
+                    size="icon-sm"
+                    aria-label="前へ"
                     onClick={() => onPageChange(page - 1)}
                     disabled={page <= 0}
                   >
-                    前へ
+                    <ChevronLeftIcon />
                   </Button>
+
+                  {Array.from({ length: windowSize }, (_, i) => {
+                    const buttonPage = windowStart + i;
+                    return (
+                      <Button
+                        key={buttonPage}
+                        variant="outline"
+                        size="sm"
+                        className={
+                          buttonPage === page
+                            ? 'border-primary bg-primary/10 text-primary-strong'
+                            : undefined
+                        }
+                        onClick={() => onPageChange(buttonPage)}
+                      >
+                        {buttonPage + 1}
+                      </Button>
+                    );
+                  })}
+
                   <Button
                     variant="outline"
-                    size="sm"
-                    className="ml-3"
+                    size="icon-sm"
+                    aria-label="次へ"
                     onClick={() => onPageChange(page + 1)}
                     disabled={page >= pageCount - 1}
                   >
-                    次へ
+                    <ChevronRightIcon />
                   </Button>
-                </div>
-                <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
-                  <div>
-                    <p className="text-sm text-muted-foreground">
-                      {total} 件中 {from}-{to} を表示
-                    </p>
-                  </div>
-                  <div>
-                    <nav className="flex gap-1">
-                      <Button
-                        variant="outline"
-                        size="icon-sm"
-                        onClick={() => onPageChange(page - 1)}
-                        disabled={page <= 0}
-                      >
-                        <ChevronLeftIcon />
-                      </Button>
-
-                      {Array.from({ length: Math.min(5, pageCount) }, (_, i) => {
-                        const buttonPage = i;
-                        return (
-                          <Button
-                            key={buttonPage}
-                            variant="outline"
-                            size="sm"
-                            className={
-                              buttonPage === page
-                                ? 'border-primary bg-primary/10 text-primary-strong'
-                                : undefined
-                            }
-                            onClick={() => onPageChange(buttonPage)}
-                          >
-                            {buttonPage + 1}
-                          </Button>
-                        );
-                      })}
-
-                      <Button
-                        variant="outline"
-                        size="icon-sm"
-                        onClick={() => onPageChange(page + 1)}
-                        disabled={page >= pageCount - 1}
-                      >
-                        <ChevronRightIcon />
-                      </Button>
-                    </nav>
-                  </div>
-                </div>
+                </nav>
               </div>
-            )}
-          </>
+            </div>
+          </div>
         )}
       </Card>
     </div>

--- a/frontend/src/widgets/list-page/ui/ListPage.tsx
+++ b/frontend/src/widgets/list-page/ui/ListPage.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
+import { Button, Card, CardContent } from '@/shared/ui';
+
+export interface ListPageSearch {
+  /** 検索カードの中身（入力欄・ボタンなど） */
+  content: ReactNode;
+  /** フォーム submit（Enter 提出含む）で発火する */
+  onSearch: () => void;
+}
+
+export interface ListPageState {
+  rows: unknown[];
+  /** 0 起点 */
+  page: number;
+  pageCount: number;
+  total: number;
+  isLoading: boolean;
+  onPageChange: (page: number) => void;
+}
+
+interface ListPageProps {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+  search?: ListPageSearch;
+  state: ListPageState;
+  emptyMessage: ReactNode;
+  /** テーブルの markup。汎用テーブル化はせず、各ページの責務のまま受け取る */
+  children: ReactNode;
+}
+
+/**
+ * 一覧ページ外殻（外枠・検索カード・テーブルカード包装・loading/empty 分岐・ページネーション）。
+ * widgets/page-header は同一レイヤーの他 slice のため import できず（Steiger fsd/forbidden-imports）、
+ * 見出し markup はここに直接複製している。
+ */
+export function ListPage({
+  title,
+  description,
+  actions,
+  search,
+  state,
+  emptyMessage,
+  children,
+}: ListPageProps) {
+  const { rows, page, pageCount, total, isLoading, onPageChange } = state;
+  const isEmpty = !isLoading && rows.length === 0;
+
+  const searchCard = search && (
+    <Card>
+      <CardContent className="flex flex-col md:flex-row md:items-center gap-4">
+        {search.content}
+      </CardContent>
+    </Card>
+  );
+
+  // 非最終ページは常に満杯という offset pagination の前提から、rows.length だけで件数範囲を算出できる
+  const isLastPage = page === pageCount - 1;
+  const from = isLastPage ? total - rows.length + 1 : page * rows.length + 1;
+  const to = isLastPage ? total : from + rows.length - 1;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">{title}</h1>
+          {description && <p className="text-sm text-muted-foreground mt-1">{description}</p>}
+        </div>
+        {actions && <div className="flex items-center gap-3">{actions}</div>}
+      </div>
+
+      {search && (
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            search.onSearch();
+          }}
+        >
+          {searchCard}
+        </form>
+      )}
+
+      <Card className="py-0 overflow-hidden">
+        {isLoading ? (
+          <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
+        ) : isEmpty ? (
+          <div className="p-8 text-center text-muted-foreground">{emptyMessage}</div>
+        ) : (
+          <>
+            {children}
+
+            {pageCount > 1 && (
+              <div className="px-4 py-3 flex items-center justify-between border-t sm:px-6">
+                <div className="flex-1 flex justify-between sm:hidden">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onPageChange(page - 1)}
+                    disabled={page <= 0}
+                  >
+                    前へ
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="ml-3"
+                    onClick={() => onPageChange(page + 1)}
+                    disabled={page >= pageCount - 1}
+                  >
+                    次へ
+                  </Button>
+                </div>
+                <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-sm text-muted-foreground">
+                      {total} 件中 {from}-{to} を表示
+                    </p>
+                  </div>
+                  <div>
+                    <nav className="flex gap-1">
+                      <Button
+                        variant="outline"
+                        size="icon-sm"
+                        onClick={() => onPageChange(page - 1)}
+                        disabled={page <= 0}
+                      >
+                        <ChevronLeftIcon />
+                      </Button>
+
+                      {Array.from({ length: Math.min(5, pageCount) }, (_, i) => {
+                        const buttonPage = i;
+                        return (
+                          <Button
+                            key={buttonPage}
+                            variant="outline"
+                            size="sm"
+                            className={
+                              buttonPage === page
+                                ? 'border-primary bg-primary/10 text-primary-strong'
+                                : undefined
+                            }
+                            onClick={() => onPageChange(buttonPage)}
+                          >
+                            {buttonPage + 1}
+                          </Button>
+                        );
+                      })}
+
+                      <Button
+                        variant="outline"
+                        size="icon-sm"
+                        onClick={() => onPageChange(page + 1)}
+                        disabled={page >= pageCount - 1}
+                      >
+                        <ChevronRightIcon />
+                      </Button>
+                    </nav>
+                  </div>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/widgets/list-page/ui/ListPage.tsx
+++ b/frontend/src/widgets/list-page/ui/ListPage.tsx
@@ -146,6 +146,7 @@ export function ListPage({
                         key={buttonPage}
                         variant="outline"
                         size="sm"
+                        aria-current={buttonPage === page ? 'page' : undefined}
                         className={
                           buttonPage === page
                             ? 'border-primary bg-primary/10 text-primary-strong'

--- a/frontend/src/widgets/list-page/ui/ListPage.tsx
+++ b/frontend/src/widgets/list-page/ui/ListPage.tsx
@@ -100,7 +100,9 @@ export function ListPage({
           children
         )}
 
-        {!isLoading && pageCount > 1 && (
+        {/* pageCount が 1 に潰れても、削除等で page が範囲外（page > 0）になった場合は
+            戻る手段を残す必要があるため、pageCount > 1 だけでは判定しない */}
+        {!isLoading && (pageCount > 1 || page > 0) && (
           <div className="px-4 py-3 flex items-center justify-between border-t sm:px-6">
             <div className="flex-1 flex justify-between sm:hidden">
               <Button
@@ -128,7 +130,7 @@ export function ListPage({
                 </p>
               </div>
               <div>
-                <nav className="flex gap-1">
+                <nav className="flex gap-1" aria-label="ページネーション">
                   <Button
                     variant="outline"
                     size="icon-sm"

--- a/frontend/src/widgets/list-page/ui/__tests__/ListPage.test.tsx
+++ b/frontend/src/widgets/list-page/ui/__tests__/ListPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { ListPage, ListPageState } from '../ListPage';
 
 const baseState = (override: Partial<ListPageState> = {}): ListPageState => ({
@@ -171,5 +171,58 @@ describe('ListPage', () => {
     );
 
     expect(container.querySelector('form')).toBeNull();
+  });
+
+  it('削除等で現在ページの rows が空になっても pageCount > 1 ならページネーションを描き続けること', () => {
+    render(
+      <ListPage
+        title="顧客管理"
+        state={baseState({ page: 2, pageCount: 3, total: 25, rows: [] })}
+        emptyMessage="empty"
+      >
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    expect(screen.getByText('empty')).toBeInTheDocument();
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+    expect(screen.getByText('25 件')).toBeInTheDocument();
+  });
+
+  it('現在ページが 5 起点の window を超えても番号ボタンに含まれること', () => {
+    const onPageChange = jest.fn();
+    render(
+      <ListPage
+        title="顧客管理"
+        state={baseState({
+          page: 6,
+          pageCount: 10,
+          total: 100,
+          rows: Array(10).fill('x'),
+          onPageChange,
+        })}
+        emptyMessage="empty"
+      >
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    expect(screen.getByRole('button', { name: '7' })).toHaveClass('border-primary');
+  });
+
+  it('デスクトップ用の前へ/次へアイコンボタンにアクセシブルネームがあること', () => {
+    render(
+      <ListPage
+        title="顧客管理"
+        state={baseState({ page: 1, pageCount: 3, total: 21, rows: Array(10).fill('x') })}
+        emptyMessage="empty"
+      >
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    const nav = screen.getByRole('navigation');
+    expect(within(nav).getByRole('button', { name: '前へ' })).toBeInTheDocument();
+    expect(within(nav).getByRole('button', { name: '次へ' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/widgets/list-page/ui/__tests__/ListPage.test.tsx
+++ b/frontend/src/widgets/list-page/ui/__tests__/ListPage.test.tsx
@@ -89,7 +89,9 @@ describe('ListPage', () => {
     );
 
     expect(screen.getByRole('button', { name: '1' })).toHaveClass('border-primary');
+    expect(screen.getByRole('button', { name: '1' })).toHaveAttribute('aria-current', 'page');
     expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '2' })).not.toHaveAttribute('aria-current');
     expect(screen.getByRole('button', { name: '3' })).toBeInTheDocument();
   });
 

--- a/frontend/src/widgets/list-page/ui/__tests__/ListPage.test.tsx
+++ b/frontend/src/widgets/list-page/ui/__tests__/ListPage.test.tsx
@@ -1,0 +1,175 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ListPage, ListPageState } from '../ListPage';
+
+const baseState = (override: Partial<ListPageState> = {}): ListPageState => ({
+  rows: ['a', 'b'],
+  page: 0,
+  pageCount: 1,
+  total: 2,
+  isLoading: false,
+  onPageChange: jest.fn(),
+  ...override,
+});
+
+describe('ListPage', () => {
+  it('見出しを h1 として描き、副題とアクションを並べること', () => {
+    render(
+      <ListPage
+        title="顧客管理"
+        description="顧客情報の登録・編集ができます。"
+        actions={<button type="button">新規顧客登録</button>}
+        state={baseState()}
+        emptyMessage="顧客が登録されていません"
+      >
+        <div>table</div>
+      </ListPage>
+    );
+
+    expect(screen.getByRole('heading', { level: 1, name: '顧客管理' })).toBeInTheDocument();
+    expect(screen.getByText('顧客情報の登録・編集ができます。')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '新規顧客登録' })).toBeInTheDocument();
+  });
+
+  it('isLoading 中は children を描かず読み込み中を表示すること', () => {
+    render(
+      <ListPage
+        title="顧客管理"
+        state={baseState({ isLoading: true, rows: [] })}
+        emptyMessage="empty"
+      >
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    expect(screen.queryByText('table-content')).not.toBeInTheDocument();
+  });
+
+  it('rows が空なら emptyMessage を表示すること', () => {
+    render(
+      <ListPage title="顧客管理" state={baseState({ rows: [], total: 0 })} emptyMessage="empty">
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    expect(screen.getByText('empty')).toBeInTheDocument();
+    expect(screen.queryByText('table-content')).not.toBeInTheDocument();
+  });
+
+  it('rows があれば children をそのまま描くこと', () => {
+    render(
+      <ListPage title="顧客管理" state={baseState()} emptyMessage="empty">
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    expect(screen.getByText('table-content')).toBeInTheDocument();
+    expect(screen.queryByText('empty')).not.toBeInTheDocument();
+  });
+
+  it('pageCount が 1 以下ならページネーションを描かないこと', () => {
+    render(
+      <ListPage title="顧客管理" state={baseState({ pageCount: 1 })} emptyMessage="empty">
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+  });
+
+  it('0 起点の page をボタン表示では 1 起点に換算すること', () => {
+    render(
+      <ListPage
+        title="顧客管理"
+        state={baseState({ page: 0, pageCount: 3, total: 21, rows: Array(10).fill('x') })}
+        emptyMessage="empty"
+      >
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    expect(screen.getByRole('button', { name: '1' })).toHaveClass('border-primary');
+    expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '3' })).toBeInTheDocument();
+  });
+
+  it('件数範囲は非最終ページで rows.length を基準に算出すること', () => {
+    render(
+      <ListPage
+        title="顧客管理"
+        state={baseState({ page: 1, pageCount: 3, total: 25, rows: Array(10).fill('x') })}
+        emptyMessage="empty"
+      >
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    expect(screen.getByText('25 件中 11-20 を表示')).toBeInTheDocument();
+  });
+
+  it('件数範囲は最終ページで total から逆算すること', () => {
+    render(
+      <ListPage
+        title="顧客管理"
+        state={baseState({ page: 2, pageCount: 3, total: 25, rows: Array(5).fill('x') })}
+        emptyMessage="empty"
+      >
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    expect(screen.getByText('25 件中 21-25 を表示')).toBeInTheDocument();
+  });
+
+  it('ページボタン押下で onPageChange が 0 起点の対象ページで呼ばれること', () => {
+    const onPageChange = jest.fn();
+    render(
+      <ListPage
+        title="顧客管理"
+        state={baseState({
+          page: 0,
+          pageCount: 3,
+          total: 21,
+          rows: Array(10).fill('x'),
+          onPageChange,
+        })}
+        emptyMessage="empty"
+      >
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '2' }));
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  it('form の submit で onSearch が発火し、ページ遷移は起きないこと', () => {
+    const onSearch = jest.fn();
+    render(
+      <ListPage
+        title="顧客管理"
+        search={{ content: <input aria-label="検索" />, onSearch }}
+        state={baseState()}
+        emptyMessage="empty"
+      >
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    const form = screen.getByLabelText('検索').closest('form');
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it('search を渡さなければフォームを描かないこと', () => {
+    const { container } = render(
+      <ListPage title="顧客管理" state={baseState()} emptyMessage="empty">
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    expect(container.querySelector('form')).toBeNull();
+  });
+});

--- a/frontend/src/widgets/list-page/ui/__tests__/ListPage.test.tsx
+++ b/frontend/src/widgets/list-page/ui/__tests__/ListPage.test.tsx
@@ -191,6 +191,39 @@ describe('ListPage', () => {
     expect(screen.getByText('25 件')).toBeInTheDocument();
   });
 
+  it('削除で pageCount が 1 に潰れても、範囲外の page なら前へ戻る手段を残すこと', () => {
+    const onPageChange = jest.fn();
+    render(
+      <ListPage
+        title="顧客管理"
+        state={baseState({ page: 1, pageCount: 1, total: 10, rows: [], onPageChange })}
+        emptyMessage="empty"
+      >
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    const nav = screen.getByRole('navigation');
+    const prev = within(nav).getByRole('button', { name: '前へ' });
+    expect(prev).not.toBeDisabled();
+    fireEvent.click(prev);
+    expect(onPageChange).toHaveBeenCalledWith(0);
+  });
+
+  it('ページネーションの nav にアクセシブルネームがあること', () => {
+    render(
+      <ListPage
+        title="顧客管理"
+        state={baseState({ page: 0, pageCount: 3, total: 21, rows: Array(10).fill('x') })}
+        emptyMessage="empty"
+      >
+        <div>table-content</div>
+      </ListPage>
+    );
+
+    expect(screen.getByRole('navigation', { name: 'ページネーション' })).toBeInTheDocument();
+  });
+
   it('現在ページが 5 起点の window を超えても番号ボタンに含まれること', () => {
     const onPageChange = jest.fn();
     render(


### PR DESCRIPTION
## 概要

一覧ページ外殻（外枠・検索カード・テーブルカード・loading/empty・ページネーション）の深化基盤（scaffold）を新設する。既存 6 ページには一切触れない、挙動変化ゼロの純増分。

Closes #509

## 変更内容

- `shared/api` に正規化ページ型 `PageResult<T>`（0 起点 `page`）と、Spring Data `Page` / `/platform/stores` の Laravel 風封筒それぞれの応答・リクエスト双方向 adapter（`fromSpringPage` / `fromLaravelPage` / `toSpringPageParams` / `toLaravelPageParams`）を新設。ワイヤ形式の知識をここへ隠蔽する。
- `shared/lib` に `useListPage` を新設。page state・失敗トースト・順不同レスポンス守衛（requestId）を hook が持つ（`useManagedList` と同じ守衛パターン）。検索時は 1 ページ目へ戻す。既存 `useManagedList` は配列形取得用途としてそのまま残す。
- `widgets/list-page` に `ListPage` を新設。外枠・見出し・検索カード・テーブルカード包装・loading/empty 分岐・ページネーション描画を implementation として隠す。テーブル markup は従来どおり `children` で各ページの責務のまま。検索提出は shell が持つ `<form onSubmit>` に統一。ページネーションは現行 `StoresPage` の番号付き形態（数字ページ + 応答式折畳 + 件数範囲表示）を移設し、表示は `page + 1`（1 起点表示への換算は shell 内のみ）。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e` — 本 PR はどのページにも配線されていないため、既存シナリオへの影響なし（新規コードを exercise する導線が存在しない）
- [x] ローカルで code-review 実施済み（Standards / Spec 両軸、Standards 軸の 1 件（コメント言語規約違反）は修正済み、Spec 軸は指摘なし）

### 視覚確認（UI 変更時）

該当なし（scaffold のみで、どのページの画面にも現れない）

## 決定ログ

- **見出し markup の複製**: `ListPage` は DESIGN.md の List page shell 仕様に合わせて見出し・検索カード・テーブルカードを内包する。`widgets/page-header` の `PageHeader` を import して再利用したかったが、Steiger の `fsd/forbidden-imports` が同一レイヤー（widgets）間の cross-slice import を禁止しており実測で確認済み（プロジェクト全体スキャンで検出、単体ディレクトリでは検出されない）。そのため見出し markup は `ListPage.tsx` 内に複製している。`widgets/page-header` は現状 6 ページ（今回のスコープ外）からのみ参照されており、後続の移行票で全ページが `ListPage` に切り替われば `widgets/page-header` は不要になり削除できる見込み。
- **件数範囲表示の算出**: `PageResult` は仕様どおり `size`（1 ページ件数）を持たないため、`rows.length` から算出する。offset pagination では最終ページ以外は必ず満杯という前提のもと、非最終ページは `page * rows.length + 1` 〜、最終ページは `total - rows.length + 1` 〜 `total` で求める。両バックエンド（Spring Data / Laravel 風封筒）ともこの前提を満たすため、`size` を型に持ち込まずに済ませた。
- **`search` / `state` の形**: issue のインターフェース列挙（`title / description / actions / search / state / emptyMessage / children`）は各 prop の中身までは規定していないため、`search: { content, onSearch }` ・ `state: { rows, page, pageCount, total, isLoading, onPageChange }` として設計。受け入れ基準が名指す `onSearch` の発火を含め、module テストで固定している。

## 備考 / レビュー観点

- 既存 6 一覧ページ・`DESIGN.md`・バックエンドは無変更（`git diff --stat` で確認済み）。
- adapter は `shared/api/__tests__/page.test.ts` で実ワイヤ形の snake_case fixture を直接与えて 0/1 起点変換を固定。`ListPage` は `widgets/list-page/ui/__tests__/ListPage.test.tsx` で外枠構造・loading/empty 分岐・ページネーション描画・0 起点換算・form submit → onSearch を固定。
- 6 ページの移行・class アンカー収束・DESIGN.md 縮編・`/platform/stores` のワイヤ形式統一はいずれもスコープ外（後続票）。