### PR TITLE
fix(backend): t_stores.domain に NOT NULL 制約を追加し JPA 宣言との乖離を解消する

### DIFF
--- a/backend/src/main/resources/db/changelog/releases/v0.1.0/platform/01-store.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.1.0/platform/01-store.yaml
@@ -28,6 +28,7 @@ databaseChangeLog:
                   name: domain
                   type: VARCHAR(128)
                   constraints:
+                    nullable: false
                     unique: true
                     uniqueConstraintName: uq_t_stores_domain
                   remarks: 公開サイトのホスト名（店舗文脈の解決キー）


### PR DESCRIPTION
## 概要

`t_stores.domain` は Store エンティティが `@Column(nullable = false, unique = true)` を宣言する一方、Liquibase 基線では `unique` のみで NOT NULL が欠けており、DB 層では空値が許容されていた（PR #518 の codex 指摘で発覚）。domain は店舗文脈の解決キーであり必須のため、基線 changeset に `nullable: false` を追加して DB 側を宣言に合わせる。

## 変更内容

- `releases/v0.1.0/platform/01-store.yaml` の `domain` 列制約に `nullable: false` を追加（1 行）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（統合テストは臨時スタックで changelog 全量を再生し、修正後の基線での移行を検証済み）
- [x] `task build` exit 0
- [ ] `task e2e` — 共有 dev ボリュームが旧チェックサムのままのため実行不可。DB 再作成（オーナー側で実施予定）後に確認
- [ ] ローカルで code-review 実施済み — 1 行の制約追加のため省略

## 決定ログ

- **基線 changeset を直接修正**（未リリースのためのオーナー裁定）。増分 changeset（`addNotNullConstraint`）は本番適用実績が無い現状では履歴を増やすだけのため見送り。
- **エンティティ側を nullable に緩める案は不採用**：domain は店舗文脈の解決キーで、demo 種子・全テストも常に値を持つ。空値を許す実態の方が誤り。

## 備考 / レビュー観点

- 適用済み changeset の checksum が変わるため、既存の開発 DB は `DROP DATABASE kizuna` + `CREATE DATABASE kizuna` での再作成が必要（ボリュームは削除しない）。再作成後は master ビルドの旧イメージが checksum 不一致で起動しなくなるため、マージまでの窓は短めに。
- 空値挿入経路の確認済み：demo 種子は両店舗とも domain 値あり、単体・統合テストはすべて JPA 経由（エンティティ側 `nullable = false` が既に強制）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)