### PR TITLE
fix(customer): 検索語の LIKE メタ文字を字面として扱う

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/customer/CustomerCrossStoreIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/CustomerCrossStoreIT.java
@@ -67,4 +67,30 @@ class CustomerCrossStoreIT extends CrossStoreTestSupport {
     // 重要なのは 200 でデータが漏れないこと
     assertThat(leaked.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
   }
+
+  // "customer-it-likeesc-a_b" は _ をワイルドカードとして扱うと customer-it-likeesc-acb に一致してしまう。
+  // 検索語は字面として照合されるべきなので 0 件が正。
+  @Test
+  @DisplayName("検索語中の LIKE メタ文字は字面として扱われ、ワイルドカードにならないこと")
+  void searchTreatsLikeMetacharactersAsLiterals() {
+    createCustomerAs(STORE_A, "customer-it-likeesc-acb");
+
+    ResponseEntity<JsonNode> underscore =
+        rest.exchange(
+            "/store/customers?search=customer-it-likeesc-a_b",
+            HttpMethod.GET,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(underscore.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(underscore.getBody().path("total_elements").asLong()).isZero();
+
+    ResponseEntity<JsonNode> literal =
+        rest.exchange(
+            "/store/customers?search=customer-it-likeesc-acb",
+            HttpMethod.GET,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(literal.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(literal.getBody().path("total_elements").asLong()).isGreaterThanOrEqualTo(1);
+  }
 }

--- a/backend/src/integrationTest/java/com/kizuna/store/PlatformStoreApiIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/store/PlatformStoreApiIT.java
@@ -213,6 +213,47 @@ class PlatformStoreApiIT {
     assertThat(body.has("current_page")).as("Laravel 風封筒の current_page キーが消えていること").isFalse();
   }
 
+  // findByNameContainingIgnoreCase 系の派生クエリは Spring Data JPA が _ % を既定でエスケープする
+  // （EscapeCharacter.DEFAULT）。手書き like への置き換えでこの保証を失わないよう固定する。
+  @Test
+  @DisplayName("GET /platform/stores の検索語中の LIKE メタ文字は字面として扱われ、ワイルドカードにならないこと")
+  void searchTreatsLikeMetacharactersAsLiterals() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.setBearerAuth(platformToken(HQ_EMAIL));
+    String uniqueSuffix = UUID.randomUUID().toString();
+    String name = "store-it-likeesc-acb-" + uniqueSuffix;
+    String body =
+        String.format(
+            "{\"name\": \"%s\","
+                + " \"domain\": \"store-it-likeesc-%s.kizuna.test\","
+                + " \"email\": \"store-it-likeesc@kizuna.test\"}",
+            name, uniqueSuffix);
+
+    ResponseEntity<Void> created =
+        rest.postForEntity("/platform/stores", new HttpEntity<>(body, headers), Void.class);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+    String wildcardSearch = name.replace("acb", "a_b");
+    ResponseEntity<JsonNode> underscore =
+        rest.exchange(
+            "/platform/stores?search=" + wildcardSearch,
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(platformToken(HQ_EMAIL))),
+            JsonNode.class);
+    assertThat(underscore.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(underscore.getBody().path("total_elements").asLong()).isZero();
+
+    ResponseEntity<JsonNode> literal =
+        rest.exchange(
+            "/platform/stores?search=" + name,
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(platformToken(HQ_EMAIL))),
+            JsonNode.class);
+    assertThat(literal.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(literal.getBody().path("total_elements").asLong()).isEqualTo(1);
+  }
+
   @Test
   @DisplayName("GET /platform/stores/me は店長トークンで 200 と授権店舗(1,2)のみを返すこと（受入基準3）")
   void meReturnsAuthorizedStoresOnly() {

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
@@ -22,6 +22,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CustomerService {
 
+  /** LIKE パターンのエスケープ文字。検索語中のメタ文字を字面へ戻すために使う。 */
+  private static final char LIKE_ESCAPE = '\\';
+
   private final CustomerRepository customerRepository;
   private final CustomerMapper customerMapper;
 
@@ -43,12 +46,12 @@ public class CustomerService {
     return (root, query, cb) -> {
       List<Predicate> predicates = new ArrayList<>();
       if (search != null) {
-        String pattern = "%" + search.toLowerCase() + "%";
+        String pattern = "%" + escapeLike(search.toLowerCase()) + "%";
         predicates.add(
             cb.or(
-                cb.like(cb.lower(root.get("name")), pattern),
-                cb.like(root.get("phoneNumber"), "%" + search + "%"),
-                cb.like(cb.lower(root.get("lineId")), pattern)));
+                cb.like(cb.lower(root.get("name")), pattern, LIKE_ESCAPE),
+                cb.like(root.get("phoneNumber"), "%" + escapeLike(search) + "%", LIKE_ESCAPE),
+                cb.like(cb.lower(root.get("lineId")), pattern, LIKE_ESCAPE)));
       }
       if (rank != null) {
         predicates.add(cb.equal(root.get("rank"), rank));
@@ -62,6 +65,19 @@ public class CustomerService {
 
   private static String blankToNull(String value) {
     return (value == null || value.isBlank()) ? null : value;
+  }
+
+  /**
+   * 検索語中の LIKE メタ文字を字面へ戻す。
+   *
+   * <p>エスケープしないと {@code _} が 1 文字ワイルドカードとして働き、{@code a_b} の検索が {@code acb} のような別人まで拾う。エスケープ文字自身を先に
+   * 二重化しないと、末尾の {@code \} が後続の {@code %} を打ち消す。
+   */
+  private static String escapeLike(String value) {
+    return value
+        .replace(String.valueOf(LIKE_ESCAPE), String.valueOf(LIKE_ESCAPE) + LIKE_ESCAPE)
+        .replace("%", LIKE_ESCAPE + "%")
+        .replace("_", LIKE_ESCAPE + "_");
   }
 
   @StoreScoped


### PR DESCRIPTION
<!-- タイトルは conventional commit 形式（feat/fix/chore/refactor …）・日本語 -->

## 概要

顧客検索で `_` が SQL の LIKE ワイルドカードとして働き、`a_b` の検索が `acb` のような別人まで拾っていた不具合を修正した。

## 変更内容

- `CustomerService.searchSpec` の手書き `cb.like(...)`（name / phoneNumber / lineId）に escape 指定を追加し、`PlatformStaffService` と同じ `LIKE_ESCAPE` + `escapeLike()` の手法で検索語中の `%` `_` を字面として照合するようにした
- `CustomerCrossStoreIT` に回帰テストを追加（修正前に red、修正後に green を確認済み）
- 当初「店舗一覧（`StoreRepository.findByNameContainingIgnoreCase...`）にも同じ不具合がある」という報告だったが、これは Spring Data JPA の派生クエリで `_` `%` は既定で自動エスケープされる（`EscapeCharacter.DEFAULT`、spring-data-jpa 3.4 のソースで確認）。実際に未修正のまま検証用テストが green になることを確認し、対象外と判断した。手書き `like` に置き換える改修はフレームワーク保証を自前実装で置き換えるだけで不要な複雑化になるため見送り、代わりに `PlatformStoreApiIT` に「安全であること」を固定する回帰テストを追加した

## 検証

- [x] `task test-unit service=backend` exit 0
- [x] `task test-integration service=backend` exit 0（新規 IT 含む）
- [ ] `task lint` 未実行（本 PR はバックエンドのみ、対象ファイルは Spotless 適用済み）
- [ ] `task e2e`（UI 変更なしのため未実施）
- [x] ローカルで code-review 相当の自己レビュー実施済み

### 視覚確認（UI 変更時）

UI 変更なし。

## 決定ログ

- 店舗一覧側は手を入れず据え置いた。理由は上記「変更内容」の通り、Spring Data JPA の派生クエリが既定でエスケープ済みであることを red/green 実験とソース確認の両方で裏付けたため。派生クエリを Specification 化する代替案は検討したが、フレームワーク保証を自前コードに置き換えるだけで同種バグの再発余地を増やすため採用しなかった

## 備考 / レビュー観点

- `escapeLike()` はエスケープ文字自身を最初に二重化してから `%` `_` を置換する順序が重要（末尾の `\` が後続の `%` を打ち消す事故を防ぐ）。`PlatformStaffService` と同一の実装