### PR TITLE
fix: 店舗一覧が全店舗「無効」・「Invalid Date」表示になる契約不一致を解消する

### DIFF
--- a/backend/src/main/java/com/kizuna/store/api/dto/StoreVO.java
+++ b/backend/src/main/java/com/kizuna/store/api/dto/StoreVO.java
@@ -2,6 +2,7 @@ package com.kizuna.store.api.dto;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,4 +19,5 @@ public class StoreVO implements Serializable {
   private String name;
   private String domain;
   private String email;
+  private OffsetDateTime createdAt;
 }

--- a/backend/src/main/java/com/kizuna/store/application/StoreRegistryService.java
+++ b/backend/src/main/java/com/kizuna/store/application/StoreRegistryService.java
@@ -89,6 +89,7 @@ public class StoreRegistryService {
   }
 
   private StoreVO toDto(Store t) {
-    return new StoreVO(String.valueOf(t.getId()), t.getName(), t.getDomain(), t.getEmail());
+    return new StoreVO(
+        String.valueOf(t.getId()), t.getName(), t.getDomain(), t.getEmail(), t.getCreatedAt());
   }
 }

--- a/backend/src/test/java/com/kizuna/store/application/StoreRegistryServiceTest.java
+++ b/backend/src/test/java/com/kizuna/store/application/StoreRegistryServiceTest.java
@@ -15,6 +15,7 @@ import com.kizuna.store.api.dto.StoreVO;
 import com.kizuna.store.domain.Store;
 import com.kizuna.store.domain.StoreRepository;
 import com.kizuna.storeprofile.domain.StoreProfileRepository;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -78,6 +79,7 @@ class StoreRegistryServiceTest {
     assertThat(result).isPresent();
     assertThat(result.get().getName()).isEqualTo("Store1");
     assertThat(result.get().getDomain()).isEqualTo("store1.com");
+    assertThat(result.get().getCreatedAt()).isEqualTo(t.getCreatedAt());
   }
 
   @Test
@@ -167,6 +169,7 @@ class StoreRegistryServiceTest {
     t.setName(name);
     t.setDomain(domain);
     t.setEmail(email);
+    t.setCreatedAt(OffsetDateTime.parse("2026-01-01T00:00:00Z"));
     return t;
   }
 }

--- a/frontend/src/_pages/platform-dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/_pages/platform-dashboard/__tests__/DashboardPage.test.tsx
@@ -33,7 +33,6 @@ const store = (override: Partial<Store>): Store => ({
   email: 'alpha@example.com',
   domain: 'alpha.example.com',
   domains: ['alpha.example.com'],
-  is_active: true,
   created_at: '2026-01-01T00:00:00Z',
   ...override,
 });

--- a/frontend/src/_pages/platform-dashboard/ui/DashboardPage.tsx
+++ b/frontend/src/_pages/platform-dashboard/ui/DashboardPage.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { useAuth } from '@/entities/user';
 import { useRouter } from 'next/navigation';
 import { Store, StoreStats, platformStoreApi } from '@/entities/store';
-import { Badge, Button, Card, CardContent, Skeleton } from '@/shared/ui';
+import { Button, Card, CardContent, Skeleton } from '@/shared/ui';
 import toast from 'react-hot-toast';
 
 export default function AdminDashboard() {
@@ -236,16 +236,6 @@ export default function AdminDashboard() {
                         </div>
                       </div>
                       <div className="flex items-center space-x-3">
-                        <Badge
-                          variant="outline"
-                          className={`border-transparent ${
-                            store.is_active
-                              ? 'bg-success/10 text-success-strong'
-                              : 'bg-destructive/10 text-destructive-strong'
-                          }`}
-                        >
-                          {store.is_active ? '有効' : '無効'}
-                        </Badge>
                         <span className="text-sm text-muted-foreground">
                           {new Date(store.created_at).toLocaleDateString('ja-JP')}
                         </span>

--- a/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
+++ b/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
@@ -39,7 +39,6 @@ const store = (override: Partial<Store>): Store => ({
   email: 'alpha@example.com',
   domain: 'alpha.example.com',
   domains: ['alpha.example.com'],
-  is_active: true,
   created_at: '2026-01-01T00:00:00Z',
   ...override,
 });
@@ -61,20 +60,15 @@ describe('店舗管理 3 画面の挙動', () => {
     mockedApi.getList.mockResolvedValue(paginated([]));
   });
 
-  it('一覧は店舗名と有効/無効の状態を表示すること', async () => {
+  it('一覧は店舗名を表示すること', async () => {
     mockedApi.getList.mockResolvedValue(
-      paginated([
-        store({ id: '1', name: 'アルファ店', is_active: true }),
-        store({ id: '2', name: 'ベータ店', is_active: false }),
-      ])
+      paginated([store({ id: '1', name: 'アルファ店' }), store({ id: '2', name: 'ベータ店' })])
     );
 
     render(<StoresPage />);
 
     expect(await screen.findByText('アルファ店')).toBeInTheDocument();
     expect(screen.getByText('ベータ店')).toBeInTheDocument();
-    expect(screen.getByText('有効')).toBeInTheDocument();
-    expect(screen.getByText('無効')).toBeInTheDocument();
   });
 
   it('検索は 0 起点の page/size/search のペイロードで再取得すること', async () => {

--- a/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { Store, platformStoreApi } from '@/entities/store';
 import { useListPage } from '@/shared/lib';
 import { ListPage } from '@/widgets/list-page';
-import { Badge, Button, ConfirmDialog, Input } from '@/shared/ui';
+import { Button, ConfirmDialog, Input } from '@/shared/ui';
 import toast from 'react-hot-toast';
 
 /** 一覧 1 ページあたりの件数 */
@@ -134,19 +134,7 @@ export default function StoresPage() {
                     </div>
                   </div>
                   <div className="ml-4 min-w-0 flex-1">
-                    <div className="flex items-center">
-                      <p className="text-lg font-medium text-foreground truncate">{store.name}</p>
-                      <Badge
-                        variant="outline"
-                        className={`ml-2 border-transparent ${
-                          store.is_active
-                            ? 'bg-success/10 text-success-strong'
-                            : 'bg-destructive/10 text-destructive-strong'
-                        }`}
-                      >
-                        {store.is_active ? '有効' : '無効'}
-                      </Badge>
-                    </div>
+                    <p className="text-lg font-medium text-foreground truncate">{store.name}</p>
                   </div>
                 </div>
                 <div className="flex items-center space-x-2">

--- a/frontend/src/entities/store/model/types.ts
+++ b/frontend/src/entities/store/model/types.ts
@@ -5,7 +5,6 @@ export interface Store {
   email: string;
   domain: string;
   domains: string[];
-  is_active: boolean;
   created_at: string;
   updated_at?: string;
 }


### PR DESCRIPTION
## 概要

/platform/stores 一覧と /platform/dashboard の店舗一覧が、フロント `Store` 型とバックエンド `StoreVO` の契約不一致により全店舗「無効」バッジ・「Invalid Date」表示になる不具合を解消する。

Closes #515

## 変更内容

- `StoreVO` に `createdAt` を追加し、`toDto` で `BaseEntity.createdAt` を返す（グローバルの Jackson SNAKE_CASE 設定で `created_at` として出力される）
- ドメイン未モデル化の `is_active` は、`Store` 型・StoresPage / DashboardPage の「有効/無効」バッジごと撤去（孤児化した `Badge` import も削除）
- 両ページのテストフィクスチャと一覧テストの断言を実態に合わせて更新

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全 20 シナリオ pass）
- [x] ローカルで code-review 実施済み（Standards / Spec 二軸、blocking 0 件）

### 視覚確認（UI 変更時）

rebase 後の新イメージで `task up` → 実ブラウザ確認済み: /platform/stores と /platform/dashboard の両方で実日付（2026/7/28）が表示され、「無効」バッジは消えている。

## 決定ログ

- `created_at` は `BaseEntity.createdAt` に実データがあるため返却する側で解決。`is_active` はドメインに active フラグ自体が存在せず（`StoreRegistryService.stats()` の既存 TODO 参照）、モデル化はマイグレーション・切替 UI を伴う機能追加になるため本票では表示を撤去し、モデル化時に再導入する判断。
- テストは赤→緑の順（`StoreVO#getCreatedAt` の断言を先に追加してコンパイル失敗を確認してから実装）。

## 備考 / レビュー観点

- 同型の契約不一致として `Store.domains: string[]`（バックエンド未返却、StoreEditPage 表示はガードで空フォールバック）が残存。別セッションで対応中。
- Redis `storeByDomain` キャッシュの既存エントリは失効まで `created_at: null` で復元されるが、当該パス（店舗ドメイン解決）は `created_at` を消費しないため実害なし。
- ダッシュボード上部の「有効店舗/無効店舗」統計カードは `stats()` の既存プレースホルダ実装（total/total/0/0）のままで本票の範囲外。active フラグのモデル化票で扱う想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
