### PR TITLE
fix(store): 店舗更新後も公開ドメイン照会が古い店舗情報を返す問題を直す

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/shared/CacheTransactionAwarenessIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/shared/CacheTransactionAwarenessIT.java
@@ -1,0 +1,33 @@
+package com.kizuna.shared;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.transaction.TransactionAwareCacheDecorator;
+
+/**
+ * キャッシュが事務対応で組み上がっていることを固定する IT。
+ *
+ * <p>この装飾が外れると {@code @CacheEvict} はコミット前に走り、失効からコミットまでの間に読んだ並行要求が 陳腐な値を載せ直せてしまう。装飾自体の意味（失効を
+ * afterCommit へ回す）は Spring の {@link TransactionAwareCacheDecorator} が担うため、ここで固定するのは配線が実際に効いていることだけ。
+ */
+@SpringBootTest
+class CacheTransactionAwarenessIT {
+
+  @Autowired private CacheManager cacheManager;
+
+  @Test
+  @DisplayName("キャッシュは事務対応で装飾され、失効がコミット後に回ること")
+  void cachesAreTransactionAware() {
+    assertThat(cacheManager.getCache("storeByDomain"))
+        .as("公開ドメイン照会のキャッシュ")
+        .isInstanceOf(TransactionAwareCacheDecorator.class);
+    assertThat(cacheManager.getCache("systemConfigValues"))
+        .as("システム設定のキャッシュ（装飾は CacheManager 単位なので全キャッシュに効く）")
+        .isInstanceOf(TransactionAwareCacheDecorator.class);
+  }
+}

--- a/backend/src/integrationTest/java/com/kizuna/store/PlatformStoreApiIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/store/PlatformStoreApiIT.java
@@ -381,6 +381,54 @@ class PlatformStoreApiIT {
     assertThat(literal.getBody().path("total_elements").asLong()).isEqualTo(1);
   }
 
+  // /lookup は @Cacheable("storeByDomain") 経由。更新でキャッシュを失効させないと、未認証で叩ける
+  // 公開照会が古い StoreVO を返し続ける（frontend の middleware が店舗解決に使う経路）。
+  // StoreVO は name と email を含むため、更新できる項目はいずれも陳腐化する。
+  @Test
+  @DisplayName("PUT /platform/stores/{id} の後、GET /platform/stores/lookup が更新後の値を返すこと")
+  void updateInvalidatesDomainLookupCache() {
+    String hq = platformToken(HQ_EMAIL);
+    String unique = UUID.randomUUID().toString();
+    String originalName = "store-it-cache-evict-" + unique;
+    String domain = "store-it-cache-evict-" + unique + ".kizuna.test";
+    String id = createStore(hq, originalName, domain, "before@kizuna.test");
+
+    // 更新前に一度引いてキャッシュへ載せる（これを省くと失効の有無を判定できない）
+    ResponseEntity<JsonNode> beforeUpdate =
+        rest.exchange(
+            "/platform/stores/lookup?domain=" + domain,
+            HttpMethod.GET,
+            HttpEntity.EMPTY,
+            JsonNode.class);
+    assertThat(beforeUpdate.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(beforeUpdate.getBody().path("name").asString()).isEqualTo(originalName);
+    assertThat(beforeUpdate.getBody().path("email").asString()).isEqualTo("before@kizuna.test");
+
+    HttpHeaders headers = bearer(hq);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    String updatedName = originalName + "-updated";
+    String body =
+        String.format("{\"name\": \"%s\", \"email\": \"after@kizuna.test\"}", updatedName);
+    ResponseEntity<Void> updated =
+        rest.exchange(
+            "/platform/stores/" + id, HttpMethod.PUT, new HttpEntity<>(body, headers), Void.class);
+    assertThat(updated.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+    ResponseEntity<JsonNode> afterUpdate =
+        rest.exchange(
+            "/platform/stores/lookup?domain=" + domain,
+            HttpMethod.GET,
+            HttpEntity.EMPTY,
+            JsonNode.class);
+    assertThat(afterUpdate.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(afterUpdate.getBody().path("name").asString())
+        .as("公開照会が更新後の店舗名を返すこと")
+        .isEqualTo(updatedName);
+    assertThat(afterUpdate.getBody().path("email").asString())
+        .as("公開照会が更新後の email を返すこと")
+        .isEqualTo("after@kizuna.test");
+  }
+
   @Test
   @DisplayName("GET /platform/stores/me は店長トークンで 200 と授権店舗(1,2)のみを返すこと（受入基準3）")
   void meReturnsAuthorizedStoresOnly() {

--- a/backend/src/main/java/com/kizuna/shared/config/CacheConfig.java
+++ b/backend/src/main/java/com/kizuna/shared/config/CacheConfig.java
@@ -1,13 +1,24 @@
 package com.kizuna.shared.config;
 
+import org.springframework.boot.cache.autoconfigure.RedisCacheManagerBuilderCustomizer;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/**
- * キャッシュ設定クラス。
- *
- * <p>デフォルトでは ConcurrentMapCacheManager（メモリキャッシュ）を使用。 必要に応じて Redis キャッシュに切り替え可能。
- */
+/** キャッシュ設定クラス。実体は Redis（{@code spring.cache.type: redis}）。 */
 @Configuration
 @EnableCaching
-public class CacheConfig {}
+public class CacheConfig {
+
+  /**
+   * キャッシュへの書き込みと失効を事務のコミット後まで遅らせる。
+   *
+   * <p>既定では {@code @CacheEvict} はメソッド復帰時＝コミット前に走る。失効からコミットまでの間に読んだ並行要求は
+   * 更新前の行を読むため、失効させたばかりのキーへ陳腐な値を載せ直し、それが TTL まで配られてしまう。コミット後に失効させれば
+   * この窓が閉じる。ロールバック時は行が変わっていないので、失効が走らないのが正しい。
+   */
+  @Bean
+  RedisCacheManagerBuilderCustomizer transactionAwareCacheManagerCustomizer() {
+    return builder -> builder.transactionAware();
+  }
+}

--- a/backend/src/main/java/com/kizuna/store/application/StoreRegistryService.java
+++ b/backend/src/main/java/com/kizuna/store/application/StoreRegistryService.java
@@ -69,7 +69,10 @@ public class StoreRegistryService {
     storeProfileRepository.save(StoreProfile.createDefault(saved.getId()));
   }
 
+  // storeByDomain のキーは domain。だが注釈の式から見えるのは引数の id と戻り値（void）だけで、
+  // domain はメソッド本体のローカルにしか現れずキーとして書けない。delete と同じ全件失効に揃える。
   @Transactional
+  @CacheEvict(value = "storeByDomain", allEntries = true)
   public void update(String id, StoreUpdateDTO req) {
     var store = storeRepository.findById(parseId(id)).orElseThrow(() -> notFound(id));
     store.setName(req.getName());


### PR DESCRIPTION
## 概要

店舗を更新しても、未認証で叩ける公開照会 `GET /platform/stores/lookup?domain=...` が古い店舗情報を返し続ける不具合を直す。`StoreRegistryService.getByDomain` は `@Cacheable("storeByDomain")` だが `update` に失効処理が無く（`delete` には元からある）、frontend の middleware が店舗解決に使う経路で name も email も陳腐化していた。

あわせて、失効がコミット前に走る問題（codex 指摘）を CacheManager 単位で閉じている。**この 2 本目はリポジトリ全体のキャッシュ意味論を変えるので、下の「影響範囲」を見て判断してほしい。**

<!-- issue は起票しない方針（利用者判断）のため Closes は無し -->

## 変更内容

**1. 失効の欠落を塞ぐ（`fix(store)`）**

- `StoreRegistryService.update` に `@CacheEvict(value = "storeByDomain", allEntries = true)` を追加。選択理由はコード内コメントに明記
- `PlatformStoreApiIT`: 作成 → `/lookup` で一度キャッシュに載せる → `PUT /{id}` で name/email を変更 → 再度 `/lookup` で更新後の値が返ることを固定

**2. 失効を事務のコミット後に回す（`fix(shared)`・codex 指摘への対応）**

- `CacheConfig` に `RedisCacheManagerBuilderCustomizer` を追加し `transactionAware()` を掛ける。既定の `@CacheEvict` はメソッド復帰時＝コミット前に走るため、失効からコミットまでの間に読んだ並行要求が更新前の行を読み、失効させたばかりのキーへ陳腐な値を載せ直す
- `CacheTransactionAwarenessIT`: `CacheManager` が返すキャッシュが `TransactionAwareCacheDecorator` で装飾されていることを固定

### 影響範囲（要確認）

`transactionAware()` は **CacheManager 単位**なので、`storeByDomain` だけでなく `systemConfigValues`（`SystemConfigServiceImpl`）を含む全キャッシュの失効が事務のコミット後に回る。codex は `delete` にも同じ手当てを求めていたので、個別注釈を増やすより一箇所で揃える形にした。ロールバック時は行が変わっていないので失効が走らないのが正しい挙動。事務の外からの失効は従来どおり即時（`TransactionAwareCacheDecorator` は同期が有効なときだけ afterCommit へ回す）。

## 検証

<!-- 合否はすべて exit code で判定（出力は日本語ロケールのことがある） -->

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task test-unit` と `task test-integration` を個別に実行。統合は 153 件 / failures 0・errors 0。統合テストは単独で走らせている — 他の docker コマンドと並行させると tmpfs の DB が落ちて無関係な IT が大量に落ちるため）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全 feature 22 件通過。公開照会のキャッシュを覆うシナリオは元から無いため、既存シナリオの非回帰確認）
- [ ] ローカルで code-review 実施済み — **未実施**。作成者による差分の自己確認のみ。`/code-review` は未実行

上記はすべて、`origin/master` が `f3a58408`（権限目録の播種）まで進んだ後の base で通し直したもの。

### red の実測

いずれも推測ではなく、実際に red を確認している。

- **失効の欠落**: master 時点で `expected "...-updated" but was "..."` ＝ キャッシュ由来の陳腐な名前で失敗、同クラスの他 14 件は通過。#535 マージ後の base へ rebase したのち `@CacheEvict` を一時的に外して再確認し、同じ 1 件だけが同じ形で失敗。
- **事務対応**: `RedisCacheManagerBuilderCustomizer` を外すと `CacheTransactionAwarenessIT` が `RedisCache` を検出して失敗、戻すと通る（両方向で確認）。

### 検証の限界（正直に）

`CacheTransactionAwarenessIT` が固定しているのは**配線が効いていること**だけで、競合そのものは再現していない。失効を afterCommit へ回す意味論は Spring の `TransactionAwareCacheDecorator`（`clear()` が `registerSynchronization` → `afterCommit`）に依存しており、そこは実装ソースで確認した。

当初は「事務の中で `update` を呼び、キャッシュがまだ載っていること」を見る挙動レベルの IT を書いたが、**修正無しでも通ってしまい**（かつ同一コードで前提部分が一度だけ落ちる非決定性があった）、red-green の証拠にならないので破棄した。flaky な IT を統合スイートに足すのは避けている。

### 視覚確認（UI 変更時）

UI の変更なし（backend のみ）。

## 決定ログ

- **`allEntries = true` にした（キー指定にしなかった）**: キャッシュのキーは `domain` だが、注釈の式から見えるのは引数の `id` と戻り値（void）だけで、`domain` はメソッド本体のローカルにしか現れずキーとして書けない。署名や戻り値を変えるより、`delete` の全件失効に揃えるのが最小。店舗更新は運営操作で頻度が低く、全件失効の代償も小さい。
- **コミット後への繰り下げを、注釈ではなく CacheManager の設定で入れた**: `TransactionSynchronizationManager` を手書きするより、Spring 既製の `transactionAware()` を使う。`update` と `delete` の両方（codex の要求）に加え、将来足されるキャッシュにも自動で効く。Spring Boot 4.1 の autoconfig は `transactionAware()` を呼んでいない（`RedisCacheConfiguration` の逆アセンブルで確認）ため、これは実挙動の変更であって no-op ではない。
- **`RedisCacheManagerBuilderCustomizer` が実際に読まれることを先に確認した**: 同じ逆アセンブルで `cacheManager(...)` が `ObjectProvider<RedisCacheManagerBuilderCustomizer>` を `orderedStream()` して `.customize(builder)` を呼んでいることを確認。無視される bean を「修正」として出すのを避けるため。
- **テストの読み戻しを `/lookup` にした**: 本件はキャッシュ経路そのものの不具合なので、`/{id}` では正しい修正でも green のままになり red を作れない。
- **更新前の `/lookup` を assert している**: これを省くとキャッシュに載っていない状態でも通ってしまい、失効の有無を判定できない。

## 備考 / レビュー観点

- #535（`update` で email が保存されない問題）がこの不具合を「別 issue に切り出し」として挙げていた件の対応。作業中に #535 がマージされ、さらに権限目録の播種が master に入ったため、都度 rebase して全門禁を通し直している。
- 追加したテストは #535 が導入した `createStore` ヘルパを使っている。
- `CacheConfig` の class javadoc が「デフォルトでは ConcurrentMapCacheManager」と書いていたが実体は Redis（`spring.cache.type: redis`）。この class に Redis 固有の bean を足すため、記述を実態に合わせた。
- **残る既知の制約（miss 競合・codex 指摘、未修正）**: 読み手がキャッシュを外し、コミット前に旧行を読み、失効の後に書き戻すと陳腐な値が `SPRING_CACHE_TTL_MS`（既定 600s）まで残る。版付けや施錠を入れない read-through キャッシュに固有のもので、本 PR 以前から存在する。本 PR は陳腐化を悪化させない（修正前は競合と無関係に毎回 TTL まで陳腐だった）。閉じるなら版付きエントリか、キャッシュ自体を外すか（`findByDomain` は一意索引の単一行照会）の設計判断が要る。
- **重点的に見てほしいのは 2 本目の影響範囲**。`systemConfigValues` の失効タイミングも変わる。範囲を絞りたければ 2 本目のコミット（`9550ddb3`）だけ落とせば 1 本目は独立して成立する。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
