### PR TITLE
fix(store): 店舗更新で email が保存されない問題を直す

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/store/PlatformStoreApiIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/store/PlatformStoreApiIT.java
@@ -183,6 +183,88 @@ class PlatformStoreApiIT {
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
   }
 
+  // 編集画面は name と email を送る。更新 DTO が受け取らない項目は
+  // fail-on-unknown-properties: false により黙って捨てられ、成功応答だけが返る。
+  // 読み戻しは storeByDomain キャッシュを経ない /{id}（編集画面が実際に読む経路）で行う。
+  @Test
+  @DisplayName("PUT /platform/stores/{id} は email だけの変更を永続化すること")
+  void updateStorePersistsEmail() {
+    String hq = platformToken(HQ_EMAIL);
+    String unique = UUID.randomUUID().toString();
+    String name = "store-it-update-email-" + unique;
+    String id =
+        createStore(
+            hq, name, "store-it-update-email-" + unique + ".kizuna.test", "before@kizuna.test");
+
+    HttpHeaders headers = bearer(hq);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    String body = String.format("{\"name\": \"%s\", \"email\": \"after@kizuna.test\"}", name);
+    ResponseEntity<Void> updated =
+        rest.exchange(
+            "/platform/stores/" + id, HttpMethod.PUT, new HttpEntity<>(body, headers), Void.class);
+    assertThat(updated.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+    ResponseEntity<JsonNode> reloaded =
+        rest.exchange(
+            "/platform/stores/" + id, HttpMethod.GET, new HttpEntity<>(bearer(hq)), JsonNode.class);
+    assertThat(reloaded.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(reloaded.getBody().path("email").asString()).isEqualTo("after@kizuna.test");
+    assertThat(reloaded.getBody().path("name").asString()).as("name は据え置きのまま").isEqualTo(name);
+  }
+
+  // email を伴わない更新要求で email が null に上書きされないこと。
+  // PUT は全項目の置換であり、必須項目の欠落は保存の手前で拒む。
+  @Test
+  @DisplayName("PUT /platform/stores/{id} は email を欠く要求を 400 で拒むこと")
+  void updateStoreRejectsMissingEmail() {
+    String hq = platformToken(HQ_EMAIL);
+    String unique = UUID.randomUUID().toString();
+    String name = "store-it-update-noemail-" + unique;
+    String id =
+        createStore(
+            hq, name, "store-it-update-noemail-" + unique + ".kizuna.test", "keep@kizuna.test");
+
+    HttpHeaders headers = bearer(hq);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    ResponseEntity<String> res =
+        rest.exchange(
+            "/platform/stores/" + id,
+            HttpMethod.PUT,
+            new HttpEntity<>(String.format("{\"name\": \"%s\"}", name), headers),
+            String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+    ResponseEntity<JsonNode> reloaded =
+        rest.exchange(
+            "/platform/stores/" + id, HttpMethod.GET, new HttpEntity<>(bearer(hq)), JsonNode.class);
+    assertThat(reloaded.getBody().path("email").asString())
+        .as("拒まれた要求で既存の email が消えないこと")
+        .isEqualTo("keep@kizuna.test");
+  }
+
+  /** 店舗を作成し、その id を返す。POST は 204 で本文を返さないため、一意な name で検索して引く。 */
+  private String createStore(String token, String name, String domain, String email) {
+    HttpHeaders headers = bearer(token);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    String body =
+        String.format(
+            "{\"name\": \"%s\", \"domain\": \"%s\", \"email\": \"%s\"}", name, domain, email);
+    ResponseEntity<Void> created =
+        rest.postForEntity("/platform/stores", new HttpEntity<>(body, headers), Void.class);
+    assertThat(created.getStatusCode()).as("前提: 店舗が作成されること").isEqualTo(HttpStatus.NO_CONTENT);
+
+    ResponseEntity<JsonNode> found =
+        rest.exchange(
+            "/platform/stores?search=" + name,
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(token)),
+            JsonNode.class);
+    assertThat(found.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(found.getBody().path("content").size()).as("前提: 作成した店舗が一意に引けること").isEqualTo(1);
+    return found.getBody().path("content").get(0).path("id").asString();
+  }
+
   @Test
   @DisplayName("GET /platform/stores/lookup?domain= は未認証で 200 と店舗情報を返すこと（受入基準3）")
   void lookupByDomainIsPublic() {

--- a/backend/src/main/java/com/kizuna/store/api/dto/StoreCreateDTO.java
+++ b/backend/src/main/java/com/kizuna/store/api/dto/StoreCreateDTO.java
@@ -34,6 +34,8 @@ public class StoreCreateDTO {
   @Pattern(regexp = DOMAIN_PATTERN, message = "domain must be a hostname")
   private String domain;
 
+  // 長さ上限は列定義（VARCHAR(128)）に合わせる。超過を通すと保存時の制約違反が 500 になる。
   @NotBlank(message = "email is required")
+  @Size(max = 128, message = "email is too long")
   private String email;
 }

--- a/backend/src/main/java/com/kizuna/store/api/dto/StoreUpdateDTO.java
+++ b/backend/src/main/java/com/kizuna/store/api/dto/StoreUpdateDTO.java
@@ -1,6 +1,7 @@
 package com.kizuna.store.api.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,4 +13,13 @@ public class StoreUpdateDTO {
 
   @NotBlank(message = "name is required")
   private String name;
+
+  /**
+   * 代表連絡先。PUT は全項目の置換であり、欠落は既存値を null で潰すことになるため必須で受ける。
+   *
+   * <p>長さ上限は列定義（VARCHAR(128)）に合わせる。超過を通すと保存時の制約違反が 500 になる。
+   */
+  @NotBlank(message = "email is required")
+  @Size(max = 128, message = "email is too long")
+  private String email;
 }

--- a/backend/src/main/java/com/kizuna/store/api/platform/PlatformStoreController.java
+++ b/backend/src/main/java/com/kizuna/store/api/platform/PlatformStoreController.java
@@ -87,7 +87,8 @@ public class PlatformStoreController {
 
   @PutMapping("/{id}")
   @PreAuthorize("hasAuthority('PERM_STORE_MANAGE')")
-  public ResponseEntity<Void> update(@PathVariable String id, @RequestBody StoreUpdateDTO store) {
+  public ResponseEntity<Void> update(
+      @PathVariable String id, @Valid @RequestBody StoreUpdateDTO store) {
     storeRegistryService.update(id, store);
     return ResponseEntity.noContent().build();
   }

--- a/backend/src/main/java/com/kizuna/store/application/StoreRegistryService.java
+++ b/backend/src/main/java/com/kizuna/store/application/StoreRegistryService.java
@@ -73,6 +73,7 @@ public class StoreRegistryService {
   public void update(String id, StoreUpdateDTO req) {
     var store = storeRepository.findById(parseId(id)).orElseThrow(() -> notFound(id));
     store.setName(req.getName());
+    store.setEmail(req.getEmail());
     storeRepository.save(store);
   }
 

--- a/backend/src/test/java/com/kizuna/store/api/platform/PlatformStoreControllerTest.java
+++ b/backend/src/test/java/com/kizuna/store/api/platform/PlatformStoreControllerTest.java
@@ -2,8 +2,13 @@ package com.kizuna.store.api.platform;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.kizuna.settings.application.SystemConfigService;
@@ -23,12 +28,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-/** 呼出側の {@code ?sort=} 上書きで一意な副キー id が消えないことの単体テスト（offset ページングの安定性）。 */
+/** 平台店舗 API のうち、ハンドラ層で閉じている約束（ページングの全順序・要求本文の検査）の単体テスト。 */
 @WebMvcTest(PlatformStoreController.class)
 @Import({PlatformStoreControllerTest.MethodSecurityConfig.class, StoreContext.class})
 class PlatformStoreControllerTest {
@@ -59,5 +65,22 @@ class PlatformStoreControllerTest {
     mockMvc.perform(get("/platform/stores?sort=name")).andExpect(status().isOk());
 
     assertThat(pageableCaptor.getValue().getSort().getOrderFor("id")).isNotNull();
+  }
+
+  // 更新は全項目の置換。必須項目を欠く要求を通すと既存値が null で潰れるため、
+  // ハンドラ引数の検査（@Valid）が効いていることを固定する。
+  @Test
+  @DisplayName("PUT /platform/stores/{id} は email を欠く要求を検査で弾き、サービスへ渡さないこと")
+  @WithMockUser(authorities = "PERM_STORE_MANAGE")
+  void updateRejectsRequestMissingEmailBeforeService() throws Exception {
+    mockMvc
+        .perform(
+            put("/platform/stores/1")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\": \"店舗\"}"))
+        .andExpect(status().isBadRequest());
+
+    verify(storeRegistryService, never()).update(anyString(), any());
   }
 }

--- a/backend/src/test/java/com/kizuna/store/application/StoreRegistryServiceTest.java
+++ b/backend/src/test/java/com/kizuna/store/application/StoreRegistryServiceTest.java
@@ -140,10 +140,28 @@ class StoreRegistryServiceTest {
 
     StoreUpdateDTO req = new StoreUpdateDTO();
     req.setName("New");
+    req.setEmail("o@o.com");
 
     storeRegistryService.update("1", req);
 
     assertThat(t.getName()).isEqualTo("New");
+    verify(storeRepository).save(t);
+  }
+
+  // 編集画面は name と email を送る。email が取り込まれなければ、成功応答だけ返って値が変わらない。
+  @Test
+  void update_modifiesEmail() {
+    Store t = createStore(1L, "Old", "old.com", "before@example.com");
+    when(storeRepository.findById(1L)).thenReturn(Optional.of(t));
+
+    StoreUpdateDTO req = new StoreUpdateDTO();
+    req.setName("Old");
+    req.setEmail("after@example.com");
+
+    storeRegistryService.update("1", req);
+
+    assertThat(t.getEmail()).isEqualTo("after@example.com");
+    assertThat(t.getName()).as("name は据え置きのまま").isEqualTo("Old");
     verify(storeRepository).save(t);
   }
 
@@ -153,6 +171,7 @@ class StoreRegistryServiceTest {
 
     StoreUpdateDTO req = new StoreUpdateDTO();
     req.setName("New");
+    req.setEmail("n@n.com");
 
     assertThatThrownBy(() -> storeRegistryService.update("99", req))
         .isInstanceOf(NotFoundException.class)

--- a/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
+++ b/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
@@ -261,6 +261,35 @@ describe('店舗管理 3 画面の挙動', () => {
     );
     await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/platform/stores'));
   });
+
+  // 上のケースは name を変えて email が素通りすることしか見ていない。
+  // 編集した email が要求に載ることは、保存が反映されるための前提として別に固定する。
+  it('編集は email だけの変更でも新しい email を送信すること', async () => {
+    mockedApi.getById.mockResolvedValue(
+      store({
+        id: '1',
+        name: 'デルタ店',
+        email: 'delta@example.com',
+        domain: 'delta.example.com',
+      })
+    );
+    mockedApi.update.mockResolvedValue(store({}));
+
+    render(<StoreEditPage />);
+
+    const emailInput = (await screen.findByLabelText(/連絡用メール/)) as HTMLInputElement;
+    await waitFor(() => expect(emailInput.value).toBe('delta@example.com'));
+
+    fireEvent.change(emailInput, { target: { value: 'delta-new@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() =>
+      expect(mockedApi.update).toHaveBeenCalledWith('1', {
+        name: 'デルタ店',
+        email: 'delta-new@example.com',
+      })
+    );
+  });
 });
 
 describe('店舗一覧ページ固有の要素', () => {


### PR DESCRIPTION
## 概要

`/platform/stores/{id}/edit` で email だけを変更して保存すると「店舗情報を更新しました」と表示されるのに値が保存されない不具合を直す。編集画面は `name` と `email` を送るが、更新 DTO に `email` が無く、`fail-on-unknown-properties: false` により黙って捨てられていた。

<!-- issue は起票しない方針（利用者判断）のため Closes は無し -->

## 変更内容

- `StoreUpdateDTO` に `email` を追加（`@NotBlank` + `@Size(max = 128)`）し、`StoreRegistryService.update` で取り込む
- `PlatformStoreController.update` に `@Valid` を追加。付けないと必須項目の宣言が効かず、`email` を欠く要求で既存値が null に潰れる
- `StoreCreateDTO.email` にも `@Size(max = 128)` を追加（列定義 `VARCHAR(128)` に対する同じ穴が作成側にもあったため揃える）
- テスト
  - `PlatformStoreApiIT`: email だけの変更が永続化されること / `email` を欠く要求が 400 で拒まれ既存値が消えないこと（この 2 件が修正前の red）
  - `StoreRegistryServiceTest`: `update_modifiesEmail` を追加。既存 `update_modifiesName` は DTO に email を入れて null 上書きを黙認しないよう修正
  - `PlatformStoreControllerTest`: 検査で弾かれサービスへ渡らないこと（統合テストは CI で走らないため、`@Valid` はこちらでゲートを張る）
  - `platform-stores/__tests__/pages.test.tsx`: 「email だけを変更」ケースを追加。既存ケースは name を変えて email が素通りするのを見ているだけで、email 編集そのものが未カバーだった

### ワイヤ契約の変更（意図的）

`PUT /platform/stores/{id}` に `{"name": "..."}` だけを送った場合、これまで 204 だったものが **400** になる。`@Valid` 無しで `setEmail` を入れると「email を送らない呼出で既存のメールが null に潰れる」という現状より悪い穴が開くため、対で入れている。呼び手は `StoreEditPage` → `platformStoreApi.update` のみで常に両方を送るため、既存の動作は壊れない。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task test-unit` exit 0 / frontend 517 件全通過、`task test-integration` exit 0 / 150 件全緑・`PlatformStoreApiIT` 16 件 0 failure）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全 feature 22 件通過。店舗編集を覆うシナリオは元から無いため、既存シナリオの非回帰確認）
- [ ] ローカルで code-review 実施済み — **未実施**。作成者による差分の自己確認のみ。`/code-review` は未実行

途中 1 回、統合テストが 23 件落ちたが、`relation "t_users" does not exist` とシードユーザーのログイン失敗でクラス丸ごと全滅する形で、並行して走らせた `task lint` の docker 負荷で tmpfs の DB が落ちたことが原因。単独実行で全緑を確認済み。

### 視覚確認（UI 変更時）

UI の変更なし（frontend はテスト追加のみ）。

## 決定ログ

- **`@Valid` を同じコミットに含めた**: 別 PR に切ると、その間だけ「email 未送信で既存値が消える」状態が生まれる。修正が開ける穴なので同時に閉じる。400 への写像は `CommonExceptionHandler` の既存経路で、作成側の IT が既に固定している。
- **PUT を部分更新にせず `email` を必須にした**: PUT は全項目の置換。省略可にすると「省略＝据え置き」と「省略＝クリア」が区別できず、DTO 側で null と未指定を分ける仕掛けが要る。呼び手は常に両方送るため、必須で受けるのが最小。
- **`@Email` は入れていない**: 作成側にも元から無く、片方だけ入れると非対称になる。現状 email の形式ゲートは frontend の正規表現のみで、REST を直接叩けば迂回できる（`domain` は `@Pattern` で厳格、という非対称は残る）。方針として閉じるなら別途。
- **`@Size(max = 128)` を作成側にも入れた**: 更新側で email を書くようになって初めて「列長超過 → 保存時の制約違反 → 500」の穴を持つが、作成側は元から同じ穴だった。同根因を片方だけ塞ぐのを避ける。上限値は `domain` と同じく列定義に合わせている。
- **IT の読み戻しを `GET /{id}` にした**: `GET /platform/stores/lookup` は `@Cacheable("storeByDomain")` 経由で、更新後もキャッシュが失効しないため陳腐な値を返す（下記の別 issue）。lookup で読み戻すと正しい修正でも red のままになる。`/{id}` は編集画面が実際に読む経路でもある。

## 備考 / レビュー観点

- `t_stores.email` に一意制約は無い（`uq_t_stores_domain` は domain のみ）ため、作成側と同様に重複の事前照会は入れていない。
- **別 issue に切り出し（この PR には含めない）**: `StoreRegistryService.getByDomain` は `@Cacheable("storeByDomain")` だが `update` に `@CacheEvict` が無い（`delete` にはある）。そのため公開の `GET /platform/stores/lookup` が古い name / email を返し続ける。name については本 PR 以前から起きている独立の不具合。
- **既存の不一致（未修正）**: バリデーションエラー本文は `{error, details}` だが、`StoreCreatePage` / `StoreEditPage` は `data.errors` を読んでいるため、フィールド別エラーが表示されずトーストのみになる。両ページ共通で、本 PR が開けた穴ではない。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
