### PR TITLE
feat(frontend): 店舗一覧の体裁を揃え、スタッフ・ロール管理に検索と分頁を足す

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/store/PlatformStoreApiIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/store/PlatformStoreApiIT.java
@@ -96,6 +96,27 @@ class PlatformStoreApiIT {
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
   }
 
+  // ドメインは管理画面で店舗サイトへのリンクとして描画される。`/` `:` `@` を通すと
+  // `正規.example@攻撃者.example` が別ホストへの導線になるため、保存の手前で閉じる。
+  @Test
+  @DisplayName("POST /platform/stores はホスト名の形でないドメインを 400 で拒むこと")
+  void createStoreRejectsNonHostnameDomain() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.setBearerAuth(platformToken(HQ_EMAIL));
+    String body =
+        String.format(
+            "{\"name\": \"店舗作成テスト\","
+                + " \"domain\": \"store-create-it-%s.kizuna.test@evil.example\","
+                + " \"email\": \"store-create-it@kizuna.test\"}",
+            UUID.randomUUID());
+
+    ResponseEntity<String> res =
+        rest.postForEntity("/platform/stores", new HttpEntity<>(body, headers), String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
   @Test
   @DisplayName("GET /platform/stores/lookup?domain= は未認証で 200 と店舗情報を返すこと（受入基準3）")
   void lookupByDomainIsPublic() {

--- a/backend/src/integrationTest/java/com/kizuna/store/PlatformStoreApiIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/store/PlatformStoreApiIT.java
@@ -117,6 +117,27 @@ class PlatformStoreApiIT {
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
   }
 
+  // ドメインは Host ヘッダによる店舗文脈の解決キー。ブラウザは Host を小文字で送るのに
+  // 照合は大小を区別するため、大文字を呑むと誰も到達できない店舗ができる。
+  @Test
+  @DisplayName("POST /platform/stores は大文字を含むドメインを 400 で拒むこと")
+  void createStoreRejectsUppercaseDomain() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.setBearerAuth(platformToken(HQ_EMAIL));
+    String body =
+        String.format(
+            "{\"name\": \"店舗作成テスト\","
+                + " \"domain\": \"Store-Create-IT-%s.Kizuna.test\","
+                + " \"email\": \"store-create-it@kizuna.test\"}",
+            UUID.randomUUID());
+
+    ResponseEntity<String> res =
+        rest.postForEntity("/platform/stores", new HttpEntity<>(body, headers), String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
   @Test
   @DisplayName("GET /platform/stores/lookup?domain= は未認証で 200 と店舗情報を返すこと（受入基準3）")
   void lookupByDomainIsPublic() {

--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -397,6 +397,30 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
     assertThat(none.getBody().path("total_elements").asLong()).isZero();
   }
 
+  // "staff-it-n_nhq" は _ をワイルドカードとして扱うと staff-it-nonhq に一致してしまう。
+  // 検索語は字面として照合されるべきなので 0 件が正。
+  @Test
+  @DisplayName("検索語中の LIKE メタ文字は字面として扱われ、ワイルドカードにならないこと")
+  void staffSearchTreatsLikeMetacharactersAsLiterals() {
+    String hq = platformToken(SEED_EMAIL, PASSWORD);
+
+    ResponseEntity<JsonNode> underscore =
+        rest.exchange(
+            "/platform/staff?search=staff-it-n_nhq",
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(hq)),
+            JsonNode.class);
+    assertThat(underscore.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(underscore.getBody().path("total_elements").asLong()).isZero();
+
+    ResponseEntity<JsonNode> percent =
+        rest.exchange(
+            "/platform/staff?search=staff-it-%25nonhq",
+            HttpMethod.GET, new HttpEntity<>(bearer(hq)), JsonNode.class);
+    assertThat(percent.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(percent.getBody().path("total_elements").asLong()).isZero();
+  }
+
   @Test
   @DisplayName("兼務(HQ管理者+店長の複数束)のスタッフは中央端点と店舗端点の両方へ到達できること")
   void multiRoleStaffReachesBothConsoles() {

--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -397,6 +397,42 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
     assertThat(none.getBody().path("total_elements").asLong()).isZero();
   }
 
+  // 一覧の現在ページに居ない対象でも最新の版を取り直せる経路（競合後の再試行に要る）。
+  // 一覧・作成と同じく CAST/MEMBER は不可視のため 404。
+  @Test
+  @DisplayName("GET /platform/staff/{id} は STAFF を返し、CAST は 404 になること")
+  void getStaffByIdReturnsStaffAndHidesCast() {
+    String hq = platformToken(SEED_EMAIL, PASSWORD);
+    long staffId = platformUserRepository.findByEmail(NON_HQ_EMAIL).orElseThrow().getId();
+    long castId = platformUserRepository.findByEmail(CAST_CANARY_EMAIL).orElseThrow().getId();
+
+    ResponseEntity<JsonNode> found =
+        rest.exchange(
+            "/platform/staff/" + staffId,
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(hq)),
+            JsonNode.class);
+    assertThat(found.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(found.getBody().path("email").asString()).isEqualTo(NON_HQ_EMAIL);
+    assertThat(found.getBody().path("version").isNumber()).isTrue();
+
+    ResponseEntity<String> cast =
+        rest.exchange(
+            "/platform/staff/" + castId,
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(hq)),
+            String.class);
+    assertThat(cast.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+
+    ResponseEntity<String> forbidden =
+        rest.exchange(
+            "/platform/staff/" + staffId,
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(platformToken(NON_HQ_EMAIL, PASSWORD))),
+            String.class);
+    assertThat(forbidden.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
   // "staff-it-n_nhq" は _ をワイルドカードとして扱うと staff-it-nonhq に一致してしまう。
   // 検索語は字面として照合されるべきなので 0 件が正。
   @Test

--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -349,6 +349,9 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
   }
 
+  // 検索語は STAFF 限定と AND で重なる。両者の email に共通する接頭辞で引くことで、
+  // 「検索で拾える範囲にいてもなお CAST は現れない」ことまで断言する。size はページ境界に
+  // 隠れて偽陰性にならないよう、IT が作る件数より十分大きく取る。
   @Test
   @DisplayName("スタッフ一覧に CAST が現れず、STAFF は現れること(強断言)")
   void staffListExcludesCastAndMember() {
@@ -356,12 +359,42 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
 
     ResponseEntity<String> res =
         rest.exchange(
-            "/platform/staff", HttpMethod.GET, new HttpEntity<>(bearer(hq)), String.class);
+            "/platform/staff?search=staff-it-&size=100",
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(hq)),
+            String.class);
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(res.getBody())
         .as("STAFF は現れ、CAST は一覧の生ボディに一切現れないこと")
         .contains(NON_HQ_EMAIL)
         .doesNotContain(CAST_CANARY_EMAIL);
+  }
+
+  @Test
+  @DisplayName("スタッフ一覧は search で表示名・メールを横断して絞り込み、Spring Page 形で返すこと")
+  void staffListFiltersBySearchAndReturnsPage() {
+    String hq = platformToken(SEED_EMAIL, PASSWORD);
+
+    ResponseEntity<JsonNode> res =
+        rest.exchange(
+            "/platform/staff?search=" + NON_HQ_EMAIL,
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(hq)),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(res.getBody().path("total_elements").asLong()).isEqualTo(1);
+    assertThat(res.getBody().path("content").get(0).path("email").asString())
+        .isEqualTo(NON_HQ_EMAIL);
+
+    // 該当なしは空ページ（404 でも 500 でもない）
+    ResponseEntity<JsonNode> none =
+        rest.exchange(
+            "/platform/staff?search=staff-it-no-such-person",
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(hq)),
+            JsonNode.class);
+    assertThat(none.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(none.getBody().path("total_elements").asLong()).isZero();
   }
 
   @Test
@@ -442,17 +475,27 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
     // 行は残る: 一覧に停止済みスタッフが現れる（過去の実行主体の記録保持）。
     ResponseEntity<String> list =
         rest.exchange(
-            "/platform/staff", HttpMethod.GET, new HttpEntity<>(bearer(hq)), String.class);
+            "/platform/staff?search=" + email,
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(hq)),
+            String.class);
     assertThat(list.getBody()).as("停止後も一覧に残ること").contains(email);
   }
 
-  /** スタッフ一覧から email 一致の 1 件を返す（見つからなければ失敗）。 */
+  /**
+   * スタッフ一覧から email 一致の 1 件を返す（見つからなければ失敗）。
+   *
+   * <p>一覧は Spring Page 形のため、対象がページ境界の向こうに隠れないよう email そのもので絞り込んでから {@code content} を走査する。
+   */
   private JsonNode findStaffByEmail(String token, String email) {
     ResponseEntity<JsonNode> res =
         rest.exchange(
-            "/platform/staff", HttpMethod.GET, new HttpEntity<>(bearer(token)), JsonNode.class);
+            "/platform/staff?search=" + email,
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(token)),
+            JsonNode.class);
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
-    for (JsonNode node : res.getBody()) {
+    for (JsonNode node : res.getBody().path("content")) {
       if (email.equals(node.path("email").asString())) {
         return node;
       }

--- a/backend/src/main/java/com/kizuna/store/api/dto/StoreCreateDTO.java
+++ b/backend/src/main/java/com/kizuna/store/api/dto/StoreCreateDTO.java
@@ -1,6 +1,8 @@
 package com.kizuna.store.api.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,10 +12,21 @@ import lombok.Setter;
 @NoArgsConstructor
 public class StoreCreateDTO {
 
+  /**
+   * ホスト名（ラベルを . で連ねた形）だけを受け付ける。
+   *
+   * <p>この項目は店舗サイトへのリンクとして描画されるため、{@code /} {@code :} {@code @} を通すと {@code 正規.example@攻撃者.example}
+   * のような値が別ホストへの導線になる。形式検査は前端にもあるが、REST を直接叩けば迂回できるので 保存の手前で閉じる。長さ上限は列定義（VARCHAR(128)）に合わせる。
+   */
+  private static final String DOMAIN_PATTERN =
+      "^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$";
+
   @NotBlank(message = "name is required")
   private String name;
 
   @NotBlank(message = "domain is required")
+  @Size(max = 128, message = "domain is too long")
+  @Pattern(regexp = DOMAIN_PATTERN, message = "domain must be a hostname")
   private String domain;
 
   @NotBlank(message = "email is required")

--- a/backend/src/main/java/com/kizuna/store/api/dto/StoreCreateDTO.java
+++ b/backend/src/main/java/com/kizuna/store/api/dto/StoreCreateDTO.java
@@ -13,13 +13,16 @@ import lombok.Setter;
 public class StoreCreateDTO {
 
   /**
-   * ホスト名（ラベルを . で連ねた形）だけを受け付ける。
+   * 小文字のホスト名（ラベルを . で連ねた形）だけを受け付ける。
    *
    * <p>この項目は店舗サイトへのリンクとして描画されるため、{@code /} {@code :} {@code @} を通すと {@code 正規.example@攻撃者.example}
-   * のような値が別ホストへの導線になる。形式検査は前端にもあるが、REST を直接叩けば迂回できるので 保存の手前で閉じる。長さ上限は列定義（VARCHAR(128)）に合わせる。
+   * のような値が別ホストへの導線になる。形式検査は前端にもあるが、REST を直接叩けば迂回できるので保存の手前で閉じる。長さ上限は列定義（VARCHAR(128)）に合わせる。
+   *
+   * <p>大文字を受け付けないのは、この値が Host ヘッダによる店舗文脈の解決キーだから。ブラウザは Host を小文字で送るのに照合は大小を区別するため、{@code
+   * Shop.Example.com} を保存すると誰も到達できない店舗ができる。正規化して呑まずに拒むことで、その取り違えを保存時に表面化させる。
    */
   private static final String DOMAIN_PATTERN =
-      "^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$";
+      "^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$";
 
   @NotBlank(message = "name is required")
   private String name;

--- a/backend/src/main/java/com/kizuna/user/api/platform/PlatformStaffController.java
+++ b/backend/src/main/java/com/kizuna/user/api/platform/PlatformStaffController.java
@@ -38,6 +38,15 @@ public class PlatformStaffController {
     return ResponseEntity.ok(platformStaffService.list(search, pageable));
   }
 
+  @GetMapping("/{id}")
+  @PreAuthorize("hasAuthority('PERM_STAFF_MANAGE')")
+  public ResponseEntity<PlatformStaffResponse> get(@PathVariable Long id) {
+    return platformStaffService
+        .get(id)
+        .map(ResponseEntity::ok)
+        .orElseGet(() -> ResponseEntity.notFound().build());
+  }
+
   @PostMapping
   @PreAuthorize("hasAuthority('PERM_STAFF_MANAGE')")
   public ResponseEntity<PlatformStaffResponse> create(

--- a/backend/src/main/java/com/kizuna/user/api/platform/PlatformStaffController.java
+++ b/backend/src/main/java/com/kizuna/user/api/platform/PlatformStaffController.java
@@ -6,8 +6,10 @@ import com.kizuna.user.api.dto.PlatformStaffUpdateRequest;
 import com.kizuna.user.application.PlatformStaffService;
 import jakarta.validation.Valid;
 import java.security.Principal;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** 平台スタッフ（ロール×店舗集合）管理 API。全操作 STAFF_MANAGE 権限限定。 */
@@ -26,10 +29,13 @@ public class PlatformStaffController {
 
   private final PlatformStaffService platformStaffService;
 
+  // offset ページングはページ境界の安定に全順序を要するため、表示名の並びに一意な副キー id を添える。
   @GetMapping
   @PreAuthorize("hasAuthority('PERM_STAFF_MANAGE')")
-  public ResponseEntity<List<PlatformStaffResponse>> list() {
-    return ResponseEntity.ok(platformStaffService.list());
+  public ResponseEntity<Page<PlatformStaffResponse>> list(
+      @RequestParam(required = false) String search,
+      @PageableDefault(sort = {"displayName", "id"}) Pageable pageable) {
+    return ResponseEntity.ok(platformStaffService.list(search, pageable));
   }
 
   @PostMapping

--- a/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
+++ b/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
@@ -15,6 +15,8 @@ import com.kizuna.user.domain.RoleRepository;
 import com.kizuna.user.domain.SelfStopNotAllowedException;
 import com.kizuna.user.domain.StaleStaffUpdateException;
 import com.kizuna.user.domain.UserType;
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -26,6 +28,9 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,12 +48,39 @@ public class PlatformStaffService {
   private final ApplicationEventPublisher eventPublisher;
 
   @Transactional(readOnly = true)
-  public List<PlatformStaffResponse> list() {
-    List<PlatformUser> staff = repository.findByUserTypeOrderByDisplayNameAsc(UserType.STAFF);
+  public Page<PlatformStaffResponse> list(String search, Pageable pageable) {
+    Page<PlatformUser> staff = repository.findAll(staffSpec(blankToNull(search)), pageable);
     Set<Long> allRoleIds =
-        staff.stream().flatMap(user -> user.getRoleIds().stream()).collect(Collectors.toSet());
+        staff.getContent().stream()
+            .flatMap(user -> user.getRoleIds().stream())
+            .collect(Collectors.toSet());
     Map<Long, String> roleNames = roleNamesOf(allRoleIds);
-    return staff.stream().map(user -> toResponse(user, roleNames)).toList();
+    return staff.map(user -> toResponse(user, roleNames));
+  }
+
+  /**
+   * 一覧の対象は本人種別 STAFF に限る（CAST/MEMBER は専用フローが扱う）。検索語は表示名とメールアドレスを横断する部分一致。
+   *
+   * <p>null の条件は述語を生成しない（JPQL の ":param is null or ..." パターンは PostgreSQL の null パラメータ型推論で 500 になるため
+   * Specification で組み立てる）。
+   */
+  private static Specification<PlatformUser> staffSpec(String search) {
+    return (root, query, cb) -> {
+      List<Predicate> predicates = new ArrayList<>();
+      predicates.add(cb.equal(root.get("userType"), UserType.STAFF));
+      if (search != null) {
+        String pattern = "%" + search.toLowerCase(Locale.ROOT) + "%";
+        predicates.add(
+            cb.or(
+                cb.like(cb.lower(root.get("displayName")), pattern),
+                cb.like(cb.lower(root.get("email")), pattern)));
+      }
+      return cb.and(predicates.toArray(new Predicate[0]));
+    };
+  }
+
+  private static String blankToNull(String value) {
+    return value == null || value.isBlank() ? null : value.trim();
   }
 
   @Transactional

--- a/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
+++ b/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
@@ -42,6 +42,9 @@ public class PlatformStaffService {
 
   private static final String EMAIL_UNIQUE_CONSTRAINT = "uq_t_users_email";
 
+  /** LIKE パターンのエスケープ文字。検索語中のメタ文字を字面へ戻すために使う。 */
+  private static final char LIKE_ESCAPE = '\\';
+
   private final PlatformUserRepository repository;
   private final RoleRepository roleRepository;
   private final PasswordEncoder passwordEncoder;
@@ -69,14 +72,27 @@ public class PlatformStaffService {
       List<Predicate> predicates = new ArrayList<>();
       predicates.add(cb.equal(root.get("userType"), UserType.STAFF));
       if (search != null) {
-        String pattern = "%" + search.toLowerCase(Locale.ROOT) + "%";
+        String pattern = "%" + escapeLike(search.toLowerCase(Locale.ROOT)) + "%";
         predicates.add(
             cb.or(
-                cb.like(cb.lower(root.get("displayName")), pattern),
-                cb.like(cb.lower(root.get("email")), pattern)));
+                cb.like(cb.lower(root.get("displayName")), pattern, LIKE_ESCAPE),
+                cb.like(cb.lower(root.get("email")), pattern, LIKE_ESCAPE)));
       }
       return cb.and(predicates.toArray(new Predicate[0]));
     };
+  }
+
+  /**
+   * 検索語中の LIKE メタ文字を字面へ戻す。
+   *
+   * <p>エスケープしないと {@code _} が 1 文字ワイルドカードとして働き、メールに {@code _} を含む検索（{@code a_b}）が {@code acb}
+   * のような別人まで拾う。エスケープ文字自身を先に二重化しないと、末尾の {@code \} が後続の {@code %} を打ち消す。
+   */
+  private static String escapeLike(String value) {
+    return value
+        .replace(String.valueOf(LIKE_ESCAPE), String.valueOf(LIKE_ESCAPE) + LIKE_ESCAPE)
+        .replace("%", LIKE_ESCAPE + "%")
+        .replace("_", LIKE_ESCAPE + "_");
   }
 
   private static String blankToNull(String value) {

--- a/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
+++ b/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
@@ -119,6 +119,19 @@ public class PlatformStaffService {
     return toResponse(save(user), roleNames);
   }
 
+  /**
+   * 1 件取得。編集中に競合（409）が起きたとき、一覧の現在ページに対象が居なくても最新の版を取り直せるようにするための経路。
+   *
+   * <p>対象の本人種別がスタッフ以外（CAST/MEMBER）なら不可視として空を返す（list/update と同じ扱い）。
+   */
+  @Transactional(readOnly = true)
+  public Optional<PlatformStaffResponse> get(Long id) {
+    return repository
+        .findById(id)
+        .filter(user -> user.getUserType() == UserType.STAFF)
+        .map(user -> toResponse(user, roleNamesOf(user.getRoleIds())));
+  }
+
   @Transactional
   public Optional<PlatformStaffResponse> update(
       Long id, PlatformStaffUpdateRequest req, String actorEmail) {

--- a/backend/src/main/java/com/kizuna/user/domain/PlatformUserRepository.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PlatformUserRepository.java
@@ -4,14 +4,14 @@ import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface PlatformUserRepository extends JpaRepository<PlatformUser, Long> {
+public interface PlatformUserRepository
+    extends JpaRepository<PlatformUser, Long>, JpaSpecificationExecutor<PlatformUser> {
   Optional<PlatformUser> findByEmail(String email);
-
-  List<PlatformUser> findByUserTypeOrderByDisplayNameAsc(UserType userType);
 
   /**
    * 指定した本人種別で、現店舗を授権する（ALL_STORES または個別授権店舗集合に含む）有効なユーザーを表示名昇順で取得する。店舗スコープの絞り込みを DB

--- a/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
@@ -3,6 +3,7 @@ package com.kizuna.user.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -31,12 +32,18 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -45,6 +52,7 @@ class PlatformStaffServiceTest {
 
   private static final long HQ_ROLE = 10L;
   private static final long MANAGER_ROLE = 11L;
+  private static final Pageable PAGEABLE = PageRequest.of(0, 20);
 
   @Mock private PlatformUserRepository repository;
 
@@ -129,27 +137,28 @@ class PlatformStaffServiceTest {
 
   @Test
   void list_returnsStaffWithResolvedRoleNames() {
-    when(repository.findByUserTypeOrderByDisplayNameAsc(UserType.STAFF))
-        .thenReturn(
-            List.of(
-                staff(1L, "hq@kizuna.test", Set.of(HQ_ROLE), StoreScopeType.ALL_STORES, Set.of()),
-                staff(
-                    2L,
-                    "mgr@kizuna.test",
-                    Set.of(MANAGER_ROLE),
-                    StoreScopeType.SPECIFIC_STORES,
-                    Set.of(1L))));
+    List<PlatformUser> staff =
+        List.of(
+            staff(1L, "hq@kizuna.test", Set.of(HQ_ROLE), StoreScopeType.ALL_STORES, Set.of()),
+            staff(
+                2L,
+                "mgr@kizuna.test",
+                Set.of(MANAGER_ROLE),
+                StoreScopeType.SPECIFIC_STORES,
+                Set.of(1L)));
+    when(repository.findAll(ArgumentMatchers.<Specification<PlatformUser>>any(), eq(PAGEABLE)))
+        .thenReturn(new PageImpl<>(staff, PAGEABLE, staff.size()));
     when(roleRepository.findAllById(Set.of(HQ_ROLE, MANAGER_ROLE)))
         .thenReturn(List.of(role(HQ_ROLE, "HQ管理者"), role(MANAGER_ROLE, "店長")));
 
-    List<PlatformStaffResponse> result = service.list();
+    Page<PlatformStaffResponse> result = service.list(null, PAGEABLE);
 
-    assertThat(result).hasSize(2);
-    assertThat(result.get(0).roles())
+    assertThat(result.getTotalElements()).isEqualTo(2);
+    assertThat(result.getContent().get(0).roles())
         .containsExactly(new PlatformStaffResponse.RoleRef(HQ_ROLE, "HQ管理者"));
-    assertThat(result.get(1).roles())
+    assertThat(result.getContent().get(1).roles())
         .containsExactly(new PlatformStaffResponse.RoleRef(MANAGER_ROLE, "店長"));
-    assertThat(result.get(1).storeIds()).containsExactly(1L);
+    assertThat(result.getContent().get(1).storeIds()).containsExactly(1L);
   }
 
   @Test

--- a/e2e/steps/staff-management.steps.ts
+++ b/e2e/steps/staff-management.steps.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test';
+import { Page, expect } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 import { PLATFORM_URL } from '../base-url';
 
@@ -12,6 +12,21 @@ const STAFF_URL = `${PLATFORM_URL}/platform/staff`;
 // 氏名をそのままメールへ流用できない）。
 let createdStaffName = '';
 let createdStaffEmail = '';
+
+/**
+ * 作成した一意名で一覧を絞り込み、その行を返す。
+ *
+ * 一覧は 10 件ごとのページングのため、直前に作った 1 件が先頭ページに載る保証はない。
+ * 検索を通してから照合することで、過去 run の残骸が何件積もっても行を特定できる。
+ */
+async function findCreatedStaffRow(page: Page) {
+  const search = page.getByLabel('スタッフを検索', { exact: true });
+  await search.fill(createdStaffName);
+  await page.getByRole('button', { name: '検索', exact: true }).click();
+  const row = page.getByRole('row', { name: new RegExp(createdStaffName) });
+  await expect(row).toBeVisible({ timeout: 15000 });
+  return row;
+}
 
 When('スタッフ管理画面を開く', async ({ page }) => {
   await page.goto(STAFF_URL, { waitUntil: 'domcontentloaded' });
@@ -88,15 +103,13 @@ Then(
   'スタッフ一覧に {string} が {string} として表示される',
   async ({ page }, _label: string, roleLabel: string) => {
     // {string} は可読性のための表記。実際の照合は一意名（createdStaffName）で行う。
-    const row = page.getByRole('row', { name: new RegExp(createdStaffName) });
-    await expect(row).toBeVisible({ timeout: 15000 });
+    const row = await findCreatedStaffRow(page);
     await expect(row.getByText(roleLabel, { exact: true })).toBeVisible();
   }
 );
 
 When('{string} の編集モーダルを開く', async ({ page }, _label: string) => {
-  const row = page.getByRole('row', { name: new RegExp(createdStaffName) });
-  await expect(row).toBeVisible({ timeout: 15000 });
+  const row = await findCreatedStaffRow(page);
   await row.getByRole('button', { name: '編集', exact: true }).click();
   await expect(
     page.getByRole('heading', { name: `${createdStaffName} の権限を編集`, exact: true })
@@ -134,7 +147,7 @@ When('保存する', async ({ page }) => {
 Then(
   'スタッフ一覧の {string} の担当店舗が {string} と表示される',
   async ({ page }, _label: string, scopeLabel: string) => {
-    const row = page.getByRole('row', { name: new RegExp(createdStaffName) });
+    const row = await findCreatedStaffRow(page);
     await expect(row.getByText(scopeLabel, { exact: true })).toBeVisible({ timeout: 15000 });
   }
 );

--- a/frontend/src/_pages/platform-roles/__tests__/RolesPage.test.tsx
+++ b/frontend/src/_pages/platform-roles/__tests__/RolesPage.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { RoleResponse, platformRoleApi } from '@/entities/user';
+import RolesPage from '../ui/RolesPage';
+
+jest.mock('@/entities/user', () => ({
+  platformRoleApi: { list: jest.fn(), remove: jest.fn() },
+}));
+
+jest.mock('../ui/RoleFormModal', () => {
+  const React = require('react');
+  return {
+    RoleFormModal: ({ open }: { open: boolean }) =>
+      open ? React.createElement('div', null, 'ロールモーダル表示中') : null,
+  };
+});
+
+jest.mock('react-hot-toast', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockedRoleApi = platformRoleApi as jest.Mocked<typeof platformRoleApi>;
+
+const role = (override: Partial<RoleResponse>): RoleResponse => ({
+  id: 1,
+  name: '店長',
+  permissions: [],
+  system: false,
+  version: 0,
+  ...override,
+});
+
+describe('ロール一覧ページ', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedRoleApi.list.mockResolvedValue([
+      role({ id: 1, name: '店長' }),
+      role({ id: 2, name: '受付担当' }),
+    ]);
+  });
+
+  // ロールは全量取得のため絞り込みは取得済み配列に対して行う。再取得は走らない。
+  it('検索は再取得せず取得済みの一覧をロール名で絞り込むこと', async () => {
+    render(<RolesPage />);
+    await screen.findByText('店長');
+
+    fireEvent.change(screen.getByLabelText('ロールを検索'), { target: { value: '受付' } });
+    fireEvent.click(screen.getByRole('button', { name: '検索' }));
+
+    expect(screen.getByText('受付担当')).toBeInTheDocument();
+    expect(screen.queryByText('店長')).not.toBeInTheDocument();
+    expect(mockedRoleApi.list).toHaveBeenCalledTimes(1);
+  });
+
+  it('該当なしのときは検索向けの空文言を出し、クリアで全件へ戻ること', async () => {
+    render(<RolesPage />);
+    await screen.findByText('店長');
+
+    fireEvent.change(screen.getByLabelText('ロールを検索'), { target: { value: '存在しない' } });
+    fireEvent.click(screen.getByRole('button', { name: '検索' }));
+    expect(screen.getByText('該当するロールが見つかりません')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'クリア' }));
+
+    expect(screen.getByText('店長')).toBeInTheDocument();
+    expect(screen.getByText('受付担当')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/_pages/platform-roles/ui/RolesPage.tsx
+++ b/frontend/src/_pages/platform-roles/ui/RolesPage.tsx
@@ -10,6 +10,7 @@ import {
   Badge,
   Button,
   ConfirmDialog,
+  Input,
   Table,
   TableBody,
   TableCell,
@@ -22,10 +23,17 @@ import { RoleFormModal } from './RoleFormModal';
 /** ロール一覧ページ。一覧内モーダルで新規作成・編集を行う。 */
 export default function RolesPage() {
   const {
-    items: roles,
+    items: allRoles,
     isLoading,
     refetch,
   } = useManagedList<RoleResponse>(() => platformRoleApi.list(), 'ロール一覧の取得に失敗しました');
+  const [searchTerm, setSearchTerm] = useState('');
+  // ロールは定義数が限られ、GET /platform/roles も全量を返す（付与 UI のロール目録が同じ端点を
+  // 使うため分頁できない）。絞り込みは取得済みの配列に対して行い、送信で確定させる。
+  const [appliedSearch, setAppliedSearch] = useState('');
+  const roles = appliedSearch
+    ? allRoles.filter(role => role.name.toLowerCase().includes(appliedSearch.toLowerCase()))
+    : allRoles;
   // フォームは 1 つだけ開く。新規と編集で実体を分けると権限目録の取得が二重に走るため、
   // 「閉じている / 新規 / 既存の編集」を 1 つの状態で表す。
   // 編集対象は id で保持し、role オブジェクトは現在の一覧から導出する。
@@ -61,8 +69,43 @@ export default function RolesPage() {
             ロールを追加
           </Button>
         }
+        search={{
+          onSearch: () => setAppliedSearch(searchTerm),
+          content: (
+            <>
+              <div className="w-full md:max-w-xs">
+                <label htmlFor="search" className="sr-only">
+                  ロールを検索
+                </label>
+                <Input
+                  type="text"
+                  name="search"
+                  id="search"
+                  value={searchTerm}
+                  onChange={e => setSearchTerm(e.target.value)}
+                  placeholder="ロール名で検索..."
+                />
+              </div>
+              <Button type="submit">検索</Button>
+              {searchTerm && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setSearchTerm('');
+                    setAppliedSearch('');
+                  }}
+                >
+                  クリア
+                </Button>
+              )}
+            </>
+          ),
+        }}
         state={{ rows: roles, isLoading }}
-        emptyMessage="ロールが登録されていません"
+        emptyMessage={
+          appliedSearch ? '該当するロールが見つかりません' : 'ロールが登録されていません'
+        }
       >
         <Table>
           <TableHeader>

--- a/frontend/src/_pages/platform-roles/ui/RolesPage.tsx
+++ b/frontend/src/_pages/platform-roles/ui/RolesPage.tsx
@@ -38,9 +38,11 @@ export default function RolesPage() {
   // 「閉じている / 新規 / 既存の編集」を 1 つの状態で表す。
   // 編集対象は id で保持し、role オブジェクトは現在の一覧から導出する。
   // これにより refetch がそのままモーダル内容の最新化になる（409 リフレッシュ）。
+  // 導出元は絞り込み前の allRoles。roles から引くと、409 の再取得で他の管理者による改名が
+  // 入った瞬間に絞り込みから外れ、最新値を見せるはずのモーダルが黙って閉じてしまう。
   const [formTarget, setFormTarget] = useState<'closed' | 'create' | number>('closed');
   const editingRole =
-    typeof formTarget === 'number' ? (roles.find(role => role.id === formTarget) ?? null) : null;
+    typeof formTarget === 'number' ? (allRoles.find(role => role.id === formTarget) ?? null) : null;
   const formOpen = formTarget === 'create' || editingRole !== null;
   const [deleteTarget, setDeleteTarget] = useState<RoleResponse | null>(null);
 

--- a/frontend/src/_pages/platform-staff/__tests__/StaffPage.test.tsx
+++ b/frontend/src/_pages/platform-staff/__tests__/StaffPage.test.tsx
@@ -87,21 +87,22 @@ describe('スタッフ一覧ページ', () => {
     expect(screen.getByText('停止中')).toBeInTheDocument();
   });
 
-  it('行クリックで対象スタッフの編集モーダルが開くこと', async () => {
-    render(<StaffPage />);
-
-    fireEvent.click(await screen.findByText('鈴木花子'));
-
-    expect(screen.getByText('編集モーダル:鈴木花子')).toBeInTheDocument();
-  });
-
-  it('行内の編集ボタンでも対象スタッフの編集モーダルが開くこと', async () => {
+  // 編集の導線は行内のボタンのみ（行クリックは廃止。マウス専用の導線を残さない）
+  it('行内の編集ボタンで対象スタッフの編集モーダルが開くこと', async () => {
     render(<StaffPage />);
     await screen.findByText('山田太郎');
 
     fireEvent.click(screen.getAllByRole('button', { name: '編集' })[0]);
 
     expect(screen.getByText('編集モーダル:山田太郎')).toBeInTheDocument();
+  });
+
+  it('行そのものをクリックしても編集モーダルは開かないこと', async () => {
+    render(<StaffPage />);
+
+    fireEvent.click(await screen.findByText('鈴木花子'));
+
+    expect(screen.queryByText('編集モーダル:鈴木花子')).not.toBeInTheDocument();
   });
 
   it('スタッフを追加ボタンで作成モーダルが開くこと', async () => {
@@ -122,7 +123,8 @@ describe('スタッフ一覧ページ', () => {
     );
 
     render(<StaffPage />);
-    fireEvent.click(await screen.findByText('鈴木花子'));
+    await screen.findByText('鈴木花子');
+    fireEvent.click(screen.getAllByRole('button', { name: '編集' })[1]);
     expect(screen.getByText('編集モーダル:鈴木花子')).toBeInTheDocument();
 
     // 再取得後の頁には対象が居ない
@@ -137,7 +139,8 @@ describe('スタッフ一覧ページ', () => {
     mockedStaffApi.get.mockRejectedValue(new Error('not found'));
 
     render(<StaffPage />);
-    fireEvent.click(await screen.findByText('鈴木花子'));
+    await screen.findByText('鈴木花子');
+    fireEvent.click(screen.getAllByRole('button', { name: '編集' })[1]);
 
     mockedStaffApi.list.mockResolvedValue(paginated([staff({ id: 1, display_name: '山田太郎' })]));
     fireEvent.click(screen.getByRole('button', { name: '競合再取得' }));

--- a/frontend/src/_pages/platform-staff/__tests__/StaffPage.test.tsx
+++ b/frontend/src/_pages/platform-staff/__tests__/StaffPage.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { PageResult } from '@/shared/api';
 import { PlatformStaffResponse, platformAuthApi, platformStaffApi } from '@/entities/user';
 import StaffPage from '../ui/StaffPage';
 
@@ -38,14 +39,27 @@ const staff = (override: Partial<PlatformStaffResponse>): PlatformStaffResponse 
   ...override,
 });
 
+const paginated = (
+  rows: PlatformStaffResponse[],
+  override: Partial<PageResult<PlatformStaffResponse>> = {}
+): PageResult<PlatformStaffResponse> => ({
+  rows,
+  page: 0,
+  pageCount: 1,
+  total: rows.length,
+  ...override,
+});
+
 describe('スタッフ一覧ページ', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedAuthApi.stores.mockResolvedValue([]);
-    mockedStaffApi.list.mockResolvedValue([
-      staff({ id: 1, display_name: '山田太郎', enabled: true }),
-      staff({ id: 2, display_name: '鈴木花子', enabled: false }),
-    ]);
+    mockedStaffApi.list.mockResolvedValue(
+      paginated([
+        staff({ id: 1, display_name: '山田太郎', enabled: true }),
+        staff({ id: 2, display_name: '鈴木花子', enabled: false }),
+      ])
+    );
   });
 
   it('氏名と在籍状態を一覧表示すること', async () => {
@@ -82,13 +96,74 @@ describe('スタッフ一覧ページ', () => {
 
     expect(screen.getByText('作成モーダル表示中')).toBeInTheDocument();
   });
+
+  it('検索は 0 起点の page/size/search のペイロードで再取得すること', async () => {
+    render(<StaffPage />);
+    await screen.findByText('山田太郎');
+
+    fireEvent.change(screen.getByLabelText('スタッフを検索'), { target: { value: '山田' } });
+    fireEvent.click(screen.getByRole('button', { name: '検索' }));
+
+    await waitFor(() =>
+      expect(mockedStaffApi.list).toHaveBeenLastCalledWith({
+        page: 0,
+        size: 10,
+        search: '山田',
+      })
+    );
+  });
+
+  // クリアは入力を空にすると同時に取り直す。検索語 state をそのまま読むと更新前の値で
+  // 取得してしまうため、適用済み検索語は ref で持っている（その回帰を固定する）。
+  it('クリアは検索語を空にして取り直すこと', async () => {
+    render(<StaffPage />);
+    await screen.findByText('山田太郎');
+
+    fireEvent.change(screen.getByLabelText('スタッフを検索'), { target: { value: '山田' } });
+    fireEvent.click(screen.getByRole('button', { name: '検索' }));
+    await waitFor(() =>
+      expect(mockedStaffApi.list).toHaveBeenLastCalledWith({ page: 0, size: 10, search: '山田' })
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'クリア' }));
+
+    await waitFor(() =>
+      expect(mockedStaffApi.list).toHaveBeenLastCalledWith({
+        page: 0,
+        size: 10,
+        search: undefined,
+      })
+    );
+    expect(screen.getByLabelText('スタッフを検索')).toHaveValue('');
+  });
+
+  it('ページ番号のクリックで該当ページを取得すること', async () => {
+    mockedStaffApi.list.mockImplementation(({ page }) =>
+      Promise.resolve(
+        paginated([staff({ id: 1, display_name: '山田太郎' })], { page, pageCount: 3, total: 25 })
+      )
+    );
+
+    render(<StaffPage />);
+    await screen.findByText('山田太郎');
+
+    fireEvent.click(screen.getByRole('button', { name: '2' }));
+
+    await waitFor(() =>
+      expect(mockedStaffApi.list).toHaveBeenLastCalledWith({
+        page: 1,
+        size: 10,
+        search: undefined,
+      })
+    );
+  });
 });
 
 describe('スタッフ一覧ページ固有の要素', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedAuthApi.stores.mockResolvedValue([]);
-    mockedStaffApi.list.mockResolvedValue([]);
+    mockedStaffApi.list.mockResolvedValue(paginated([]));
   });
 
   it('見出し（h1）・副題を備え、主アクションが button ロールのままであること', async () => {

--- a/frontend/src/_pages/platform-staff/__tests__/StaffPage.test.tsx
+++ b/frontend/src/_pages/platform-staff/__tests__/StaffPage.test.tsx
@@ -4,7 +4,7 @@ import { PlatformStaffResponse, platformAuthApi, platformStaffApi } from '@/enti
 import StaffPage from '../ui/StaffPage';
 
 jest.mock('@/entities/user', () => ({
-  platformStaffApi: { list: jest.fn() },
+  platformStaffApi: { list: jest.fn(), get: jest.fn() },
   platformAuthApi: { stores: jest.fn() },
 }));
 
@@ -114,29 +114,36 @@ describe('スタッフ一覧ページ', () => {
   });
 
   // 409 の再取得は「最新の内容を確認してください」と言うための導線。対象が現在ページから
-  // 外れても（本人の改名で検索から外れる・他の追加で次ページへずれる）モーダルは閉じない。
-  it('再取得で対象が現在ページから外れても編集モーダルは閉じないこと', async () => {
+  // 外れても（本人の改名で検索から外れる・他の追加で次ページへずれる）モーダルは閉じず、
+  // 版が古いまま再試行が 409 を繰り返さないよう id で最新値を取り直す。
+  it('再取得で対象が現在ページから外れても、id で最新値を取り直してモーダルを開いたままにすること', async () => {
+    mockedStaffApi.get.mockResolvedValue(
+      staff({ id: 2, display_name: '鈴木花子（改名後）', version: 3 })
+    );
+
     render(<StaffPage />);
     fireEvent.click(await screen.findByText('鈴木花子'));
     expect(screen.getByText('編集モーダル:鈴木花子')).toBeInTheDocument();
+
+    // 再取得後の頁には対象が居ない
+    mockedStaffApi.list.mockResolvedValue(paginated([staff({ id: 1, display_name: '山田太郎' })]));
+    fireEvent.click(screen.getByRole('button', { name: '競合再取得' }));
+
+    expect(await screen.findByText('編集モーダル:鈴木花子（改名後）')).toBeInTheDocument();
+    expect(mockedStaffApi.get).toHaveBeenCalledWith(2);
+  });
+
+  it('対象を取り直せなくてもモーダルは閉じないこと', async () => {
+    mockedStaffApi.get.mockRejectedValue(new Error('not found'));
+
+    render(<StaffPage />);
+    fireEvent.click(await screen.findByText('鈴木花子'));
 
     mockedStaffApi.list.mockResolvedValue(paginated([staff({ id: 1, display_name: '山田太郎' })]));
     fireEvent.click(screen.getByRole('button', { name: '競合再取得' }));
 
-    await waitFor(() => expect(mockedStaffApi.list).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockedStaffApi.get).toHaveBeenCalledWith(2));
     expect(screen.getByText('編集モーダル:鈴木花子')).toBeInTheDocument();
-  });
-
-  it('再取得で対象が現在ページに居れば最新値へ差し替わること', async () => {
-    render(<StaffPage />);
-    fireEvent.click(await screen.findByText('鈴木花子'));
-
-    mockedStaffApi.list.mockResolvedValue(
-      paginated([staff({ id: 2, display_name: '鈴木花子（改名後）' })])
-    );
-    fireEvent.click(screen.getByRole('button', { name: '競合再取得' }));
-
-    expect(await screen.findByText('編集モーダル:鈴木花子（改名後）')).toBeInTheDocument();
   });
 
   it('検索は 0 起点の page/size/search のペイロードで再取得すること', async () => {

--- a/frontend/src/_pages/platform-staff/__tests__/StaffPage.test.tsx
+++ b/frontend/src/_pages/platform-staff/__tests__/StaffPage.test.tsx
@@ -13,8 +13,24 @@ jest.mock('@/features/staff-management', () => {
   return {
     StaffCreateModal: ({ open }: { open: boolean }) =>
       open ? React.createElement('div', null, '作成モーダル表示中') : null,
-    StaffEditModal: ({ open, staff }: { open: boolean; staff: { display_name: string } | null }) =>
-      open ? React.createElement('div', null, `編集モーダル:${staff?.display_name ?? ''}`) : null,
+    StaffEditModal: ({
+      open,
+      staff,
+      onUpdated,
+    }: {
+      open: boolean;
+      staff: { display_name: string } | null;
+      onUpdated: () => void;
+    }) =>
+      open
+        ? React.createElement(
+            'div',
+            null,
+            `編集モーダル:${staff?.display_name ?? ''}`,
+            // 409 で本体が呼ぶ一覧再取得を、テストから起こせるようにする
+            React.createElement('button', { onClick: onUpdated }, '競合再取得')
+          )
+        : null,
     roleSetLabel: () => 'ロールラベル',
     storeSetLabel: () => '担当店舗ラベル',
   };
@@ -95,6 +111,32 @@ describe('スタッフ一覧ページ', () => {
     fireEvent.click(screen.getByRole('button', { name: 'スタッフを追加' }));
 
     expect(screen.getByText('作成モーダル表示中')).toBeInTheDocument();
+  });
+
+  // 409 の再取得は「最新の内容を確認してください」と言うための導線。対象が現在ページから
+  // 外れても（本人の改名で検索から外れる・他の追加で次ページへずれる）モーダルは閉じない。
+  it('再取得で対象が現在ページから外れても編集モーダルは閉じないこと', async () => {
+    render(<StaffPage />);
+    fireEvent.click(await screen.findByText('鈴木花子'));
+    expect(screen.getByText('編集モーダル:鈴木花子')).toBeInTheDocument();
+
+    mockedStaffApi.list.mockResolvedValue(paginated([staff({ id: 1, display_name: '山田太郎' })]));
+    fireEvent.click(screen.getByRole('button', { name: '競合再取得' }));
+
+    await waitFor(() => expect(mockedStaffApi.list).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('編集モーダル:鈴木花子')).toBeInTheDocument();
+  });
+
+  it('再取得で対象が現在ページに居れば最新値へ差し替わること', async () => {
+    render(<StaffPage />);
+    fireEvent.click(await screen.findByText('鈴木花子'));
+
+    mockedStaffApi.list.mockResolvedValue(
+      paginated([staff({ id: 2, display_name: '鈴木花子（改名後）' })])
+    );
+    fireEvent.click(screen.getByRole('button', { name: '競合再取得' }));
+
+    expect(await screen.findByText('編集モーダル:鈴木花子（改名後）')).toBeInTheDocument();
   });
 
   it('検索は 0 起点の page/size/search のペイロードで再取得すること', async () => {

--- a/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
+++ b/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { PlusIcon } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import {
   PlatformStaffResponse,
   PlatformStore,
@@ -64,14 +64,26 @@ export default function StaffPage() {
   // 他の管理者の追加で行が次ページへずれる等）にモーダルが黙って閉じ、
   // 「最新の内容を確認してください」と言いながら内容を見せない状態になる。
   const [editingStaff, setEditingStaff] = useState<PlatformStaffResponse | null>(null);
-  // 再取得した頁に対象が居れば最新値へ差し替える（これが 409 リフレッシュの本体）。
-  // 居なければ直前の値を保つ — 版が古いままなので再試行は再び 409 になるが、
-  // 競合を伝えたうえで利用者が閉じるか取り直すかを選べる。
-  useEffect(() => {
-    setEditingStaff(current =>
-      current ? (staff.find(member => member.id === current.id) ?? current) : current
-    );
-  }, [staff]);
+
+  /**
+   * 更新後の後始末。一覧を取り直しつつ、編集対象は id で取り直す。
+   *
+   * 競合（409）でモーダルが開いたままのとき、最新の版を渡せて初めて再試行が通る。
+   * 一覧の現在ページから導出すると対象が頁の外にいる場合に古い版のままとなり、
+   * 再試行が 409 を繰り返すため、頁とは無関係な id 取得で最新化する。
+   */
+  const handleEditUpdated = () => {
+    void list.reload();
+    const target = editingStaff;
+    if (!target) return;
+    void platformStaffApi
+      .get(target.id)
+      // 成功保存の直後は onClose と競合するため、まだ同じ対象を開いているときだけ差し替える
+      .then(fresh => setEditingStaff(current => (current?.id === fresh.id ? fresh : current)))
+      .catch(() => {
+        // 取り直せない（削除済み等）ときは古い値のまま。利用者は閉じて一覧から確認できる
+      });
+  };
 
   return (
     <>
@@ -192,7 +204,7 @@ export default function StaffPage() {
         open={editingStaff !== null}
         staff={editingStaff}
         onClose={() => setEditingStaff(null)}
-        onUpdated={list.reload}
+        onUpdated={handleEditUpdated}
       />
     </>
   );

--- a/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
+++ b/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
@@ -1,24 +1,20 @@
 'use client';
 
 import { PlusIcon } from 'lucide-react';
-import { useState } from 'react';
-import {
-  PlatformStaffResponse,
-  PlatformStore,
-  platformAuthApi,
-  platformStaffApi,
-} from '@/entities/user';
+import { useRef, useState } from 'react';
+import { PlatformStore, platformAuthApi, platformStaffApi } from '@/entities/user';
 import {
   StaffCreateModal,
   StaffEditModal,
   roleSetLabel,
   storeSetLabel,
 } from '@/features/staff-management';
-import { useManagedList } from '@/shared/lib';
+import { useListPage, useManagedList } from '@/shared/lib';
 import { ListPage } from '@/widgets/list-page';
 import {
   Badge,
   Button,
+  Input,
   Table,
   TableBody,
   TableCell,
@@ -27,23 +23,39 @@ import {
   TableRow,
 } from '@/shared/ui';
 
+/** 一覧 1 ページあたりの件数 */
+const PAGE_SIZE = 10;
+
 /** スタッフ一覧ページ。一覧内モーダルで新規作成・編集を行う。 */
 export default function StaffPage() {
-  const {
-    items: staff,
-    isLoading,
-    refetch,
-  } = useManagedList<PlatformStaffResponse>(
-    () => platformStaffApi.list(),
+  const [searchTerm, setSearchTerm] = useState('');
+  // 適用済みの検索語。入力の state をそのまま読むと、値を変えた同一ハンドラ内で再取得したとき
+  // 再レンダー前の古い値で取得してしまう（useListPage の search 制約）ため ref で持つ。
+  const appliedSearch = useRef('');
+
+  const list = useListPage(
+    page =>
+      platformStaffApi.list({
+        page,
+        size: PAGE_SIZE,
+        search: appliedSearch.current || undefined,
+      }),
     'スタッフ一覧の取得に失敗しました'
   );
+  const staff = list.rows;
   const { items: stores } = useManagedList<PlatformStore>(
     () => platformAuthApi.stores(),
     '店舗一覧の取得に失敗しました'
   );
+
+  /** 検索語を適用して 1 ページ目から取り直す */
+  const applySearch = (term: string) => {
+    appliedSearch.current = term;
+    list.search();
+  };
   const [createOpen, setCreateOpen] = useState(false);
   // 編集対象は id で保持し、staff オブジェクトは現在の一覧から導出する。
-  // これにより refetch がそのままモーダル内容の最新化になる（409 リフレッシュ）。
+  // これにより再取得がそのままモーダル内容の最新化になる（409 リフレッシュ）。
   const [editingId, setEditingId] = useState<number | null>(null);
   const editingStaff = staff.find(member => member.id === editingId) ?? null;
 
@@ -58,8 +70,43 @@ export default function StaffPage() {
             スタッフを追加
           </Button>
         }
-        state={{ rows: staff, isLoading }}
-        emptyMessage="スタッフが登録されていません"
+        search={{
+          onSearch: () => applySearch(searchTerm),
+          content: (
+            <>
+              <div className="w-full md:max-w-xs">
+                <label htmlFor="search" className="sr-only">
+                  スタッフを検索
+                </label>
+                <Input
+                  type="text"
+                  name="search"
+                  id="search"
+                  value={searchTerm}
+                  onChange={e => setSearchTerm(e.target.value)}
+                  placeholder="氏名またはメールアドレスで検索..."
+                />
+              </div>
+              <Button type="submit">検索</Button>
+              {searchTerm && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setSearchTerm('');
+                    applySearch('');
+                  }}
+                >
+                  クリア
+                </Button>
+              )}
+            </>
+          ),
+        }}
+        state={list}
+        emptyMessage={
+          searchTerm ? '該当するスタッフが見つかりません' : 'スタッフが登録されていません'
+        }
       >
         <Table>
           <TableHeader>
@@ -125,13 +172,13 @@ export default function StaffPage() {
       <StaffCreateModal
         open={createOpen}
         onClose={() => setCreateOpen(false)}
-        onCreated={refetch}
+        onCreated={list.reload}
       />
       <StaffEditModal
         open={editingId !== null}
         staff={editingStaff}
         onClose={() => setEditingId(null)}
-        onUpdated={refetch}
+        onUpdated={list.reload}
       />
     </>
   );

--- a/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
+++ b/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
@@ -146,11 +146,7 @@ export default function StaffPage() {
           </TableHeader>
           <TableBody>
             {staff.map(member => (
-              <TableRow
-                key={member.id}
-                className="cursor-pointer"
-                onClick={() => setEditingStaff(member)}
-              >
+              <TableRow key={member.id}>
                 <TableCell className="font-medium text-foreground">{member.display_name}</TableCell>
                 <TableCell className="text-muted-foreground">
                   {roleSetLabel(member.roles)}
@@ -180,10 +176,7 @@ export default function StaffPage() {
                     variant="ghost"
                     size="sm"
                     className="text-primary-strong"
-                    onClick={e => {
-                      e.stopPropagation();
-                      setEditingStaff(member);
-                    }}
+                    onClick={() => setEditingStaff(member)}
                   >
                     編集
                   </Button>

--- a/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
+++ b/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
@@ -1,8 +1,13 @@
 'use client';
 
 import { PlusIcon } from 'lucide-react';
-import { useRef, useState } from 'react';
-import { PlatformStore, platformAuthApi, platformStaffApi } from '@/entities/user';
+import { useEffect, useRef, useState } from 'react';
+import {
+  PlatformStaffResponse,
+  PlatformStore,
+  platformAuthApi,
+  platformStaffApi,
+} from '@/entities/user';
 import {
   StaffCreateModal,
   StaffEditModal,
@@ -54,10 +59,19 @@ export default function StaffPage() {
     list.search();
   };
   const [createOpen, setCreateOpen] = useState(false);
-  // 編集対象は id で保持し、staff オブジェクトは現在の一覧から導出する。
-  // これにより再取得がそのままモーダル内容の最新化になる（409 リフレッシュ）。
-  const [editingId, setEditingId] = useState<number | null>(null);
-  const editingStaff = staff.find(member => member.id === editingId) ?? null;
+  // 編集対象は一覧から独立して保持する。分頁後の現在ページから導出すると、409 の再取得で
+  // 対象がそのページから外れた瞬間（本人が PUT /platform/me で改名して検索から外れる、
+  // 他の管理者の追加で行が次ページへずれる等）にモーダルが黙って閉じ、
+  // 「最新の内容を確認してください」と言いながら内容を見せない状態になる。
+  const [editingStaff, setEditingStaff] = useState<PlatformStaffResponse | null>(null);
+  // 再取得した頁に対象が居れば最新値へ差し替える（これが 409 リフレッシュの本体）。
+  // 居なければ直前の値を保つ — 版が古いままなので再試行は再び 409 になるが、
+  // 競合を伝えたうえで利用者が閉じるか取り直すかを選べる。
+  useEffect(() => {
+    setEditingStaff(current =>
+      current ? (staff.find(member => member.id === current.id) ?? current) : current
+    );
+  }, [staff]);
 
   return (
     <>
@@ -123,7 +137,7 @@ export default function StaffPage() {
               <TableRow
                 key={member.id}
                 className="cursor-pointer"
-                onClick={() => setEditingId(member.id)}
+                onClick={() => setEditingStaff(member)}
               >
                 <TableCell className="font-medium text-foreground">{member.display_name}</TableCell>
                 <TableCell className="text-muted-foreground">
@@ -156,7 +170,7 @@ export default function StaffPage() {
                     className="text-primary-strong"
                     onClick={e => {
                       e.stopPropagation();
-                      setEditingId(member.id);
+                      setEditingStaff(member);
                     }}
                   >
                     編集
@@ -175,9 +189,9 @@ export default function StaffPage() {
         onCreated={list.reload}
       />
       <StaffEditModal
-        open={editingId !== null}
+        open={editingStaff !== null}
         staff={editingStaff}
-        onClose={() => setEditingId(null)}
+        onClose={() => setEditingStaff(null)}
         onUpdated={list.reload}
       />
     </>

--- a/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
+++ b/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
@@ -8,6 +8,8 @@ import StoreEditPage from '../ui/StoreEditPage';
 const mockPush = jest.fn();
 
 jest.mock('@/entities/store', () => ({
+  // ドメイン形式の判定は本物を使う（リンク化の可否そのものを検証したいため）
+  ...jest.requireActual('@/entities/store'),
   platformStoreApi: {
     getList: jest.fn(),
     getById: jest.fn(),
@@ -79,6 +81,19 @@ describe('店舗管理 3 画面の挙動', () => {
     expect(link).toHaveAttribute('href', '//alpha.example.com');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  // 保存の手前でも形を検査しているが、それ以前に入った行は検査を経ていない。
+  // `正規.example@攻撃者.example` は前半が userinfo と解釈され別ホストへ飛ぶ。
+  it('ホスト名の形でないドメインはリンクにしないこと', async () => {
+    mockedApi.getList.mockResolvedValue(
+      paginated([store({ id: '1', domain: 'alpha.example.com@evil.example' })])
+    );
+
+    render(<StoresPage />);
+
+    expect(await screen.findByText('alpha.example.com@evil.example')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
   it('検索は 0 起点の page/size/search のペイロードで再取得すること', async () => {

--- a/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
+++ b/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
@@ -17,10 +17,6 @@ jest.mock('@/entities/store', () => ({
   },
 }));
 
-jest.mock('@/entities/user', () => ({
-  useAuth: () => ({ logout: jest.fn() }),
-}));
-
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
   useParams: () => ({ id: '1' }),
@@ -68,6 +64,21 @@ describe('店舗管理 3 画面の挙動', () => {
 
     expect(await screen.findByText('アルファ店')).toBeInTheDocument();
     expect(screen.getByText('ベータ店')).toBeInTheDocument();
+  });
+
+  // ドメインは店舗サイトへの導線。別ホストのため管理コンソールを閉じずに別タブで開く。
+  it('一覧はドメインを別タブで開く店舗サイトのリンクとして表示すること', async () => {
+    mockedApi.getList.mockResolvedValue(
+      paginated([store({ id: '1', domain: 'alpha.example.com' })])
+    );
+
+    render(<StoresPage />);
+
+    const link = await screen.findByRole('link', { name: /alpha\.example\.com/ });
+    // プロトコル相対 URL。開発は http、本番は https と、現在のスキームを引き継ぐ
+    expect(link).toHaveAttribute('href', '//alpha.example.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('検索は 0 起点の page/size/search のペイロードで再取得すること', async () => {

--- a/frontend/src/_pages/platform-stores/ui/StoreCreatePage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoreCreatePage.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { Loader2Icon } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { CreateStoreRequest, platformStoreApi } from '@/entities/store';
+import { CreateStoreRequest, isStoreDomain, platformStoreApi } from '@/entities/store';
 import { Button, Card, CardContent, Input, Label } from '@/shared/ui';
 import toast from 'react-hot-toast';
 
@@ -28,8 +28,7 @@ export default function CreateStorePage() {
     if (!formData.domain.trim()) {
       newErrors.domain = 'ドメインは必須です';
     } else {
-      const domainRegex = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
-      if (!domainRegex.test(formData.domain)) {
+      if (!isStoreDomain(formData.domain)) {
         newErrors.domain = 'ドメイン形式が正しくありません';
       }
 

--- a/frontend/src/_pages/platform-stores/ui/StoreCreatePage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoreCreatePage.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useState, useCallback } from 'react';
-import { useAuth } from '@/entities/user';
+import { useState } from 'react';
+import { Loader2Icon } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { CreateStoreRequest, platformStoreApi } from '@/entities/store';
 import { Button, Card, CardContent, Input, Label } from '@/shared/ui';
 import toast from 'react-hot-toast';
 
 export default function CreateStorePage() {
-  const { logout } = useAuth();
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formData, setFormData] = useState<CreateStoreRequest>({
@@ -81,165 +80,94 @@ export default function CreateStorePage() {
   };
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* ナビゲーションバー */}
-      <nav className="bg-card shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between h-16">
-            <div className="flex items-center space-x-4">
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">店舗作成</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          新しい店舗の基本情報を入力してください。ドメインは独立サイトへのアクセスに使用されます。
+        </p>
+      </div>
+
+      <Card>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* 店舗名 */}
+            <div className="grid gap-2">
+              <Label htmlFor="name">
+                店舗名 <span className="text-destructive-strong">*</span>
+              </Label>
+              <Input
+                type="text"
+                name="name"
+                id="name"
+                value={formData.name}
+                onChange={e => handleInputChange('name', e.target.value)}
+                aria-invalid={!!errors.name}
+                placeholder="例：ABC株式会社"
+              />
+              {errors.name && <p className="text-sm text-destructive-strong">{errors.name}</p>}
+            </div>
+
+            {/* 域名 */}
+            <div className="grid gap-2">
+              <Label htmlFor="domain">
+                ドメイン <span className="text-destructive-strong">*</span>
+              </Label>
+              <Input
+                type="text"
+                name="domain"
+                id="domain"
+                value={formData.domain}
+                onChange={e => handleInputChange('domain', e.target.value.toLowerCase())}
+                aria-invalid={!!errors.domain}
+                placeholder="example.com"
+              />
+              {errors.domain && <p className="text-sm text-destructive-strong">{errors.domain}</p>}
+              <p className="text-sm text-muted-foreground">
+                完全なドメイン名を入力してください（例：company.shop.example.org）
+              </p>
+            </div>
+
+            {/* 連絡用メール */}
+            <div className="grid gap-2">
+              <Label htmlFor="email">
+                連絡用メール <span className="text-destructive-strong">*</span>
+              </Label>
+              <Input
+                type="email"
+                name="email"
+                id="email"
+                value={formData.email}
+                onChange={e => handleInputChange('email', e.target.value)}
+                aria-invalid={!!errors.email}
+                placeholder="contact@abc-company.com"
+              />
+              {errors.email && <p className="text-sm text-destructive-strong">{errors.email}</p>}
+            </div>
+
+            {/* 提交按钮 */}
+            <div className="flex justify-end space-x-3">
               <Button
-                variant="ghost"
-                size="sm"
-                className="text-primary-strong"
+                type="button"
+                variant="outline"
                 onClick={() => router.push('/platform/stores')}
               >
-                ← 店舗一覧に戻る
+                キャンセル
               </Button>
-              <h1 className="text-xl font-semibold text-foreground">店舗作成</h1>
-            </div>
-            <div className="flex items-center space-x-4">
-              <span className="text-sm text-muted-foreground">ようこそ、someone さん</span>
-              <Button variant="ghost" size="sm" onClick={logout}>
-                ログアウト
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? (
+                  <>
+                    <Loader2Icon className="animate-spin" />
+                    作成中...
+                  </>
+                ) : (
+                  '店舗を作成'
+                )}
               </Button>
             </div>
-          </div>
-        </div>
-      </nav>
-
-      {/* メインコンテンツ */}
-      <div className="max-w-3xl mx-auto py-6 sm:px-6 lg:px-8">
-        <div className="px-4 py-6 sm:px-0">
-          <Card>
-            <CardContent>
-              <div className="mb-6">
-                <h3 className="text-lg leading-6 font-medium text-foreground">店舗情報</h3>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  新しい店舗の基本情報を入力してください。ドメインは独立サイトへのアクセスに使用されます。
-                </p>
-              </div>
-
-              <form onSubmit={handleSubmit} className="space-y-6">
-                {/* 店舗名 */}
-                <div className="grid gap-2">
-                  <Label htmlFor="name">
-                    店舗名 <span className="text-destructive-strong">*</span>
-                  </Label>
-                  <Input
-                    type="text"
-                    name="name"
-                    id="name"
-                    value={formData.name}
-                    onChange={e => handleInputChange('name', e.target.value)}
-                    aria-invalid={!!errors.name}
-                    placeholder="例：ABC株式会社"
-                  />
-                  {errors.name && <p className="text-sm text-destructive-strong">{errors.name}</p>}
-                </div>
-
-                {/* 域名 */}
-                <div className="grid gap-2">
-                  <Label htmlFor="domain">
-                    ドメイン <span className="text-destructive-strong">*</span>
-                  </Label>
-                  <Input
-                    type="text"
-                    name="domain"
-                    id="domain"
-                    value={formData.domain}
-                    onChange={e => handleInputChange('domain', e.target.value.toLowerCase())}
-                    aria-invalid={!!errors.domain}
-                    placeholder="example.com"
-                  />
-                  {errors.domain && (
-                    <p className="text-sm text-destructive-strong">{errors.domain}</p>
-                  )}
-                  <p className="text-sm text-muted-foreground">
-                    完全なドメイン名を入力してください（例：company.shop.example.org）
-                  </p>
-                </div>
-
-                {/* 連絡用メール */}
-                <div className="grid gap-2">
-                  <Label htmlFor="email">
-                    連絡用メール <span className="text-destructive-strong">*</span>
-                  </Label>
-                  <Input
-                    type="email"
-                    name="email"
-                    id="email"
-                    value={formData.email}
-                    onChange={e => handleInputChange('email', e.target.value)}
-                    aria-invalid={!!errors.email}
-                    placeholder="contact@abc-company.com"
-                  />
-                  {errors.email && (
-                    <p className="text-sm text-destructive-strong">{errors.email}</p>
-                  )}
-                </div>
-
-                {/* 预览信息 */}
-                <div className="rounded-lg border p-4">
-                  <h4 className="text-sm font-medium text-foreground mb-2">プレビュー情報</h4>
-                  <dl className="grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-2">
-                    <div>
-                      <dt className="text-sm font-medium text-muted-foreground">店舗名</dt>
-                      <dd className="mt-1 text-sm text-foreground">{formData.name || '未入力'}</dd>
-                    </div>
-                    <div>
-                      <dt className="text-sm font-medium text-muted-foreground">
-                        アクセスドメイン
-                      </dt>
-                      <dd className="mt-1 text-sm text-foreground">
-                        {formData.domain || '未入力'}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="text-sm font-medium text-muted-foreground">連絡用メール</dt>
-                      <dd className="mt-1 text-sm text-foreground">{formData.email || '未入力'}</dd>
-                    </div>
-                  </dl>
-                </div>
-
-                {/* 提交按钮 */}
-                <div className="flex justify-end space-x-3">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => router.push('/platform/stores')}
-                  >
-                    キャンセル
-                  </Button>
-                  <Button type="submit" disabled={isSubmitting}>
-                    {isSubmitting ? (
-                      <>
-                        <svg className="animate-spin" fill="none" viewBox="0 0 24 24">
-                          <circle
-                            className="opacity-25"
-                            cx="12"
-                            cy="12"
-                            r="10"
-                            stroke="currentColor"
-                            strokeWidth="4"
-                          ></circle>
-                          <path
-                            className="opacity-75"
-                            fill="currentColor"
-                            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                          ></path>
-                        </svg>
-                        作成中...
-                      </>
-                    ) : (
-                      '店舗を作成'
-                    )}
-                  </Button>
-                </div>
-              </form>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
+          </form>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/_pages/platform-stores/ui/StoreEditPage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoreEditPage.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { useAuth } from '@/entities/user';
 import { Store, UpdateStoreRequest, platformStoreApi } from '@/entities/store';
 import { Button, Card, CardContent, Input, Label } from '@/shared/ui';
 import toast from 'react-hot-toast';
@@ -10,7 +9,6 @@ import toast from 'react-hot-toast';
 export default function EditStorePage() {
   const id = useParams<{ id: string }>()?.id;
   const router = useRouter();
-  const { logout } = useAuth();
 
   const [saving, setSaving] = useState(false);
   const [store, setStore] = useState<Store | null>(null);
@@ -80,103 +78,71 @@ export default function EditStorePage() {
   };
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* ナビゲーションバー */}
-      <nav className="bg-card shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between h-16">
-            <div className="flex items-center space-x-4">
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">店舗編集</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          店舗の基本情報を編集します。ドメインは現在変更できません。
+        </p>
+      </div>
+
+      <Card>
+        <CardContent>
+          <form onSubmit={handleSave} className="space-y-6">
+            {/* 店舗名 */}
+            <div className="grid gap-2">
+              <Label htmlFor="name">
+                店舗名 <span className="text-destructive-strong">*</span>
+              </Label>
+              <Input
+                id="name"
+                type="text"
+                value={formData.name}
+                onChange={e => setFormData(p => ({ ...p, name: e.target.value }))}
+                aria-invalid={!!errors.name}
+              />
+              {errors.name && <p className="text-sm text-destructive-strong">{errors.name}</p>}
+            </div>
+
+            {/* 連絡用メール */}
+            <div className="grid gap-2">
+              <Label htmlFor="email">
+                連絡用メール <span className="text-destructive-strong">*</span>
+              </Label>
+              <Input
+                id="email"
+                type="email"
+                value={formData.email}
+                onChange={e => setFormData(p => ({ ...p, email: e.target.value }))}
+                aria-invalid={!!errors.email}
+              />
+              {errors.email && <p className="text-sm text-destructive-strong">{errors.email}</p>}
+            </div>
+
+            {/* ドメイン（読み取り専用） */}
+            {store && (
+              <div className="rounded-lg border p-4">
+                <h2 className="text-sm font-medium text-foreground mb-2">ドメイン</h2>
+                <p className="text-sm text-foreground break-all">{store.domain}</p>
+              </div>
+            )}
+
+            {/* 操作 */}
+            <div className="flex justify-end space-x-3">
               <Button
-                variant="ghost"
-                size="sm"
-                className="text-primary-strong"
+                type="button"
+                variant="outline"
                 onClick={() => router.push('/platform/stores')}
               >
-                ← 店舗一覧に戻る
+                キャンセル
               </Button>
-              <h1 className="text-xl font-semibold text-foreground">店舗編集</h1>
-            </div>
-            <div className="flex items-center space-x-4">
-              <span className="text-sm text-muted-foreground">ようこそ、someone さん</span>
-              <Button variant="ghost" size="sm" onClick={logout}>
-                ログアウト
+              <Button type="submit" disabled={saving}>
+                {saving ? '保存中...' : '保存'}
               </Button>
             </div>
-          </div>
-        </div>
-      </nav>
-
-      {/* メイン */}
-      <div className="max-w-3xl mx-auto py-6 sm:px-6 lg:px-8">
-        <div className="px-4 py-6 sm:px-0">
-          <Card>
-            <CardContent>
-              <div className="mb-6">
-                <h3 className="text-lg leading-6 font-medium text-foreground">店舗情報</h3>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  店舗の基本情報を編集します。ドメインは現在変更できません。
-                </p>
-              </div>
-
-              <form onSubmit={handleSave} className="space-y-6">
-                {/* 店舗名 */}
-                <div className="grid gap-2">
-                  <Label htmlFor="name">
-                    店舗名 <span className="text-destructive-strong">*</span>
-                  </Label>
-                  <Input
-                    id="name"
-                    type="text"
-                    value={formData.name}
-                    onChange={e => setFormData(p => ({ ...p, name: e.target.value }))}
-                    aria-invalid={!!errors.name}
-                  />
-                  {errors.name && <p className="text-sm text-destructive-strong">{errors.name}</p>}
-                </div>
-
-                {/* 連絡用メール */}
-                <div className="grid gap-2">
-                  <Label htmlFor="email">
-                    連絡用メール <span className="text-destructive-strong">*</span>
-                  </Label>
-                  <Input
-                    id="email"
-                    type="email"
-                    value={formData.email}
-                    onChange={e => setFormData(p => ({ ...p, email: e.target.value }))}
-                    aria-invalid={!!errors.email}
-                  />
-                  {errors.email && (
-                    <p className="text-sm text-destructive-strong">{errors.email}</p>
-                  )}
-                </div>
-
-                {/* ドメイン（読み取り専用） */}
-                {store && (
-                  <div className="rounded-lg border p-4">
-                    <h4 className="text-sm font-medium text-foreground mb-2">ドメイン</h4>
-                    <p className="text-sm text-foreground break-all">{store.domain}</p>
-                  </div>
-                )}
-
-                {/* 操作 */}
-                <div className="flex justify-end space-x-3">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => router.push('/platform/stores')}
-                  >
-                    キャンセル
-                  </Button>
-                  <Button type="submit" disabled={saving}>
-                    {saving ? '保存中...' : '保存'}
-                  </Button>
-                </div>
-              </form>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
+          </form>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from 'react';
 import { ExternalLinkIcon, PlusIcon, SquarePenIcon, StoreIcon, Trash2Icon } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { Store, platformStoreApi } from '@/entities/store';
+import { Store, isStoreDomain, platformStoreApi } from '@/entities/store';
 import { useListPage } from '@/shared/lib';
 import { ListPage } from '@/widgets/list-page';
 import {
@@ -134,16 +134,22 @@ export default function StoresPage() {
                 <TableCell className="font-medium text-foreground">{store.name}</TableCell>
                 <TableCell>
                   {/* 店舗サイトは店舗ドメインの別ホストで配信されるため、
-                      現在のスキームを引き継ぐプロトコル相対 URL で別タブへ開く */}
-                  <a
-                    href={`//${store.domain}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-primary-strong hover:underline"
-                  >
-                    {store.domain}
-                    <ExternalLinkIcon className="h-3.5 w-3.5" />
-                  </a>
+                      現在のスキームを引き継ぐプロトコル相対 URL で別タブへ開く。
+                      ホスト名の形でない値はリンクにしない（`正規.example@攻撃者.example` の
+                      ような行は前半が userinfo と解釈され、別ホストへの導線になる） */}
+                  {isStoreDomain(store.domain) ? (
+                    <a
+                      href={`//${store.domain}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-primary-strong hover:underline"
+                    >
+                      {store.domain}
+                      <ExternalLinkIcon className="h-3.5 w-3.5" />
+                    </a>
+                  ) : (
+                    <span className="text-muted-foreground">{store.domain}</span>
+                  )}
                 </TableCell>
                 <TableCell className="text-muted-foreground">
                   {new Date(store.created_at).toLocaleDateString('ja-JP')}

--- a/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
@@ -1,12 +1,22 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import { PlusIcon } from 'lucide-react';
+import { ExternalLinkIcon, PlusIcon, SquarePenIcon, StoreIcon, Trash2Icon } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { Store, platformStoreApi } from '@/entities/store';
 import { useListPage } from '@/shared/lib';
 import { ListPage } from '@/widgets/list-page';
-import { Button, ConfirmDialog, Input } from '@/shared/ui';
+import {
+  Button,
+  ConfirmDialog,
+  Input,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/ui';
 import toast from 'react-hot-toast';
 
 /** 一覧 1 ページあたりの件数 */
@@ -95,19 +105,7 @@ export default function StoresPage() {
         state={list}
         emptyMessage={
           <>
-            <svg
-              className="mx-auto h-12 w-12 text-muted-foreground"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-              />
-            </svg>
+            <StoreIcon className="mx-auto h-12 w-12 text-muted-foreground" />
             <h3 className="mt-2 text-sm font-medium text-foreground">店舗がありません</h3>
             <p className="mt-1 text-sm text-muted-foreground">
               {searchTerm ? '該当する店舗が見つかりません' : '最初の店舗を作成しましょう'}
@@ -121,43 +119,59 @@ export default function StoresPage() {
           </>
         }
       >
-        <ul className="divide-y">
-          {stores.map(store => (
-            <li key={store.id} className="px-4 py-4">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center min-w-0 flex-1">
-                  <div className="flex-shrink-0">
-                    <div className="h-12 w-12 rounded-full bg-primary/10 flex items-center justify-center">
-                      <span className="text-lg font-medium text-primary-strong">
-                        {store.name.charAt(0).toUpperCase()}
-                      </span>
-                    </div>
-                  </div>
-                  <div className="ml-4 min-w-0 flex-1">
-                    <p className="text-lg font-medium text-foreground truncate">{store.name}</p>
-                  </div>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <span className="text-sm text-muted-foreground">
-                    {new Date(store.created_at).toLocaleDateString('ja-JP')}
-                  </span>
-                  <div className="flex space-x-2">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>店舗名</TableHead>
+              <TableHead>ドメイン</TableHead>
+              <TableHead>登録日</TableHead>
+              <TableHead className="text-right">アクション</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {stores.map(store => (
+              <TableRow key={store.id}>
+                <TableCell className="font-medium text-foreground">{store.name}</TableCell>
+                <TableCell>
+                  {/* 店舗サイトは店舗ドメインの別ホストで配信されるため、
+                      現在のスキームを引き継ぐプロトコル相対 URL で別タブへ開く */}
+                  <a
+                    href={`//${store.domain}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-primary-strong hover:underline"
+                  >
+                    {store.domain}
+                    <ExternalLinkIcon className="h-3.5 w-3.5" />
+                  </a>
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {new Date(store.created_at).toLocaleDateString('ja-JP')}
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex justify-end gap-1">
                     <Button
-                      variant="outline"
-                      size="sm"
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label="編集"
                       onClick={() => router.push(`/platform/stores/${store.id}/edit`)}
                     >
-                      編集
+                      <SquarePenIcon />
                     </Button>
-                    <Button variant="destructive" size="sm" onClick={() => setDeleteTarget(store)}>
-                      削除
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label="削除"
+                      onClick={() => setDeleteTarget(store)}
+                    >
+                      <Trash2Icon />
                     </Button>
                   </div>
-                </div>
-              </div>
-            </li>
-          ))}
-        </ul>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
       </ListPage>
 
       {/* ダイアログは一覧の loading / empty に連動して消えないよう外殻の外に置く */}

--- a/frontend/src/_pages/store-cast-fields/__tests__/CastFieldsPage.test.tsx
+++ b/frontend/src/_pages/store-cast-fields/__tests__/CastFieldsPage.test.tsx
@@ -80,7 +80,7 @@ describe('カスタムフィールド定義の管理ページ', () => {
     expect(mockedToast.success).toHaveBeenCalledWith('フィールドを削除しました');
   });
 
-  it('削除ボタンのクリックは行クリックへ伝播せず編集モーダルを開かない', async () => {
+  it('削除ボタンのクリックは編集モーダルを開かない', async () => {
     render(<CastFieldsPage />);
     await screen.findByText('blood_type');
 
@@ -89,13 +89,23 @@ describe('カスタムフィールド定義の管理ページ', () => {
     expect(screen.queryByText('フィールドを編集')).not.toBeInTheDocument();
   });
 
-  it('行クリックで対象定義の編集モーダルが開く', async () => {
+  // 編集の導線は行内のボタンのみ（行クリックは廃止。マウス専用の導線を残さない）
+  it('編集ボタンで対象定義の編集モーダルが開く', async () => {
+    render(<CastFieldsPage />);
+    await screen.findByText('hobby');
+
+    fireEvent.click(screen.getAllByRole('button', { name: '編集' })[1]);
+
+    expect(await screen.findByText('フィールドを編集')).toBeInTheDocument();
+    expect(screen.getByLabelText('label')).toHaveValue('趣味');
+  });
+
+  it('行そのものをクリックしても編集モーダルは開かないこと', async () => {
     render(<CastFieldsPage />);
 
     fireEvent.click(await screen.findByText('hobby'));
 
-    expect(await screen.findByText('フィールドを編集')).toBeInTheDocument();
-    expect(screen.getByLabelText('label')).toHaveValue('趣味');
+    expect(screen.queryByText('フィールドを編集')).not.toBeInTheDocument();
   });
 
   it('フィールドを追加ボタンで作成モーダルが開く', async () => {

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
@@ -71,11 +71,7 @@ export default function CastFieldsPage() {
           </TableHeader>
           <TableBody>
             {definitions.map(definition => (
-              <TableRow
-                key={definition.id}
-                className="cursor-pointer"
-                onClick={() => setEditing(definition)}
-              >
+              <TableRow key={definition.id}>
                 <TableCell className="font-medium text-foreground">{definition.key}</TableCell>
                 <TableCell className="text-muted-foreground">{definition.label}</TableCell>
                 <TableCell>
@@ -101,21 +97,16 @@ export default function CastFieldsPage() {
                     <Button
                       variant="ghost"
                       size="icon-sm"
-                      onClick={e => {
-                        e.stopPropagation();
-                        setEditing(definition);
-                      }}
+                      aria-label="編集"
+                      onClick={() => setEditing(definition)}
                     >
                       <SquarePenIcon />
                     </Button>
                     <Button
                       variant="ghost"
                       size="icon-sm"
-                      onClick={e => {
-                        e.stopPropagation();
-                        setDeleteTarget(definition);
-                      }}
                       aria-label="削除"
+                      onClick={() => setDeleteTarget(definition)}
                     >
                       <Trash2Icon />
                     </Button>

--- a/frontend/src/entities/store/index.ts
+++ b/frontend/src/entities/store/index.ts
@@ -1,2 +1,3 @@
 export * from './model/types';
+export { isStoreDomain } from './model/domain';
 export { platformStoreApi } from './api/platform';

--- a/frontend/src/entities/store/model/domain.ts
+++ b/frontend/src/entities/store/model/domain.ts
@@ -1,0 +1,13 @@
+/** ホスト名の形（ラベルを . で連ねた形）。`/` `:` `@` を含む値は通さない。 */
+const HOSTNAME = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
+
+/**
+ * 店舗ドメインがホスト名の形をしているか。
+ *
+ * リンクとして描画する前に必ず通すこと。`正規.example@攻撃者.example` のような値は
+ * プロトコル相対 URL の中で前半が userinfo と解釈され、別ホストへの導線になる。
+ * 保存の手前でも同じ形を検査しているが、それ以前に入った行は検査を経ていない。
+ */
+export function isStoreDomain(domain: string): boolean {
+  return HOSTNAME.test(domain);
+}

--- a/frontend/src/entities/user/__tests__/platform-staff-api.test.ts
+++ b/frontend/src/entities/user/__tests__/platform-staff-api.test.ts
@@ -25,6 +25,10 @@ describe('platformStaffApi', () => {
       params: { page: 1, size: 10, search: '山田' },
     });
   });
+  it('get は /platform/staff/{id} を GET する', async () => {
+    const res = await platformStaffApi.get(7);
+    expect(res).toEqual({ ok: true, url: '/platform/staff/7' });
+  });
   it('create は /platform/staff を POST する', async () => {
     const res = await platformStaffApi.create({
       email: 'staff@example.com',

--- a/frontend/src/entities/user/__tests__/platform-staff-api.test.ts
+++ b/frontend/src/entities/user/__tests__/platform-staff-api.test.ts
@@ -12,9 +12,18 @@ jest.mock('@/shared/api/client', () => ({
 }));
 
 describe('platformStaffApi', () => {
-  it('list は /platform/staff を GET する', async () => {
-    const res = await platformStaffApi.list();
-    expect(res).toEqual({ ok: true, url: '/platform/staff' });
+  // 一覧は他一覧と同形の Spring Page 形（0 起点）
+  it('list は /platform/staff を page/size/search 付きで GET し正規化ページを返す', async () => {
+    (apiClient.get as jest.Mock).mockResolvedValueOnce({
+      data: { content: [{ id: 1 }], total_pages: 3, total_elements: 21, size: 10, number: 1 },
+    });
+
+    const res = await platformStaffApi.list({ page: 1, size: 10, search: '山田' });
+
+    expect(res).toEqual({ rows: [{ id: 1 }], page: 1, pageCount: 3, total: 21 });
+    expect(apiClient.get).toHaveBeenCalledWith('/platform/staff', {
+      params: { page: 1, size: 10, search: '山田' },
+    });
   });
   it('create は /platform/staff を POST する', async () => {
     const res = await platformStaffApi.create({

--- a/frontend/src/entities/user/api/platform-staff.ts
+++ b/frontend/src/entities/user/api/platform-staff.ts
@@ -21,6 +21,11 @@ export const platformStaffApi = {
     });
     return fromSpringPage(response.data);
   },
+  /** 1 件取得。競合後に一覧の現在ページへ居ない対象の最新版を取り直すために使う。 */
+  get: async (id: number): Promise<PlatformStaffResponse> => {
+    const response = await apiClient.get(`/platform/staff/${id}`);
+    return response.data;
+  },
   create: async (data: PlatformStaffCreateRequest): Promise<PlatformStaffResponse> => {
     const response = await apiClient.post('/platform/staff', data);
     return response.data;

--- a/frontend/src/entities/user/api/platform-staff.ts
+++ b/frontend/src/entities/user/api/platform-staff.ts
@@ -1,4 +1,4 @@
-import { apiClient } from '@/shared/api';
+import { apiClient, PageResult, fromSpringPage, toSpringPageParams } from '@/shared/api';
 import {
   PermissionResponse,
   PlatformStaffCreateRequest,
@@ -10,9 +10,16 @@ import {
 } from '../model/types';
 
 export const platformStaffApi = {
-  list: async (): Promise<PlatformStaffResponse[]> => {
-    const response = await apiClient.get('/platform/staff');
-    return response.data;
+  /** スタッフ一覧を取得する。page は他一覧と同じ 0 起点（Spring Page 形） */
+  list: async (params: {
+    page: number;
+    size: number;
+    search?: string;
+  }): Promise<PageResult<PlatformStaffResponse>> => {
+    const response = await apiClient.get('/platform/staff', {
+      params: { ...toSpringPageParams(params.page, params.size), search: params.search },
+    });
+    return fromSpringPage(response.data);
   },
   create: async (data: PlatformStaffCreateRequest): Promise<PlatformStaffResponse> => {
     const response = await apiClient.post('/platform/staff', data);

--- a/frontend/src/widgets/list-page/ui/ListPage.tsx
+++ b/frontend/src/widgets/list-page/ui/ListPage.tsx
@@ -91,7 +91,9 @@ export function ListPage({
         </form>
       )}
 
-      <Card className="py-0 overflow-hidden">
+      {/* Card は既定で gap-6 の flex 列。テーブルとページネーションを地続きに見せるため間隔を潰す
+          （残すと最終行の下に 24px の空白が挟まる） */}
+      <Card className="py-0 gap-0 overflow-hidden">
         {isLoading ? (
           <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
         ) : isEmpty ? (


### PR DESCRIPTION
## 概要

店舗一覧だけ他の一覧と体裁が違っていたので shadcn Table へ寄せ、ドメイン列から店舗サイトを別タブで開けるようにした。併せて店舗編集・作成画面のコンソール外殻と重複した nav を外し、スタッフ管理へ分頁と検索、ロール管理へ絞り込みを足した。

## 変更内容

### 店舗管理 3 画面

- 一覧本体を手書きの `ul` + アバター円から shadcn `Table` へ（店舗名 / ドメイン / 登録日 / アクション）。行内操作は `CustomersPage` と同じ `ghost` + `icon-sm`、`aria-label` 付き
- ドメイン列に店舗サイトへの外部リンク（`target="_blank"` + `rel="noopener noreferrer"`）
- 店舗編集・作成から重複外殻を撤去（`nav` / `min-h-screen` / 二重の幅上限と余白）。`nav` 内にあった `h1` は見出しブロックとして書き直し、道連れで不要になった `useAuth`/`logout` と固定文言の挨拶も削除
- 手書き `svg`（空状態アイコン・送信中スピナー）を lucide へ、店舗作成のプレビュー情報パネルを削除

### スタッフ管理・ロール管理

- `GET /platform/staff` を `Page` + `search` 対応へ。検索は表示名とメールアドレスを横断
- 前端 `platformStaffApi.list` を店舗一覧と同形の `PageResult` へ、`StaffPage` を `useListPage` へ移行し検索カードを追加
- `RolesPage` はロール名での前端絞り込み（送信で確定）
- `ListPage` の `Card` に `gap-0`。`Card` 既定の `gap-6` が最終行とページャの間に 24px の空白を作っていた（分頁のある一覧すべてに効く）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全 22 シナリオ）
- [ ] ローカルで code-review 実施済み

### 視覚確認（UI 変更時）

`task build` + `task up` で実機のブラウザから 5 画面を目視（店舗一覧 / 店舗編集 / 店舗作成 / スタッフ管理 + 検索結果 / ロール管理）。ドメインリンクの解決先が `//store2.kizuna.test` になること、スタッフ一覧に「16 件中 1-10 を表示」とページャが出ること、`gap-0` 追加後に最終行とページャの間の空白が消えることを確認済み。

## 決定ログ

**分頁が出ていなかったのは前端の実装漏れではない。** `ListPage` は `onPageChange` が渡されたときだけページャを描く。店舗一覧は `useListPage` + Spring `Page` 応答なので出ていたが、スタッフ・ロールは端点が素の配列を返すため `useManagedList` しか使えず、`total`/`pageCount` を持てなかった。

**スタッフは端点を分頁化し、ロールは前端絞り込みに留めた。** ロールは定義数が構造的に限られるうえ、`/platform/roles` は `StaffCreateModal` / `StaffEditModal` のロール目録としても使われており、分頁すると付与 UI の選択肢が 1 ページ目に切り詰められる。両方分頁する案は、目録用に不分頁の通路（新端点か size 誇大）を別途用意する必要があり、回帰面に見合わないと判断した。

**店舗編集はモーダル化せず独立ページのまま外殻だけ整理した。** `StaffEditModal` に倣ってモーダル化する案もあったが、ルートと既存テストが残るこちらを採用（顧客・キャスト・受注の編集も独立ページで、モーダル化すると作成だけページのままで非対称になる）。

**ドメインリンクはプロトコル相対 `//domain`。** 開発は traefik の http、本番は https で、現在のスキームを引き継ぐ必要がある。値は店舗作成時の正規表現で `[a-z0-9.-]` に限られており（`/`・`:`・`@` を含めない）、平台管理者が入力する項目なので外部へ飛ぶ経路にはならない。

**offset 分頁の並びに副キー `id` を添えた。** `displayName` だけでは全順序にならず、ページ境界で行の重複・取りこぼしが起きる。検索条件は `Specification` で組んでいる（JPQL の `":param is null or ..."` は PostgreSQL の null パラメータ型推論で 500 になる。`CustomerService.searchSpec` と同じ理由）。

## 備考 / レビュー観点

- **`GET /platform/staff` の応答形状が配列から Spring `Page` へ変わる破壊的変更。** リポジトリ内の消費者は前端 1 箇所だけ（grep 済み）だが、外部に直接叩いている経路があれば追随が要る
- 分頁化の副作用で、一覧全体を走査していた既存 IT の補助 `findStaffByEmail` と e2e の行特定が「先頭ページに載っている」前提になってしまうため、いずれも検索を通してから照合するよう変更した。IT は実際に 2 本赤くなったのを修正している
- `ListPage` の `gap-0` は共用外殻の変更なので、分頁のある他の一覧（顧客 / キャスト / 受注）にも効く
- 「ローカルで code-review 実施済み」は未実施。マージ前に走らせてほしい
