### PR TITLE
fix(frontend): テーブルとカレンダーの内側余白をカード内壁 24px に揃える

### DIFF
--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -262,8 +262,34 @@ Each template owns a `templates/<key>/theme.css` that defines the same `--storef
 
 ## Spacing
 
-- Admin: content padding 24px (`p-6`); card padding ~25px (`p-6`); gap between cards 24px (`gap-6`); sidebar fixed 256px (`w-64`); header 64px (`h-16`); card radius `rounded-lg` (= `var(--radius)`, 0.5rem); subtle shadow (`shadow-sm`).
-- Storefront: sections manage their own rhythm; follow existing `_sections/` patterns (max-w-7xl containers, px-5 lg:px-10).
+There is no custom spacing scale: `globals.css`'s `@theme inline` block defines radius and colour only, so Tailwind v4's default 4px step is what every `p-*` / `gap-*` resolves against. **Do not override `--spacing`** — it would rescale all three visual worlds at once, auth and storefront included.
+
+### Admin scale
+
+| Role                                      | Value                                                                                                                                                                                                                                             |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Console content padding                   | `p-8` (32px) + `max-w-7xl mx-auto` — supplied by the console layouts, never by a page                                                                                                                                                             |
+| **Card gutter — content ↔ card edge**     | **24px**, the one invariant this table exists for; see below                                                                                                                                                                                      |
+| Between cards / between form field blocks | 24px (`space-y-6` / the `Card`'s own `gap-6`)                                                                                                                                                                                                     |
+| Label ↔ control                           | 8px (`gap-2`, already in `FormItem`)                                                                                                                                                                                                              |
+| Control group in a header or toolbar      | 12px (`gap-3`)                                                                                                                                                                                                                                    |
+| In-row icon action cluster                | 4px (`gap-1`)                                                                                                                                                                                                                                     |
+| **Table cell**                            | horizontal 8px — the primitive's own `p-2`, deliberately left alone; vertical 12px (`py-3`); header `h-11`. 44px is the floor for a text-only row; in practice a row carrying an `icon-sm` action measures 56px and one carrying a thumbnail more |
+| **Calendar day cell**                     | `p-3` (12px) — a 7-column grid divides the available width, so the horizontal constraint that binds a table does not apply here                                                                                                                   |
+| **Row card** (one record per card)        | 16px (`p-4`). Precedent: `ShiftRequestInbox`                                                                                                                                                                                                      |
+| Fixed shell dimensions                    | sidebar `w-64` (256px); header `h-16` (64px); card radius `rounded-xl` (= `var(--radius)` + 4px, 12px); `shadow-sm` elevation                                                                                                                     |
+
+### The card gutter is a constant, the cell density is not
+
+A form never writes padding: `Card` supplies `py-6` and `CardContent` supplies `px-6`, so its content sits 24px inside the card for free. A table cannot get it the same way — wrapping a `Table` in `CardContent` would make every row's `border-b` and hover fill stop 24px short of the card edge, and a data table's row bands have to run full width.
+
+So a table builds the same gutter from the **edge cells** instead: `TableCard` (`@/shared/ui`) applies `pl-6` to the first cell of every row and `pr-6` to the last. Primer's `DataTable` solves it identically (`.TableRow > *:first-child { padding-inline-start: … }`, offset "to make sure type aligns regardless of cell padding selection"); Material Design states the same target as "24dp of padding around the perimeter of table cards".
+
+The consequence to keep hold of: **the 24px belongs to the card, the cell density belongs to the cell.** Changing one must not move the other. If a second density is ever genuinely needed, add it the way Primer does — condensed / normal / spacious tiers over one unchanged edge constant — rather than by nudging both numbers together.
+
+The two are also bounded by different things, which is why the table's horizontal cell padding stays at the primitive's 8px while its vertical padding goes to 12px. **Horizontal padding is multiplied by the column count and vertical padding is not**: widening cells to 12px adds 88px to the 8-column キャスト一覧's intrinsic width, enough to overflow the content column on a 1024px window where it previously fit. The edge gutter costs a fixed 32px and buys the alignment the whole rule is about, so it is worth paying; per-column width is not. Measure with `scrollWidth` on `[data-slot="table-container"]` before widening a cell.
+
+`TableCard`'s cell rules are descendant selectors (specificity 0,1,1), so they out-rank a `padding` a page writes on its own `TableCell`. No page does today. If one needs to, change `TableCard` rather than fighting it at the call site.
 
 ### The admin console has a floor, not a phone layout
 
@@ -278,6 +304,10 @@ Two traps this rule exists to catch, both hit in practice:
 - **A single measurement is not the worst case.** A row containing user data (a store name, a person's name) is only as wide as whatever happened to be on screen when you measured. Cap such labels — an uncapped `whitespace-nowrap` label has no upper bound, and a floor cannot hold a row that has none.
 - **Adding a cap changes the worst case.** The cap becomes the new maximum, so the floor must be recomputed **after** capping, not before.
 
+### Storefront
+
+Sections manage their own rhythm; follow existing `_sections/` patterns (max-w-7xl containers, px-5 lg:px-10).
+
 ## Components (admin)
 
 Primitives come from `@/shared/ui` (the barrel over the vendored shadcn components). This section records **which primitive to use and how to compose it** — never a restatement of the styling already baked into the primitive.
@@ -291,7 +321,7 @@ Primitives come from `@/shared/ui` (the barrel over the vendored shadcn componen
 - **Destructive menu item**: do not use the vendored `DropdownMenuItem`'s own `variant="destructive"` — it keeps the default red as the text over its tinted focus fill (`text-destructive` on `bg-destructive/10`), which measures **3.99 in light mode** (dark passes at 4.58 over its `/20` fill). Spell the colours out on the consumer instead: `className="text-destructive-strong focus:bg-destructive/10 focus:text-destructive-strong"` — certified by the `bg-destructive/10` + `text-destructive-strong` row (8.42 / 5.39). The primitive itself stays as generated; this rule binds the call sites. Precedent: the logout item in `widgets/header`.
 - **Card section heading**: `CardTitle` renders a `<div>`, so wherever it stands for a section heading it must be written `<CardTitle role="heading" aria-level={N}>`. Without both attributes the section disappears from screen-reader heading navigation, and the loss is invisible in a rendered diff. The primitive stays pristine — it spreads `React.ComponentProps<'div'>`, so the consumer supplies them. (Where the card is genuinely not a section heading — a bare label on a stat card — leave it a `div` and do not add the role.)
   - **Pick `N` from the outline the page actually has, never from the tag the card replaced.** Levels must not skip: a card section directly under the page's `<h1>` is `aria-level={2}`, whatever the pre-shadcn markup used. Every admin page today is `<h1>` + card sections, so **2** is the level in practice; a nested sub-section inside such a card would be 3. Sibling headings written as real tags follow the same outline (`CustomerEditPage`'s 注文履歴 is an `<h2>`, not an `<h3>`).
-- **Table**: shadcn `Table` inside a `Card`. Precedent: `CustomersPage`.
+- **Table**: shadcn `Table` inside a **`TableCard`**, never a hand-assembled `Card className="py-0 …"` — the card gutter and cell density live in that one component (see Spacing). A list page gets it through `ListPage`; a table embedded in another page uses `TableCard` directly (precedent: `CustomerEditPage`'s 注文履歴).
 - **Tabs**: shadcn `Tabs`. Precedent: `ShiftsPage`.
 - **Loading placeholder**: `Skeleton` sized with layout classes, never a hand-rolled `animate-pulse` block.
 - **Status pill**: `Badge variant="outline"` plus one tint recipe — `border-transparent bg-success/10 text-success-strong` (確定) / `bg-warning/10 text-warning-strong` (保留) / `bg-destructive/10 text-destructive-strong` (却下 / NG). Precedent: `CustomersPage`.
@@ -318,7 +348,7 @@ The paging state comes from `useListPage` (`@/shared/lib`), whose fetcher return
 
 Consequences that the module cannot enforce for the page:
 
-- **The console layout already supplies `p-8` and `max-w-7xl mx-auto`** (`app/platform/(console)/layout.tsx`, `app/store/layout.tsx`), so a list page adds no padding, width cap or `min-h-screen` of its own — and no navigation bar: the sidebar and header own logout, store switching and cross-page navigation.
+- **The console layout already supplies `p-8` and `max-w-7xl mx-auto`** (`app/(admin)/platform/layout.tsx`, `app/(admin)/store/layout.tsx`), so a list page adds no padding, width cap or `min-h-screen` of its own — and no navigation bar: the sidebar and header own logout, store switching and cross-page navigation.
 - **The primary action keeps its element type.** A page that opens a modal passes a plain `Button`; only a page that navigates passes `Button asChild` wrapping a `Link`. The two differ in ARIA role (`button` vs `link`), and the Playwright steps under `e2e/steps/` select by role — swapping one for the other breaks them silently, since e2e does not run in CI.
 - **The search card submits through the shell's `<form>`.** The page's `search.content` is just the fields plus a `type="submit"` button; Enter submission is native form semantics, so no per-input `onKeyDown` is written.
 - **The fetcher reads _applied_ filters, never the live input state.** Keep the typed value in state for the field and the submitted value in a `useRef`; the submit handler copies state into the ref and then calls `search()`. Reading input state directly breaks twice: a page change would silently apply a filter the user typed but never submitted (the fetched page then belongs to a different result set), and a handler that changes a filter and refetches in one go — a clear button — would fetch with the pre-update value. Precedent: `StoresPage` / `CustomersPage`.
@@ -413,9 +443,11 @@ Everything else that still matches the grep — the unconverted slices, `widgets
 `src/shared/ui` holds two kinds of file, and only one of them is frozen.
 
 - **Vendored shadcn primitives** — `alert-dialog` / `button` / `card` / `dialog` / `select` / `form` / `table` / `badge` / `popover` / `command` / `skeleton` / `tabs` / `dropdown-menu` / `checkbox` / `switch` / `radio-group` / `input` / `label` / `textarea`. Kept exactly as generated; per-screen deviation goes in the consumer's `className`, never here.
-- **Kizuna-authored components** — `image-upload.tsx`, `auth-layout.tsx`, `theme-provider.tsx`, `confirm-dialog.tsx`. Hand-written, so they obey the token rules like any other admin file. `auth-layout.tsx` is the exception noted above: it belongs to the auth world.
+- **Kizuna-authored components** — `image-upload.tsx`, `auth-layout.tsx`, `theme-provider.tsx`, `confirm-dialog.tsx`, `table-card.tsx`. Hand-written, so they obey the token rules like any other admin file. `auth-layout.tsx` is the exception noted above: it belongs to the auth world.
 
-Tell them apart by the generator's fingerprint rather than by guessing. The one reliable single test is **`data-slot`**: all 19 vendored files carry it and none of the four hand-written ones do. The other markers are only suggestive — a `radix-ui` import is absent from 6 of the 19, and `cva` from 16 of the 19, so "some of these, not all" is the honest reading and neither is usable alone. The negative direction is what holds: the hand-written four carry none of the markers, and either import application code a generator would never emit (`@/shared/api`, `react-hot-toast`, `next-themes`) or, as `confirm-dialog.tsx` does, compose sibling primitives through relative imports where the generator emits the `@/shared/ui` alias. `git log --follow` settles any remaining doubt.
+  `table-card.tsx` is where a per-context deviation from a primitive is _supposed_ to live: the table's card gutter depends on what the table is sitting in (the same rule baked into `table.tsx` would double to 48px inside an already-padded `CardContent`), so it belongs to the consumer side, composed once rather than copied.
+
+Tell them apart by the generator's fingerprint rather than by guessing. The one reliable single test is **`data-slot`**: all 19 vendored files carry it and none of the five hand-written ones do. The other markers are only suggestive — a `radix-ui` import is absent from 6 of the 19, and `cva` from 16 of the 19, so "some of these, not all" is the honest reading and neither is usable alone. The negative direction is what holds: the hand-written five carry none of the markers, and either import application code a generator would never emit (`@/shared/api`, `react-hot-toast`, `next-themes`) or, as `confirm-dialog.tsx` and `table-card.tsx` do, compose sibling primitives through relative imports where the generator emits the `@/shared/ui` alias. `git log --follow` settles any remaining doubt.
 
 Editing a hand-written one is still a shared-file change, so it goes through the contract below rather than through a slice PR.
 

--- a/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
@@ -7,7 +7,15 @@ import { CustomerResponse, customerApi } from '@/entities/customer';
 import { Order, orderApi } from '@/entities/order';
 import { toast } from 'react-hot-toast';
 import { storePath } from '@/shared/lib';
-import { Card, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/shared/ui';
+import {
+  Table,
+  TableBody,
+  TableCard,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/ui';
 
 /** 顧客編集ページ（プロフィール編集 + 注文履歴） */
 export default function CustomerEditPage() {
@@ -96,7 +104,7 @@ export default function CustomerEditPage() {
       />
 
       {/* 注文履歴 */}
-      <Card className="py-0 overflow-hidden">
+      <TableCard>
         <div className="border-b bg-muted/50 px-6 py-4">
           <h2 className="text-lg font-medium text-foreground">注文履歴</h2>
         </div>
@@ -129,7 +137,7 @@ export default function CustomerEditPage() {
             </TableBody>
           </Table>
         )}
-      </Card>
+      </TableCard>
     </div>
   );
 }

--- a/frontend/src/_pages/store-shifts/ui/ShiftCalendar.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftCalendar.tsx
@@ -67,7 +67,7 @@ export function ShiftCalendar({
         {WEEKDAYS.map((w, i) => (
           <div
             key={w}
-            className={`px-2 py-2 text-center text-xs font-medium ${
+            className={`px-3 py-2.5 text-center text-xs font-medium ${
               i === 0
                 ? 'text-destructive'
                 : i === 6
@@ -91,7 +91,7 @@ export function ShiftCalendar({
               type="button"
               key={ds}
               onClick={() => onSelectDate(ds)}
-              className="group h-24 border-b border-r p-2 text-left align-top transition-colors hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary"
+              className="group h-28 border-b border-r p-3 text-left align-top transition-colors hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary"
             >
               {/* 当月外はホバーの色地に載るため、注記色のままだと沈む。ホバー時だけ本文色へ上げる。 */}
               <span

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -19,5 +19,6 @@ export * from './select';
 export * from './skeleton';
 export * from './switch';
 export * from './table';
+export * from './table-card';
 export * from './tabs';
 export * from './textarea';

--- a/frontend/src/shared/ui/table-card.tsx
+++ b/frontend/src/shared/ui/table-card.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+import { cn } from '@/shared/lib/utils';
+import { Card } from './card';
+
+/**
+ * テーブルを内包するカード。カード内壁 24px という規約をテーブルにも成立させる。
+ *
+ * テーブルは CardContent（px-6）に包めない。包むと行の border-b と hover 帯が
+ * カード縁の 24px 手前で切れてしまい、データ表として読めなくなる。そのため内壁は
+ * 端セル側の pl-6 / pr-6 で作る。この 24px は「カードの内壁」という定数であり、
+ * セルの密度とは独立に据え置く。
+ *
+ * 列間（セル左右）は primitive の 8px のまま触らない。列数だけ効いてくる値なので、
+ * ここを広げると列の多い一覧がより早く横スクロールに落ちる（8 列のキャスト一覧で
+ * 12px にすると固有幅が 88px 増え、1024px 幅の窓で溢れる）。縦の 12px は行数にしか
+ * 効かず幅を増やさないので、行の詰まりはこちらで解く。
+ *
+ * Card 既定の py-6 / gap-6 は潰す。残すとテーブル最終行の下と、見出し帯とテーブルの
+ * 間にそれぞれ 24px の空白が挟まり、カードとテーブルが地続きに見えなくなる。
+ *
+ * セルへの指定は子孫セレクタ（詳細度 0,1,1）なので、呼び出し側が TableCell に
+ * 直接書いた padding より強い。個別に変えたいセルが出たら、ここを直すこと。
+ */
+export function TableCard({ className, ...props }: ComponentProps<'div'>) {
+  return (
+    <Card
+      className={cn(
+        'py-0 gap-0 overflow-hidden',
+        '[&_th]:h-11 [&_td]:py-3',
+        '[&_tr>*:first-child]:pl-6 [&_tr>*:last-child]:pr-6',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/widgets/list-page/ui/ListPage.tsx
+++ b/frontend/src/widgets/list-page/ui/ListPage.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from 'react';
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
-import { Button, Card, CardContent } from '@/shared/ui';
+import { Button, Card, CardContent, TableCard } from '@/shared/ui';
 
 export interface ListPageSearch {
   /** 検索カードの中身（入力欄・ボタンなど） */
@@ -91,9 +91,7 @@ export function ListPage({
         </form>
       )}
 
-      {/* Card は既定で gap-6 の flex 列。テーブルとページネーションを地続きに見せるため間隔を潰す
-          （残すと最終行の下に 24px の空白が挟まる） */}
-      <Card className="py-0 gap-0 overflow-hidden">
+      <TableCard>
         {isLoading ? (
           <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
         ) : isEmpty ? (
@@ -105,7 +103,7 @@ export function ListPage({
         {/* pageCount が 1 に潰れても、削除等で page が範囲外（page > 0）になった場合は
             戻る手段を残す必要があるため、pageCount > 1 だけでは判定しない */}
         {onPageChange && !isLoading && (pageCount > 1 || page > 0) && (
-          <div className="px-4 py-3 flex items-center justify-between border-t sm:px-6">
+          <div className="px-6 py-4 flex items-center justify-between border-t">
             <div className="flex-1 flex justify-between sm:hidden">
               <Button
                 variant="outline"
@@ -177,7 +175,7 @@ export function ListPage({
             </div>
           </div>
         )}
-      </Card>
+      </TableCard>
     </div>
   );
 }


### PR DESCRIPTION
## 概要

管理画面のテーブルとカレンダーの内側余白が、同じカード内のフォーム（24px）と食い違って 8px しかなかったのを、**「カード内の内容はカード縁から 24px」** という一本の不変量に揃えた。あわせて 2 行しかなかった DESIGN.md の Spacing を刻度表に書き直した。

Closes #

## 変更内容

### 根因

余白の決め方が「決まっていなかった」。`globals.css` の `@theme inline` は radius と色しか定義しておらず spacing scale が無いため、各コンポーネントの余白は継承した shadcn 既定値そのままになっていた。

- **フォーム**は padding を 1 行も書いていない。`Card` の `py-6` と `CardContent` の `px-6` で内壁 24px を無償で得ている
- **テーブル**は `CardContent` を経由せず `Card` 直下に置かれるため内壁を一切受け取らず、primitive の `TableCell p-2` = **8px** が唯一の内側余白として残っていた

### 対応

- **`shared/ui/table-card.tsx` を新設**（hand-written 側。vendored primitive は据え置き）
  - テーブルを `CardContent` で包むと行の `border-b` と hover 帯がカード縁の手前で切れ、データ表として読めなくなる。そのため内壁は**端セルの `pl-6` / `pr-6`** で作る
  - 端 gutter は「テーブルが何の中にいるか」に依存する値なので、primitive に入れると padding 済み容器の中で 48px に二重化する。消費側に置くのが正しい層
- **列間はあえて primitive の 8px のまま据え置き**。横方向の padding は列数だけ効くため、12px にすると 8 列のキャスト一覧で固有幅が 88px 増え、1024px 幅の窓で新たに横スクロールへ落ちる（実測）。行の詰まりは幅に効かない縦方向（`py-3`）とヘッダー `h-11` で解いた
- **呼び出し元 2 箇所を `TableCard` へ統一** — 全リポジトリで「`Card py-0` + 素の `Table`」はこの 2 箇所のみ
  - `widgets/list-page/ui/ListPage.tsx`（一覧 7 ページを覆う）
  - `_pages/store-customers/ui/CustomerEditPage.tsx`（注文履歴）。こちらは `gap-0` が無く見出し帯とテーブルの間に 24px の空白が挟まっていたが、統一によりこれも解消
- **ページネーション帯**を `px-6 py-4` へ（`sm:` の段差は廃止）。セル内容・件数ラベル・ページ送りボタンが同じ 24px で揃う
- **カレンダー**日枠を `h-28 p-3`、曜日帯を `px-3 py-2.5` へ
- **DESIGN.md**
  - Spacing を刻度表に書き直し、「カード内壁は定数・セル密度とは非連動」を明文化（Primer `DataTable` の同形実装と Material Design の "24dp around the perimeter of table cards" を典拠として記載）
  - コードと矛盾していた記述を訂正：content padding `p-6`→`p-8`／card padding `p-6`→根 `py-6` + slot `px-6`／card radius `rounded-lg`→`rounded-xl`／console layout の存在しないパス
  - hand-written コンポーネントの員数（four→five）と `data-slot` 判別法の記述を更新

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [x] `task e2e` exit 0（22 シナリオ全通過。実行シナリオ: 全 feature）
- [ ] ローカルで code-review 実施済み — **未実施**

### 視覚確認（UI 変更時）

jsdom にはレイアウトが無く Jest では証明できないため、`task build service=frontend` + `task up` で実際に起動し、スクリーンショットに加えて `getComputedStyle` / `getBoundingClientRect` で実測した。

キャスト一覧（1440px）:

| 項目 | 実測 |
| --- | --- |
| 端セル padding | `pl: 24px` / `pr: 24px` |
| 中間セル padding | `8px`（primitive のまま） |
| セル縦 padding | `12px` |
| ヘッダー高さ | `44px` |
| カード縁 → セル内容 | `25px`（= 24px padding + 1px border。フォームの `CardContent` と同値） |

1024px 窓での横スクロール判定（`[data-slot="table-container"]`）: `clientWidth 702 / scrollWidth 702` → **溢れなし**。列間を 12px にした場合は `743` となり 41px 溢れることを実測で確認したうえで 8px 据え置きを採用した。

ページネーション帯（スタッフ一覧、22 件・3 ページ）: 件数ラベル左端 `25px` / セル内容左端 `25px` / ページ送りボタン右端 `25px` — 三者一致。

顧客編集の注文履歴カード: `gap: 0px`（従来は `gap-6` により 24px の空白）。

カレンダー・フォーム各ページも目視確認済み。

## 決定ログ

**採った案**: 端セルに gutter を持たせる（Primer / Material 系）。

- **見送り: vendored `table.tsx` の restyle** — DESIGN.md の凍結規則を修訂せずに済むだけでなく、端 gutter は本質的に文脈依存（padding 済み容器の中では 48px に二重化する）なので、primitive に置くこと自体が誤り
- **見送り: `Table` を `CardContent` で包む** — 行の `border-b` と hover 帯が縁の手前で切れる。データ表の行帯は全幅であるべき
- **見送り: `globals.css` で `--spacing` を上書き** — storefront と auth を含む 3 つの視覚世界すべてを等比スケールしてしまう
- **見送り: Primer 風の密度 3 段（condensed / normal / spacious）** — 2 つ目の具体的ユースケースが無い。将来必要になった際の拡張方針だけ DESIGN.md に記載
- **見送り: 列間 12px（Primer normal 相当）** — 上記の実測どおり 1024px で横スクロールを生む。オーナー裁定により 8px 据え置き

**調査した外部設計システム**: Primer（GitHub）の `DataTable` は `.TableRow > *:first-child { padding-inline-start: 16px }` という同形の実装を持ち、ソースコメントに "Offset padding to make sure type aligns regardless of cell padding selection" と理由が書かれている（＝端 gutter は密度段と非連動の定数）。Material Design は "24dp of padding around the perimeter of table cards"。一方 Carbon / MUI / Polaris は均一 padding・端定数なしだが、それはテーブルが内壁を持つカードに入っていないことが前提であり、本リポジトリの構成には当てはまらない。

## 備考 / レビュー観点

- **`TableCard` のセル指定は子孫セレクタ（詳細度 0,1,1）**で、呼び出し側が `TableCell` に直接書いた padding より強い。現状そう書いているページは無い（grep 確認済み）が、将来の落とし穴になり得るのでコメントに明記してある
- **ページネーション帯から `sm:px-6` の段差を落とした**ため、640px 未満で 16px → 24px に変わる。サポート幅（704px）の外なので実害は無いが、依頼範囲外の responsive 挙動変更ではある
- **`min-w-[44rem]` の幅の床（704px 未満で伸縮を止めて横スクロール）は本 PR の対象外**。オーナー確認済みの既存の意図的な決定であり、DESIGN.md の該当節も無変更
- カバレッジ確認は `<Table>` ではなく `TableCell|TableHead` で grep（属性付き・改行分割を取りこぼさないため）。ページ 8 ファイルすべてが `TableCard` 経由になっていること、手書き `<table>` が primitive 以外に無いことを確認済み
- **dev DB に検証用データが 1 件残っている**: 顧客「余白確認用テスト顧客」（`CustomerEditPage` の呼び出し元を確認するために作成）。削除は未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)
