### PR TITLE
refactor(backend): 失敗の表明と HTTP status の写像を CommonExceptionHandler へ収束させる

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/cast/CastFieldDefinitionCrossStoreIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/cast/CastFieldDefinitionCrossStoreIT.java
@@ -28,7 +28,7 @@ import tools.jackson.databind.JsonNode;
  * （弱い「所有者不一致」ではなく他店舗の値・ラベルが本文に一切現れないことを断言）。
  *
  * <p>定義 CRUD は {@code ROLE_STORE_MANAGER} 限定のため、店舗{1,2} 授権の店長シードユーザー tanaka.hanako を使う。 tanaka
- * は両店舗に授権されるため、越境は「インターセプタのスコープ拒否 403」ではなく「storeFilter による不可視化 → 400（見つからない）」として現れる。純粋なヘッダ詐称 403
+ * は両店舗に授権されるため、越境は「インターセプタのスコープ拒否 403」ではなく「storeFilter による不可視化 → 404（見つからない）」として現れる。純粋なヘッダ詐称 403
  * は基底クラスの yamada（店舗{1} 授権）で別途固定する。
  */
 class CastFieldDefinitionCrossStoreIT extends CrossStoreTestSupport {
@@ -110,7 +110,7 @@ class CastFieldDefinitionCrossStoreIT extends CrossStoreTestSupport {
   }
 
   @Test
-  @DisplayName("他店舗の定義は storeFilter で不可視化され、GET一覧に現れず PUT/DELETE も 400 になること")
+  @DisplayName("他店舗の定義は storeFilter で不可視化され、GET一覧に現れず PUT/DELETE も 404 になること")
   void foreignStoreDefinitionIsInvisibleAndUnmutable() {
     String keyA = "blood_type_" + nonce;
     String idA = createDefinitionAs(STORE_A, keyA, "血液型A", true);
@@ -139,14 +139,14 @@ class CastFieldDefinitionCrossStoreIT extends CrossStoreTestSupport {
     assertThat(listB.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(listB.getBody()).contains(keyB).contains(labelB);
 
-    // 変更不可: store A 文脈で store B の定義を PUT/DELETE すると不可視で 400
+    // 変更不可: store A 文脈で store B の定義を PUT/DELETE すると不可視で 404（不在と区別がつかない）
     ResponseEntity<JsonNode> putForeign =
         rest.exchange(
             "/store/casts/fields/" + idB,
             HttpMethod.PUT,
             new HttpEntity<>("{\"label\": \"改ざん\"}", managerHeaders(STORE_A)),
             JsonNode.class);
-    assertThat(putForeign.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(putForeign.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
 
     ResponseEntity<JsonNode> deleteForeign =
         rest.exchange(
@@ -154,7 +154,7 @@ class CastFieldDefinitionCrossStoreIT extends CrossStoreTestSupport {
             HttpMethod.DELETE,
             new HttpEntity<>(managerHeaders(STORE_A)),
             JsonNode.class);
-    assertThat(deleteForeign.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(deleteForeign.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
 
     // データ不変: store B からは idB の定義がなお見える（改ざん・削除されていない）
     ResponseEntity<String> listBAfter =
@@ -165,7 +165,7 @@ class CastFieldDefinitionCrossStoreIT extends CrossStoreTestSupport {
             String.class);
     assertThat(listBAfter.getBody()).contains(labelB);
 
-    // 正向対照: store A は自店舗の定義を更新できる（400 がバリデーション起因でない証明）
+    // 正向対照: store A は自店舗の定義を更新できる（404 がバリデーション起因でない証明）
     ResponseEntity<JsonNode> putOwn =
         rest.exchange(
             "/store/casts/fields/" + idA,
@@ -251,7 +251,7 @@ class CastFieldDefinitionCrossStoreIT extends CrossStoreTestSupport {
   }
 
   @Test
-  @DisplayName("他店舗を詐称したヘッダは定義エンドポイントでも 403 で拒否され、本文を返さないこと")
+  @DisplayName("他店舗を詐称したヘッダは定義エンドポイントでも 403 で拒否され、他店舗のデータを一切返さないこと")
   void spoofedForeignStoreHeaderIsRejected() {
     // 基底クラスの yamada（店舗{1} 授権）で X-Store-ID: 2 を詐称 → インターセプタのスコープ検証が 403 で弾く。
     ResponseEntity<String> spoofed =
@@ -261,6 +261,7 @@ class CastFieldDefinitionCrossStoreIT extends CrossStoreTestSupport {
             new HttpEntity<>(storeHeaders(STORE_B)),
             String.class);
     assertThat(spoofed.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
-    assertThat(spoofed.getBody()).as("拒否時は本文を返さない").isNullOrEmpty();
+    // 拒否応答は CommonExceptionHandler の固定文言のみ。定義行（key / label）が一つでも混じれば漏洩。
+    assertThat(spoofed.getBody()).contains("アクセス権限がありません").doesNotContain("\"key\"", "\"label\"");
   }
 }

--- a/backend/src/integrationTest/java/com/kizuna/cast/CastInvitationApiIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/cast/CastInvitationApiIT.java
@@ -213,7 +213,7 @@ class CastInvitationApiIT extends CrossStoreTestSupport {
   }
 
   @Test
-  @DisplayName("他店舗の档案 ID を自店文脈から発行しても 400 で拒否され、他店舗のデータが不変であること")
+  @DisplayName("他店舗の档案 ID を自店文脈から発行しても 404 で拒否され、他店舗のデータが不変であること")
   void crossStoreIssueIsRejectedAndForeignDataUnchanged() {
     // リポジトリ直挿（テストスレッドは @StoreScoped を経由せず storeFilter が無効なので他店舗にも書ける）。
     Cast foreignCast = Cast.builder().name("他店舗機密キャスト").build();
@@ -223,7 +223,7 @@ class CastInvitationApiIT extends CrossStoreTestSupport {
     // tanaka の授権店舗(店舗1)文脈から、他店舗の档案 ID を発行しようとする。
     ResponseEntity<JsonNode> res = issueInvitation(foreignCastId, STORE_A, managerToken);
 
-    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     // 他店舗の档案には招待が一切作られていない（実データ断言）。
     assertThat(castInvitationRepository.findByCastIdIn(List.of(foreignCastId))).isEmpty();
     // 他店舗の档案の紐づけも変わっていない。

--- a/backend/src/integrationTest/java/com/kizuna/shift/ShiftCrossStoreIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/shift/ShiftCrossStoreIT.java
@@ -254,7 +254,7 @@ class ShiftCrossStoreIT extends CrossStoreTestSupport {
                 shiftBody(foreignCastId, "2026-07-12", "18:00:00", "23:00:00"),
                 storeHeaders(STORE_A)),
             JsonNode.class);
-    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
 
     // 作成されていないこと（区間 GET に当該 cast_id のシフトが現れない）。
     // 実 DB は実行間で残留し得るため件数一致ではなく「含まない」で判定する。
@@ -288,7 +288,7 @@ class ShiftCrossStoreIT extends CrossStoreTestSupport {
             HttpMethod.PUT,
             new HttpEntity<>("{\"cast_id\": \"" + foreignCastId + "\"}", storeHeaders(STORE_A)),
             JsonNode.class);
-    assertThat(put.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(put.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
 
     // データ不変: cast_id は自店のキャストのまま
     JsonNode found = findInRange(STORE_A, "from=2026-07-13&to=2026-07-13", shiftId);

--- a/backend/src/main/java/com/kizuna/auth/application/PlatformAuthService.java
+++ b/backend/src/main/java/com/kizuna/auth/application/PlatformAuthService.java
@@ -5,6 +5,7 @@ import com.kizuna.auth.api.dto.Token;
 import com.kizuna.auth.infrastructure.PlatformJwtIssuer;
 import com.kizuna.auth.infrastructure.PlatformUserDetails;
 import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.StaleSessionException;
 import com.kizuna.user.domain.PermissionCode;
 import com.kizuna.user.domain.PermissionRepository;
 import com.kizuna.user.domain.PlatformUser;
@@ -81,7 +82,9 @@ public class PlatformAuthService {
   @Transactional
   public PlatformMeResponse updateMe(String email, String displayName) {
     PlatformUser user =
-        userRepository.findByEmail(email).orElseThrow(() -> new ServiceException("ユーザーが見つかりません"));
+        userRepository
+            .findByEmail(email)
+            .orElseThrow(() -> new StaleSessionException("認証セッションの主体が存在しません"));
     user.updateDisplayName(displayName);
     userRepository.save(user);
     return toMeResponse(user);
@@ -92,7 +95,9 @@ public class PlatformAuthService {
   public void changePassword(
       String email, String currentPassword, String newPassword, String currentToken) {
     PlatformUser user =
-        userRepository.findByEmail(email).orElseThrow(() -> new ServiceException("ユーザーが見つかりません"));
+        userRepository
+            .findByEmail(email)
+            .orElseThrow(() -> new StaleSessionException("認証セッションの主体が存在しません"));
     if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
       throw new ServiceException("現在のパスワードが正しくありません");
     }

--- a/backend/src/main/java/com/kizuna/cast/application/CastFieldDefinitionService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastFieldDefinitionService.java
@@ -6,6 +6,7 @@ import com.kizuna.cast.api.dto.CastFieldDefinitionResponse;
 import com.kizuna.cast.api.dto.CastFieldDefinitionUpdateRequest;
 import com.kizuna.cast.domain.CastFieldDefinition;
 import com.kizuna.cast.domain.CastFieldDefinitionRepository;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreScoped;
 import java.util.List;
@@ -70,7 +71,7 @@ public class CastFieldDefinitionService {
     CastFieldDefinition definition =
         repository
             .findById(id)
-            .orElseThrow(() -> new ServiceException("カスタムフィールド定義が見つかりません: " + id));
+            .orElseThrow(() -> new NotFoundException("カスタムフィールド定義が見つかりません: " + id));
     definition.apply(mapper.toPatch(request));
     return mapper.toResponse(repository.save(definition));
   }
@@ -79,7 +80,7 @@ public class CastFieldDefinitionService {
   @Transactional
   public void delete(String id) {
     if (!repository.existsById(id)) {
-      throw new ServiceException("カスタムフィールド定義が見つかりません: " + id);
+      throw new NotFoundException("カスタムフィールド定義が見つかりません: " + id);
     }
     repository.deleteById(id);
   }

--- a/backend/src/main/java/com/kizuna/cast/application/CastInvitationAcceptanceService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastInvitationAcceptanceService.java
@@ -8,6 +8,7 @@ import com.kizuna.cast.domain.CastInvitation;
 import com.kizuna.cast.domain.CastInvitationRepository;
 import com.kizuna.cast.domain.CastInvitationStateException;
 import com.kizuna.cast.domain.CastRepository;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.store.domain.Store;
 import com.kizuna.store.domain.StoreRepository;
@@ -146,11 +147,11 @@ public class CastInvitationAcceptanceService {
   private CastInvitation findByToken(String token) {
     return castInvitationRepository
         .findByToken(token)
-        .orElseThrow(() -> new ServiceException("招待が見つかりません"));
+        .orElseThrow(() -> new NotFoundException("招待が見つかりません"));
   }
 
   private Cast requireCast(String castId) {
-    return castRepository.findById(castId).orElseThrow(() -> new ServiceException("キャストが見つかりません"));
+    return castRepository.findById(castId).orElseThrow(() -> new NotFoundException("キャストが見つかりません"));
   }
 
   private String storeName(Long storeId) {

--- a/backend/src/main/java/com/kizuna/cast/application/CastInvitationService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastInvitationService.java
@@ -7,7 +7,7 @@ import com.kizuna.cast.domain.CastInvitationRepository;
 import com.kizuna.cast.domain.CastInvitationStateException;
 import com.kizuna.cast.domain.CastInvitationStatus;
 import com.kizuna.cast.domain.CastRepository;
-import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.storescope.StoreScoped;
 import java.security.SecureRandom;
 import java.time.OffsetDateTime;
@@ -35,7 +35,7 @@ public class CastInvitationService {
 
   /**
    * 招待を発行する。紐づき済みの档案は拒否し、既存の PENDING 招待を全て失効させてから最新 1 枚を新規発行する。 storeFilter により他店舗の档案は見えず
-   * ServiceException となる（越権はインターセプタが先に 403）。
+   * NotFoundException となる（越権はインターセプタが先に 403）。
    *
    * <p>档案あたりの有効な招待は最大 1 枚であることを部分ユニークインデックス {@code uq_t_cast_invitations_pending_cast}（{@code WHERE
    * status = 'PENDING'}）が DB レベルで保証する。 これにより店長の二重クリック等で issue() が並行しても、複数の有効トークンが同時に発行される事態を塞ぐ
@@ -53,7 +53,7 @@ public class CastInvitationService {
     Cast cast =
         castRepository
             .findById(castId)
-            .orElseThrow(() -> new ServiceException("キャストが見つかりません: " + castId));
+            .orElseThrow(() -> new NotFoundException("キャストが見つかりません: " + castId));
     if (cast.getPlatformUserId() != null) {
       throw new CastInvitationStateException(ALREADY_LINKED_MESSAGE);
     }

--- a/backend/src/main/java/com/kizuna/cast/application/CastSelfService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastSelfService.java
@@ -2,7 +2,7 @@ package com.kizuna.cast.application;
 
 import com.kizuna.cast.api.dto.CastStoreResponse;
 import com.kizuna.cast.domain.CastRepository;
-import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.StaleSessionException;
 import com.kizuna.user.domain.PlatformUserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +27,7 @@ public class CastSelfService {
     Long userId =
         platformUserRepository
             .findByEmail(email)
-            .orElseThrow(() -> new ServiceException("ユーザーが見つかりません"))
+            .orElseThrow(() -> new StaleSessionException("認証セッションの主体が存在しません"))
             .getId();
     return castRepository.findStoresByPlatformUserId(userId).stream()
         .map(view -> new CastStoreResponse(view.getStoreId(), view.getStoreName()))

--- a/backend/src/main/java/com/kizuna/cast/application/CastService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastService.java
@@ -11,6 +11,7 @@ import com.kizuna.cast.domain.CastFieldDefinitionRepository;
 import com.kizuna.cast.domain.CastInvitationStatus;
 import com.kizuna.cast.domain.CastPatch;
 import com.kizuna.cast.domain.CastRepository;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreScoped;
 import java.util.List;
@@ -51,7 +52,7 @@ public class CastService {
   @Transactional(readOnly = true)
   public CastResponse get(String id) {
     Cast cast =
-        castRepository.findById(id).orElseThrow(() -> new ServiceException("キャストが見つかりません: " + id));
+        castRepository.findById(id).orElseThrow(() -> new NotFoundException("キャストが見つかりません: " + id));
     CastInvitationStatus status = castInvitationService.deriveStatuses(List.of(cast)).get(id);
     return castMapper.toResponse(cast, status);
   }
@@ -78,7 +79,7 @@ public class CastService {
   @Transactional
   public CastResponse update(String id, CastUpdateRequest request) {
     Cast cast =
-        castRepository.findById(id).orElseThrow(() -> new ServiceException("キャストが見つかりません: " + id));
+        castRepository.findById(id).orElseThrow(() -> new NotFoundException("キャストが見つかりません: " + id));
 
     CastPatch patch = castMapper.toPatch(request);
     if (patch.customFields() != null) {
@@ -111,7 +112,7 @@ public class CastService {
   @Transactional
   public void delete(String id) {
     if (!castRepository.existsById(id)) {
-      throw new ServiceException("キャストが見つかりません: " + id);
+      throw new NotFoundException("キャストが見つかりません: " + id);
     }
     castRepository.deleteById(id);
   }

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
@@ -6,7 +6,7 @@ import com.kizuna.customer.api.dto.CustomerResponse;
 import com.kizuna.customer.api.dto.CustomerUpdateRequest;
 import com.kizuna.customer.domain.Customer;
 import com.kizuna.customer.domain.CustomerRepository;
-import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.storescope.StoreScoped;
 import jakarta.persistence.criteria.Predicate;
 import java.util.ArrayList;
@@ -86,7 +86,7 @@ public class CustomerService {
     return customerRepository
         .findById(id)
         .map(customerMapper::toResponse)
-        .orElseThrow(() -> new ServiceException("顧客が見つかりません: " + id));
+        .orElseThrow(() -> new NotFoundException("顧客が見つかりません: " + id));
   }
 
   @StoreScoped
@@ -103,7 +103,7 @@ public class CustomerService {
     Customer customer =
         customerRepository
             .findById(id)
-            .orElseThrow(() -> new ServiceException("顧客が見つかりません: " + id));
+            .orElseThrow(() -> new NotFoundException("顧客が見つかりません: " + id));
 
     customer.apply(customerMapper.toPatch(request));
 
@@ -114,7 +114,7 @@ public class CustomerService {
   @Transactional
   public void delete(String id) {
     if (!customerRepository.existsById(id)) {
-      throw new ServiceException("顧客が見つかりません: " + id);
+      throw new NotFoundException("顧客が見つかりません: " + id);
     }
     customerRepository.deleteById(id);
   }

--- a/backend/src/main/java/com/kizuna/order/application/OrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderService.java
@@ -11,6 +11,7 @@ import com.kizuna.order.api.dto.OrderUpdateRequest;
 import com.kizuna.order.domain.Order;
 import com.kizuna.order.domain.OrderRepository;
 import com.kizuna.order.domain.OrderStatus;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.shared.storescope.StoreScoped;
@@ -65,7 +66,7 @@ public class OrderService {
 
     // 関連 ID の割り当て（存在確認のうえ）
     if (!castRepository.existsById(request.getCastId())) {
-      throw new ServiceException("キャストが見つかりません: " + request.getCastId());
+      throw new NotFoundException("キャストが見つかりません: " + request.getCastId());
     }
     order.assignCast(request.getCastId());
     validateReceptionist(request.getReceptionistId());
@@ -79,7 +80,7 @@ public class OrderService {
   @Transactional
   public OrderResponse update(String id, OrderUpdateRequest request) {
     Order order =
-        orderRepository.findById(id).orElseThrow(() -> new ServiceException("注文が見つかりません: " + id));
+        orderRepository.findById(id).orElseThrow(() -> new NotFoundException("注文が見つかりません: " + id));
 
     // 非nullフィールドのみをドメインの部分更新コマンドとして適用
     order.apply(orderMapper.toPatch(request));
@@ -88,7 +89,7 @@ public class OrderService {
     validateReceptionist(request.getReceptionistId());
     order.assignReceptionist(request.getReceptionistId());
     if (!castRepository.existsById(request.getCastId())) {
-      throw new ServiceException("キャストが見つかりません: " + request.getCastId());
+      throw new NotFoundException("キャストが見つかりません: " + request.getCastId());
     }
     order.assignCast(request.getCastId());
 
@@ -105,7 +106,7 @@ public class OrderService {
     return orderRepository
         .findViewById(id)
         .map(orderMapper::toResponse)
-        .orElseThrow(() -> new ServiceException("注文が見つかりません: " + id));
+        .orElseThrow(() -> new NotFoundException("注文が見つかりません: " + id));
   }
 
   private OrderStatus parseStatus(String raw) {
@@ -123,7 +124,7 @@ public class OrderService {
     platformUserRepository
         .findById(receptionistId)
         .filter(user -> isEligibleReceptionist(user, storeId, orderManageRoleIds))
-        .orElseThrow(() -> new ServiceException("受付担当者が見つかりません: " + receptionistId));
+        .orElseThrow(() -> new NotFoundException("受付担当者が見つかりません: " + receptionistId));
   }
 
   /**
@@ -168,7 +169,7 @@ public class OrderService {
   @Transactional
   public void delete(String id) {
     if (!orderRepository.existsById(id)) {
-      throw new ServiceException("注文が見つかりません: " + id);
+      throw new NotFoundException("注文が見つかりません: " + id);
     }
     orderRepository.deleteById(id);
   }
@@ -176,7 +177,7 @@ public class OrderService {
   private void handleCustomerLinking(OrderCreateRequest req, Order order) {
     if (req.getCustomerId() != null && !req.getCustomerId().isEmpty()) {
       if (!customerRepository.existsById(req.getCustomerId())) {
-        throw new ServiceException("顧客が見つかりません: " + req.getCustomerId());
+        throw new NotFoundException("顧客が見つかりません: " + req.getCustomerId());
       }
       order.linkCustomer(req.getCustomerId());
     } else if (req.getPhoneNumber() != null && !req.getPhoneNumber().isEmpty()) {

--- a/backend/src/main/java/com/kizuna/settings/application/SystemConfigServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/settings/application/SystemConfigServiceImpl.java
@@ -5,6 +5,7 @@ import com.kizuna.settings.api.dto.SystemConfigResponse;
 import com.kizuna.settings.api.dto.SystemConfigUpdateRequest;
 import com.kizuna.settings.domain.SystemConfig;
 import com.kizuna.settings.domain.SystemConfigRepository;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import java.util.List;
 import java.util.Optional;
@@ -46,7 +47,7 @@ public class SystemConfigServiceImpl implements SystemConfigService {
     SystemConfig config =
         systemConfigRepository
             .findByConfigKey(request.getConfigKey())
-            .orElseThrow(() -> new ServiceException("設定キーが見つかりません: " + request.getConfigKey()));
+            .orElseThrow(() -> new NotFoundException("設定キーが見つかりません: " + request.getConfigKey()));
 
     validateValue(config, request.getConfigValue());
     systemConfigMapper.updateEntityFromRequest(request, config);

--- a/backend/src/main/java/com/kizuna/shared/exception/CommonExceptionHandler.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/CommonExceptionHandler.java
@@ -159,6 +159,15 @@ public class CommonExceptionHandler {
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
   }
 
+  /** 記録は error 級。到達すれば不変量が壊れており、通常のセッション期限切れに紛れて調査されないことを防ぐ。 */
+  @ExceptionHandler(StaleSessionException.class)
+  public ResponseEntity<Map<String, Object>> handle(StaleSessionException ex) {
+    log.error(ex.getMessage());
+    Map<String, Object> body = new HashMap<>();
+    body.put("error", "セッションが無効です。再度ログインしてください");
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+  }
+
   @ExceptionHandler(ServiceUnavailableException.class)
   public ResponseEntity<Map<String, Object>> handle(ServiceUnavailableException ex) {
     log.warn(ex.getMessage());

--- a/backend/src/main/java/com/kizuna/shared/exception/CommonExceptionHandler.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/CommonExceptionHandler.java
@@ -1,11 +1,15 @@
 package com.kizuna.shared.exception;
 
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -15,7 +19,9 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
+import tools.jackson.databind.DatabindException;
 
 @Slf4j
 @ControllerAdvice
@@ -54,13 +60,71 @@ public class CommonExceptionHandler {
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
   }
 
-  /** 必須クエリ／リクエストパラメータの欠落を、既定の 500 でなくクライアント誤りとして 400 へ映射する。 */
+  /**
+   * 必須クエリ／リクエストパラメータの欠落を、既定の 500 でなくクライアント誤りとして 400 へ映射する。
+   *
+   * <p>{@code error} は利用者向けの固定文言、{@code details} は開発者向けにどのフィールドが原因かを示す。 フィールド名は API
+   * 契約の一部なので露出してよいが、フレームワークの生 message は Java の型名や内部構造を含むため転送しない。
+   */
   @ExceptionHandler(MissingServletRequestParameterException.class)
   public ResponseEntity<Map<String, Object>> handle(MissingServletRequestParameterException ex) {
     log.warn(ex.getMessage());
     Map<String, Object> body = new HashMap<>();
-    body.put("error", ex.getMessage());
+    body.put("error", "必須パラメータが不足しています");
+    Map<String, String> details = new HashMap<>();
+    details.put(ex.getParameterName(), "必須です");
+    body.put("details", details);
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+  }
+
+  /** パスやクエリの値が宣言された型に変換できない（{@code /roles/abc} 等）ことを、クライアント誤りとして 400 へ映射する。 */
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<Map<String, Object>> handle(MethodArgumentTypeMismatchException ex) {
+    log.warn(ex.getMessage());
+    Map<String, Object> body = new HashMap<>();
+    body.put("error", "リクエストの形式が正しくありません");
+    Map<String, String> details = new HashMap<>();
+    details.put(ex.getName(), "値の形式が正しくありません");
+    body.put("details", details);
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+  }
+
+  /**
+   * 要求本文を解釈できない（壊れた JSON、列挙に無い値など）ことを、クライアント誤りとして 400 へ映射する。
+   *
+   * <p>原因が値の不一致であればワイヤ上のフィールド名を {@code details} に載せる。構文自体が壊れている場合は対象フィールドが 存在しないため {@code details}
+   * を省く。
+   */
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<Map<String, Object>> handle(HttpMessageNotReadableException ex) {
+    log.warn(ex.getMessage());
+    Map<String, Object> body = new HashMap<>();
+    body.put("error", "リクエストの形式が正しくありません");
+    String field = wireFieldOf(ex);
+    if (field != null) {
+      Map<String, String> details = new HashMap<>();
+      details.put(field, "値の形式が正しくありません");
+      body.put("details", details);
+    }
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+  }
+
+  /**
+   * 解釈失敗の原因からワイヤ上のフィールド名を取り出す。取り出せなければ {@code null}。
+   *
+   * <p>{@link DatabindException#getPath()} は Jackson の命名戦略適用後の名前（本アプリでは snake_case）を返すため、 そのまま
+   * {@code details} のキーに使える。配列添字の要素は名前を持たないので除く。
+   */
+  private static String wireFieldOf(HttpMessageNotReadableException ex) {
+    if (!(ex.getCause() instanceof DatabindException cause)) {
+      return null;
+    }
+    String path =
+        cause.getPath().stream()
+            .map(DatabindException.Reference::getPropertyName)
+            .filter(Objects::nonNull)
+            .collect(Collectors.joining("."));
+    return path.isEmpty() ? null : path;
   }
 
   @ExceptionHandler(AccessDeniedException.class)
@@ -85,6 +149,45 @@ public class CommonExceptionHandler {
     Map<String, Object> body = new HashMap<>();
     body.put("error", ex.getMessage());
     return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+  }
+
+  @ExceptionHandler(NotFoundException.class)
+  public ResponseEntity<Map<String, Object>> handle(NotFoundException ex) {
+    log.warn(ex.getMessage());
+    Map<String, Object> body = new HashMap<>();
+    body.put("error", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+  }
+
+  @ExceptionHandler(ServiceUnavailableException.class)
+  public ResponseEntity<Map<String, Object>> handle(ServiceUnavailableException ex) {
+    log.warn(ex.getMessage());
+    Map<String, Object> body = new HashMap<>();
+    body.put("error", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(body);
+  }
+
+  /**
+   * 一意制約違反<b>だけ</b>を 409 の兜底として受ける。検査してから書く経路が競合に敗れた場合の最後の一枚で、 業務上の重複判定そのものをここへ委ねてはならない。
+   *
+   * <p>他の整合性違反（FK・NOT NULL・CHECK）は利用者が是正できる誤りではなく実装の欠陥なので、 409 に化けさせず catch-all の 500
+   * のまま大きく失敗させる。ここで一括して 409 にすると、 呼出側に「やり直せば直る」と誤って伝わり、欠陥が運用に埋もれる。
+   */
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ResponseEntity<Map<String, Object>> handle(DataIntegrityViolationException ex) {
+    if (!isUniqueViolation(ex)) {
+      return handle((Exception) ex);
+    }
+    log.warn(ex.getMessage());
+    Map<String, Object> body = new HashMap<>();
+    body.put("error", "既に登録されている値と重複しています");
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+  }
+
+  /** SQLSTATE 23505（unique_violation）で判定する。制約名の字面照合と違い、命名規約の変更に影響されない。 */
+  private static boolean isUniqueViolation(DataIntegrityViolationException ex) {
+    return ex.getMostSpecificCause() instanceof SQLException cause
+        && "23505".equals(cause.getSQLState());
   }
 
   /** JPA @Version の楽観ロック競合（並行トランザクションの敗者）を 500 でなく 409 へ映射する。 */

--- a/backend/src/main/java/com/kizuna/shared/exception/ConflictException.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/ConflictException.java
@@ -1,10 +1,6 @@
 package com.kizuna.shared.exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-/** 並行更新の競合（楽観ロック・バージョン不一致）を表す例外基底。HTTP 409 で応答される。 */
-@ResponseStatus(HttpStatus.CONFLICT)
+/** 並行更新の競合（楽観ロック・バージョン不一致）を表す例外基底。status への写像は {@link CommonExceptionHandler} が一手に持つ。 */
 public class ConflictException extends RuntimeException {
 
   public ConflictException(String message) {

--- a/backend/src/main/java/com/kizuna/shared/exception/NotFoundException.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/NotFoundException.java
@@ -1,0 +1,23 @@
+package com.kizuna.shared.exception;
+
+/**
+ * 指名された業務資源が見つからないことを表す例外基底。HTTP 404 で応答される。
+ *
+ * <p>「見つからない」に 404 を割り当てる境界は、<b>呼出側が何を指名したか</b>で決まる。
+ *
+ * <ul>
+ *   <li><b>行の id を指名した</b>場合は本例外（404）。その行が他店舗に存在するか否かは呼出側が知ってよい情報ではなく、404
+ *       は「本当に存在しない」と区別がつかないため漏洩しない。加えて {@code storeFilter} 有効時のサービスは他店舗の行の存在を そもそも判定できず、403
+ *       を返すには作用域を外した問い合わせを別途行う必要がある — それは濾過機構に穴を開けることになるため採らない。
+ *   <li><b>店舗を指名した</b>（{@code X-Store-ID}）場合は 403。店舗は公開ドメインを持ち存在自体が秘匿対象ではないため、 授権の有無をそのまま答えてよい。
+ * </ul>
+ *
+ * <p>授権判定の一部として実在性を確かめる経路（{@link com.kizuna.shared.storescope.StoreScopeExecutor}）は本例外を使わない。 そこで
+ * 404 を返すと、403（授権なし）との対比で「どの店舗 id が実在するか」が判別可能になるため。
+ */
+public class NotFoundException extends RuntimeException {
+
+  public NotFoundException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/com/kizuna/shared/exception/ServiceException.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/ServiceException.java
@@ -1,13 +1,8 @@
 package com.kizuna.shared.exception;
 
 import lombok.NoArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
 
-/**
- * @author kanghouchao
- */
-@ResponseStatus(HttpStatus.BAD_REQUEST)
+/** 利用者が是正しうる要求誤りを表す例外基底。status への写像は {@link CommonExceptionHandler} が一手に持つ。 */
 @NoArgsConstructor
 public class ServiceException extends RuntimeException {
 

--- a/backend/src/main/java/com/kizuna/shared/exception/ServiceUnavailableException.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/ServiceUnavailableException.java
@@ -1,0 +1,9 @@
+package com.kizuna.shared.exception;
+
+/** 一時的に要求を受け付けられないことを表す例外。HTTP 503 で応答される。 */
+public class ServiceUnavailableException extends RuntimeException {
+
+  public ServiceUnavailableException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/com/kizuna/shared/exception/StaleSessionException.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/StaleSessionException.java
@@ -1,0 +1,17 @@
+package com.kizuna.shared.exception;
+
+/**
+ * 認証セッション（AuthSession）が指す主体が既に存在しないことを表す例外。HTTP 401 で応答される。
+ *
+ * <p>トークン自体は有効期限内で署名も正しいが、それが指す利用者の行が引けない状態を指す。要求の誤りではないので 400 ではなく、要求された資源（{@code /platform/me}
+ * 等）は概念上存在するので 404 でもない — 無効なのはセッションであり、正しい回復手段は再ログインである。
+ *
+ * <p>現状この状態はアプリケーションの操作からは到達しない（利用者行の削除経路が無く、停止は {@code enabled=false} で行を残す）。
+ * 到達した場合は不変量が壊れているため、応答は 401 でも記録は {@code log.error} とし、通常のセッション期限切れに紛れて調査されないことを防ぐ。
+ */
+public class StaleSessionException extends RuntimeException {
+
+  public StaleSessionException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/com/kizuna/shared/storescope/StoreIdInterceptor.java
+++ b/backend/src/main/java/com/kizuna/shared/storescope/StoreIdInterceptor.java
@@ -1,5 +1,6 @@
 package com.kizuna.shared.storescope;
 
+import com.kizuna.shared.exception.ServiceException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -14,6 +16,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+/**
+ * 拒否は例外送出で表明し、応答の成形は {@link com.kizuna.shared.exception.CommonExceptionHandler} へ委ねる — ここでは
+ * response へ直接書かない。同じ status を返す経路が複数のワイヤ形を持つと、呼出側が応答体の形を一つに決められなくなるため。
+ */
 @Log4j2
 @Component
 @AllArgsConstructor
@@ -51,18 +57,15 @@ public class StoreIdInterceptor implements HandlerInterceptor {
         // 店舗ヘッダを名乗るのは詐称として 403 で拒否する。授権スコープ検証より前に弾き、
         // isAuthenticated() のみの端点（/files/upload 等）への店舗文脈確立の漏れを塞ぐ。
         if (!Boolean.TRUE.equals(claims.getClaimAsBoolean(CLAIM_STORE_BRIDGE))) {
-          response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-          return false;
+          throw new AccessDeniedException("店舗コンソールの権限がありません");
         }
         Long headerValue = tryParseStoreId(request.getHeader(HEADER_STORE_ID));
         if (headerValue == null) {
           // 全桁数字だが long 範囲外。
-          response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-          return false;
+          throw new ServiceException("店舗 ID の形式が正しくありません");
         }
         if (!scope.authorizes(headerValue)) {
-          response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-          return false;
+          throw new AccessDeniedException("この店舗の権限がありません");
         }
         this.storeContext.setStoreId(headerValue);
         return true;
@@ -73,8 +76,7 @@ public class StoreIdInterceptor implements HandlerInterceptor {
       // ヘッダで店舗を名乗る主張は詐称として 403 で拒否する。詐称ヘッダが無ければ下の
       // @StoreOptional 判定に委ね、プラットフォームの正当な素通り（例: /files/upload の platform 保存）を保つ。
       if (claimsStoreHeaderPresent) {
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-        return false;
+        throw new AccessDeniedException("店舗文脈を名乗る権限がありません");
       }
     } else if (claimsStoreHeaderPresent
         && StringUtils.isNumeric(request.getHeader(HEADER_STORE_ID))) {
@@ -82,8 +84,7 @@ public class StoreIdInterceptor implements HandlerInterceptor {
       Long headerValue = tryParseStoreId(request.getHeader(HEADER_STORE_ID));
       if (headerValue == null) {
         // 全桁数字だが long 範囲外。
-        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-        return false;
+        throw new ServiceException("店舗 ID の形式が正しくありません");
       }
       this.storeContext.setStoreId(headerValue);
       return true;
@@ -95,8 +96,7 @@ public class StoreIdInterceptor implements HandlerInterceptor {
         && handlerMethod.hasMethodAnnotation(StoreOptional.class)) {
       return true;
     }
-    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-    return false;
+    throw new AccessDeniedException("店舗文脈が解決できません");
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/shared/storescope/StoreScopeExecutor.java
+++ b/backend/src/main/java/com/kizuna/shared/storescope/StoreScopeExecutor.java
@@ -18,6 +18,10 @@ import org.springframework.stereotype.Component;
  * で解決した授権集合で検証し、解決不能または 授権外なら fail-closed（{@link AccessDeniedException} → 403）で拒否する。授権通過後、{@link
  * StoreExistenceCheck} で実在性を 検証し、実在しなければ {@link ServiceException}（400 — 制約違反が 500 に逃げるのは
  * bug）で拒否する。検証通過後に {@link StoreContext} へ storeId を 設定し、try/finally で必ず消す。
+ *
+ * <p>この実在性違反を {@link com.kizuna.shared.exception.NotFoundException}（404）にしてはならない。 直前の授権判定が 403
+ * を返すため、404 と対比させると「授権外だが実在する店舗」と「実在しない店舗」が 呼出側から判別可能になり、平台に存在する店舗 id が漏れる。行の id を指名した照会（404）とは異なり、
+ * ここは授権判定の一部であり、応答は授権の有無以上を語ってはならない。
  */
 @Component
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/kizuna/shift/application/CastScheduleService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/CastScheduleService.java
@@ -2,6 +2,7 @@ package com.kizuna.shift.application;
 
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.StaleSessionException;
 import com.kizuna.shift.api.dto.CastScheduleResponse;
 import com.kizuna.shift.api.dto.ShiftMapper;
 import com.kizuna.shift.domain.ShiftRepository;
@@ -38,7 +39,7 @@ public class CastScheduleService {
     Long userId =
         platformUserRepository
             .findByEmail(email)
-            .orElseThrow(() -> new ServiceException("ユーザーが見つかりません"))
+            .orElseThrow(() -> new StaleSessionException("認証セッションの主体が存在しません"))
             .getId();
     List<String> castIds = castRepository.findIdsByPlatformUserId(userId);
     if (castIds.isEmpty()) {

--- a/backend/src/main/java/com/kizuna/shift/application/CastShiftRequestService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/CastShiftRequestService.java
@@ -3,6 +3,7 @@ package com.kizuna.shift.application;
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.config.AppProperties;
 import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.StaleSessionException;
 import com.kizuna.shift.api.dto.CastShiftRequestResponse;
 import com.kizuna.shift.api.dto.ShiftRequestCreateRequest;
 import com.kizuna.shift.api.dto.ShiftRequestMapper;
@@ -78,7 +79,7 @@ public class CastShiftRequestService {
   private Long resolveUserId(String email) {
     return platformUserRepository
         .findByEmail(email)
-        .orElseThrow(() -> new ServiceException("ユーザーが見つかりません"))
+        .orElseThrow(() -> new StaleSessionException("認証セッションの主体が存在しません"))
         .getId();
   }
 }

--- a/backend/src/main/java/com/kizuna/shift/application/ShiftRequestService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ShiftRequestService.java
@@ -1,5 +1,6 @@
 package com.kizuna.shift.application;
 
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreScoped;
 import com.kizuna.shift.api.dto.ShiftRequestMapper;
@@ -68,7 +69,7 @@ public class ShiftRequestService {
   private ShiftRequest findOwnRequest(String id) {
     return shiftRequestRepository
         .findById(id)
-        .orElseThrow(() -> new ServiceException("出勤希望が見つかりません: " + id));
+        .orElseThrow(() -> new NotFoundException("出勤希望が見つかりません: " + id));
   }
 
   private ShiftRequestStatus parseStatus(String status) {

--- a/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
@@ -4,6 +4,7 @@ import com.kizuna.cast.application.CastService;
 import com.kizuna.cast.domain.Cast;
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.config.AppProperties;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreScoped;
 import com.kizuna.shift.api.dto.PublicShiftResponse;
@@ -87,7 +88,7 @@ public class ShiftService {
     }
     validateStatus(request.getStatus());
     if (!castService.existsForCurrentStore(request.getCastId())) {
-      throw new ServiceException("キャストが見つかりません: " + request.getCastId());
+      throw new NotFoundException("キャストが見つかりません: " + request.getCastId());
     }
 
     // store_id は StoreScopeStampListener が @PrePersist で採番する
@@ -99,11 +100,11 @@ public class ShiftService {
   @Transactional
   public ShiftResponse update(String id, ShiftUpdateRequest request) {
     Shift shift =
-        shiftRepository.findById(id).orElseThrow(() -> new ServiceException("シフトが見つかりません: " + id));
+        shiftRepository.findById(id).orElseThrow(() -> new NotFoundException("シフトが見つかりません: " + id));
 
     validateStatus(request.getStatus());
     if (request.getCastId() != null && !castService.existsForCurrentStore(request.getCastId())) {
-      throw new ServiceException("キャストが見つかりません: " + request.getCastId());
+      throw new NotFoundException("キャストが見つかりません: " + request.getCastId());
     }
 
     // 部分更新のマージ結果（実効の開始・終了）で判定する。片方だけ来て既存値と一致する穴を塞ぐ。
@@ -124,7 +125,7 @@ public class ShiftService {
   @Transactional
   public void delete(String id) {
     if (!shiftRepository.existsById(id)) {
-      throw new ServiceException("シフトが見つかりません: " + id);
+      throw new NotFoundException("シフトが見つかりません: " + id);
     }
     shiftRepository.deleteById(id);
   }

--- a/backend/src/main/java/com/kizuna/store/api/platform/PlatformStoreController.java
+++ b/backend/src/main/java/com/kizuna/store/api/platform/PlatformStoreController.java
@@ -63,10 +63,7 @@ public class PlatformStoreController {
   @GetMapping("/{id}")
   @PreAuthorize("hasAuthority('PERM_STORE_MANAGE')")
   public ResponseEntity<StoreVO> getById(@PathVariable String id) {
-    return storeRegistryService
-        .getById(id)
-        .map(ResponseEntity::ok)
-        .orElseGet(() -> ResponseEntity.notFound().build());
+    return ResponseEntity.ok(storeRegistryService.getById(id));
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/store/application/StoreRegistryService.java
+++ b/backend/src/main/java/com/kizuna/store/application/StoreRegistryService.java
@@ -1,5 +1,6 @@
 package com.kizuna.store.application;
 
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.store.api.dto.StoreCreateDTO;
 import com.kizuna.store.api.dto.StoreStatusVO;
@@ -36,8 +37,8 @@ public class StoreRegistryService {
   }
 
   @Transactional(readOnly = true)
-  public Optional<StoreVO> getById(String id) {
-    return storeRepository.findById(parseId(id)).map(this::toDto);
+  public StoreVO getById(String id) {
+    return storeRepository.findById(parseId(id)).map(this::toDto).orElseThrow(() -> notFound(id));
   }
 
   @Transactional(readOnly = true)
@@ -49,8 +50,16 @@ public class StoreRegistryService {
     return storeRepository.findByDomain(domain).map(this::toDto);
   }
 
+  /**
+   * 新規登録する。
+   *
+   * <p>ドメインの重複は、制約違反を捕まえるのではなく事前に照会して判定する — 一意制約はここを擦り抜けた競合を受け止める 最後の一枚（409）であり、業務上の重複判定を委ねる先ではない。
+   */
   @Transactional
   public void create(StoreCreateDTO req) {
+    if (storeRepository.findByDomain(req.getDomain()).isPresent()) {
+      throw new ServiceException("このドメインは既に登録されています");
+    }
     Store t = new Store();
     t.setName(req.getName());
     t.setDomain(req.getDomain());
@@ -61,8 +70,7 @@ public class StoreRegistryService {
 
   @Transactional
   public void update(String id, StoreUpdateDTO req) {
-    var store =
-        storeRepository.findById(parseId(id)).orElseThrow(() -> new ServiceException("店舗が見つかりません"));
+    var store = storeRepository.findById(parseId(id)).orElseThrow(() -> notFound(id));
     store.setName(req.getName());
     storeRepository.save(store);
   }
@@ -76,6 +84,10 @@ public class StoreRegistryService {
   @Transactional(readOnly = true)
   public StoreStatusVO stats() {
     return new StoreStatusVO(storeRepository.count());
+  }
+
+  private static NotFoundException notFound(String id) {
+    return new NotFoundException("店舗が見つかりません: " + id);
   }
 
   private Long parseId(String id) {

--- a/backend/src/main/java/com/kizuna/store/infrastructure/MaintenanceModeInterceptor.java
+++ b/backend/src/main/java/com/kizuna/store/infrastructure/MaintenanceModeInterceptor.java
@@ -1,16 +1,20 @@
 package com.kizuna.store.infrastructure;
 
 import com.kizuna.settings.application.SystemConfigService;
+import com.kizuna.shared.exception.ServiceUnavailableException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-/** メンテナンスモード中に店舗向けリクエストを 503 で拒否するインターセプタ。 */
+/**
+ * メンテナンスモード中に店舗向けリクエストを 503 で拒否するインターセプタ。
+ *
+ * <p>応答の成形は {@link ServiceUnavailableException} を送出して {@link
+ * com.kizuna.shared.exception.CommonExceptionHandler} へ委ね、ここでは response へ直接書かない。
+ */
 @Component
 @RequiredArgsConstructor
 public class MaintenanceModeInterceptor implements HandlerInterceptor {
@@ -33,10 +37,6 @@ public class MaintenanceModeInterceptor implements HandlerInterceptor {
     if (!maintenance) {
       return true;
     }
-    response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
-    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-    response.getWriter().write("{\"error\":\"メンテナンス中です。しばらくしてから再度お試しください\"}");
-    return false;
+    throw new ServiceUnavailableException("メンテナンス中です。しばらくしてから再度お試しください");
   }
 }

--- a/backend/src/main/java/com/kizuna/store/infrastructure/StoreExistenceInterceptor.java
+++ b/backend/src/main/java/com/kizuna/store/infrastructure/StoreExistenceInterceptor.java
@@ -1,13 +1,12 @@
 package com.kizuna.store.infrastructure;
 
+import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.shared.storescope.StoreExistenceCheck;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -19,8 +18,9 @@ import org.springframework.web.servlet.HandlerInterceptor;
  * com.kizuna.shared.storescope.StoreScopeExecutor} と同一の判定経路にする。
  *
  * <p>JWT の授権店舗集合は次回ログインまで陳旧化しうるため、存在しない storeId が文脈に載ることがある。純 FK 兜底だと制約違反が 500 に逃げてしまうため、 本インターセプタが
- * 400 の保証点となり、{@link com.kizuna.shared.exception.CommonExceptionHandler} と同じ {@code error} キーの JSON
- * ボディを返す（同一パッケージの {@code MaintenanceModeInterceptor} の先例に倣う）。
+ * 400 の保証点となる。応答の成形は {@link ServiceException} を送出して {@link
+ * com.kizuna.shared.exception.CommonExceptionHandler} へ委ね、ここでは response へ直接書かない — 同じ status
+ * を返す経路が複数のワイヤ形を持つと、 呼出側が応答体の形を一つに決められなくなるため。
  *
  * <p>店舗文脈が無い（{@code @StoreOptional} の素通り）場合は検証対象外として許可する。
  */
@@ -38,11 +38,7 @@ public class StoreExistenceInterceptor implements HandlerInterceptor {
       @NonNull Object handler)
       throws Exception {
     if (storeContext.hasStoreId() && !storeExistenceCheck.exists(storeContext.getStoreId())) {
-      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-      response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-      response.getWriter().write("{\"error\":\"店舗が見つかりません\"}");
-      return false;
+      throw new ServiceException("店舗が見つかりません");
     }
     return true;
   }

--- a/backend/src/main/java/com/kizuna/storeprofile/application/StoreProfileService.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/application/StoreProfileService.java
@@ -1,6 +1,6 @@
 package com.kizuna.storeprofile.application;
 
-import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.shared.storescope.StoreScoped;
 import com.kizuna.storeprofile.api.dto.StoreProfileMapper;
@@ -27,7 +27,7 @@ public class StoreProfileService {
     StoreProfile config =
         storeProfileRepository
             .findByStoreId(storeId)
-            .orElseThrow(() -> new ServiceException("店舗設定が見つかりません"));
+            .orElseThrow(() -> new NotFoundException("店舗設定が見つかりません"));
     return storeProfileMapper.toResponse(config);
   }
 
@@ -38,7 +38,7 @@ public class StoreProfileService {
     StoreProfile config =
         storeProfileRepository
             .findByStoreId(storeId)
-            .orElseThrow(() -> new ServiceException("店舗設定が見つかりません"));
+            .orElseThrow(() -> new NotFoundException("店舗設定が見つかりません"));
     storeProfileMapper.updateEntityFromRequest(request, config);
     return storeProfileMapper.toResponse(storeProfileRepository.saveAndFlush(config));
   }

--- a/backend/src/main/java/com/kizuna/user/api/platform/PlatformStaffController.java
+++ b/backend/src/main/java/com/kizuna/user/api/platform/PlatformStaffController.java
@@ -44,10 +44,7 @@ public class PlatformStaffController {
   @GetMapping("/{id}")
   @PreAuthorize("hasAuthority('PERM_STAFF_MANAGE')")
   public ResponseEntity<PlatformStaffResponse> get(@PathVariable Long id) {
-    return platformStaffService
-        .get(id)
-        .map(ResponseEntity::ok)
-        .orElseGet(() -> ResponseEntity.notFound().build());
+    return ResponseEntity.ok(platformStaffService.get(id));
   }
 
   @PostMapping
@@ -63,9 +60,6 @@ public class PlatformStaffController {
       @PathVariable Long id,
       @Valid @RequestBody PlatformStaffUpdateRequest req,
       Principal principal) {
-    return platformStaffService
-        .update(id, req, principal.getName())
-        .map(ResponseEntity::ok)
-        .orElseGet(() -> ResponseEntity.notFound().build());
+    return ResponseEntity.ok(platformStaffService.update(id, req, principal.getName()));
   }
 }

--- a/backend/src/main/java/com/kizuna/user/api/platform/RoleController.java
+++ b/backend/src/main/java/com/kizuna/user/api/platform/RoleController.java
@@ -42,17 +42,13 @@ public class RoleController {
   @PreAuthorize("hasAuthority('PERM_STAFF_MANAGE')")
   public ResponseEntity<RoleResponse> update(
       @PathVariable Long id, @Valid @RequestBody RoleUpdateRequest req) {
-    return roleService
-        .update(id, req)
-        .map(ResponseEntity::ok)
-        .orElseGet(() -> ResponseEntity.notFound().build());
+    return ResponseEntity.ok(roleService.update(id, req));
   }
 
   @DeleteMapping("/{id}")
   @PreAuthorize("hasAuthority('PERM_STAFF_MANAGE')")
   public ResponseEntity<Void> delete(@PathVariable Long id) {
-    return roleService.delete(id)
-        ? ResponseEntity.noContent().build()
-        : ResponseEntity.notFound().build();
+    roleService.delete(id);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
+++ b/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
@@ -1,5 +1,6 @@
 package com.kizuna.user.application;
 
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.api.dto.PlatformStaffCreateRequest;
 import com.kizuna.user.api.dto.PlatformStaffResponse;
@@ -22,7 +23,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -119,59 +119,59 @@ public class PlatformStaffService {
     return toResponse(save(user), roleNames);
   }
 
-  /**
-   * 1 件取得。編集中に競合（409）が起きたとき、一覧の現在ページに対象が居なくても最新の版を取り直せるようにするための経路。
-   *
-   * <p>対象の本人種別がスタッフ以外（CAST/MEMBER）なら不可視として空を返す（list/update と同じ扱い）。
-   */
+  /** 1 件取得。編集中に競合（409）が起きたとき、一覧の現在ページに対象が居なくても最新の版を取り直せるようにするための経路。 */
   @Transactional(readOnly = true)
-  public Optional<PlatformStaffResponse> get(Long id) {
-    return repository
-        .findById(id)
-        .filter(user -> user.getUserType() == UserType.STAFF)
-        .map(user -> toResponse(user, roleNamesOf(user.getRoleIds())));
+  public PlatformStaffResponse get(Long id) {
+    PlatformUser user = requireStaff(id);
+    return toResponse(user, roleNamesOf(user.getRoleIds()));
   }
 
   @Transactional
-  public Optional<PlatformStaffResponse> update(
-      Long id, PlatformStaffUpdateRequest req, String actorEmail) {
+  public PlatformStaffResponse update(Long id, PlatformStaffUpdateRequest req, String actorEmail) {
     Map<Long, String> roleNames = requireRoles(req.getRoleIds());
+    PlatformUser user = requireStaff(id);
+    // 陳腐化した編集フォームの提出は JPA の @Version では捕まらない（再読込後の正当な更新に見える）
+    // ため、応答で往復させた version を明示比対して 409 で拒否する。
+    if (!user.getVersion().equals(req.getVersion())) {
+      throw new StaleStaffUpdateException("他の管理者が更新しました。最新の内容を確認してください");
+    }
+    // 自分自身を停止すると自らのセッションも即時失効し、以後の操作ができなくなる（サポート経路がない自己ロックアウト）ため拒否する。
+    if (Boolean.FALSE.equals(req.getEnabled()) && user.getEmail().equals(actorEmail)) {
+      throw new SelfStopNotAllowedException("自分自身を停止することはできません");
+    }
+    user.reassignGrants(req.getRoleIds(), req.getStoreScopeType(), req.getStoreIds());
+    // enabled の遷移（null=現状維持）。停止は行を残し、過去の実行主体の記録を保持する。
+    if (Boolean.FALSE.equals(req.getEnabled()) && user.getEnabled()) {
+      user.stop();
+    }
+    if (Boolean.TRUE.equals(req.getEnabled()) && !user.getEnabled()) {
+      user.resume();
+    }
+    // 失効の即時反映は「本リクエストが停止/再開を明示的に要求したか」で判定する（現在状態との差分ではない）。
+    // AFTER_COMMIT の Redis 書き込みが失敗して 500 になっても、最新 version を取り直して同じ停止要求を
+    // 再送すれば失効が書き直されるようにするための冪等化（差分語義だと再送時には既に enabled=false の
+    // ためイベントが発行されず、resume→stop 以外に復旧手段が無くなる）。version は楽観ロックで
+    // commit 済みの更新ぶん進んでいるため、再送には GET の取り直しが要る点に注意。
+    if (Boolean.FALSE.equals(req.getEnabled())) {
+      eventPublisher.publishEvent(new PlatformUserStopped(user.getEmail()));
+    }
+    if (Boolean.TRUE.equals(req.getEnabled())) {
+      eventPublisher.publishEvent(new PlatformUserResumed(user.getEmail()));
+    }
+    return toResponse(save(user), roleNames);
+  }
+
+  /**
+   * スタッフ管理の対象行を取り出す。
+   *
+   * <p>本人種別がスタッフ以外（CAST/MEMBER）の行は、存在しても本 API の対象外として「見つからない」に倒す（list/create と同じ扱い）。 種別違いと不在を呼出側から
+   * 区別できないようにするため、両者は同一の応答になる。
+   */
+  private PlatformUser requireStaff(Long id) {
     return repository
         .findById(id)
-        // 対象の本人種別がスタッフ以外（CAST/MEMBER）なら不可視として空を返す（list/create と同じ扱い）。
         .filter(user -> user.getUserType() == UserType.STAFF)
-        .map(
-            user -> {
-              // 陳腐化した編集フォームの提出は JPA の @Version では捕まらない（再読込後の正当な更新に見える）
-              // ため、応答で往復させた version を明示比対して 409 で拒否する。
-              if (!user.getVersion().equals(req.getVersion())) {
-                throw new StaleStaffUpdateException("他の管理者が更新しました。最新の内容を確認してください");
-              }
-              // 自分自身を停止すると自らのセッションも即時失効し、以後の操作ができなくなる（サポート経路がない自己ロックアウト）ため拒否する。
-              if (Boolean.FALSE.equals(req.getEnabled()) && user.getEmail().equals(actorEmail)) {
-                throw new SelfStopNotAllowedException("自分自身を停止することはできません");
-              }
-              user.reassignGrants(req.getRoleIds(), req.getStoreScopeType(), req.getStoreIds());
-              // enabled の遷移（null=現状維持）。停止は行を残し、過去の実行主体の記録を保持する。
-              if (Boolean.FALSE.equals(req.getEnabled()) && user.getEnabled()) {
-                user.stop();
-              }
-              if (Boolean.TRUE.equals(req.getEnabled()) && !user.getEnabled()) {
-                user.resume();
-              }
-              // 失効の即時反映は「本リクエストが停止/再開を明示的に要求したか」で判定する（現在状態との差分ではない）。
-              // AFTER_COMMIT の Redis 書き込みが失敗して 500 になっても、最新 version を取り直して同じ停止要求を
-              // 再送すれば失効が書き直されるようにするための冪等化（差分語義だと再送時には既に enabled=false の
-              // ためイベントが発行されず、resume→stop 以外に復旧手段が無くなる）。version は楽観ロックで
-              // commit 済みの更新ぶん進んでいるため、再送には GET の取り直しが要る点に注意。
-              if (Boolean.FALSE.equals(req.getEnabled())) {
-                eventPublisher.publishEvent(new PlatformUserStopped(user.getEmail()));
-              }
-              if (Boolean.TRUE.equals(req.getEnabled())) {
-                eventPublisher.publishEvent(new PlatformUserResumed(user.getEmail()));
-              }
-              return toResponse(save(user), roleNames);
-            });
+        .orElseThrow(() -> new NotFoundException("スタッフが見つかりません: " + id));
   }
 
   /** 指定 id のロールが全て実在することを検証し、id→名称の対応を返す（応答組立にも使う）。 */

--- a/backend/src/main/java/com/kizuna/user/application/RoleService.java
+++ b/backend/src/main/java/com/kizuna/user/application/RoleService.java
@@ -1,5 +1,6 @@
 package com.kizuna.user.application;
 
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.api.dto.RoleCreateRequest;
 import com.kizuna.user.api.dto.RoleResponse;
@@ -14,7 +15,6 @@ import com.kizuna.user.domain.StaleRoleUpdateException;
 import com.kizuna.user.domain.SystemRoleImmutableException;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -63,31 +63,22 @@ public class RoleService {
   }
 
   @Transactional
-  public Optional<RoleResponse> update(Long id, RoleUpdateRequest req) {
+  public RoleResponse update(Long id, RoleUpdateRequest req) {
     Map<Long, String> codesById = requirePermissions(req.getPermissions());
-    return roleRepository
-        .findById(id)
-        .map(
-            role -> {
-              // 陳腐化した編集フォームの提出は JPA の @Version では捕まらない（再読込後の正当な更新に見える）
-              // ため、応答で往復させた version を明示比対して 409 で拒否する。
-              if (!role.getVersion().equals(req.getVersion())) {
-                throw new StaleRoleUpdateException("他の管理者が更新しました。最新の内容を確認してください");
-              }
-              role.rename(req.getName());
-              role.replacePermissions(codesById.keySet());
-              return toResponse(save(role), codesById);
-            });
+    Role role = roleRepository.findById(id).orElseThrow(() -> notFound(id));
+    // 陳腐化した編集フォームの提出は JPA の @Version では捕まらない（再読込後の正当な更新に見える）
+    // ため、応答で往復させた version を明示比対して 409 で拒否する。
+    if (!role.getVersion().equals(req.getVersion())) {
+      throw new StaleRoleUpdateException("他の管理者が更新しました。最新の内容を確認してください");
+    }
+    role.rename(req.getName());
+    role.replacePermissions(codesById.keySet());
+    return toResponse(save(role), codesById);
   }
 
-  /** 削除する。対象が存在しなければ false（呼び出し側が 404 にする）。 */
   @Transactional
-  public boolean delete(Long id) {
-    Optional<Role> found = roleRepository.findById(id);
-    if (found.isEmpty()) {
-      return false;
-    }
-    Role role = found.get();
+  public void delete(Long id) {
+    Role role = roleRepository.findById(id).orElseThrow(() -> notFound(id));
     if (Boolean.TRUE.equals(role.getSystemRole())) {
       throw new SystemRoleImmutableException("平台既定ロールは削除できません");
     }
@@ -102,7 +93,10 @@ public class RoleService {
     } catch (DataIntegrityViolationException ex) {
       throw new RoleInUseException("授与中のロールは削除できません");
     }
-    return true;
+  }
+
+  private static NotFoundException notFound(Long id) {
+    return new NotFoundException("ロールが見つかりません: " + id);
   }
 
   /** 指定コードが全て権限目録に実在することを検証し、id→コードの対応を返す（応答組立にも使う）。 */

--- a/backend/src/test/java/com/kizuna/auth/application/PlatformAuthServiceTest.java
+++ b/backend/src/test/java/com/kizuna/auth/application/PlatformAuthServiceTest.java
@@ -13,6 +13,7 @@ import com.kizuna.auth.api.dto.Token;
 import com.kizuna.auth.infrastructure.PlatformJwtIssuer;
 import com.kizuna.auth.infrastructure.PlatformUserDetails;
 import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.StaleSessionException;
 import com.kizuna.user.domain.Permission;
 import com.kizuna.user.domain.PermissionCode;
 import com.kizuna.user.domain.PermissionRepository;
@@ -348,11 +349,11 @@ class PlatformAuthServiceTest {
   }
 
   @Test
-  void updateMe_emailNotFound_throwsServiceException() {
+  void updateMe_emailNotFound_throwsStaleSession() {
     when(userRepository.findByEmail("missing@kizuna.test")).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> authService.updateMe("missing@kizuna.test", "新表示名"))
-        .isInstanceOf(ServiceException.class);
+        .isInstanceOf(StaleSessionException.class);
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/cast/application/CastFieldDefinitionServiceTest.java
+++ b/backend/src/test/java/com/kizuna/cast/application/CastFieldDefinitionServiceTest.java
@@ -14,6 +14,7 @@ import com.kizuna.cast.api.dto.CastFieldDefinitionUpdateRequest;
 import com.kizuna.cast.domain.CastFieldDefinition;
 import com.kizuna.cast.domain.CastFieldDefinitionPatch;
 import com.kizuna.cast.domain.CastFieldDefinitionRepository;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -153,7 +154,7 @@ class CastFieldDefinitionServiceTest {
     when(repository.findById("missing")).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> service.update("missing", new CastFieldDefinitionUpdateRequest()))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("見つかりません");
   }
 
@@ -171,7 +172,7 @@ class CastFieldDefinitionServiceTest {
     when(repository.existsById("missing")).thenReturn(false);
 
     assertThatThrownBy(() -> service.delete("missing"))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("見つかりません");
 
     verify(repository, never()).deleteById(any());

--- a/backend/src/test/java/com/kizuna/cast/application/CastInvitationServiceTest.java
+++ b/backend/src/test/java/com/kizuna/cast/application/CastInvitationServiceTest.java
@@ -15,7 +15,7 @@ import com.kizuna.cast.domain.CastInvitationRepository;
 import com.kizuna.cast.domain.CastInvitationStateException;
 import com.kizuna.cast.domain.CastInvitationStatus;
 import com.kizuna.cast.domain.CastRepository;
-import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.NotFoundException;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -74,7 +74,7 @@ class CastInvitationServiceTest {
     when(castRepository.findById("missing")).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> castInvitationService.issue("missing"))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("キャストが見つかりません");
     verify(castInvitationRepository, never()).saveAndFlush(any());
   }

--- a/backend/src/test/java/com/kizuna/cast/application/CastSelfServiceTest.java
+++ b/backend/src/test/java/com/kizuna/cast/application/CastSelfServiceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.cast.domain.CastStoreView;
-import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.StaleSessionException;
 import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
 import java.util.List;
@@ -47,8 +47,8 @@ class CastSelfServiceTest {
     when(platformUserRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> service.myStores(EMAIL))
-        .isInstanceOf(ServiceException.class)
-        .hasMessageContaining("ユーザーが見つかりません");
+        .isInstanceOf(StaleSessionException.class)
+        .hasMessageContaining("認証セッションの主体が存在しません");
 
     verifyNoInteractions(castRepository);
   }

--- a/backend/src/test/java/com/kizuna/cast/application/CastServiceTest.java
+++ b/backend/src/test/java/com/kizuna/cast/application/CastServiceTest.java
@@ -20,6 +20,7 @@ import com.kizuna.cast.domain.CastFieldDefinitionRepository;
 import com.kizuna.cast.domain.CastInvitationStatus;
 import com.kizuna.cast.domain.CastPatch;
 import com.kizuna.cast.domain.CastRepository;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import java.util.List;
 import java.util.Map;
@@ -116,7 +117,7 @@ class CastServiceTest {
     when(castRepository.findById("missing")).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> castService.get("missing"))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("キャストが見つかりません");
   }
 
@@ -244,7 +245,7 @@ class CastServiceTest {
     when(castRepository.findById("missing")).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> castService.update("missing", new CastUpdateRequest()))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("キャストが見つかりません");
   }
 
@@ -260,7 +261,7 @@ class CastServiceTest {
     when(castRepository.existsById("missing")).thenReturn(false);
 
     assertThatThrownBy(() -> castService.delete("missing"))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("キャストが見つかりません");
   }
 

--- a/backend/src/test/java/com/kizuna/customer/application/CustomerServiceTest.java
+++ b/backend/src/test/java/com/kizuna/customer/application/CustomerServiceTest.java
@@ -13,7 +13,7 @@ import com.kizuna.customer.api.dto.CustomerUpdateRequest;
 import com.kizuna.customer.domain.Customer;
 import com.kizuna.customer.domain.CustomerPatch;
 import com.kizuna.customer.domain.CustomerRepository;
-import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.NotFoundException;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -91,7 +91,7 @@ class CustomerServiceTest {
     when(customerRepository.findById("missing")).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> customerService.get("missing"))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("顧客が見つかりません");
   }
 
@@ -152,7 +152,7 @@ class CustomerServiceTest {
     when(customerRepository.findById("missing")).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> customerService.update("missing", new CustomerUpdateRequest()))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("顧客が見つかりません");
   }
 
@@ -168,7 +168,7 @@ class CustomerServiceTest {
     when(customerRepository.existsById("missing")).thenReturn(false);
 
     assertThatThrownBy(() -> customerService.delete("missing"))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("顧客が見つかりません");
   }
 }

--- a/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
@@ -24,6 +24,7 @@ import com.kizuna.order.domain.OrderPatch;
 import com.kizuna.order.domain.OrderRepository;
 import com.kizuna.order.domain.OrderStatus;
 import com.kizuna.order.domain.OrderView;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.user.domain.PermissionCode;
@@ -139,7 +140,7 @@ class OrderServiceTest {
     when(orderRepository.findViewById("o2")).thenReturn(Optional.empty());
 
     assertThat(service.get("o1").getId()).isEqualTo("o1");
-    assertThatThrownBy(() -> service.get("o2")).isInstanceOf(ServiceException.class);
+    assertThatThrownBy(() -> service.get("o2")).isInstanceOf(NotFoundException.class);
   }
 
   @Test
@@ -216,7 +217,7 @@ class OrderServiceTest {
             Optional.of(receptionist(UserType.STAFF, StoreScopeType.SPECIFIC_STORES, Set.of(2L))));
 
     assertThatThrownBy(() -> service.create(req))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("受付担当者が見つかりません");
     verify(orderRepository, never()).save(any());
   }
@@ -235,7 +236,7 @@ class OrderServiceTest {
         .thenReturn(Optional.of(receptionist(UserType.CAST, StoreScopeType.ALL_STORES, Set.of())));
 
     assertThatThrownBy(() -> service.create(req))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("受付担当者が見つかりません");
     verify(orderRepository, never()).save(any());
   }
@@ -264,7 +265,7 @@ class OrderServiceTest {
     when(platformUserRepository.findById(1L)).thenReturn(Optional.of(staffWithoutOrderManage));
 
     assertThatThrownBy(() -> service.create(req))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("受付担当者が見つかりません");
     verify(orderRepository, never()).save(any());
   }
@@ -284,7 +285,7 @@ class OrderServiceTest {
     when(platformUserRepository.findById(1L)).thenReturn(Optional.of(stopped));
 
     assertThatThrownBy(() -> service.create(req))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("受付担当者が見つかりません");
     verify(orderRepository, never()).save(any());
   }
@@ -409,7 +410,7 @@ class OrderServiceTest {
     req.setCastId("none");
     req.setReceptionistId(2L);
 
-    assertThatThrownBy(() -> service.update("o1", req)).isInstanceOf(ServiceException.class);
+    assertThatThrownBy(() -> service.update("o1", req)).isInstanceOf(NotFoundException.class);
   }
 
   @Test
@@ -428,7 +429,7 @@ class OrderServiceTest {
     req.setReceptionistId(2L);
 
     assertThatThrownBy(() -> service.update("o1", req))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("受付担当者が見つかりません");
     verify(orderRepository, never()).save(any());
   }
@@ -448,7 +449,7 @@ class OrderServiceTest {
     req.setReceptionistId(2L);
 
     assertThatThrownBy(() -> service.update("o1", req))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("受付担当者が見つかりません");
     verify(orderRepository, never()).save(any());
   }
@@ -463,7 +464,7 @@ class OrderServiceTest {
   @Test
   void deleteThrowsWhenMissing() {
     when(orderRepository.existsById("nope")).thenReturn(false);
-    assertThatThrownBy(() -> service.delete("nope")).isInstanceOf(ServiceException.class);
+    assertThatThrownBy(() -> service.delete("nope")).isInstanceOf(NotFoundException.class);
   }
 
   /** {@link #authorizedReceptionist()} を id・表示名だけ差し替えて複製する（一覧テストで複数件を区別するため）。 */

--- a/backend/src/test/java/com/kizuna/settings/application/SystemConfigServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/settings/application/SystemConfigServiceImplTest.java
@@ -14,6 +14,7 @@ import com.kizuna.settings.api.dto.SystemConfigResponse;
 import com.kizuna.settings.api.dto.SystemConfigUpdateRequest;
 import com.kizuna.settings.domain.SystemConfig;
 import com.kizuna.settings.domain.SystemConfigRepository;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import java.util.List;
 import java.util.Optional;
@@ -184,7 +185,7 @@ class SystemConfigServiceImplTest {
     when(systemConfigRepository.findByConfigKey(key)).thenReturn(Optional.empty());
 
     // 実行・検証
-    assertThrows(ServiceException.class, () -> systemConfigService.updateConfig(request));
+    assertThrows(NotFoundException.class, () -> systemConfigService.updateConfig(request));
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/shared/exception/CommonExceptionHandlerTest.java
+++ b/backend/src/test/java/com/kizuna/shared/exception/CommonExceptionHandlerTest.java
@@ -2,16 +2,24 @@ package com.kizuna.shared.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.kizuna.user.api.dto.PlatformStaffCreateRequest;
+import java.sql.SQLException;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.mock.http.MockHttpInputMessage;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.json.JsonMapper;
 
-/** {@link CommonExceptionHandler} の AuthenticationException 型別文言マッピングの単体テスト。 */
+/** {@link CommonExceptionHandler} の例外型 → status・ワイヤ形の写像を固定する単体テスト。 */
 class CommonExceptionHandlerTest {
 
   private final CommonExceptionHandler handler = new CommonExceptionHandler();
@@ -45,5 +53,108 @@ class CommonExceptionHandlerTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
     assertThat(response.getBody()).containsEntry("error", "認証に失敗しました");
     assertThat(response.getBody()).doesNotContainValue("internal detail not for wire");
+  }
+
+  @Test
+  @DisplayName("NotFoundException は 404 で、領域が付けた文言をそのまま返す")
+  void notFoundReturns404() {
+    ResponseEntity<Map<String, Object>> response =
+        handler.handle(new NotFoundException("ロールが見つかりません: 404"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getBody()).containsEntry("error", "ロールが見つかりません: 404");
+  }
+
+  @Test
+  @DisplayName("ServiceUnavailableException は 503")
+  void serviceUnavailableReturns503() {
+    ResponseEntity<Map<String, Object>> response =
+        handler.handle(new ServiceUnavailableException("メンテナンス中です"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    assertThat(response.getBody()).containsEntry("error", "メンテナンス中です");
+  }
+
+  @Test
+  @DisplayName("一意制約違反（SQLSTATE 23505）だけが 409 になる")
+  void uniqueViolationReturns409() {
+    ResponseEntity<Map<String, Object>> response =
+        handler.handle(
+            new DataIntegrityViolationException(
+                "save failed", new SQLException("duplicate key", "23505")));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(response.getBody()).containsEntry("error", "既に登録されている値と重複しています");
+  }
+
+  @Test
+  @DisplayName("一意制約以外の整合性違反（FK 等）は 409 に化けず 500 のまま、内部 message も漏らさない")
+  void otherIntegrityViolationStays500() {
+    ResponseEntity<Map<String, Object>> response =
+        handler.handle(
+            new DataIntegrityViolationException(
+                "fk violated", new SQLException("foreign key violation", "23503")));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getBody()).containsEntry("error", "サーバー内部エラーが発生しました");
+    assertThat(response.getBody()).doesNotContainValue("foreign key violation");
+  }
+
+  @Test
+  @DisplayName("列挙に無い値は 400 で、details にワイヤ上のフィールド名（snake_case）を載せ、Java の型名は載せない")
+  void unreadableBodyExposesWireFieldOnly() {
+    HttpMessageNotReadableException ex = unreadable("{\"store_scope_type\":\"NOT_A_REAL_TYPE\"}");
+
+    ResponseEntity<Map<String, Object>> response = handler.handle(ex);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody()).containsEntry("error", "リクエストの形式が正しくありません");
+    assertThat(response.getBody())
+        .extracting("details")
+        .isEqualTo(Map.of("store_scope_type", "値の形式が正しくありません"));
+    assertThat(response.getBody().toString()).doesNotContain("com.kizuna");
+  }
+
+  @Test
+  @DisplayName("構文自体が壊れた JSON は対象フィールドが無いので details を付けない")
+  void malformedJsonHasNoDetails() {
+    HttpMessageNotReadableException ex = unreadable("{\"email\": ");
+
+    ResponseEntity<Map<String, Object>> response = handler.handle(ex);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody()).doesNotContainKey("details");
+  }
+
+  @Test
+  @DisplayName("必須パラメータ欠落は固定文言 + details で、フレームワークの生 message を透過しない")
+  void missingParameterDoesNotLeakRawMessage() {
+    MissingServletRequestParameterException ex =
+        new MissingServletRequestParameterException("domain", "String");
+
+    ResponseEntity<Map<String, Object>> response = handler.handle(ex);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody()).containsEntry("error", "必須パラメータが不足しています");
+    assertThat(response.getBody()).extracting("details").isEqualTo(Map.of("domain", "必須です"));
+    assertThat(response.getBody().toString()).doesNotContain("java.lang.String");
+  }
+
+  /**
+   * 実際に Jackson へ解釈させて、本番と同じ原因例外を持つ {@link HttpMessageNotReadableException} を組み立てる。
+   *
+   * <p>命名戦略は本番（{@code spring.jackson.property-naming-strategy: SNAKE_CASE}）に揃える — 原因例外の path
+   * が返す名前がワイヤ形かどうかが、この検証の対象そのものであるため。
+   */
+  private HttpMessageNotReadableException unreadable(String json) {
+    JsonMapper mapper =
+        JsonMapper.builder().propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE).build();
+    try {
+      mapper.readValue(json, PlatformStaffCreateRequest.class);
+      throw new IllegalStateException("前提: この JSON は解釈に失敗するはず");
+    } catch (RuntimeException cause) {
+      return new HttpMessageNotReadableException(
+          "unreadable", cause, new MockHttpInputMessage(json.getBytes()));
+    }
   }
 }

--- a/backend/src/test/java/com/kizuna/shared/exception/CommonExceptionHandlerTest.java
+++ b/backend/src/test/java/com/kizuna/shared/exception/CommonExceptionHandlerTest.java
@@ -66,6 +66,17 @@ class CommonExceptionHandlerTest {
   }
 
   @Test
+  @DisplayName("StaleSessionException は 401 で、内部 message ではなく再ログインを促す固定文言を返す")
+  void staleSessionReturns401() {
+    ResponseEntity<Map<String, Object>> response =
+        handler.handle(new StaleSessionException("認証セッションの主体が存在しません"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(response.getBody()).containsEntry("error", "セッションが無効です。再度ログインしてください");
+    assertThat(response.getBody()).doesNotContainValue("認証セッションの主体が存在しません");
+  }
+
+  @Test
   @DisplayName("ServiceUnavailableException は 503")
   void serviceUnavailableReturns503() {
     ResponseEntity<Map<String, Object>> response =

--- a/backend/src/test/java/com/kizuna/shared/storescope/StoreIdInterceptorTest.java
+++ b/backend/src/test/java/com/kizuna/shared/storescope/StoreIdInterceptorTest.java
@@ -1,7 +1,9 @@
 package com.kizuna.shared.storescope;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.kizuna.shared.exception.ServiceException;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -77,10 +80,8 @@ class StoreIdInterceptorTest {
     request.addHeader("X-Store-ID", "42");
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, response, new Object());
-
-    assertThat(result).isFalse();
-    assertThat(response.getStatus()).isEqualTo(403);
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+        .isInstanceOf(AccessDeniedException.class);
     assertThat(storeContext.hasStoreId()).isFalse();
   }
 
@@ -92,10 +93,8 @@ class StoreIdInterceptorTest {
     request.addHeader("X-Store-ID", "abc");
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, response, new Object());
-
-    assertThat(result).isFalse();
-    assertThat(response.getStatus()).isEqualTo(403);
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+        .isInstanceOf(AccessDeniedException.class);
     assertThat(storeContext.hasStoreId()).isFalse();
   }
 
@@ -135,10 +134,8 @@ class StoreIdInterceptorTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, response, handlerMethod("required"));
-
-    assertThat(result).isFalse();
-    assertThat(response.getStatus()).isEqualTo(403);
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod("required")))
+        .isInstanceOf(AccessDeniedException.class);
     assertThat(storeContext.hasStoreId()).isFalse();
   }
 
@@ -148,10 +145,8 @@ class StoreIdInterceptorTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, response, new Object());
-
-    assertThat(result).isFalse();
-    assertThat(response.getStatus()).isEqualTo(403);
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+        .isInstanceOf(AccessDeniedException.class);
     assertThat(storeContext.hasStoreId()).isFalse();
   }
 
@@ -164,10 +159,8 @@ class StoreIdInterceptorTest {
     request.addHeader("X-Store-ID", "2");
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, response, new Object());
-
-    assertThat(result).isFalse();
-    assertThat(response.getStatus()).isEqualTo(403);
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+        .isInstanceOf(AccessDeniedException.class);
     assertThat(storeContext.hasStoreId()).isFalse();
   }
 
@@ -179,10 +172,8 @@ class StoreIdInterceptorTest {
     request.addHeader("X-Store-ID", "99999999999999999999");
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, response, new Object());
-
-    assertThat(result).isFalse();
-    assertThat(response.getStatus()).isEqualTo(400);
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+        .isInstanceOf(ServiceException.class);
     assertThat(storeContext.hasStoreId()).isFalse();
   }
 
@@ -234,10 +225,8 @@ class StoreIdInterceptorTest {
     request.addHeader("X-Store-ID", "2");
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, response, new Object());
-
-    assertThat(result).isFalse();
-    assertThat(response.getStatus()).isEqualTo(403);
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+        .isInstanceOf(AccessDeniedException.class);
     assertThat(storeContext.hasStoreId()).isFalse();
   }
 
@@ -262,10 +251,8 @@ class StoreIdInterceptorTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, response, handlerMethod("required"));
-
-    assertThat(result).isFalse();
-    assertThat(response.getStatus()).isEqualTo(403);
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod("required")))
+        .isInstanceOf(AccessDeniedException.class);
     assertThat(storeContext.hasStoreId()).isFalse();
   }
 
@@ -290,10 +277,8 @@ class StoreIdInterceptorTest {
     request.addHeader("X-Store-ID", "1");
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, response, new Object());
-
-    assertThat(result).isFalse();
-    assertThat(response.getStatus()).isEqualTo(403);
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+        .isInstanceOf(AccessDeniedException.class);
     assertThat(storeContext.hasStoreId()).isFalse();
   }
 
@@ -306,10 +291,8 @@ class StoreIdInterceptorTest {
     request.addHeader("X-Store-ID", "1");
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, response, new Object());
-
-    assertThat(result).isFalse();
-    assertThat(response.getStatus()).isEqualTo(403);
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+        .isInstanceOf(AccessDeniedException.class);
     assertThat(storeContext.hasStoreId()).isFalse();
   }
 
@@ -324,10 +307,8 @@ class StoreIdInterceptorTest {
     request.addHeader("X-Store-ID", "1");
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, response, new Object());
-
-    assertThat(result).isFalse();
-    assertThat(response.getStatus()).isEqualTo(403);
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+        .isInstanceOf(AccessDeniedException.class);
     assertThat(storeContext.hasStoreId()).isFalse();
   }
 
@@ -360,10 +341,8 @@ class StoreIdInterceptorTest {
     request.addHeader("X-Store-ID", "1");
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, response, new Object());
-
-    assertThat(result).isFalse();
-    assertThat(response.getStatus()).isEqualTo(403);
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+        .isInstanceOf(AccessDeniedException.class);
     assertThat(storeContext.hasStoreId()).isFalse();
   }
 

--- a/backend/src/test/java/com/kizuna/shift/application/CastScheduleServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/CastScheduleServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.StaleSessionException;
 import com.kizuna.shift.api.dto.CastScheduleResponse;
 import com.kizuna.shift.api.dto.ShiftMapper;
 import com.kizuna.shift.domain.CastScheduleView;
@@ -51,8 +52,8 @@ class CastScheduleServiceTest {
     when(platformUserRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> service.myWeek(EMAIL, FROM, TO))
-        .isInstanceOf(ServiceException.class)
-        .hasMessageContaining("ユーザーが見つかりません");
+        .isInstanceOf(StaleSessionException.class)
+        .hasMessageContaining("認証セッションの主体が存在しません");
 
     verifyNoInteractions(castRepository, shiftRepository, shiftMapper);
   }

--- a/backend/src/test/java/com/kizuna/shift/application/CastShiftRequestServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/CastShiftRequestServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.config.AppProperties;
 import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.StaleSessionException;
 import com.kizuna.shift.api.dto.CastShiftRequestResponse;
 import com.kizuna.shift.api.dto.ShiftRequestCreateRequest;
 import com.kizuna.shift.api.dto.ShiftRequestMapper;
@@ -93,8 +94,8 @@ class CastShiftRequestServiceTest {
     when(platformUserRepository.findByEmail(EMAIL)).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> service.submit(EMAIL, req))
-        .isInstanceOf(ServiceException.class)
-        .hasMessageContaining("ユーザーが見つかりません");
+        .isInstanceOf(StaleSessionException.class)
+        .hasMessageContaining("認証セッションの主体が存在しません");
 
     verifyNoInteractions(castRepository, shiftRequestRepository);
   }

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftRequestServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftRequestServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shift.api.dto.ShiftRequestMapper;
 import com.kizuna.shift.api.dto.StoreShiftRequestResponse;
@@ -86,7 +87,7 @@ class ShiftRequestServiceTest {
     when(shiftRequestRepository.findById("missing")).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> shiftRequestService.approve("missing"))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("出勤希望が見つかりません");
 
     verify(shiftRepository, never()).save(any());
@@ -148,7 +149,7 @@ class ShiftRequestServiceTest {
     when(shiftRequestRepository.findById("missing")).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> shiftRequestService.decline("missing"))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("出勤希望が見つかりません");
   }
 }

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
@@ -10,6 +10,7 @@ import com.kizuna.cast.application.CastService;
 import com.kizuna.cast.domain.Cast;
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.config.AppProperties;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shift.api.dto.PublicShiftResponse;
 import com.kizuna.shift.api.dto.ShiftCreateRequest;
@@ -109,7 +110,7 @@ class ShiftServiceTest {
     when(castService.existsForCurrentStore("c1")).thenReturn(false);
 
     assertThatThrownBy(() -> shiftService.create(req))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("キャストが見つかりません");
   }
 
@@ -139,7 +140,7 @@ class ShiftServiceTest {
     when(shiftRepository.findById("missing")).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> shiftService.update("missing", new ShiftUpdateRequest()))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("シフトが見つかりません");
   }
 
@@ -154,7 +155,7 @@ class ShiftServiceTest {
     req.setCastId("foreign");
 
     assertThatThrownBy(() -> shiftService.update("s1", req))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("キャストが見つかりません");
   }
 
@@ -224,7 +225,7 @@ class ShiftServiceTest {
     when(shiftRepository.existsById("missing")).thenReturn(false);
 
     assertThatThrownBy(() -> shiftService.delete("missing"))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("シフトが見つかりません");
   }
 

--- a/backend/src/test/java/com/kizuna/store/application/StoreRegistryServiceTest.java
+++ b/backend/src/test/java/com/kizuna/store/application/StoreRegistryServiceTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.store.api.dto.StoreCreateDTO;
 import com.kizuna.store.api.dto.StoreStatusVO;
@@ -60,6 +62,23 @@ class StoreRegistryServiceTest {
   }
 
   @Test
+  void create_duplicateDomain_rejectedBeforeInsert() {
+    // 重複判定は一意制約違反の捕捉ではなく事前照会で行う（制約違反は競合に敗れた場合の兜底）。
+    StoreCreateDTO req = new StoreCreateDTO();
+    req.setName("T2");
+    req.setDomain("taken.example.com");
+    when(storeRepository.findByDomain("taken.example.com"))
+        .thenReturn(Optional.of(createStore(9L, "既存", "taken.example.com", "x@y.com")));
+
+    assertThatThrownBy(() -> storeRegistryService.create(req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("既に登録されています");
+
+    verify(storeRepository, never()).save(any());
+    verify(storeProfileRepository, never()).save(any());
+  }
+
+  @Test
   void list_handlesNullSearch() {
     Page<Store> page = new PageImpl<>(List.of());
     when(storeRepository.findByNameContainingIgnoreCaseOrDomainContainingIgnoreCase(
@@ -74,19 +93,19 @@ class StoreRegistryServiceTest {
     Store t = createStore(1L, "Store1", "store1.com", "a@b.com");
     when(storeRepository.findById(1L)).thenReturn(Optional.of(t));
 
-    Optional<StoreVO> result = storeRegistryService.getById("1");
+    StoreVO result = storeRegistryService.getById("1");
 
-    assertThat(result).isPresent();
-    assertThat(result.get().getName()).isEqualTo("Store1");
-    assertThat(result.get().getDomain()).isEqualTo("store1.com");
-    assertThat(result.get().getCreatedAt()).isEqualTo(t.getCreatedAt());
+    assertThat(result.getName()).isEqualTo("Store1");
+    assertThat(result.getDomain()).isEqualTo("store1.com");
+    assertThat(result.getCreatedAt()).isEqualTo(t.getCreatedAt());
   }
 
   @Test
-  void getById_returnsEmptyWhenNotFound() {
+  void getById_throwsNotFoundWhenAbsent() {
     when(storeRepository.findById(99L)).thenReturn(Optional.empty());
 
-    assertThat(storeRegistryService.getById("99")).isEmpty();
+    assertThatThrownBy(() -> storeRegistryService.getById("99"))
+        .isInstanceOf(NotFoundException.class);
   }
 
   @Test
@@ -136,7 +155,7 @@ class StoreRegistryServiceTest {
     req.setName("New");
 
     assertThatThrownBy(() -> storeRegistryService.update("99", req))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("店舗が見つかりません");
   }
 

--- a/backend/src/test/java/com/kizuna/store/infrastructure/MaintenanceModeInterceptorTest.java
+++ b/backend/src/test/java/com/kizuna/store/infrastructure/MaintenanceModeInterceptorTest.java
@@ -1,9 +1,11 @@
 package com.kizuna.store.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import com.kizuna.settings.application.SystemConfigService;
+import com.kizuna.shared.exception.ServiceUnavailableException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,17 +24,15 @@ class MaintenanceModeInterceptorTest {
   @InjectMocks private MaintenanceModeInterceptor interceptor;
 
   @Test
-  @DisplayName("メンテナンスモード中はリクエストを 503 で拒否すること")
-  void preHandle_maintenanceOn() throws Exception {
+  @DisplayName("メンテナンスモード中はリクエストを 503 の例外で拒否すること")
+  void preHandle_maintenanceOn() {
     when(systemConfigService.getConfigValue("maintenance_mode")).thenReturn(Optional.of("true"));
     MockHttpServletRequest request = new MockHttpServletRequest("GET", "/store/orders");
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    boolean result = interceptor.preHandle(request, response, new Object());
-
-    assertThat(result).isFalse();
-    assertThat(response.getStatus()).isEqualTo(503);
-    assertThat(response.getContentAsString()).contains("メンテナンス中");
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+        .isInstanceOf(ServiceUnavailableException.class)
+        .hasMessageContaining("メンテナンス中");
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/storeprofile/application/StoreProfileServiceTest.java
+++ b/backend/src/test/java/com/kizuna/storeprofile/application/StoreProfileServiceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.storeprofile.api.dto.StoreProfileMapper;
 import com.kizuna.storeprofile.api.dto.StoreProfileResponse;
@@ -62,7 +62,7 @@ class StoreProfileServiceTest {
     when(storeProfileRepository.findByStoreId(STORE_ID)).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> storeProfileService.get())
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessage("店舗設定が見つかりません");
   }
 
@@ -150,7 +150,7 @@ class StoreProfileServiceTest {
     StoreProfileUpdateRequest request = new StoreProfileUpdateRequest();
 
     assertThatThrownBy(() -> storeProfileService.update(request))
-        .isInstanceOf(ServiceException.class)
+        .isInstanceOf(NotFoundException.class)
         .hasMessage("店舗設定が見つかりません");
   }
 

--- a/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.kizuna.shared.exception.ConflictException;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.api.dto.PlatformStaffCreateRequest;
 import com.kizuna.user.api.dto.PlatformStaffResponse;
@@ -292,7 +293,7 @@ class PlatformStaffServiceTest {
               return existing;
             });
 
-    Optional<PlatformStaffResponse> res =
+    PlatformStaffResponse res =
         service.update(
             3L,
             updateRequest(Set.of(MANAGER_ROLE), StoreScopeType.SPECIFIC_STORES, Set.of(1L)),
@@ -301,11 +302,9 @@ class PlatformStaffServiceTest {
     assertThat(existing.getRoleIds()).containsExactly(MANAGER_ROLE);
     assertThat(existing.getStoreScopeType()).isEqualTo(StoreScopeType.SPECIFIC_STORES);
     assertThat(existing.getStoreIds()).containsExactly(1L);
-    assertThat(res).isPresent();
-    assertThat(res.get().id()).isEqualTo(3L);
-    assertThat(res.get().roles())
-        .containsExactly(new PlatformStaffResponse.RoleRef(MANAGER_ROLE, "店長"));
-    assertThat(res.get().version()).as("応答は保存後の増加した version を返すこと").isEqualTo(1L);
+    assertThat(res.id()).isEqualTo(3L);
+    assertThat(res.roles()).containsExactly(new PlatformStaffResponse.RoleRef(MANAGER_ROLE, "店長"));
+    assertThat(res.version()).as("応答は保存後の増加した version を返すこと").isEqualTo(1L);
   }
 
   @Test
@@ -332,29 +331,31 @@ class PlatformStaffServiceTest {
   }
 
   @Test
-  void update_unknownId_returnsEmptyWithoutSaving() {
+  void update_unknownId_throwsNotFoundWithoutSaving() {
     when(roleRepository.findAllById(Set.of(HQ_ROLE))).thenReturn(List.of(role(HQ_ROLE, "HQ管理者")));
     when(repository.findById(404L)).thenReturn(Optional.empty());
 
-    Optional<PlatformStaffResponse> res =
-        service.update(
-            404L, updateRequest(Set.of(HQ_ROLE), StoreScopeType.ALL_STORES, Set.of()), ACTOR);
-
-    assertThat(res).isEmpty();
+    assertThatThrownBy(
+            () ->
+                service.update(
+                    404L,
+                    updateRequest(Set.of(HQ_ROLE), StoreScopeType.ALL_STORES, Set.of()),
+                    ACTOR))
+        .isInstanceOf(NotFoundException.class);
     verify(repository, never()).save(any());
   }
 
   @Test
-  void update_targetIsNonStaff_returnsEmptyWithoutSaving() {
-    // CAST/MEMBER はスタッフ管理の可視対象外。id を直接指定してもスタッフへ昇格させない（本人種別検証）。
+  void update_targetIsNonStaff_throwsNotFoundWithoutSaving() {
+    // CAST/MEMBER はスタッフ管理の可視対象外。id を直接指定してもスタッフへ昇格させず、不在と同じ応答にする（本人種別検証）。
     when(roleRepository.findAllById(Set.of(HQ_ROLE))).thenReturn(List.of(role(HQ_ROLE, "HQ管理者")));
     when(repository.findById(8L)).thenReturn(Optional.of(castUser(8L, "cast@kizuna.test")));
 
-    Optional<PlatformStaffResponse> res =
-        service.update(
-            8L, updateRequest(Set.of(HQ_ROLE), StoreScopeType.ALL_STORES, Set.of()), ACTOR);
-
-    assertThat(res).isEmpty();
+    assertThatThrownBy(
+            () ->
+                service.update(
+                    8L, updateRequest(Set.of(HQ_ROLE), StoreScopeType.ALL_STORES, Set.of()), ACTOR))
+        .isInstanceOf(NotFoundException.class);
     verify(repository, never()).save(any());
   }
 
@@ -428,11 +429,10 @@ class PlatformStaffServiceTest {
         updateRequest(Set.of(HQ_ROLE), StoreScopeType.ALL_STORES, Set.of());
     req.setEnabled(false);
 
-    Optional<PlatformStaffResponse> res = service.update(3L, req, ACTOR);
+    PlatformStaffResponse res = service.update(3L, req, ACTOR);
 
     assertThat(existing.getEnabled()).isFalse();
-    assertThat(res).isPresent();
-    assertThat(res.get().enabled()).isFalse();
+    assertThat(res.enabled()).isFalse();
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/user/application/RoleServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/RoleServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.api.dto.RoleCreateRequest;
 import com.kizuna.user.api.dto.RoleResponse;
@@ -153,22 +154,21 @@ class RoleServiceTest {
     when(roleRepository.findById(7L)).thenReturn(Optional.of(existing));
     when(roleRepository.saveAndFlush(existing)).thenReturn(existing);
 
-    Optional<RoleResponse> res =
-        service.update(7L, updateRequest("受付リーダー", Set.of("CUSTOMER_MANAGE"), 0L));
+    RoleResponse res = service.update(7L, updateRequest("受付リーダー", Set.of("CUSTOMER_MANAGE"), 0L));
 
     assertThat(existing.getName()).isEqualTo("受付リーダー");
     assertThat(existing.getPermissionIds()).containsExactly(CUSTOMER_MANAGE_ID);
-    assertThat(res).isPresent();
-    assertThat(res.get().permissions()).containsExactly("CUSTOMER_MANAGE");
+    assertThat(res.permissions()).containsExactly("CUSTOMER_MANAGE");
   }
 
   @Test
-  void update_unknownId_returnsEmpty() {
+  void update_unknownId_throwsNotFound() {
     when(permissionRepository.findByCodeIn(Set.of("ORDER_MANAGE")))
         .thenReturn(List.of(permission(ORDER_MANAGE_ID, PermissionCode.ORDER_MANAGE)));
     when(roleRepository.findById(404L)).thenReturn(Optional.empty());
 
-    assertThat(service.update(404L, updateRequest("受付", Set.of("ORDER_MANAGE"), 0L))).isEmpty();
+    assertThatThrownBy(() -> service.update(404L, updateRequest("受付", Set.of("ORDER_MANAGE"), 0L)))
+        .isInstanceOf(NotFoundException.class);
   }
 
   @Test
@@ -201,10 +201,10 @@ class RoleServiceTest {
   }
 
   @Test
-  void delete_unknownId_returnsFalse() {
+  void delete_unknownId_throwsNotFound() {
     when(roleRepository.findById(404L)).thenReturn(Optional.empty());
 
-    assertThat(service.delete(404L)).isFalse();
+    assertThatThrownBy(() -> service.delete(404L)).isInstanceOf(NotFoundException.class);
     verify(roleRepository, never()).delete(any());
   }
 
@@ -214,7 +214,8 @@ class RoleServiceTest {
     when(roleRepository.findById(7L)).thenReturn(Optional.of(existing));
     when(platformUserRepository.existsByRoleId(7L)).thenReturn(false);
 
-    assertThat(service.delete(7L)).isTrue();
+    service.delete(7L);
+
     verify(roleRepository).delete(existing);
   }
 


### PR DESCRIPTION
## 概要

同じ概念の失敗が呼出点ごとに別の status・別のワイヤ形で返っていた状態を、`CommonExceptionHandler` の一箇所へ収束させる。統一 handler 自体は以前から存在しており、本 PR が正すのはその**語彙の欠落**と、handler の前で例外を横取りしていた 3 つの interceptor。

関連 issue なし（アーキテクチャレビューから直接起票せずに着手したもの。必要なら追って起票する）。

## 変更内容

- **`NotFoundException`（404）/ `ServiceUnavailableException`（503）を新設。** 「見つからない」を表す型が無く、`ResponseEntity.notFound()` を書いた controller では 404、`ServiceException` を投げた service では 400 と、同じ概念が二つの status になっていた。指名された行が見つからない **26 箇所**を 404 へ移し、指名型の service メソッド（`update` / `delete` / `getById`）は `Optional` ではなく送出で表明する。controller の `notFound()` 翻訳は 6 箇所中 5 箇所が不要になる。
- **`StaleSessionException`（401）を新設。** トークンの principal から自分自身の行を引く 5 箇所が、行を引けないときに 400 へ倒れていた。呼出側の要求誤りではなく不変量の破れなので、セッション無効として 401 で表明する（詳細は「決定ログ」）。
- **一意制約違反（SQLSTATE 23505）だけを 409 の兜底として受ける。** FK・NOT NULL 等の他の整合性違反は利用者が是正できる誤りではないため、409 に化けさせず catch-all の 500 のまま大きく失敗させる。
- **壊れた本文・パス変数の型不一致を 400 化。** 従来は catch-all で 500 になり、純粋な呼出側の誤りが真の障害と混ざっていた。応答は `error` に利用者向けの固定文言、`details` に原因フィールド名を載せる。フィールド名は API 契約の一部なので露出してよいが、フレームワークの生 message は Java の型名や内部構造を含むため転送しない。必須パラメータ欠落の handler が生 message を透過していた点も同じ形へ揃えた。
- **interceptor 3 種の拒否を例外送出へ統一。** `StoreIdInterceptor` は status のみで本文を持たず、`StoreExistenceInterceptor` と `MaintenanceModeInterceptor` は JSON を手書きしていたため、同じ 403 に 3 つのワイヤ形があった。前端の `getApiErrorMessage` は `{error}` しか解釈できず、本文の無い 403 では呼出点ごとの固定 fallback に落ちる。
- **店舗ドメインの重複判定を事前照会に変更。** 従来は一意制約違反任せで、catch を持たない `create` を突き抜けて **500** になっていた。
- `ServiceException` / `ConflictException` の `@ResponseStatus` を削除（handler の宣言と二重で、実際には handler が優先される死んだ宣言）。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（unit + integration）
- [x] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: **未実行**）
- [ ] ローカルで code-review 実施済み（**未実施**）

着手前に、設計の前提となる 3 点を実測で確認した。

| 前提 | 結果 |
| --- | --- |
| `HandlerInterceptor#preHandle` から送出した例外が `@ControllerAdvice` へ到達するか（Spring Boot 4.1.0） | 到達する。`StoreExistenceInterceptor` を例外送出へ変えても、400 と `error` キーの本文を固定済みの `StoreExistenceInterceptorIT` が無改変で通る |
| 一意制約違反を構造的に判別できるか | `getMostSpecificCause()` が `PSQLException`、`SQLState` は `23505` |
| Jackson 3 から取れる原因フィールド名はワイヤ形か | `DatabindException#getPath()` は命名戦略適用後の `store_scope_type` を返す。構文エラーは `StreamReadException` で path を持たないため `details` を省く |

## 決定ログ

**404 と 403 の境界は「呼出側が何を指名したか」で決める。**

- **行の id を指名した → 404。** 他店舗に存在するか否かは呼出側が知ってよい情報ではなく、404 は不在と区別がつかない。加えて `storeFilter` 有効時の service は他店舗の行の存在を**そもそも判定できず**、403 を返すには作用域を外した問い合わせを別途行う必要がある — 濾過機構に穴を開けることになるため採らない（403 は「より親切な選択肢」ではなく、正しい手段では実装できない）。
- **店舗を指名した（`X-Store-ID`）→ 403。** 店舗は公開ドメインを持ち、存在自体が秘匿対象ではない。
- **授権判定の一部としての実在性検証（`StoreScopeExecutor`）は 400 のまま据え置く。** ここを 404 にすると、直前の授権判定が返す 403 との対比で「授権外だが実在する店舗」と「実在しない店舗」が判別可能になり、平台に存在する店舗 id が漏れる。

**自分自身の行が引けない場合は 401。** email は利用者が渡した引数ではなく検証済み JWT の principal なので、上の「何を指名したか」の判据が覆わない。要求の誤りではないので 400 ではなく、要求された資源（`/platform/me` 等）は概念上存在するので 404 でもない — 無効なのはセッションであり、回復手段は再ログイン。前端は 401 で token を破棄しログインへ倒す既存経路を持つため利用者は自力で復帰できる。現状この状態は**アプリケーション操作からは到達しない**（`t_users` に削除端点が無く、コード上に削除呼び出しも無い。停止は `enabled=false` で行を残す）ため、到達は不変量の破れを意味する。応答は 401 でも記録は `log.error` とし、通常のセッション期限切れに紛れて調査されないことを防ぐ。

**業務上の重複判定は検査してから書く。制約違反は競合に敗れた場合の兜底に限る。** 一括して `DataIntegrityViolation` を 409 にする案は見送った。FK・NOT NULL 違反まで 409 になると、呼出側に「やり直せば直る」と誤って伝わり実装の欠陥が運用に埋もれる。

**見送った代替案**: interceptor が共有の応答書き出しヘルパを持つ案（seam が handler の外に残り、消費者 2 つのためだけの道具が増える）／「見つからない」を全て 400 に寄せる案（HTTP 語義を捨てる上、前端が「この行は消えた」と「入力が誤り」を区別する手掛かりを永久に失う）／自分自身の行が無い場合を 500 とする案（最も正直だが、利用者が壊れたセッションから抜け出す導線が画面上に無くなる）。

## 備考 / レビュー観点

**クロス店舗の安全テストに手を入れている。** 不可視化も 404 の規則に入るため、`CastFieldDefinitionCrossStoreIT` / `ShiftCrossStoreIT` / `CastInvitationApiIT` の期待 status を差し替えた。**データ不変の検証部分は一切変更していない。** ヘッダ詐称の拒否テストのみ、本文を持つようになったため「本文が空」→「固定文言のみで定義行（`key` / `label`）が混入しない」へ主張を書き換えた（漏洩検知としては強くなっている）。

**ADR にするか判断してほしい。** 404/403 の境界・「一意制約は兜底」・自分自身の行が無い場合の 401 は再提案されやすい。理由は `NotFoundException` / `StaleSessionException` / `StoreScopeExecutor` の javadoc に書いてあるが、`docs/adr/` へ落とすかは未定。

**ワイヤの変更点**（前端は現状 401/403/409 でしか分岐しておらず、破壊的な影響は確認できていない）:
- 「見つからない」が 400 → 404（クロス店舗の不可視化を含む）
- 自分自身の行が引けない場合が 400 → 401
- interceptor 由来の 403/400/503 が本文 `{error}` を持つようになった
- 壊れた JSON・型不一致・必須パラメータ欠落が 500/生 message → 400 + `{error, details}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
