### PR TITLE
fix: 店舗編集画面の関連ドメインが常に空表示になる契約不一致を解消する

### DIFF
--- a/frontend/src/_pages/platform-dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/_pages/platform-dashboard/__tests__/DashboardPage.test.tsx
@@ -32,7 +32,6 @@ const store = (override: Partial<Store>): Store => ({
   name: 'アルファ店',
   email: 'alpha@example.com',
   domain: 'alpha.example.com',
-  domains: ['alpha.example.com'],
   is_active: true,
   created_at: '2026-01-01T00:00:00Z',
   ...override,

--- a/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
+++ b/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
@@ -38,7 +38,6 @@ const store = (override: Partial<Store>): Store => ({
   name: 'アルファ店',
   email: 'alpha@example.com',
   domain: 'alpha.example.com',
-  domains: ['alpha.example.com'],
   is_active: true,
   created_at: '2026-01-01T00:00:00Z',
   ...override,
@@ -188,7 +187,7 @@ describe('店舗管理 3 画面の挙動', () => {
         id: '1',
         name: 'デルタ店',
         email: 'delta@example.com',
-        domains: ['delta.example.com', 'delta2.example.com'],
+        domain: 'delta.example.com',
       })
     );
     mockedApi.update.mockResolvedValue(store({}));
@@ -197,7 +196,7 @@ describe('店舗管理 3 画面の挙動', () => {
 
     const nameInput = (await screen.findByLabelText(/店舗名/)) as HTMLInputElement;
     await waitFor(() => expect(nameInput.value).toBe('デルタ店'));
-    expect(screen.getByText('delta2.example.com')).toBeInTheDocument();
+    expect(screen.getByText('delta.example.com')).toBeInTheDocument();
 
     fireEvent.change(nameInput, { target: { value: 'デルタ本店' } });
     fireEvent.click(screen.getByRole('button', { name: '保存' }));

--- a/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
+++ b/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
@@ -203,6 +203,14 @@ describe('店舗管理 3 画面の挙動', () => {
     );
     await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/platform/stores'));
   });
+
+  it('編集はドメインが空のとき未設定の文言を表示すること', async () => {
+    mockedApi.getById.mockResolvedValue(store({ domain: '' }));
+
+    render(<StoreEditPage />);
+
+    expect(await screen.findByText('ドメインは設定されていません')).toBeInTheDocument();
+  });
 });
 
 describe('店舗一覧ページ固有の要素', () => {

--- a/frontend/src/_pages/platform-stores/ui/StoreEditPage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoreEditPage.tsx
@@ -154,18 +154,8 @@ export default function EditStorePage() {
                 {/* ドメイン（読み取り専用） */}
                 {store && (
                   <div className="rounded-lg border p-4">
-                    <h4 className="text-sm font-medium text-foreground mb-2">関連ドメイン</h4>
-                    {store.domains && store.domains.length > 0 ? (
-                      <ul className="list-disc ml-6 text-sm text-foreground">
-                        {store.domains.map(d => (
-                          <li key={d} className="break-all">
-                            {d}
-                          </li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <p className="text-sm text-muted-foreground">ドメインは設定されていません</p>
-                    )}
+                    <h4 className="text-sm font-medium text-foreground mb-2">ドメイン</h4>
+                    <p className="text-sm text-foreground break-all">{store.domain}</p>
                   </div>
                 )}
 

--- a/frontend/src/_pages/platform-stores/ui/StoreEditPage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoreEditPage.tsx
@@ -155,7 +155,12 @@ export default function EditStorePage() {
                 {store && (
                   <div className="rounded-lg border p-4">
                     <h4 className="text-sm font-medium text-foreground mb-2">ドメイン</h4>
-                    <p className="text-sm text-foreground break-all">{store.domain}</p>
+                    {/* DB の domain 列は unique だが NOT NULL ではないため空値があり得る */}
+                    {store.domain ? (
+                      <p className="text-sm text-foreground break-all">{store.domain}</p>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">ドメインは設定されていません</p>
+                    )}
                   </div>
                 )}
 

--- a/frontend/src/entities/store/model/types.ts
+++ b/frontend/src/entities/store/model/types.ts
@@ -4,7 +4,6 @@ export interface Store {
   name: string;
   email: string;
   domain: string;
-  domains: string[];
   is_active: boolean;
   created_at: string;
   updated_at?: string;


### PR DESCRIPTION
## 概要

店舗編集画面の「関連ドメイン」欄が、フロントの `Store` 型にだけ存在する `domains: string[]` を参照していたため常に空表示フォールバックに落ちていた。バックエンドは単数 `domain` のみをモデル化しているため、表示を単数 `store.domain` に落とし、`Store` 型から `domains` を撤去する。#515 の姉妹件。

Closes #516

## 変更内容

- `entities/store` の `Store` 型から、バックエンド契約に存在しない `domains: string[]` を撤去
- `StoreEditPage` のドメイン欄を単数 `store.domain` の表示へ変更（見出しは単数化に合わせ「関連ドメイン」→「ドメイン」）
- ドメイン空値時の「ドメインは設定されていません」フォールバックは維持（`t_stores.domain` は unique だが NOT NULL 制約がないため空値があり得る。codex 指摘反映）し、その表示のテストを追加
- 両テストのモックデータから `domains` を撤去し、編集画面テストの断言を単数ドメインへ同期

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全シナリオ）
- [x] ローカルで code-review 実施済み

### 視覚確認（UI 変更時）

`task up` 起動後、実ブラウザで /platform/stores/1/edit を確認。「ドメイン」欄に `store1.kizuna.test` が正しく表示されることを確認済み（修正前は「ドメインは設定されていません」に固定）。

## 決定ログ

- 複数ドメインはバックエンド未モデル化（`Store` エンティティは単数 `domain` のみ）のため、フロントを契約へ合わせる方針を採用。API 側に `domains` を追加する代替案は、返す実データが存在しないため見送り。複数ドメイン対応が必要になればモデル化とセットで別途機能として扱う
- 見出し「関連ドメイン」は複数前提の文言のため、単一値表示への変更に合わせ「ドメイン」へ変更
- 空表示フォールバックは当初撤去したが、Liquibase 基線で `domain` 列に NOT NULL 制約がない（unique のみ）ことの codex 指摘を受けて復元。DB 側に NOT NULL を追加する案は本件（フロント表示修正）の範囲外として見送り

## 備考 / レビュー観点

- #517（#515 の修正）と `frontend/src/entities/store/model/types.ts` および両テストのモック定義で隣接行を触っており、後からマージされる側に小さな rebase が必要になる見込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

