### PR TITLE
refactor(frontend): 一覧の削除処理と検索条件の適用を module の内側へ収める

### DIFF
--- a/backend/src/main/java/com/kizuna/cast/application/CastFieldDefinitionService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastFieldDefinitionService.java
@@ -71,7 +71,7 @@ public class CastFieldDefinitionService {
     CastFieldDefinition definition =
         repository
             .findById(id)
-            .orElseThrow(() -> new NotFoundException("カスタムフィールド定義が見つかりません: " + id));
+            .orElseThrow(() -> new NotFoundException("カスタムフィールド定義が見つかりません"));
     definition.apply(mapper.toPatch(request));
     return mapper.toResponse(repository.save(definition));
   }
@@ -80,7 +80,7 @@ public class CastFieldDefinitionService {
   @Transactional
   public void delete(String id) {
     if (!repository.existsById(id)) {
-      throw new NotFoundException("カスタムフィールド定義が見つかりません: " + id);
+      throw new NotFoundException("カスタムフィールド定義が見つかりません");
     }
     repository.deleteById(id);
   }

--- a/backend/src/main/java/com/kizuna/cast/application/CastFieldDefinitionService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastFieldDefinitionService.java
@@ -69,9 +69,7 @@ public class CastFieldDefinitionService {
   @Transactional
   public CastFieldDefinitionResponse update(String id, CastFieldDefinitionUpdateRequest request) {
     CastFieldDefinition definition =
-        repository
-            .findById(id)
-            .orElseThrow(() -> new NotFoundException("カスタムフィールド定義が見つかりません"));
+        repository.findById(id).orElseThrow(() -> new NotFoundException("カスタムフィールド定義が見つかりません"));
     definition.apply(mapper.toPatch(request));
     return mapper.toResponse(repository.save(definition));
   }

--- a/backend/src/main/java/com/kizuna/cast/application/CastService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastService.java
@@ -52,7 +52,7 @@ public class CastService {
   @Transactional(readOnly = true)
   public CastResponse get(String id) {
     Cast cast =
-        castRepository.findById(id).orElseThrow(() -> new NotFoundException("キャストが見つかりません: " + id));
+        castRepository.findById(id).orElseThrow(() -> new NotFoundException("キャストが見つかりません"));
     CastInvitationStatus status = castInvitationService.deriveStatuses(List.of(cast)).get(id);
     return castMapper.toResponse(cast, status);
   }
@@ -79,7 +79,7 @@ public class CastService {
   @Transactional
   public CastResponse update(String id, CastUpdateRequest request) {
     Cast cast =
-        castRepository.findById(id).orElseThrow(() -> new NotFoundException("キャストが見つかりません: " + id));
+        castRepository.findById(id).orElseThrow(() -> new NotFoundException("キャストが見つかりません"));
 
     CastPatch patch = castMapper.toPatch(request);
     if (patch.customFields() != null) {
@@ -112,7 +112,7 @@ public class CastService {
   @Transactional
   public void delete(String id) {
     if (!castRepository.existsById(id)) {
-      throw new NotFoundException("キャストが見つかりません: " + id);
+      throw new NotFoundException("キャストが見つかりません");
     }
     castRepository.deleteById(id);
   }

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
@@ -70,7 +70,7 @@ public class CustomerService {
     return customerRepository
         .findById(id)
         .map(customerMapper::toResponse)
-        .orElseThrow(() -> new NotFoundException("顧客が見つかりません: " + id));
+        .orElseThrow(() -> new NotFoundException("顧客が見つかりません"));
   }
 
   @StoreScoped
@@ -87,7 +87,7 @@ public class CustomerService {
     Customer customer =
         customerRepository
             .findById(id)
-            .orElseThrow(() -> new NotFoundException("顧客が見つかりません: " + id));
+            .orElseThrow(() -> new NotFoundException("顧客が見つかりません"));
 
     customer.apply(customerMapper.toPatch(request));
 
@@ -98,7 +98,7 @@ public class CustomerService {
   @Transactional
   public void delete(String id) {
     if (!customerRepository.existsById(id)) {
-      throw new NotFoundException("顧客が見つかりません: " + id);
+      throw new NotFoundException("顧客が見つかりません");
     }
     customerRepository.deleteById(id);
   }

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
@@ -85,9 +85,7 @@ public class CustomerService {
   @Transactional
   public CustomerResponse update(String id, CustomerUpdateRequest request) {
     Customer customer =
-        customerRepository
-            .findById(id)
-            .orElseThrow(() -> new NotFoundException("顧客が見つかりません"));
+        customerRepository.findById(id).orElseThrow(() -> new NotFoundException("顧客が見つかりません"));
 
     customer.apply(customerMapper.toPatch(request));
 

--- a/frontend/src/_pages/platform-roles/ui/RolesPage.tsx
+++ b/frontend/src/_pages/platform-roles/ui/RolesPage.tsx
@@ -2,9 +2,8 @@
 
 import { PlusIcon } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'react-hot-toast';
 import { RoleResponse, platformRoleApi } from '@/entities/user';
-import { getApiErrorMessage, useManagedList } from '@/shared/lib';
+import { useDeleteAction, useManagedList } from '@/shared/lib';
 import { ListPage } from '@/widgets/list-page';
 import {
   Badge,
@@ -44,19 +43,13 @@ export default function RolesPage() {
   const editingRole =
     typeof formTarget === 'number' ? (allRoles.find(role => role.id === formTarget) ?? null) : null;
   const formOpen = formTarget === 'create' || editingRole !== null;
-  const [deleteTarget, setDeleteTarget] = useState<RoleResponse | null>(null);
-
-  const handleDelete = async () => {
-    if (!deleteTarget) return;
-    try {
-      await platformRoleApi.remove(deleteTarget.id);
-      toast.success('ロールを削除しました');
-      void refetch();
-    } catch (error) {
-      // 授与中のロール削除は 409、平台既定ロールは 400。文言はサーバ側が持つ。
-      toast.error(getApiErrorMessage(error, 'ロールの削除に失敗しました'));
-    }
-  };
+  // 授与中のロール削除は 409、平台既定ロールは 400。文言はサーバ側が持つ。
+  const deletion = useDeleteAction<RoleResponse>({
+    remove: role => platformRoleApi.remove(role.id),
+    successMessage: 'ロールを削除しました',
+    errorMessage: 'ロールの削除に失敗しました',
+    onDeleted: refetch,
+  });
 
   return (
     <>
@@ -158,7 +151,7 @@ export default function RolesPage() {
                     size="sm"
                     className="text-destructive-strong"
                     disabled={role.system}
-                    onClick={() => setDeleteTarget(role)}
+                    onClick={() => deletion.ask(role)}
                   >
                     削除
                   </Button>
@@ -177,11 +170,11 @@ export default function RolesPage() {
         onSaved={refetch}
       />
       <ConfirmDialog
-        open={deleteTarget !== null}
-        title={`${deleteTarget?.name ?? ''} を削除しますか？`}
+        open={deletion.target !== null}
+        title={`${deletion.target?.name ?? ''} を削除しますか？`}
         description="このロールを付与されているスタッフがいる場合は削除できません。"
-        onConfirm={handleDelete}
-        onClose={() => setDeleteTarget(null)}
+        onConfirm={() => void deletion.confirm()}
+        onClose={deletion.cancel}
       />
     </>
   );

--- a/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
+++ b/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { PlusIcon } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import {
   PlatformStaffResponse,
   PlatformStore,
@@ -34,18 +34,16 @@ const PAGE_SIZE = 10;
 /** スタッフ一覧ページ。一覧内モーダルで新規作成・編集を行う。 */
 export default function StaffPage() {
   const [searchTerm, setSearchTerm] = useState('');
-  // 適用済みの検索語。入力の state をそのまま読むと、値を変えた同一ハンドラ内で再取得したとき
-  // 再レンダー前の古い値で取得してしまう（useListPage の search 制約）ため ref で持つ。
-  const appliedSearch = useRef('');
 
-  const list = useListPage(
-    page =>
+  const list = useListPage<PlatformStaffResponse, string>(
+    (page, search) =>
       platformStaffApi.list({
         page,
         size: PAGE_SIZE,
-        search: appliedSearch.current || undefined,
+        search: search || undefined,
       }),
-    'スタッフ一覧の取得に失敗しました'
+    'スタッフ一覧の取得に失敗しました',
+    ''
   );
   const staff = list.rows;
   const { items: stores } = useManagedList<PlatformStore>(
@@ -53,11 +51,6 @@ export default function StaffPage() {
     '店舗一覧の取得に失敗しました'
   );
 
-  /** 検索語を適用して 1 ページ目から取り直す */
-  const applySearch = (term: string) => {
-    appliedSearch.current = term;
-    list.search();
-  };
   const [createOpen, setCreateOpen] = useState(false);
   // 編集対象は一覧から独立して保持する。分頁後の現在ページから導出すると、409 の再取得で
   // 対象がそのページから外れた瞬間（本人が PUT /platform/me で改名して検索から外れる、
@@ -97,7 +90,7 @@ export default function StaffPage() {
           </Button>
         }
         search={{
-          onSearch: () => applySearch(searchTerm),
+          onSearch: () => void list.search(searchTerm),
           content: (
             <>
               <div className="w-full md:max-w-xs">
@@ -120,7 +113,7 @@ export default function StaffPage() {
                   variant="outline"
                   onClick={() => {
                     setSearchTerm('');
-                    applySearch('');
+                    void list.search('');
                   }}
                 >
                   クリア

--- a/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
+++ b/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
@@ -26,7 +26,9 @@ jest.mock('next/navigation', () => ({
 
 jest.mock('react-hot-toast', () => ({
   __esModule: true,
+  // 作成・編集は既定 export、削除（useDeleteAction）は名前付き export を使う
   default: { success: jest.fn(), error: jest.fn() },
+  toast: { success: jest.fn(), error: jest.fn() },
 }));
 
 const mockedApi = platformStoreApi as jest.Mocked<typeof platformStoreApi>;

--- a/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { ExternalLinkIcon, PlusIcon, SquarePenIcon, StoreIcon, Trash2Icon } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { Store, isStoreDomain, platformStoreApi } from '@/entities/store';
-import { useListPage } from '@/shared/lib';
+import { useDeleteAction, useListPage } from '@/shared/lib';
 import { ListPage } from '@/widgets/list-page';
 import {
   Button,
@@ -17,7 +17,6 @@ import {
   TableHeader,
   TableRow,
 } from '@/shared/ui';
-import toast from 'react-hot-toast';
 
 /** 一覧 1 ページあたりの件数 */
 const PAGE_SIZE = 10;
@@ -25,38 +24,24 @@ const PAGE_SIZE = 10;
 export default function StoresPage() {
   const router = useRouter();
   const [searchTerm, setSearchTerm] = useState('');
-  const [deleteTarget, setDeleteTarget] = useState<Store | null>(null);
-  // 適用済みの検索語。入力の state をそのまま読むと、値を変えた同一ハンドラ内で再取得したとき
-  // 再レンダー前の古い値で取得してしまう（useListPage の search 制約）ため ref で持つ。
-  const appliedSearch = useRef('');
-
-  const list = useListPage(
-    page =>
+  const list = useListPage<Store, string>(
+    (page, search) =>
       platformStoreApi.getList({
         page,
         size: PAGE_SIZE,
-        search: appliedSearch.current || undefined,
+        search: search || undefined,
       }),
-    '店舗一覧の読み込みに失敗しました'
+    '店舗一覧の読み込みに失敗しました',
+    ''
   );
   const stores = list.rows;
 
-  /** 検索語を適用して 1 ページ目から取り直す */
-  const applySearch = (term: string) => {
-    appliedSearch.current = term;
-    list.search();
-  };
-
-  const handleDeleteStore = async () => {
-    if (!deleteTarget) return;
-    try {
-      await platformStoreApi.delete(deleteTarget.id);
-      toast.success('店舗を削除しました');
-      void list.reload();
-    } catch {
-      toast.error('店舗の削除に失敗しました');
-    }
-  };
+  const deletion = useDeleteAction<Store>({
+    remove: store => platformStoreApi.delete(store.id),
+    successMessage: '店舗を削除しました',
+    errorMessage: '店舗の削除に失敗しました',
+    onDeleted: list.reload,
+  });
 
   return (
     <>
@@ -70,7 +55,7 @@ export default function StoresPage() {
           </Button>
         }
         search={{
-          onSearch: () => applySearch(searchTerm),
+          onSearch: () => void list.search(searchTerm),
           content: (
             <>
               <div className="w-full md:max-w-xs">
@@ -93,7 +78,7 @@ export default function StoresPage() {
                   variant="outline"
                   onClick={() => {
                     setSearchTerm('');
-                    applySearch('');
+                    void list.search('');
                   }}
                 >
                   クリア
@@ -168,7 +153,7 @@ export default function StoresPage() {
                       variant="ghost"
                       size="icon-sm"
                       aria-label="削除"
-                      onClick={() => setDeleteTarget(store)}
+                      onClick={() => deletion.ask(store)}
                     >
                       <Trash2Icon />
                     </Button>
@@ -182,11 +167,11 @@ export default function StoresPage() {
 
       {/* ダイアログは一覧の loading / empty に連動して消えないよう外殻の外に置く */}
       <ConfirmDialog
-        open={deleteTarget !== null}
-        title={deleteTarget ? `店舗「${deleteTarget.name}」を削除しますか？` : ''}
+        open={deletion.target !== null}
+        title={deletion.target ? `店舗「${deletion.target.name}」を削除しますか？` : ''}
         description="この操作は取り消せません。"
-        onConfirm={() => void handleDeleteStore()}
-        onClose={() => setDeleteTarget(null)}
+        onConfirm={() => void deletion.confirm()}
+        onClose={deletion.cancel}
       />
     </>
   );

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
@@ -3,7 +3,7 @@
 import { PlusIcon, SquarePenIcon, Trash2Icon } from 'lucide-react';
 import { useState } from 'react';
 import { CastFieldDefinitionResponse, castFieldDefinitionApi } from '@/entities/cast';
-import { useManagedList } from '@/shared/lib';
+import { useDeleteAction, useManagedList } from '@/shared/lib';
 import { ListPage } from '@/widgets/list-page';
 import {
   Badge,
@@ -16,7 +16,6 @@ import {
   TableHeader,
   TableRow,
 } from '@/shared/ui';
-import { toast } from 'react-hot-toast';
 import { CastFieldCreateModal } from './CastFieldCreateModal';
 import { CastFieldEditModal } from './CastFieldEditModal';
 
@@ -32,18 +31,12 @@ export default function CastFieldsPage() {
   );
   const [createOpen, setCreateOpen] = useState(false);
   const [editing, setEditing] = useState<CastFieldDefinitionResponse | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<CastFieldDefinitionResponse | null>(null);
-
-  const handleDelete = async () => {
-    if (!deleteTarget) return;
-    try {
-      await castFieldDefinitionApi.delete(deleteTarget.id);
-      toast.success('フィールドを削除しました');
-      void refetch();
-    } catch {
-      toast.error('フィールドの削除に失敗しました');
-    }
-  };
+  const deletion = useDeleteAction<CastFieldDefinitionResponse>({
+    remove: definition => castFieldDefinitionApi.delete(definition.id),
+    successMessage: 'フィールドを削除しました',
+    errorMessage: 'フィールドの削除に失敗しました',
+    onDeleted: refetch,
+  });
 
   return (
     <>
@@ -106,7 +99,7 @@ export default function CastFieldsPage() {
                       variant="ghost"
                       size="icon-sm"
                       aria-label="削除"
-                      onClick={() => setDeleteTarget(definition)}
+                      onClick={() => deletion.ask(definition)}
                     >
                       <Trash2Icon />
                     </Button>
@@ -131,10 +124,10 @@ export default function CastFieldsPage() {
         onUpdated={refetch}
       />
       <ConfirmDialog
-        open={deleteTarget !== null}
-        title={deleteTarget ? `「${deleteTarget.label}」を削除しますか？` : ''}
-        onConfirm={() => void handleDelete()}
-        onClose={() => setDeleteTarget(null)}
+        open={deletion.target !== null}
+        title={deletion.target ? `「${deletion.target.label}」を削除しますか？` : ''}
+        onConfirm={() => void deletion.confirm()}
+        onClose={deletion.cancel}
       />
     </>
   );

--- a/frontend/src/_pages/store-casts/ui/CastsPage.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastsPage.tsx
@@ -4,13 +4,12 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import { PlusIcon, SearchIcon, SquarePenIcon, Trash2Icon, SettingsIcon } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CastResponse, castApi, castInvitationStatusLabel } from '@/entities/cast';
 import { platformAuthApi } from '@/entities/user';
 import { InvitationButton, InvitationModal, IssuedInvitation } from '@/features/cast-invitation';
-import { storePath, useListPage } from '@/shared/lib';
+import { storePath, useDeleteAction, useListPage } from '@/shared/lib';
 import { ListPage } from '@/widgets/list-page';
-import { toast } from 'react-hot-toast';
 import {
   Badge,
   Button,
@@ -33,7 +32,6 @@ export default function CastListPage() {
   const storeId = params.storeId as string;
   const [search, setSearch] = useState('');
   const [issuedInvitation, setIssuedInvitation] = useState<IssuedInvitation | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<CastResponse | null>(null);
   // 権限による UI 出し分け（強制はサーバ側 @PreAuthorize — ここは導線の表示制御のみ）
   const [canInvite, setCanInvite] = useState(false);
   const [canManageFieldDefs, setCanManageFieldDefs] = useState(false);
@@ -48,28 +46,20 @@ export default function CastListPage() {
         // 取得失敗時は導線を出さない（fail-closed）。操作自体はサーバ側が拒否する。
       });
   }, []);
-  // 適用済みの検索語。取得は検索の送信・ページ送り・再取得のいずれからも走るため、
-  // 入力中の state を fetcher が読むと、送信していない語がページ送りに紛れ込む。
-  const appliedSearch = useRef('');
-  const list = useListPage(
-    page =>
+  const list = useListPage<CastResponse, string>(
+    (page, appliedSearch) =>
       castApi.list({
         page,
         size: PAGE_SIZE,
         // display_order は既定値 0 のため一意でない。offset ページングの境界を確定させるには
         // 一意な副キーが要る（sort=prop1,prop2,direction は Spring Data の複数キー形式）
         sort: 'displayOrder,id,asc',
-        search: appliedSearch.current || undefined,
+        search: appliedSearch || undefined,
       }),
-    'キャスト一覧の取得に失敗しました'
+    'キャスト一覧の取得に失敗しました',
+    ''
   );
   const casts = list.rows;
-
-  /** 入力中の検索語を適用して 1 ページ目から取り直す */
-  const handleSearch = () => {
-    appliedSearch.current = search;
-    list.search();
-  };
 
   /** 招待発行成功時: モーダル表示と一覧の再取得を行う（isLoading に連動して行がアンマウントされても、
    *  モーダル state はページ層が持つためモーダルは表示され続ける） */
@@ -79,16 +69,12 @@ export default function CastListPage() {
   };
 
   /** キャストを削除する */
-  const handleDelete = async () => {
-    if (!deleteTarget) return;
-    try {
-      await castApi.delete(deleteTarget.id);
-      toast.success('キャストを削除しました');
-      void list.reload();
-    } catch {
-      toast.error('キャストの削除に失敗しました');
-    }
-  };
+  const deletion = useDeleteAction<CastResponse>({
+    remove: cast => castApi.delete(cast.id),
+    successMessage: 'キャストを削除しました',
+    errorMessage: 'キャストの削除に失敗しました',
+    onDeleted: list.reload,
+  });
 
   /** ステータスの表示ラベルと配色を返す */
   const statusLabel = (status: string) => {
@@ -127,7 +113,7 @@ export default function CastListPage() {
           </>
         }
         search={{
-          onSearch: handleSearch,
+          onSearch: () => void list.search(search),
           content: (
             <>
               <div className="flex-1 relative">
@@ -221,7 +207,7 @@ export default function CastListPage() {
                           <SquarePenIcon />
                         </Link>
                       </Button>
-                      <Button variant="ghost" size="icon-sm" onClick={() => setDeleteTarget(cast)}>
+                      <Button variant="ghost" size="icon-sm" onClick={() => deletion.ask(cast)}>
                         <Trash2Icon />
                       </Button>
                     </div>
@@ -245,10 +231,10 @@ export default function CastListPage() {
         onClose={() => setIssuedInvitation(null)}
       />
       <ConfirmDialog
-        open={deleteTarget !== null}
-        title={deleteTarget ? `「${deleteTarget.name}」を削除しますか？` : ''}
-        onConfirm={() => void handleDelete()}
-        onClose={() => setDeleteTarget(null)}
+        open={deletion.target !== null}
+        title={deletion.target ? `「${deletion.target.name}」を削除しますか？` : ''}
+        onConfirm={() => void deletion.confirm()}
+        onClose={deletion.cancel}
       />
     </>
   );

--- a/frontend/src/_pages/store-casts/ui/CastsPage.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastsPage.tsx
@@ -47,14 +47,14 @@ export default function CastListPage() {
       });
   }, []);
   const list = useListPage<CastResponse, string>(
-    (page, appliedSearch) =>
+    (page, criteria) =>
       castApi.list({
         page,
         size: PAGE_SIZE,
         // display_order は既定値 0 のため一意でない。offset ページングの境界を確定させるには
         // 一意な副キーが要る（sort=prop1,prop2,direction は Spring Data の複数キー形式）
         sort: 'displayOrder,id,asc',
-        search: appliedSearch || undefined,
+        search: criteria || undefined,
       }),
     'キャスト一覧の取得に失敗しました',
     ''

--- a/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
@@ -2,11 +2,10 @@
 
 import Link from 'next/link';
 import { PlusIcon, SearchIcon, SquarePenIcon, Trash2Icon } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { useParams } from 'next/navigation';
 import { CustomerResponse, customerApi } from '@/entities/customer';
-import { toast } from 'react-hot-toast';
-import { storePath, useListPage } from '@/shared/lib';
+import { storePath, useDeleteAction, useListPage } from '@/shared/lib';
 import { ListPage } from '@/widgets/list-page';
 import {
   Badge,
@@ -24,6 +23,13 @@ import {
 /** 一覧 1 ページあたりの件数 */
 const PAGE_SIZE = 20;
 
+/** 一覧の絞り込み条件（送信で確定した値） */
+interface CustomerCriteria {
+  search: string;
+  rank: string;
+  classification: string;
+}
+
 /** 顧客一覧ページ */
 export default function CustomersPage() {
   const params = useParams();
@@ -31,43 +37,30 @@ export default function CustomersPage() {
   const [search, setSearch] = useState('');
   const [rank, setRank] = useState('');
   const [classification, setClassification] = useState('');
-  const [deleteTarget, setDeleteTarget] = useState<CustomerResponse | null>(null);
 
-  // 適用済みの絞り込み条件。取得は検索の送信・ページ送り・再取得のいずれからも走るため、
-  // 入力中の state を fetcher が読むと、送信していない条件がページ送りに紛れ込む。
-  const applied = useRef({ search: '', rank: '', classification: '' });
-  const list = useListPage(
-    page =>
+  const list = useListPage<CustomerResponse, CustomerCriteria>(
+    (page, criteria) =>
       customerApi.list({
         page,
         size: PAGE_SIZE,
         // created_at は一意でない可能性があるため、offset ページングの境界を確定させる
         // 一意な副キーを添える（sort=prop1,prop2,direction は Spring Data の複数キー形式）
         sort: 'createdAt,id,desc',
-        search: applied.current.search || undefined,
-        rank: applied.current.rank || undefined,
-        classification: applied.current.classification || undefined,
+        search: criteria.search || undefined,
+        rank: criteria.rank || undefined,
+        classification: criteria.classification || undefined,
       }),
-    '顧客一覧の取得に失敗しました'
+    '顧客一覧の取得に失敗しました',
+    { search: '', rank: '', classification: '' }
   );
   const customers = list.rows;
 
-  /** 入力中の絞り込み条件を適用して 1 ページ目から取り直す */
-  const handleSearch = () => {
-    applied.current = { search, rank, classification };
-    list.search();
-  };
-
-  const handleDelete = async () => {
-    if (!deleteTarget) return;
-    try {
-      await customerApi.delete(deleteTarget.id);
-      toast.success('顧客を削除しました');
-      void list.reload();
-    } catch {
-      toast.error('顧客の削除に失敗しました');
-    }
-  };
+  const deletion = useDeleteAction<CustomerResponse>({
+    remove: customer => customerApi.delete(customer.id),
+    successMessage: '顧客を削除しました',
+    errorMessage: '顧客の削除に失敗しました',
+    onDeleted: list.reload,
+  });
 
   return (
     <>
@@ -83,7 +76,7 @@ export default function CustomersPage() {
           </Button>
         }
         search={{
-          onSearch: handleSearch,
+          onSearch: () => void list.search({ search, rank, classification }),
           content: (
             <>
               <div className="flex-1 relative">
@@ -166,11 +159,7 @@ export default function CustomersPage() {
                         <SquarePenIcon />
                       </Link>
                     </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => setDeleteTarget(customer)}
-                    >
+                    <Button variant="ghost" size="icon-sm" onClick={() => deletion.ask(customer)}>
                       <Trash2Icon />
                     </Button>
                   </div>
@@ -183,10 +172,10 @@ export default function CustomersPage() {
 
       {/* ダイアログは一覧の loading / empty に連動して消えないよう外殻の外に置く */}
       <ConfirmDialog
-        open={deleteTarget !== null}
-        title={deleteTarget ? `「${deleteTarget.name}」を削除しますか？` : ''}
-        onConfirm={() => void handleDelete()}
-        onClose={() => setDeleteTarget(null)}
+        open={deletion.target !== null}
+        title={deletion.target ? `「${deletion.target.name}」を削除しますか？` : ''}
+        onConfirm={() => void deletion.confirm()}
+        onClose={deletion.cancel}
       />
     </>
   );

--- a/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
@@ -121,8 +121,8 @@ export function ShiftFormModal({
       }
       onSaved();
       onClose();
-    } catch {
-      toast.error('シフトの保存に失敗しました');
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, 'シフトの保存に失敗しました'));
     }
   };
 

--- a/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
@@ -5,6 +5,7 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { CastResponse } from '@/entities/cast';
 import { ShiftResponse, shiftApi } from '@/entities/shift';
+import { getApiErrorMessage } from '@/shared/lib';
 import {
   Button,
   ConfirmDialog,
@@ -132,8 +133,8 @@ export function ShiftFormModal({
       toast.success('シフトを削除しました');
       onSaved();
       onClose();
-    } catch {
-      toast.error('シフトの削除に失敗しました');
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, 'シフトの削除に失敗しました'));
     }
   };
 

--- a/frontend/src/shared/lib/__tests__/useDeleteAction.test.tsx
+++ b/frontend/src/shared/lib/__tests__/useDeleteAction.test.tsx
@@ -1,0 +1,92 @@
+import { act, renderHook } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
+import { useDeleteAction } from '@/shared/lib';
+
+jest.mock('react-hot-toast', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+interface Row {
+  id: string;
+}
+
+const setup = (remove: (target: Row) => Promise<void>, onDeleted = jest.fn()) => {
+  const rendered = renderHook(() =>
+    useDeleteAction<Row>({
+      remove,
+      successMessage: '削除しました',
+      errorMessage: '削除に失敗しました',
+      onDeleted,
+    })
+  );
+  return { ...rendered, onDeleted };
+};
+
+describe('useDeleteAction', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('ask で対象を保持し cancel で手放す', () => {
+    const { result } = setup(jest.fn(async () => {}));
+
+    expect(result.current.target).toBeNull();
+    act(() => result.current.ask({ id: '1' }));
+    expect(result.current.target).toEqual({ id: '1' });
+    act(() => result.current.cancel());
+    expect(result.current.target).toBeNull();
+  });
+
+  it('confirm は確認中の対象を削除し、成功文言と後始末を走らせる', async () => {
+    const remove = jest.fn(async () => {});
+    const { result, onDeleted } = setup(remove);
+
+    act(() => result.current.ask({ id: '1' }));
+    await act(async () => {
+      await result.current.confirm();
+    });
+
+    expect(remove).toHaveBeenCalledWith({ id: '1' });
+    expect(toast.success).toHaveBeenCalledWith('削除しました');
+    expect(onDeleted).toHaveBeenCalledTimes(1);
+  });
+
+  it('失敗時はサーバが返した文言を出し、後始末は走らせない', async () => {
+    const remove = jest.fn(async () => {
+      throw { response: { data: { error: 'このロールは付与中のため削除できません' } } };
+    });
+    const { result, onDeleted } = setup(remove);
+
+    act(() => result.current.ask({ id: '1' }));
+    await act(async () => {
+      await result.current.confirm();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('このロールは付与中のため削除できません');
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(onDeleted).not.toHaveBeenCalled();
+  });
+
+  it('サーバが理由を返さないときだけ既定の文言へ落ちる', async () => {
+    const remove = jest.fn(async () => {
+      throw new Error('boom');
+    });
+    const { result } = setup(remove);
+
+    act(() => result.current.ask({ id: '1' }));
+    await act(async () => {
+      await result.current.confirm();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('削除に失敗しました');
+  });
+
+  it('対象がないまま confirm しても削除しない', async () => {
+    const remove = jest.fn(async () => {});
+    const { result } = setup(remove);
+
+    await act(async () => {
+      await result.current.confirm();
+    });
+
+    expect(remove).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/shared/lib/__tests__/useListPage.test.tsx
+++ b/frontend/src/shared/lib/__tests__/useListPage.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { toast } from 'react-hot-toast';
 import { useListPage } from '@/shared/lib';
@@ -23,7 +24,7 @@ describe('useListPage', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.rows).toEqual(['a', 'b']);
     expect(result.current.page).toBe(0);
-    expect(fetcher).toHaveBeenCalledWith(0);
+    expect(fetcher).toHaveBeenCalledWith(0, undefined);
   });
 
   it('onPageChange は指定ページで再取得する', async () => {
@@ -35,7 +36,7 @@ describe('useListPage', () => {
       await result.current.onPageChange(2);
     });
 
-    expect(fetcher).toHaveBeenLastCalledWith(2);
+    expect(fetcher).toHaveBeenLastCalledWith(2, undefined);
     expect(result.current.page).toBe(2);
   });
 
@@ -52,7 +53,7 @@ describe('useListPage', () => {
       await result.current.reload();
     });
 
-    expect(fetcher).toHaveBeenLastCalledWith(2);
+    expect(fetcher).toHaveBeenLastCalledWith(2, undefined);
     expect(result.current.page).toBe(2);
   });
 
@@ -70,8 +71,55 @@ describe('useListPage', () => {
       await result.current.search();
     });
 
-    expect(fetcher).toHaveBeenLastCalledWith(0);
+    expect(fetcher).toHaveBeenLastCalledWith(0, undefined);
     expect(result.current.page).toBe(0);
+  });
+
+  it('初回取得には初期条件を使う', async () => {
+    const fetcher = jest.fn(async (page: number) => pageOf(page));
+    renderHook(() => useListPage<string, string>(fetcher, '取得失敗', 'あ'));
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledWith(0, 'あ'));
+  });
+
+  it('search に渡した条件はページ送り・再取得にも引き継がれる', async () => {
+    const fetcher = jest.fn(async (page: number) => pageOf(page));
+    const { result } = renderHook(() => useListPage<string, string>(fetcher, '取得失敗', ''));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.search('やまだ');
+    });
+    expect(fetcher).toHaveBeenLastCalledWith(0, 'やまだ');
+
+    await act(async () => {
+      await result.current.onPageChange(1);
+    });
+    expect(fetcher).toHaveBeenLastCalledWith(1, 'やまだ');
+
+    await act(async () => {
+      await result.current.reload();
+    });
+    expect(fetcher).toHaveBeenLastCalledWith(1, 'やまだ');
+  });
+
+  it('条件を保持する state を更新した直後に呼んでも、渡した条件で取得する', async () => {
+    // 呼び出し側の state を fetcher のクロージャから読ませていた頃は、条件を更新した同一
+    // ハンドラ内で search を呼ぶと再レンダー前の古い値で取得していた。条件は引数で渡す。
+    const fetcher = jest.fn(async (page: number) => pageOf(page));
+    const { result } = renderHook(() => {
+      const [term, setTerm] = useState('');
+      const list = useListPage<string, string>(fetcher, '取得失敗', '');
+      return { list, term, setTerm };
+    });
+    await waitFor(() => expect(result.current.list.isLoading).toBe(false));
+
+    await act(async () => {
+      result.current.setTerm('あたらしい');
+      await result.current.list.search('あたらしい');
+    });
+
+    expect(fetcher).toHaveBeenLastCalledWith(0, 'あたらしい');
   });
 
   it('古いリクエストの遅延応答は新しい結果を上書きしない', async () => {

--- a/frontend/src/shared/lib/index.ts
+++ b/frontend/src/shared/lib/index.ts
@@ -3,6 +3,7 @@ export { default as redirectToLogin } from './navigation';
 export { getApiErrorMessage, isConflict } from './apiError';
 export { useManagedList } from './useManagedList';
 export { useListPage } from './useListPage';
+export { useDeleteAction } from './useDeleteAction';
 export {
   clearPlatformSession,
   getPlatformConsole,

--- a/frontend/src/shared/lib/useDeleteAction.ts
+++ b/frontend/src/shared/lib/useDeleteAction.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { getApiErrorMessage } from './apiError';
+
+interface DeleteActionOptions<T> {
+  /** 削除本体。確認済みの対象を受け取る */
+  remove: (target: T) => Promise<void>;
+  successMessage: string;
+  /** サーバが理由を返さなかったときの文言 */
+  errorMessage: string;
+  /** 削除成功後の後始末（一覧の取り直し等） */
+  onDeleted: () => void;
+}
+
+/**
+ * 一覧行の削除ライフサイクル（確認対象の保持・実行・トースト）。
+ * 失敗理由はサーバだけが持つ（授与中ロールの 409 等）ため、文言は常に応答から取り、
+ * 応答が理由を持たないときだけ errorMessage へ落とす。
+ * 確認ダイアログの文言は対象に依存するため、描画は呼び出し側の責務（target を読んで組み立てる）。
+ */
+export function useDeleteAction<T>({
+  remove,
+  successMessage,
+  errorMessage,
+  onDeleted,
+}: DeleteActionOptions<T>) {
+  const [target, setTarget] = useState<T | null>(null);
+
+  const confirm = async () => {
+    if (!target) return;
+    try {
+      await remove(target);
+      toast.success(successMessage);
+      onDeleted();
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, errorMessage));
+    }
+  };
+
+  return {
+    /** 確認中の対象。null なら確認ダイアログは閉じている */
+    target,
+    /** 行の削除ボタンから確認を開く */
+    ask: (row: T) => setTarget(row),
+    confirm,
+    cancel: () => setTarget(null),
+  };
+}

--- a/frontend/src/shared/lib/useListPage.ts
+++ b/frontend/src/shared/lib/useListPage.ts
@@ -6,19 +6,40 @@ import { PageResult } from '@/shared/api';
 
 const EMPTY_PAGE: PageResult<never> = { rows: [], page: 0, pageCount: 0, total: 0 };
 
+interface ListPageState<T, C> extends PageResult<T> {
+  isLoading: boolean;
+  /** 検索条件を適用して 1 ページ目から取り直す */
+  search: (criteria: C) => Promise<void>;
+  onPageChange: (page: number) => Promise<void>;
+  reload: () => Promise<void>;
+}
+
 /**
- * ListPage 向けの取得ライフサイクル（page state・失敗トースト・順不同レスポンス守衛）。
- * fetcher は毎レンダー最新のクロージャを参照するため、検索条件の state は useManagedList 同様に
- * 呼び出し側がそのまま閉じ込めてよい。hook が持つのはページ番号（0 起点）だけ。
+ * ListPage 向けの取得ライフサイクル（page・適用済み検索条件・失敗トースト・順不同レスポンス守衛）。
+ * 検索条件は fetcher の引数として渡す。呼び出し側の state を fetcher のクロージャから読ませると、
+ * 条件を更新した同一ハンドラ内で再取得したとき再レンダー前の古い値で取得してしまうため、
+ * 「どの条件で取得するか」は hook が持つ。検索条件を持たない一覧は C を省略してよい。
  */
 export function useListPage<T>(
   fetcher: (page: number) => Promise<PageResult<T>>,
   errorMessage: string
-) {
+): ListPageState<T, void>;
+export function useListPage<T, C>(
+  fetcher: (page: number, criteria: C) => Promise<PageResult<T>>,
+  errorMessage: string,
+  initialCriteria: C
+): ListPageState<T, C>;
+export function useListPage<T, C>(
+  fetcher: (page: number, criteria: C) => Promise<PageResult<T>>,
+  errorMessage: string,
+  initialCriteria?: C
+): ListPageState<T, C> {
   const fetcherRef = useRef(fetcher);
   fetcherRef.current = fetcher;
   // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する
   const requestIdRef = useRef(0);
+  // 適用済みの検索条件。ページ送りと再取得はこれをそのまま使う
+  const criteriaRef = useRef(initialCriteria as C);
   const [pageResult, setPageResult] = useState<PageResult<T>>(EMPTY_PAGE);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -27,7 +48,7 @@ export function useListPage<T>(
       const requestId = ++requestIdRef.current;
       setIsLoading(true);
       try {
-        const result = await fetcherRef.current(page);
+        const result = await fetcherRef.current(page, criteriaRef.current);
         if (requestId === requestIdRef.current) setPageResult(result);
       } catch {
         if (requestId === requestIdRef.current) toast.error(errorMessage);
@@ -47,11 +68,14 @@ export function useListPage<T>(
     };
   }, [load]);
 
-  // 検索条件が変わったときの再取得は 1 ページ目に戻す。
-  // fetcher クロージャは直近のレンダーの値を参照するため、検索条件の state を更新した
-  // 同一ハンドラ内で続けて呼ぶと再レンダー前の古い条件で取得してしまう
-  // （useManagedList の refetch と同じ制約）。state 更新の反映後（次のレンダー以降）に呼ぶこと。
-  const search = useCallback(() => load(0), [load]);
+  // 検索条件を適用して 1 ページ目から取り直す
+  const search = useCallback(
+    (criteria: C) => {
+      criteriaRef.current = criteria;
+      return load(0);
+    },
+    [load]
+  );
   const onPageChange = useCallback((page: number) => load(page), [load]);
   // 削除・発行など一覧を書き換える操作の後始末。現在のページをそのまま取り直す
   const reload = useCallback(() => load(pageResult.page), [load, pageResult.page]);

--- a/frontend/src/shared/lib/useListPage.ts
+++ b/frontend/src/shared/lib/useListPage.ts
@@ -6,7 +6,7 @@ import { PageResult } from '@/shared/api';
 
 const EMPTY_PAGE: PageResult<never> = { rows: [], page: 0, pageCount: 0, total: 0 };
 
-interface ListPageState<T, C> extends PageResult<T> {
+interface ListPageResult<T, C> extends PageResult<T> {
   isLoading: boolean;
   /** 検索条件を適用して 1 ページ目から取り直す */
   search: (criteria: C) => Promise<void>;
@@ -23,17 +23,17 @@ interface ListPageState<T, C> extends PageResult<T> {
 export function useListPage<T>(
   fetcher: (page: number) => Promise<PageResult<T>>,
   errorMessage: string
-): ListPageState<T, void>;
+): ListPageResult<T, void>;
 export function useListPage<T, C>(
   fetcher: (page: number, criteria: C) => Promise<PageResult<T>>,
   errorMessage: string,
   initialCriteria: C
-): ListPageState<T, C>;
+): ListPageResult<T, C>;
 export function useListPage<T, C>(
   fetcher: (page: number, criteria: C) => Promise<PageResult<T>>,
   errorMessage: string,
   initialCriteria?: C
-): ListPageState<T, C> {
+): ListPageResult<T, C> {
   const fetcherRef = useRef(fetcher);
   fetcherRef.current = fetcher;
   // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する


### PR DESCRIPTION
## 概要

一覧ページの削除処理（5 ページに同形の複製）と、`useListPage` が呼び出し側へ委譲していた「取得に使う検索条件」の制約（4 ページに同じ `useRef` 回避の複製）を、それぞれ module の内側へ収める。

Closes #531

## 変更内容

- `shared/lib/useDeleteAction` を新設（`{ target, ask, confirm, cancel }`）。確認対象の保持・実行・トーストを内側へ収め、失敗時は常に `getApiErrorMessage` を通す。ロール / 店舗 / カスタム項目 / キャスト / 顧客の 5 ページを移行し、各ページの `deleteTarget` の `useState` と削除用 try/catch を撤去。
- `useListPage` の fetcher を `(page, criteria)` 形へ変更し、適用済みの検索条件を hook が持つ。スタッフ / 店舗 / キャスト / 顧客の 4 ページから `appliedSearch` の `useRef` 回避を撤去。制約を呼び出し側へ委譲していた doc コメントも削除。
- `ShiftFormModal` は削除対象が prop 由来・後始末が 2 段で形が異なるため hook 化せず、握り潰していた `catch` のみ揃える。
- 削除・取得の失敗文言から裸の id を除去（`CustomerService` / `CastService` / `CastFieldDefinitionService`）。利用者向けトーストへ UUID がそのまま出るため。
- `useDeleteAction` の単体テストを追加、`useListPage` のテストを新 interface へ随動（適用済み条件がページ送り・再取得へ引き継がれることを固定）。

## 検証

- [x] `task lint` exit 0（frontend は buildx の COPY 層キャッシュを踏んだため `--no-cache-filter lint` で再実行し 0 error / 既存 48 warning / Steiger clean を確認）
- [x] `task test` exit 0（frontend 79 suites・516 tests / backend unit + integrationTest）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 22 件すべて。platform-login / staff-management / roles / store-settings / template-switch / cast-portal ほか）
- [ ] ローカルで code-review 実施済み ← **未実施**

### 視覚確認（UI 変更時）

markup と class は無変更（handler と state のみ）のため差分としての見た目変化はないが、配線を実スタックで確認した。

- ロール管理: 削除ダイアログの見出しが対象へ束縛されている（「顧客専任 を削除しますか？」＋補足文）ことと、キャンセルで閉じることを確認。
- スタッフ管理: 全 28 件 →「検証スタッフ」で 16 件へ絞り込み、2 ページ目へ送っても「16 件中 11-16 を表示」で絞り込みが維持される（＝適用済み条件がページ送りへ引き継がれる）ことを確認。

## 決定ログ

- **編集対象の保持機構（StaffPage の id 再取得 / RolesPage の一覧からの導出）は統一しない。** 一見「同じ問題に 2 つの答え」だが、両者とも `version` を往復して陳腐化フォームを 409 で拒否するという同一方針の実装であり、分かれている理由は一覧が分頁されているか否か。RolesPage は非分頁なので `refetch` がそのままモーダル最新化になり、StaffPage は分頁のため対象が頁から外れると導出が壊れる（ゆえに `GET /platform/staff/{id}` がある）。どちらも理由のコメントと回帰テストを持つので触らない。
- **`useManagedList` と `useListPage` は統合しない。** #509 が配列形の取得用途として存置を決めている。
- **`ConfirmDialog`（`shared/ui`）は変更しない。** 重複していたのは対話 UI ではなく、その外側の state と実行・文言。title / description は対象に依存するのでページの責務のまま。
- **`useListPage` の条件受け渡しは命令式（`search(criteria)`）を採った。** 宣言的に `criteria` を hook 引数にする案は、オブジェクト literal の参照が毎レンダー変わるため `useMemo` か直列化キーが必須になり、回避すべき罠を別の罠に置き換えるだけだった。「条件を渡し忘れる」を型で防ぐため、条件ありの呼び出しでは初期条件を必須にする overload を置いている。
- **`ShiftFormModal` を hook へ寄せなかった。** 削除対象が prop 由来・`confirmOpen` が boolean・後始末が `onSaved(); onClose();` の 2 段。単一の呼び出し点のために interface を広げるほうが高い。

## 備考 / レビュー観点

- **`task e2e` までは通したが、ローカルの code-review は未実施。** マージ前に必要なら別途回してほしい。
- **当初の想定より 2 箇所広げている。** ① バックエンドは delete だけでなく同ファイルの `get` / `update` の文言も裸 id を落とした（同じく利用者向けトーストへ出るため、delete だけ直すと 1 ファイル内で矛盾する）。② `ShiftFormModal` は削除だけでなく保存の `catch` も揃えた（重複シフト等の拒否理由も後端しか持たないため）。どちらも「利用者向け文言」という同一の欠陥類。
- **`pages.test.tsx`（店舗管理）の toast mock に名前付き export を足している。** 作成・編集画面は既定 export、削除は `useDeleteAction` 経由で名前付き export を使うため両方必要になった。
- **4 ページの削除失敗時に、これまで出ていなかったサーバ側の文言が出るようになる**（挙動変化）。裸 id を落としたのはこの表示経路のため。
- 対象外として #531 に明記した残件: 編集対象の保持機構の統一 / `useManagedList` の統合 / `CastFieldDefinition` 更新の楽観ロック（DTO が version を往復しないため陳腐化フォームは後勝ち）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
