### PR TITLE
fix(wire): 前後端の型契約 54 対を全量照合・修理し、請求側の静默棄却を閉じる

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/order/OrderCrossStoreIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/OrderCrossStoreIT.java
@@ -46,6 +46,17 @@ class OrderCrossStoreIT extends CrossStoreTestSupport {
         + "\"}";
   }
 
+  /** 更新の要求体。OrderUpdateRequest は営業日を持たないため、作成の体をそのまま流用できない。 */
+  private String orderUpdateBody(String castId, String remarks) {
+    return "{\"receptionist_id\": "
+        + SEED_RECEPTIONIST_ID
+        + ", \"cast_id\": \""
+        + castId
+        + "\", \"remarks\": \""
+        + remarks
+        + "\"}";
+  }
+
   private String createOrderAs(long storeId, String castId) {
     ResponseEntity<JsonNode> created =
         rest.postForEntity(
@@ -94,7 +105,7 @@ class OrderCrossStoreIT extends CrossStoreTestSupport {
         rest.exchange(
             "/store/orders/" + controlId,
             HttpMethod.PUT,
-            new HttpEntity<>(orderBody(castId, "対照・更新後"), storeHeaders(STORE_A)),
+            new HttpEntity<>(orderUpdateBody(castId, "対照・更新後"), storeHeaders(STORE_A)),
             JsonNode.class);
     assertThat(ownUpdate.getStatusCode()).isEqualTo(HttpStatus.OK);
 
@@ -104,7 +115,7 @@ class OrderCrossStoreIT extends CrossStoreTestSupport {
         rest.exchange(
             "/store/orders/" + orderId,
             HttpMethod.PUT,
-            new HttpEntity<>(orderBody(castId, "改ざん"), storeHeaders(STORE_B)),
+            new HttpEntity<>(orderUpdateBody(castId, "改ざん"), storeHeaders(STORE_B)),
             JsonNode.class);
     assertThat(tampered.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -48,7 +48,9 @@ spring:
       datetime:
         write-dates-as-timestamps: false
     deserialization:
-      fail-on-unknown-properties: false
+      # DTO に無い項目を黙って捨てず 400 にする。捨てられた項目は画面上に何も現れず、
+      # 保存は成功して値だけが入らないため、寛容にしておくと目視でも検知できない。
+      fail-on-unknown-properties: true
   cache:
     type: redis
     redis:

--- a/frontend/src/__tests__/platform-store-api.test.ts
+++ b/frontend/src/__tests__/platform-store-api.test.ts
@@ -33,14 +33,15 @@ describe('platform store api wrappers', () => {
     expect(byId).toEqual({ id: '2' });
     expect(mockGet).toHaveBeenCalledWith('/platform/stores/2');
 
-    mockPost.mockResolvedValueOnce({ data: { id: '3' } });
+    // 作成・更新の端点は 204 No Content。body は返らない。
+    mockPost.mockResolvedValueOnce({});
     const created = await platformStoreApi.create({ name: 't' } as any);
-    expect(created).toEqual({ id: '3' });
+    expect(created).toBeUndefined();
     expect(mockPost).toHaveBeenCalledWith('/platform/stores', { name: 't' });
 
-    mockPut.mockResolvedValueOnce({ data: { id: '3', name: 'u' } });
+    mockPut.mockResolvedValueOnce({});
     const updated = await platformStoreApi.update('3', { name: 'u' } as any);
-    expect(updated).toEqual({ id: '3', name: 'u' });
+    expect(updated).toBeUndefined();
     expect(mockPut).toHaveBeenCalledWith('/platform/stores/3', { name: 'u' });
 
     mockDelete.mockResolvedValueOnce({});

--- a/frontend/src/_pages/cast-invite/ui/CastInvitePage.tsx
+++ b/frontend/src/_pages/cast-invite/ui/CastInvitePage.tsx
@@ -46,7 +46,7 @@ export default function CastInvitePage() {
   }, [token]);
 
   const handleAccepted = (response: CastAcceptanceResponse) => {
-    setStoreName(response.store_name);
+    setStoreName(response.store_name ?? '');
     setStage('done');
   };
 
@@ -87,7 +87,7 @@ export default function CastInvitePage() {
       <AuthLayout title="新規登録" subtitle={`${detail.store_name}のキャストとして登録します`}>
         <RegisterForm
           token={token}
-          initialDisplayName={detail.cast_name}
+          initialDisplayName={detail.cast_name ?? ''}
           onSuccess={handleAccepted}
           onBack={() => setStage('choose')}
         />
@@ -118,7 +118,8 @@ export default function CastInvitePage() {
       <div className="space-y-6">
         <p className="text-sm text-[#4a4540]">出勤希望の提出とスケジュールの確認ができます。</p>
         <p className="text-xs text-[#9a958e]">
-          有効期限: {new Date(detail.expires_at).toLocaleString('ja-JP')}
+          有効期限:{' '}
+          {detail.expires_at ? new Date(detail.expires_at).toLocaleString('ja-JP') : '不明'}
         </p>
         <div className="space-y-3">
           <button type="button" onClick={() => setStage('register')} className="auth-btn">

--- a/frontend/src/_pages/cast-portal/lib/groupSchedule.ts
+++ b/frontend/src/_pages/cast-portal/lib/groupSchedule.ts
@@ -9,11 +9,12 @@ export interface ScheduleDayGroup {
 export function groupByWorkDate(items: CastScheduleItem[]): ScheduleDayGroup[] {
   const byDate = new Map<string, CastScheduleItem[]>();
   for (const item of items) {
-    const bucket = byDate.get(item.work_date);
+    const workDate = item.work_date ?? '';
+    const bucket = byDate.get(workDate);
     if (bucket) {
       bucket.push(item);
     } else {
-      byDate.set(item.work_date, [item]);
+      byDate.set(workDate, [item]);
     }
   }
   return [...byDate.entries()]

--- a/frontend/src/_pages/cast-portal/lib/week.ts
+++ b/frontend/src/_pages/cast-portal/lib/week.ts
@@ -31,12 +31,12 @@ export function weekDates(start: Date): Date[] {
 }
 
 /** 'HH:mm:ss' 等 → 'HH:mm' 表示。 */
-export function formatTime(time: string): string {
-  return time.slice(0, 5);
+export function formatTime(time: string | undefined): string {
+  return (time ?? '').slice(0, 5);
 }
 
 /** 終了時刻の表示。00:00 終了は跨夜の連続表記として 24:00 と表示する。 */
-export function formatEndTime(time: string): string {
-  const hm = time.slice(0, 5);
+export function formatEndTime(time: string | undefined): string {
+  const hm = (time ?? '').slice(0, 5);
   return hm === '00:00' ? '24:00' : hm;
 }

--- a/frontend/src/_pages/cast-portal/ui/CastAccountPage.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastAccountPage.tsx
@@ -14,7 +14,7 @@ export function CastAccountPage() {
     platformAuthApi
       .me()
       .then(me => {
-        if (!cancelled) setDisplayName(me.display_name);
+        if (!cancelled) setDisplayName(me.display_name ?? null);
       })
       .catch(() => {
         // シェルが mount 時に本人確認済みのため通常は到達しない。表示名は未取得のまま留める。

--- a/frontend/src/_pages/cast-portal/ui/CastRequestsPage.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastRequestsPage.tsx
@@ -5,6 +5,7 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import {
   CastShiftRequestItem,
+  ShiftRequestStatus,
   CastStoreItem,
   ShiftRequestCreateRequest,
   shiftApi,
@@ -38,13 +39,13 @@ interface RequestFormValues {
   note: string;
 }
 
-const STATUS_LABELS: Record<CastShiftRequestItem['status'], string> = {
+const STATUS_LABELS: Record<ShiftRequestStatus, string> = {
   PENDING: '受付済み',
   APPROVED: '確定済み',
   DECLINED: '却下',
 };
 
-const STATUS_PILL_CLASS: Record<CastShiftRequestItem['status'], string> = {
+const STATUS_PILL_CLASS: Record<ShiftRequestStatus, string> = {
   PENDING: 'border-transparent bg-warning/10 text-warning-strong',
   APPROVED: 'border-transparent bg-success/10 text-success-strong',
   DECLINED: 'border-transparent bg-destructive/10 text-destructive-strong',
@@ -248,12 +249,15 @@ export function CastRequestsPage() {
                   <CardContent className="px-3">
                     <div className="flex items-center justify-between">
                       <span className="text-sm font-medium text-foreground">{item.store_name}</span>
-                      <Badge variant="outline" className={STATUS_PILL_CLASS[item.status]}>
-                        {STATUS_LABELS[item.status]}
+                      <Badge
+                        variant="outline"
+                        className={item.status && STATUS_PILL_CLASS[item.status]}
+                      >
+                        {item.status && STATUS_LABELS[item.status]}
                       </Badge>
                     </div>
                     <p className="mt-1 text-xs text-muted-foreground">
-                      {item.work_date} {item.start_time.slice(0, 5)}–{item.end_time.slice(0, 5)}
+                      {item.work_date} {item.start_time?.slice(0, 5)}–{item.end_time?.slice(0, 5)}
                     </p>
                     {item.note && <p className="mt-1 text-xs text-muted-foreground">{item.note}</p>}
                   </CardContent>

--- a/frontend/src/_pages/platform-roles/ui/RoleFormModal.tsx
+++ b/frontend/src/_pages/platform-roles/ui/RoleFormModal.tsx
@@ -42,9 +42,10 @@ function groupByConsole(
 ): { key: string; label: string; items: PermissionResponse[] }[] {
   const buckets = new Map<string, PermissionResponse[]>();
   for (const entry of catalog) {
-    const bucket = buckets.get(entry.console);
+    const consoleKey = entry.console ?? '';
+    const bucket = buckets.get(consoleKey);
     if (bucket) bucket.push(entry);
-    else buckets.set(entry.console, [entry]);
+    else buckets.set(consoleKey, [entry]);
   }
   const rank = (key: string) => {
     const index = CONSOLE_ORDER.indexOf(key as PermissionConsole);
@@ -92,7 +93,7 @@ export function RoleFormModal({ open, onClose, editing, onSaved }: RoleFormModal
     }
     try {
       if (editing) {
-        await platformRoleApi.update(editing.id, {
+        await platformRoleApi.update(editing.id ?? 0, {
           name: values.name,
           permissions,
           // 楽観ロック用バージョン（応答の version をそのまま往復する）
@@ -158,16 +159,20 @@ export function RoleFormModal({ open, onClose, editing, onSaved }: RoleFormModal
                         {group.label}
                       </p>
                       <div className="space-y-1">
-                        {group.items.map(entry => (
-                          <Label key={entry.code} className="font-normal">
-                            <input
-                              type="checkbox"
-                              checked={permissions.includes(entry.code)}
-                              onChange={() => toggle(entry.code)}
-                            />
-                            {entry.code}
-                          </Label>
-                        ))}
+                        {group.items.map(entry => {
+                          const code = entry.code;
+                          if (code === undefined) return null;
+                          return (
+                            <Label key={code} className="font-normal">
+                              <input
+                                type="checkbox"
+                                checked={permissions.includes(code)}
+                                onChange={() => toggle(code)}
+                              />
+                              {code}
+                            </Label>
+                          );
+                        })}
                       </div>
                     </div>
                   );

--- a/frontend/src/_pages/platform-roles/ui/RolesPage.tsx
+++ b/frontend/src/_pages/platform-roles/ui/RolesPage.tsx
@@ -141,8 +141,9 @@ export default function RolesPage() {
                     variant="ghost"
                     size="sm"
                     className="text-primary-strong"
-                    disabled={role.system}
-                    onClick={() => setFormTarget(role.id ?? 0)}
+                    // id が無ければ編集対象を特定できず、押しても何も起きない状態になるため無効化する
+                    disabled={role.system || role.id === undefined}
+                    onClick={() => role.id !== undefined && setFormTarget(role.id)}
                   >
                     編集
                   </Button>

--- a/frontend/src/_pages/platform-roles/ui/RolesPage.tsx
+++ b/frontend/src/_pages/platform-roles/ui/RolesPage.tsx
@@ -31,7 +31,7 @@ export default function RolesPage() {
   // 使うため分頁できない）。絞り込みは取得済みの配列に対して行い、送信で確定させる。
   const [appliedSearch, setAppliedSearch] = useState('');
   const roles = appliedSearch
-    ? allRoles.filter(role => role.name.toLowerCase().includes(appliedSearch.toLowerCase()))
+    ? allRoles.filter(role => (role.name ?? '').toLowerCase().includes(appliedSearch.toLowerCase()))
     : allRoles;
   // フォームは 1 つだけ開く。新規と編集で実体を分けると権限目録の取得が二重に走るため、
   // 「閉じている / 新規 / 既存の編集」を 1 つの状態で表す。
@@ -45,7 +45,7 @@ export default function RolesPage() {
   const formOpen = formTarget === 'create' || editingRole !== null;
   // 授与中のロール削除は 409、平台既定ロールは 400。文言はサーバ側が持つ。
   const deletion = useDeleteAction<RoleResponse>({
-    remove: role => platformRoleApi.remove(role.id),
+    remove: role => platformRoleApi.remove(role.id ?? 0),
     successMessage: 'ロールを削除しました',
     errorMessage: 'ロールの削除に失敗しました',
     onDeleted: refetch,
@@ -116,7 +116,7 @@ export default function RolesPage() {
               <TableRow key={role.id}>
                 <TableCell className="font-medium text-foreground">{role.name}</TableCell>
                 <TableCell className="text-muted-foreground">
-                  {role.permissions.length} 件
+                  {role.permissions?.length ?? 0} 件
                 </TableCell>
                 <TableCell>
                   {role.system ? (
@@ -142,7 +142,7 @@ export default function RolesPage() {
                     size="sm"
                     className="text-primary-strong"
                     disabled={role.system}
-                    onClick={() => setFormTarget(role.id)}
+                    onClick={() => setFormTarget(role.id ?? 0)}
                   >
                     編集
                   </Button>

--- a/frontend/src/_pages/platform-settings/ui/SettingsPage.tsx
+++ b/frontend/src/_pages/platform-settings/ui/SettingsPage.tsx
@@ -52,7 +52,7 @@ export default function SystemSettingsPage() {
   const handleToggle = async (config: SystemConfigResponse) => {
     setSaving(true);
     try {
-      await saveConfig(config.config_key, config.config_value === 'true' ? 'false' : 'true');
+      await saveConfig(config.config_key ?? '', config.config_value === 'true' ? 'false' : 'true');
     } catch (error) {
       console.error('設定の更新に失敗しました', error);
       toast.error(getApiErrorMessage(error, '設定の更新に失敗しました'));
@@ -62,7 +62,7 @@ export default function SystemSettingsPage() {
   };
 
   const handleEdit = (config: SystemConfigResponse) => {
-    setEditingKey(config.config_key);
+    setEditingKey(config.config_key ?? null);
     // 秘匿設定は現在値を取得できないため空欄から入力する
     setEditValue(config.secret ? '' : config.config_value || '');
   };

--- a/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
+++ b/frontend/src/_pages/platform-staff/ui/StaffPage.tsx
@@ -70,7 +70,7 @@ export default function StaffPage() {
     const target = editingStaff;
     if (!target) return;
     void platformStaffApi
-      .get(target.id)
+      .get(target.id ?? 0)
       // 成功保存の直後は onClose と競合するため、まだ同じ対象を開いているときだけ差し替える
       .then(fresh => setEditingStaff(current => (current?.id === fresh.id ? fresh : current)))
       .catch(() => {

--- a/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
+++ b/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
@@ -200,7 +200,7 @@ describe('店舗管理 3 画面の挙動', () => {
   });
 
   it('新規作成は name/domain/email を送信し一覧へ遷移すること', async () => {
-    mockedApi.create.mockResolvedValue(store({}));
+    mockedApi.create.mockResolvedValue(undefined);
 
     render(<StoreCreatePage />);
     fireEvent.change(screen.getByLabelText(/店舗名/), { target: { value: 'ガンマ店' } });
@@ -242,7 +242,7 @@ describe('店舗管理 3 画面の挙動', () => {
         domain: 'delta.example.com',
       })
     );
-    mockedApi.update.mockResolvedValue(store({}));
+    mockedApi.update.mockResolvedValue(undefined);
 
     render(<StoreEditPage />);
 
@@ -273,7 +273,7 @@ describe('店舗管理 3 画面の挙動', () => {
         domain: 'delta.example.com',
       })
     );
-    mockedApi.update.mockResolvedValue(store({}));
+    mockedApi.update.mockResolvedValue(undefined);
 
     render(<StoreEditPage />);
 

--- a/frontend/src/_pages/platform-stores/ui/StoreEditPage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoreEditPage.tsx
@@ -31,8 +31,8 @@ export default function EditStorePage() {
         const t = res as unknown as Store;
         setStore(t);
         setFormData({
-          name: t.name,
-          email: t.email,
+          name: t.name ?? '',
+          email: t.email ?? '',
         });
       } catch (e) {
         console.error('Error loading store:', e);
@@ -66,7 +66,7 @@ export default function EditStorePage() {
     if (!validate()) return;
     setSaving(true);
     try {
-      await platformStoreApi.update(store.id, formData);
+      await platformStoreApi.update(store.id ?? '', formData);
       toast.success('店舗情報を更新しました');
       router.push('/platform/stores');
     } catch (err: any) {

--- a/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoresPage.tsx
@@ -37,7 +37,7 @@ export default function StoresPage() {
   const stores = list.rows;
 
   const deletion = useDeleteAction<Store>({
-    remove: store => platformStoreApi.delete(store.id),
+    remove: store => platformStoreApi.delete(store.id ?? ''),
     successMessage: '店舗を削除しました',
     errorMessage: '店舗の削除に失敗しました',
     onDeleted: list.reload,
@@ -122,7 +122,7 @@ export default function StoresPage() {
                       現在のスキームを引き継ぐプロトコル相対 URL で別タブへ開く。
                       ホスト名の形でない値はリンクにしない（`正規.example@攻撃者.example` の
                       ような行は前半が userinfo と解釈され、別ホストへの導線になる） */}
-                  {isStoreDomain(store.domain) ? (
+                  {isStoreDomain(store.domain ?? '') ? (
                     <a
                       href={`//${store.domain}`}
                       target="_blank"
@@ -137,7 +137,7 @@ export default function StoresPage() {
                   )}
                 </TableCell>
                 <TableCell className="text-muted-foreground">
-                  {new Date(store.created_at).toLocaleDateString('ja-JP')}
+                  {store.created_at ? new Date(store.created_at).toLocaleDateString('ja-JP') : ''}
                 </TableCell>
                 <TableCell className="text-right">
                   <div className="flex justify-end gap-1">

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldEditModal.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldEditModal.tsx
@@ -57,7 +57,7 @@ export function CastFieldEditModal({
         display_order: values.display_order,
         is_public: values.is_public,
       };
-      await castFieldDefinitionApi.update(definition.id, request);
+      await castFieldDefinitionApi.update(definition.id ?? '', request);
       toast.success('フィールドを更新しました');
       onUpdated();
       onClose();

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldsPage.tsx
@@ -32,7 +32,7 @@ export default function CastFieldsPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [editing, setEditing] = useState<CastFieldDefinitionResponse | null>(null);
   const deletion = useDeleteAction<CastFieldDefinitionResponse>({
-    remove: definition => castFieldDefinitionApi.delete(definition.id),
+    remove: definition => castFieldDefinitionApi.delete(definition.id ?? ''),
     successMessage: 'フィールドを削除しました',
     errorMessage: 'フィールドの削除に失敗しました',
     onDeleted: refetch,

--- a/frontend/src/_pages/store-casts/ui/CastForm.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastForm.tsx
@@ -216,26 +216,27 @@ export function CastForm({
                 </div>
               ) : (
                 <div className="space-y-4">
-                  {definitions.map(definition => (
-                    <div key={definition.key} className="grid gap-2">
-                      <Label htmlFor={`cast-custom-field-${definition.key}`}>
-                        {definition.label}
-                      </Label>
-                      <Input
-                        id={`cast-custom-field-${definition.key}`}
-                        type="text"
-                        // 自身が所有するキーのみ初期値に採用する。プレーンオブジェクトの
-                        // ブラケットアクセスは 'constructor' 等の継承プロパティを拾うため hasOwn で防ぐ。
-                        defaultValue={
-                          existingCustomFields &&
-                          Object.hasOwn(existingCustomFields, definition.key)
-                            ? existingCustomFields[definition.key]
-                            : ''
-                        }
-                        {...register(`custom_fields.${definition.key}`)}
-                      />
-                    </div>
-                  ))}
+                  {definitions.map(definition => {
+                    const key = definition.key;
+                    if (key === undefined) return null;
+                    return (
+                      <div key={key} className="grid gap-2">
+                        <Label htmlFor={`cast-custom-field-${key}`}>{definition.label}</Label>
+                        <Input
+                          id={`cast-custom-field-${key}`}
+                          type="text"
+                          // 自身が所有するキーのみ初期値に採用する。プレーンオブジェクトの
+                          // ブラケットアクセスは 'constructor' 等の継承プロパティを拾うため hasOwn で防ぐ。
+                          defaultValue={
+                            existingCustomFields && Object.hasOwn(existingCustomFields, key)
+                              ? existingCustomFields[key]
+                              : ''
+                          }
+                          {...register(`custom_fields.${key}`)}
+                        />
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </CardContent>

--- a/frontend/src/_pages/store-casts/ui/CastsPage.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastsPage.tsx
@@ -39,8 +39,8 @@ export default function CastListPage() {
     platformAuthApi
       .me()
       .then(me => {
-        setCanInvite(me.permissions.includes('CAST_INVITE'));
-        setCanManageFieldDefs(me.permissions.includes('CAST_FIELD_DEF_MANAGE'));
+        setCanInvite(me.permissions?.includes('CAST_INVITE') ?? false);
+        setCanManageFieldDefs(me.permissions?.includes('CAST_FIELD_DEF_MANAGE') ?? false);
       })
       .catch(() => {
         // 取得失敗時は導線を出さない（fail-closed）。操作自体はサーバ側が拒否する。
@@ -70,21 +70,21 @@ export default function CastListPage() {
 
   /** キャストを削除する */
   const deletion = useDeleteAction<CastResponse>({
-    remove: cast => castApi.delete(cast.id),
+    remove: cast => castApi.delete(cast.id ?? ''),
     successMessage: 'キャストを削除しました',
     errorMessage: 'キャストの削除に失敗しました',
     onDeleted: list.reload,
   });
 
   /** ステータスの表示ラベルと配色を返す */
-  const statusLabel = (status: string) => {
+  const statusLabel = (status: string | undefined) => {
     switch (status) {
       case 'ACTIVE':
         return { text: '有効', color: 'bg-success/10 text-success-strong' };
       case 'INACTIVE':
         return { text: '無効', color: 'bg-muted text-foreground' };
       default:
-        return { text: status, color: 'bg-muted text-foreground' };
+        return { text: status ?? '', color: 'bg-muted text-foreground' };
     }
   };
 
@@ -161,7 +161,7 @@ export default function CastListPage() {
                       {cast.photo_url ? (
                         <Image
                           src={cast.photo_url}
-                          alt={cast.name}
+                          alt={cast.name ?? ''}
                           fill
                           className="object-cover"
                           sizes="40px"

--- a/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
@@ -127,8 +127,8 @@ export default function CustomerEditPage() {
                   <TableCell className="text-foreground">{order.business_date}</TableCell>
                   <TableCell className="text-muted-foreground">{order.cast_name || '-'}</TableCell>
                   <TableCell className="text-muted-foreground">
-                    {order.course_minutes}分
-                    {order.extension_minutes > 0 && ` (+延長${order.extension_minutes}分)`}
+                    {order.course_minutes != null ? `${order.course_minutes}分` : '-'}
+                    {(order.extension_minutes ?? 0) > 0 && ` (+延長${order.extension_minutes}分)`}
                   </TableCell>
                   <TableCell className="text-muted-foreground">{order.used_points}</TableCell>
                   <TableCell className="text-muted-foreground">{order.status}</TableCell>

--- a/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomersPage.tsx
@@ -56,7 +56,7 @@ export default function CustomersPage() {
   const customers = list.rows;
 
   const deletion = useDeleteAction<CustomerResponse>({
-    remove: customer => customerApi.delete(customer.id),
+    remove: customer => customerApi.delete(customer.id ?? ''),
     successMessage: '顧客を削除しました',
     errorMessage: '顧客の削除に失敗しました',
     onDeleted: list.reload,

--- a/frontend/src/_pages/store-orders/__tests__/OrderFormPayload.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrderFormPayload.test.tsx
@@ -35,6 +35,11 @@ async function submitAndGetBody(onSubmit: jest.Mock) {
   return onSubmit.mock.calls[0][0] as OrderFormData;
 }
 
+/** 受付はサーバ側が @NotNull。送信まで進めるテストは先に選んでおく。 */
+async function selectReceptionist() {
+  await pickOption('受付', '受付花子');
+}
+
 /** キーボードで開く経路のみを使う（ポインタ系 API は jsdom に無い）。 */
 async function pickOption(comboboxName: string, optionName: string) {
   fireEvent.keyDown(await screen.findByRole('combobox', { name: comboboxName }), {
@@ -49,14 +54,14 @@ describe('オーダーフォームのセレクト配線と送信ペイロード'
     mockedOrderApi.listReceptionists.mockResolvedValue([{ id: 7, display_name: '受付花子' }]);
   });
 
-  it('未操作の既定値が型ごとそのまま送られること', async () => {
+  it('受付以外を未操作のまま送ると既定値が型ごとそのまま送られること', async () => {
     const { onSubmit } = renderForm();
     // 受付一覧の解決を待ってから送信する（非同期の setState が入るため）
     await waitFor(() => expect(mockedOrderApi.listReceptionists).toHaveBeenCalled());
+    await selectReceptionist();
 
     const body = await submitAndGetBody(onSubmit);
 
-    expect(body.receptionistId).toBe('');
     expect(body.classification).toBe('ーー');
     expect(body.hasPet).toBe(false);
     expect(body.courseMinutes).toBe(60);
@@ -73,19 +78,22 @@ describe('オーダーフォームのセレクト配線と送信ペイロード'
     expect(body.receptionistId).toBe('7');
   });
 
-  it('受付を未選択へ戻すと番兵ではなく空文字で送られること', async () => {
+  it('受付を未選択へ戻すと送信されないこと', async () => {
     const { onSubmit } = renderForm();
 
     await pickOption('受付', '受付花子');
     await pickOption('受付', '－－－');
-    const body = await submitAndGetBody(onSubmit);
+    fireEvent.click(screen.getByRole('button', { name: '登録する' }));
 
-    expect(body.receptionistId).toBe('');
+    // 受付は @NotNull。未選択のまま送ると 400 になるため、フォーム側で止める。
+    await waitFor(() => expect(screen.getByRole('button', { name: '登録する' })).toBeEnabled());
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it('区分の選択がそのままの文字列で送られること', async () => {
     const { onSubmit } = renderForm();
 
+    await selectReceptionist();
     await pickOption('区分', 'ラブホ');
     const body = await submitAndGetBody(onSubmit);
 
@@ -95,6 +103,7 @@ describe('オーダーフォームのセレクト配線と送信ペイロード'
   it('ペット有無が文字列ではなく真偽値へ復元されて送られること', async () => {
     const { onSubmit } = renderForm();
 
+    await selectReceptionist();
     await pickOption('ペット有無', 'あり');
     const body = await submitAndGetBody(onSubmit);
 
@@ -105,6 +114,7 @@ describe('オーダーフォームのセレクト配線と送信ペイロード'
   it('コース分が文字列ではなく数値へ復元されて送られること', async () => {
     const { onSubmit } = renderForm();
 
+    await selectReceptionist();
     await pickOption('ｺｰｽ(分)', '120');
     const body = await submitAndGetBody(onSubmit);
 
@@ -115,6 +125,7 @@ describe('オーダーフォームのセレクト配線と送信ペイロード'
   it('割引の選択と解除が番兵を経て文字列・空文字で送られること', async () => {
     const { onSubmit } = renderForm();
 
+    await selectReceptionist();
     await pickOption('割引', '一番最初割');
     const body = await submitAndGetBody(onSubmit);
 
@@ -124,6 +135,7 @@ describe('オーダーフォームのセレクト配線と送信ペイロード'
   it('割引を「なし」へ戻すと番兵ではなく空文字で送られること', async () => {
     const { onSubmit } = renderForm();
 
+    await selectReceptionist();
     await pickOption('割引', '一番最初割');
     await pickOption('割引', 'なし');
     const body = await submitAndGetBody(onSubmit);
@@ -138,7 +150,7 @@ describe('オーダーフォームのキャスト候補リストの選択配線'
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
-    mockedOrderApi.listReceptionists.mockResolvedValue([]);
+    mockedOrderApi.listReceptionists.mockResolvedValue([{ id: 7, display_name: '受付花子' }]);
     mockedCastApi.list.mockResolvedValue({
       rows: [{ id: 'cast-1', name: '花子' }],
       page: 0,
@@ -163,7 +175,9 @@ describe('オーダーフォームのキャスト候補リストの選択配線'
 
   it('候補を選ぶと castId がその id で送られること', async () => {
     const onSubmit = jest.fn<void, [OrderFormData]>();
-    render(<OrderForm onSubmit={onSubmit} isSubmitting={false} />);
+    render(
+      <OrderForm initialData={{ receptionistId: '7' }} onSubmit={onSubmit} isSubmitting={false} />
+    );
 
     await openSuggestions();
     fireEvent.click(screen.getByRole('option', { name: /花子/ }));
@@ -179,7 +193,9 @@ describe('オーダーフォームのキャスト候補リストの選択配線'
 
   it('候補選択後に名前を打ち直すと castId は空へ戻ること', async () => {
     const onSubmit = jest.fn<void, [OrderFormData]>();
-    render(<OrderForm onSubmit={onSubmit} isSubmitting={false} />);
+    render(
+      <OrderForm initialData={{ receptionistId: '7' }} onSubmit={onSubmit} isSubmitting={false} />
+    );
 
     await openSuggestions();
     fireEvent.click(screen.getByRole('option', { name: /花子/ }));

--- a/frontend/src/_pages/store-orders/__tests__/OrderFormPayload.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrderFormPayload.test.tsx
@@ -25,7 +25,10 @@ const mockedOrderApi = orderApi as jest.Mocked<typeof orderApi>;
 
 function renderForm() {
   const onSubmit = jest.fn<void, [OrderFormData]>();
-  const view = render(<OrderForm onSubmit={onSubmit} isSubmitting={false} />);
+  // キャストもサーバ側が @NotBlank。ここでの主題ではないため初期値で満たしておく。
+  const view = render(
+    <OrderForm initialData={{ castId: 'cast-1' }} onSubmit={onSubmit} isSubmitting={false} />
+  );
   return { ...view, onSubmit };
 }
 
@@ -52,6 +55,10 @@ describe('オーダーフォームのセレクト配線と送信ペイロード'
   beforeEach(() => {
     jest.clearAllMocks();
     mockedOrderApi.listReceptionists.mockResolvedValue([{ id: 7, display_name: '受付花子' }]);
+    (castApi as jest.Mocked<typeof castApi>).get.mockResolvedValue({
+      id: 'cast-1',
+      name: '花子',
+    });
   });
 
   it('受付以外を未操作のまま送ると既定値が型ごとそのまま送られること', async () => {
@@ -165,7 +172,7 @@ describe('オーダーフォームのキャスト候補リストの選択配線'
 
   /** 入力→デバウンス経過→候補描画までを進める。 */
   const openSuggestions = async () => {
-    fireEvent.change(screen.getByRole('combobox', { name: 'キャスト' }), {
+    fireEvent.change(screen.getByRole('combobox', { name: /キャスト/ }), {
       target: { value: '花' },
     });
     await act(async () => {
@@ -182,7 +189,7 @@ describe('オーダーフォームのキャスト候補リストの選択配線'
     await openSuggestions();
     fireEvent.click(screen.getByRole('option', { name: /花子/ }));
 
-    expect(screen.getByRole('combobox', { name: 'キャスト' })).toHaveValue('花子');
+    expect(screen.getByRole('combobox', { name: /キャスト/ })).toHaveValue('花子');
     fireEvent.click(screen.getByRole('button', { name: '登録する' }));
     await act(async () => {
       jest.advanceTimersByTime(0);
@@ -191,7 +198,7 @@ describe('オーダーフォームのキャスト候補リストの選択配線'
     expect(onSubmit.mock.calls[0][0].castId).toBe('cast-1');
   });
 
-  it('候補選択後に名前を打ち直すと castId は空へ戻ること', async () => {
+  it('候補選択後に名前を打ち直すと castId が空へ戻り送信されないこと', async () => {
     const onSubmit = jest.fn<void, [OrderFormData]>();
     render(
       <OrderForm initialData={{ receptionistId: '7' }} onSubmit={onSubmit} isSubmitting={false} />
@@ -199,7 +206,7 @@ describe('オーダーフォームのキャスト候補リストの選択配線'
 
     await openSuggestions();
     fireEvent.click(screen.getByRole('option', { name: /花子/ }));
-    fireEvent.change(screen.getByRole('combobox', { name: 'キャスト' }), {
+    fireEvent.change(screen.getByRole('combobox', { name: /キャスト/ }), {
       target: { value: '別の人' },
     });
 
@@ -207,7 +214,7 @@ describe('オーダーフォームのキャスト候補リストの選択配線'
     await act(async () => {
       jest.advanceTimersByTime(0);
     });
-    expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit.mock.calls[0][0].castId).toBe('');
+    // キャストは @NotBlank。候補から選び直されるまで送信を止める。
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/_pages/store-orders/__tests__/OrderFormPayload.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrderFormPayload.test.tsx
@@ -37,11 +37,11 @@ async function submitAndGetBody(onSubmit: jest.Mock) {
 
 /** 受付はサーバ側が @NotNull。送信まで進めるテストは先に選んでおく。 */
 async function selectReceptionist() {
-  await pickOption('受付', '受付花子');
+  await pickOption(/受付/, '受付花子');
 }
 
 /** キーボードで開く経路のみを使う（ポインタ系 API は jsdom に無い）。 */
-async function pickOption(comboboxName: string, optionName: string) {
+async function pickOption(comboboxName: string | RegExp, optionName: string) {
   fireEvent.keyDown(await screen.findByRole('combobox', { name: comboboxName }), {
     key: 'ArrowDown',
   });
@@ -71,7 +71,7 @@ describe('オーダーフォームのセレクト配線と送信ペイロード'
   it('受付の選択が番兵を経て素の ID 文字列で送られること', async () => {
     const { onSubmit } = renderForm();
 
-    await pickOption('受付', '受付花子');
+    await pickOption(/受付/, '受付花子');
     const body = await submitAndGetBody(onSubmit);
 
     // 番兵値 __none__ が漏れず、選んだ受付の id が文字列で載ること
@@ -81,8 +81,8 @@ describe('オーダーフォームのセレクト配線と送信ペイロード'
   it('受付を未選択へ戻すと送信されないこと', async () => {
     const { onSubmit } = renderForm();
 
-    await pickOption('受付', '受付花子');
-    await pickOption('受付', '－－－');
+    await pickOption(/受付/, '受付花子');
+    await pickOption(/受付/, '－－－');
     fireEvent.click(screen.getByRole('button', { name: '登録する' }));
 
     // 受付は @NotNull。未選択のまま送ると 400 になるため、フォーム側で止める。

--- a/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
@@ -141,7 +141,7 @@ describe('店側オーダー画面の描画', () => {
 
     render(<CreateOrderPage />);
     // 受付はサーバ側が @NotNull。選ばないと送信自体が止まる。
-    fireEvent.keyDown(await screen.findByRole('combobox', { name: '受付' }), { key: 'ArrowDown' });
+    fireEvent.keyDown(await screen.findByRole('combobox', { name: /受付/ }), { key: 'ArrowDown' });
     fireEvent.click(await screen.findByRole('option', { name: '受付花子' }));
     fireEvent.click(screen.getByRole('button', { name: '登録する' }));
 

--- a/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
@@ -34,7 +34,7 @@ describe('店側オーダー画面の描画', () => {
   });
 
   // fixture は手書きであり、バックエンドの実応答を見ているわけではない。
-  // 型（Order）との照合だけが機械的な担保で、それは as never を外すことで効いている。
+  // 機械的な担保は fixture と Order 型の照合だけで、それは tsc の側で効く（jest は型検査しない）。
   it('一覧は各行の項目を表示すること', async () => {
     mockedOrderApi.list.mockResolvedValue({
       rows: [

--- a/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import OrderListPage from '../ui/OrdersPage';
 import CreateOrderPage from '../ui/OrderCreatePage';
 import { orderApi } from '@/entities/order';
+import { castApi } from '@/entities/cast';
 
 jest.mock('@/entities/order', () => ({
   orderApi: {
@@ -17,6 +18,8 @@ jest.mock('@/entities/cast', () => ({
     list: jest.fn(),
   },
 }));
+
+const mockedCastApi = castApi as jest.Mocked<typeof castApi>;
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
@@ -138,11 +141,21 @@ describe('店側オーダー画面の描画', () => {
   it('新規登録はバックエンドの DTO に合わせ snake_case キーで POST すること', async () => {
     mockedOrderApi.create.mockResolvedValue({});
     mockedOrderApi.listReceptionists.mockResolvedValue([{ id: 7, display_name: '受付花子' }]);
+    mockedCastApi.list.mockResolvedValue({
+      rows: [{ id: 'cast-1', name: '花子' }],
+      page: 0,
+      pageCount: 1,
+      total: 1,
+    });
 
     render(<CreateOrderPage />);
-    // 受付はサーバ側が @NotNull。選ばないと送信自体が止まる。
+    // 受付・キャストはサーバ側が @NotNull / @NotBlank。選ばないと送信自体が止まる。
     fireEvent.keyDown(await screen.findByRole('combobox', { name: /受付/ }), { key: 'ArrowDown' });
     fireEvent.click(await screen.findByRole('option', { name: '受付花子' }));
+    fireEvent.change(screen.getByRole('combobox', { name: /キャスト/ }), {
+      target: { value: '花' },
+    });
+    fireEvent.click(await screen.findByRole('option', { name: /花子/ }));
     fireEvent.click(screen.getByRole('button', { name: '登録する' }));
 
     await waitFor(() => expect(mockedOrderApi.create).toHaveBeenCalledTimes(1));
@@ -155,6 +168,7 @@ describe('店側オーダー画面の描画', () => {
     expect(body).toHaveProperty('discount_name', '');
     // 受付は Java 側が Long。文字列ではなく数値で送る。
     expect(body).toHaveProperty('receptionist_id', 7);
+    expect(body).toHaveProperty('cast_id', 'cast-1');
     expect(body).not.toHaveProperty('store_name');
     expect(body).not.toHaveProperty('storeName');
     expect(body).not.toHaveProperty('businessDate');

--- a/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
@@ -7,6 +7,7 @@ jest.mock('@/entities/order', () => ({
   orderApi: {
     list: jest.fn(),
     create: jest.fn(),
+    listReceptionists: jest.fn(),
   },
 }));
 
@@ -24,13 +25,14 @@ jest.mock('next/navigation', () => ({
 
 const mockedOrderApi = orderApi as jest.Mocked<typeof orderApi>;
 
-describe('店側オーダー画面と API JSON（snake_case）の整合', () => {
+describe('店側オーダー画面の描画', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('一覧はバックエンドが実際に返す snake_case のフィールドを表示すること', async () => {
-    // バックエンドは Jackson グローバル SNAKE_CASE（既知の実レスポンス形）
+  // fixture は手書きであり、バックエンドの実応答を見ているわけではない。
+  // 型（Order）との照合だけが機械的な担保で、それは as never を外すことで効いている。
+  it('一覧は各行の項目を表示すること', async () => {
     mockedOrderApi.list.mockResolvedValue({
       rows: [
         {
@@ -50,7 +52,7 @@ describe('店側オーダー画面と API JSON（snake_case）の整合', () => 
       page: 0,
       pageCount: 1,
       total: 1,
-    } as never);
+    });
 
     render(<OrderListPage />);
 
@@ -80,7 +82,7 @@ describe('店側オーダー画面と API JSON（snake_case）の整合', () => 
       page: 0,
       pageCount: 1,
       total: 1,
-    } as never);
+    });
 
     render(<OrderListPage />);
     await screen.findByText('2026-07-03');
@@ -100,7 +102,7 @@ describe('店側オーダー画面と API JSON（snake_case）の整合', () => 
           id: '8',
           business_date: '2026-07-04',
           customer_name: '鈴木花子',
-          cast_name: null,
+          // 未指名はキーごと応答から消える（null は来ない）
           course_minutes: 90,
           extension_minutes: 0,
           option_codes: [],
@@ -113,7 +115,7 @@ describe('店側オーダー画面と API JSON（snake_case）の整合', () => 
       page: 0,
       pageCount: 1,
       total: 1,
-    } as never);
+    });
 
     render(<OrderListPage />);
 
@@ -126,7 +128,7 @@ describe('店側オーダー画面と API JSON（snake_case）の整合', () => 
       page: 0,
       pageCount: 0,
       total: 0,
-    } as never);
+    });
 
     render(<OrderListPage />);
 
@@ -134,9 +136,13 @@ describe('店側オーダー画面と API JSON（snake_case）の整合', () => 
   });
 
   it('新規登録はバックエンドの DTO に合わせ snake_case キーで POST すること', async () => {
-    mockedOrderApi.create.mockResolvedValue({} as never);
+    mockedOrderApi.create.mockResolvedValue({});
+    mockedOrderApi.listReceptionists.mockResolvedValue([{ id: 7, display_name: '受付花子' }]);
 
     render(<CreateOrderPage />);
+    // 受付はサーバ側が @NotNull。選ばないと送信自体が止まる。
+    fireEvent.keyDown(await screen.findByRole('combobox', { name: '受付' }), { key: 'ArrowDown' });
+    fireEvent.click(await screen.findByRole('option', { name: '受付花子' }));
     fireEvent.click(screen.getByRole('button', { name: '登録する' }));
 
     await waitFor(() => expect(mockedOrderApi.create).toHaveBeenCalledTimes(1));
@@ -147,8 +153,8 @@ describe('店側オーダー画面と API JSON（snake_case）の整合', () => 
     expect(body).toHaveProperty('classification', 'ーー');
     expect(body).toHaveProperty('has_pet', false);
     expect(body).toHaveProperty('discount_name', '');
-    // 受付未選択は '' のまま → マッピングで undefined になり送信時に欠落する
-    expect(body).toHaveProperty('receptionist_id', undefined);
+    // 受付は Java 側が Long。文字列ではなく数値で送る。
+    expect(body).toHaveProperty('receptionist_id', 7);
     expect(body).not.toHaveProperty('store_name');
     expect(body).not.toHaveProperty('storeName');
     expect(body).not.toHaveProperty('businessDate');
@@ -163,7 +169,7 @@ describe('オーダー一覧ページ固有の要素', () => {
       page: 0,
       pageCount: 0,
       total: 0,
-    } as never);
+    });
   });
 
   it('見出し（h1）・副題・主アクションのリンク先を備えること', async () => {
@@ -192,7 +198,7 @@ describe('オーダー一覧のページ送り', () => {
       page: 0,
       pageCount: 6,
       total: 120,
-    } as never);
+    });
 
     render(<OrderListPage />);
     await screen.findByText('2026-07-03');

--- a/frontend/src/_pages/store-orders/ui/OrderCreatePage.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderCreatePage.tsx
@@ -17,7 +17,7 @@ export default function CreateOrderPage() {
     setIsSubmitting(true);
     try {
       const request: OrderCreateRequest = {
-        receptionist_id: data.receptionistId || undefined,
+        receptionist_id: Number(data.receptionistId),
         business_date: data.businessDate,
         arrival_scheduled_start_time: data.arrivalStartTime
           ? `${data.arrivalStartTime}:00`

--- a/frontend/src/_pages/store-orders/ui/OrderForm.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderForm.tsx
@@ -112,7 +112,7 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
       try {
         const cast = await castApi.get(initialData.castId);
         skipNextSearchRef.current = true;
-        setCastNameInput(cast.name);
+        setCastNameInput(cast.name ?? '');
       } catch {
         toast.error('キャスト名の取得に失敗しました');
       }
@@ -156,8 +156,8 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
 
   const handleCastSelect = (cast: CastResponse) => {
     skipNextSearchRef.current = true;
-    setCastNameInput(cast.name);
-    setValue('castId', cast.id, { shouldValidate: true, shouldDirty: true });
+    setCastNameInput(cast.name ?? '');
+    setValue('castId', cast.id ?? '', { shouldValidate: true, shouldDirty: true });
     setIsCastOpen(false);
   };
 
@@ -181,6 +181,8 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
               <FormField
                 control={control}
                 name="receptionistId"
+                // 受付はサーバ側が @NotNull。未選択のまま送ると 400 になるため送信前に止める
+                rules={{ required: true }}
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>受付</FormLabel>
@@ -195,11 +197,15 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
                       </FormControl>
                       <SelectContent>
                         <SelectItem value={SELECT_NONE}>－－－</SelectItem>
-                        {receptionistOptions.map(option => (
-                          <SelectItem key={option.id} value={String(option.id)}>
-                            {option.display_name}
-                          </SelectItem>
-                        ))}
+                        {receptionistOptions.map(option => {
+                          const id = option.id;
+                          if (id === undefined) return null;
+                          return (
+                            <SelectItem key={id} value={String(id)}>
+                              {option.display_name}
+                            </SelectItem>
+                          );
+                        })}
                       </SelectContent>
                     </Select>
                   </FormItem>

--- a/frontend/src/_pages/store-orders/ui/OrderForm.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderForm.tsx
@@ -85,7 +85,13 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
       ...initialData,
     },
   });
-  const { register, handleSubmit, setValue, control } = form;
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    control,
+    formState: { errors },
+  } = form;
 
   const [castNameInput, setCastNameInput] = useState('');
   const [castOptions, setCastOptions] = useState<CastResponse[]>([]);
@@ -183,7 +189,7 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
                 control={control}
                 name="receptionistId"
                 // 受付はサーバ側が @NotNull。未選択のまま送ると 400 になるため送信前に止める
-                rules={{ required: true }}
+                rules={{ required: '受付を選択してください' }}
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>受付 *</FormLabel>
@@ -318,7 +324,7 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
           <CardContent>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
               <div className="relative grid gap-2">
-                <Label htmlFor="castName">キャスト</Label>
+                <Label htmlFor="castName">キャスト *</Label>
                 <Input
                   id="castName"
                   type="text"
@@ -331,7 +337,11 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
                   aria-controls="cast-suggestions"
                   autoComplete="off"
                 />
-                <input type="hidden" {...register('castId')} />
+                {/* キャストはサーバ側が @NotBlank。候補から選ばないと 400 になるため送信前に止める */}
+                <input
+                  type="hidden"
+                  {...register('castId', { required: 'キャストを候補から選択してください' })}
+                />
                 {isCastOpen && (
                   <div
                     id="cast-suggestions"
@@ -362,6 +372,9 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
                       </ul>
                     )}
                   </div>
+                )}
+                {errors.castId && (
+                  <p className="text-sm text-destructive">{errors.castId.message}</p>
                 )}
               </div>
               <FormField

--- a/frontend/src/_pages/store-orders/ui/OrderForm.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderForm.tsx
@@ -17,6 +17,7 @@ import {
   FormField,
   FormItem,
   FormLabel,
+  FormMessage,
   Input,
   Label,
   Select,
@@ -185,7 +186,7 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
                 rules={{ required: true }}
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>受付</FormLabel>
+                    <FormLabel>受付 *</FormLabel>
                     <Select
                       value={field.value ? field.value : SELECT_NONE}
                       onValueChange={v => field.onChange(v === SELECT_NONE ? '' : v)}
@@ -208,6 +209,7 @@ export function OrderForm({ initialData, onSubmit, isSubmitting }: OrderFormProp
                         })}
                       </SelectContent>
                     </Select>
+                    <FormMessage />
                   </FormItem>
                 )}
               />

--- a/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
@@ -74,7 +74,9 @@ export default function OrderListPage() {
                   {order.cast_name || 'フリー'}
                 </Badge>
               </TableCell>
-              <TableCell className="text-muted-foreground">{order.course_minutes} 分</TableCell>
+              <TableCell className="text-muted-foreground">
+                {order.course_minutes != null ? `${order.course_minutes} 分` : '-'}
+              </TableCell>
               <TableCell>
                 <Badge
                   variant="outline"

--- a/frontend/src/_pages/store-settings/ui/AccountPage.tsx
+++ b/frontend/src/_pages/store-settings/ui/AccountPage.tsx
@@ -26,8 +26,8 @@ export default function AccountPage() {
     const fetchMe = async () => {
       try {
         const me = await platformAuthApi.me();
-        setNickname(me.display_name);
-        setEmail(me.email);
+        setNickname(me.display_name ?? '');
+        setEmail(me.email ?? '');
       } catch {
         toast.error('アカウント情報の取得に失敗しました');
       } finally {
@@ -42,7 +42,7 @@ export default function AccountPage() {
     setIsSubmitting(true);
     try {
       const me = await platformAuthApi.updateMe({ display_name: nickname });
-      setNickname(me.display_name);
+      setNickname(me.display_name ?? '');
       toast.success('プロフィールを更新しました');
     } catch {
       toast.error('プロフィールの更新に失敗しました');

--- a/frontend/src/_pages/store-shifts/lib/datetime.ts
+++ b/frontend/src/_pages/store-shifts/lib/datetime.ts
@@ -30,13 +30,16 @@ export function monthGrid(month: Date): { date: Date; inMonth: boolean }[] {
 }
 
 /** 'HH:mm:ss' または 'HH:mm' を深夜 0 時からの分に変換する。 */
-export function timeToMinutes(time: string): number {
-  const [h, m] = time.split(':');
+export function timeToMinutes(time: string | undefined): number {
+  const [h, m] = (time ?? '').split(':');
   return Number(h) * 60 + Number(m);
 }
 
 /** シフトの [開始分, 終了分]。終了 <= 開始 は翌日にまたがる勤務として +1440 する。 */
-export function shiftSpan(startTime: string, endTime: string): { start: number; end: number } {
+export function shiftSpan(
+  startTime: string | undefined,
+  endTime: string | undefined
+): { start: number; end: number } {
   const start = timeToMinutes(startTime);
   let end = timeToMinutes(endTime);
   if (end <= start) end += 24 * 60;

--- a/frontend/src/_pages/store-shifts/ui/ShiftCalendar.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftCalendar.tsx
@@ -26,10 +26,11 @@ export function ShiftCalendar({
 }: ShiftCalendarProps) {
   const byDate = new Map<string, { total: number; confirmed: number }>();
   for (const s of shifts) {
-    const agg = byDate.get(s.work_date) ?? { total: 0, confirmed: 0 };
+    const workDate = s.work_date ?? '';
+    const agg = byDate.get(workDate) ?? { total: 0, confirmed: 0 };
     agg.total += 1;
     if (s.status === 'CONFIRMED') agg.confirmed += 1;
-    byDate.set(s.work_date, agg);
+    byDate.set(workDate, agg);
   }
 
   const days = monthGrid(month);

--- a/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
@@ -175,11 +175,15 @@ export function ShiftFormModal({
                       {casts.length === 0 && (
                         <SelectItem value={SELECT_NONE}>キャストが未登録です</SelectItem>
                       )}
-                      {casts.map(c => (
-                        <SelectItem key={c.id} value={c.id ?? ''}>
-                          {c.name}
-                        </SelectItem>
-                      ))}
+                      {casts.map(c => {
+                        const id = c.id;
+                        if (id === undefined) return null;
+                        return (
+                          <SelectItem key={id} value={id}>
+                            {c.name}
+                          </SelectItem>
+                        );
+                      })}
                     </SelectContent>
                   </Select>
                 </FormItem>

--- a/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
@@ -86,11 +86,11 @@ export function ShiftFormModal({
     if (!open) return;
     if (editing) {
       reset({
-        cast_id: editing.cast_id,
-        work_date: editing.work_date,
-        start_time: editing.start_time.slice(0, 5),
-        end_time: editing.end_time.slice(0, 5),
-        status: editing.status,
+        cast_id: editing.cast_id ?? '',
+        work_date: editing.work_date ?? '',
+        start_time: (editing.start_time ?? '').slice(0, 5),
+        end_time: (editing.end_time ?? '').slice(0, 5),
+        status: editing.status ?? '',
       });
     } else {
       reset({
@@ -113,7 +113,7 @@ export function ShiftFormModal({
     };
     try {
       if (editing) {
-        await shiftApi.update(editing.id, payload);
+        await shiftApi.update(editing.id ?? '', payload);
         toast.success('シフトを更新しました');
       } else {
         await shiftApi.create(payload);
@@ -129,7 +129,7 @@ export function ShiftFormModal({
   const handleDelete = async () => {
     if (!editing) return;
     try {
-      await shiftApi.delete(editing.id);
+      await shiftApi.delete(editing.id ?? '');
       toast.success('シフトを削除しました');
       onSaved();
       onClose();
@@ -176,7 +176,7 @@ export function ShiftFormModal({
                         <SelectItem value={SELECT_NONE}>キャストが未登録です</SelectItem>
                       )}
                       {casts.map(c => (
-                        <SelectItem key={c.id} value={c.id}>
+                        <SelectItem key={c.id} value={c.id ?? ''}>
                           {c.name}
                         </SelectItem>
                       ))}

--- a/frontend/src/_pages/store-shifts/ui/ShiftRequestInbox.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftRequestInbox.tsx
@@ -18,7 +18,9 @@ export function ShiftRequestInbox({ casts, onApproved }: ShiftRequestInboxProps)
   const [loading, setLoading] = useState(true);
   const [processingId, setProcessingId] = useState<string | null>(null);
 
-  const castName = (castId: string | undefined) => casts.find(c => c.id === castId)?.name ?? castId;
+  // castId が未指定のとき、id を持たないキャストと undefined 同士で一致してしまうのを防ぐ
+  const castName = (castId: string | undefined) =>
+    (castId === undefined ? undefined : casts.find(c => c.id === castId)?.name) ?? castId;
 
   const load = () => {
     setLoading(true);

--- a/frontend/src/_pages/store-shifts/ui/ShiftRequestInbox.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftRequestInbox.tsx
@@ -18,7 +18,7 @@ export function ShiftRequestInbox({ casts, onApproved }: ShiftRequestInboxProps)
   const [loading, setLoading] = useState(true);
   const [processingId, setProcessingId] = useState<string | null>(null);
 
-  const castName = (castId: string) => casts.find(c => c.id === castId)?.name ?? castId;
+  const castName = (castId: string | undefined) => casts.find(c => c.id === castId)?.name ?? castId;
 
   const load = () => {
     setLoading(true);
@@ -77,7 +77,7 @@ export function ShiftRequestInbox({ casts, onApproved }: ShiftRequestInboxProps)
           <div>
             <p className="text-sm font-medium text-foreground">{castName(request.cast_id)}</p>
             <p className="text-sm text-muted-foreground">
-              {request.work_date} {request.start_time.slice(0, 5)}–{request.end_time.slice(0, 5)}
+              {request.work_date} {request.start_time?.slice(0, 5)}–{request.end_time?.slice(0, 5)}
             </p>
             {request.note && <p className="mt-1 text-xs text-muted-foreground">{request.note}</p>}
           </div>
@@ -86,7 +86,7 @@ export function ShiftRequestInbox({ casts, onApproved }: ShiftRequestInboxProps)
               type="button"
               variant="outline"
               size="sm"
-              onClick={() => decline(request.id)}
+              onClick={() => decline(request.id ?? '')}
               disabled={processingId === request.id}
             >
               辞退
@@ -94,7 +94,7 @@ export function ShiftRequestInbox({ casts, onApproved }: ShiftRequestInboxProps)
             <Button
               type="button"
               size="sm"
-              onClick={() => approve(request.id)}
+              onClick={() => approve(request.id ?? '')}
               disabled={processingId === request.id}
             >
               承認

--- a/frontend/src/_pages/store-shifts/ui/ShiftTimeline.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftTimeline.tsx
@@ -29,8 +29,8 @@ export function ShiftTimeline({
   onAddShift,
   onEditShift,
 }: ShiftTimelineProps) {
-  const castName = (id: string) => casts.find(c => c.id === id)?.name ?? '不明';
-  const fmt = (t: string) => t.slice(0, 5);
+  const castName = (id: string | undefined) => casts.find(c => c.id === id)?.name ?? '不明';
+  const fmt = (t: string | undefined) => (t ?? '').slice(0, 5);
   const hourLabel = (min: number) => `${String(Math.floor((min % 1440) / 60)).padStart(2, '0')}:00`;
 
   const spans = shifts.map(s => shiftSpan(s.start_time, s.end_time));

--- a/frontend/src/_pages/store-shifts/ui/ShiftTimeline.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftTimeline.tsx
@@ -29,7 +29,9 @@ export function ShiftTimeline({
   onAddShift,
   onEditShift,
 }: ShiftTimelineProps) {
-  const castName = (id: string | undefined) => casts.find(c => c.id === id)?.name ?? '不明';
+  // id が未指定のとき、id を持たないキャストと undefined 同士で一致してしまうのを防ぐ
+  const castName = (id: string | undefined) =>
+    (id === undefined ? undefined : casts.find(c => c.id === id)?.name) ?? '不明';
   const fmt = (t: string | undefined) => (t ?? '').slice(0, 5);
   const hourLabel = (min: number) => `${String(Math.floor((min % 1440) / 60)).padStart(2, '0')}:00`;
 

--- a/frontend/src/_pages/store-site/model/types.ts
+++ b/frontend/src/_pages/store-site/model/types.ts
@@ -5,8 +5,8 @@ import { PartnerLink, SnsLink } from '@/entities/store-profile';
  * キャスト情報
  */
 export interface Cast {
-  id: string;
-  name: string;
+  id?: string;
+  name?: string;
   photo_url?: string;
   introduction?: string;
   age?: number;
@@ -31,7 +31,7 @@ export interface SiteConfig {
   pricing_description?: string;
   custom_texts?: Record<string, string>;
   mv_url?: string;
-  mv_type: 'image' | 'video';
+  mv_type?: 'image' | 'video';
   sns_links?: SnsLink[];
   partner_links?: PartnerLink[];
 }
@@ -48,9 +48,9 @@ export interface StorefrontData {
  * 公開出勤表のシフト情報
  */
 export interface PublicShift {
-  cast_id: string;
-  cast_name: string;
+  cast_id?: string;
+  cast_name?: string;
   cast_photo_url?: string;
-  start_time: string;
-  end_time: string;
+  start_time?: string;
+  end_time?: string;
 }

--- a/frontend/src/_pages/store-site/templates/_sections/CastDetailSection.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/CastDetailSection.tsx
@@ -18,7 +18,9 @@ export default function CastDetailSection({ cast }: CastDetailSectionProps) {
   if (cast.waist) profile.push({ label: 'ウエスト', value: `${cast.waist}` });
   if (cast.hip) profile.push({ label: 'ヒップ', value: `${cast.hip}` });
   // custom_fields はサーバ側で公開・生存・値ありの定義のみを表示順に整形済みのため、そのまま追加する
-  cast.custom_fields?.forEach(field => profile.push({ label: field.label, value: field.value }));
+  cast.custom_fields?.forEach(field =>
+    profile.push({ label: field.label ?? '', value: field.value ?? '' })
+  );
 
   return (
     <section className="py-12 md:py-20 px-5 sm:px-6" style={{ background: 'var(--storefront-bg)' }}>
@@ -34,7 +36,7 @@ export default function CastDetailSection({ cast }: CastDetailSectionProps) {
           {cast.photo_url ? (
             <Image
               src={cast.photo_url}
-              alt={cast.name}
+              alt={cast.name ?? ''}
               fill
               className="object-cover"
               sizes="(max-width: 768px) 100vw, 400px"

--- a/frontend/src/_pages/store-site/templates/_sections/CastGrid.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/CastGrid.tsx
@@ -36,7 +36,7 @@ export default function CastGrid({ casts }: CastGridProps) {
                   {cast.photo_url ? (
                     <Image
                       src={cast.photo_url}
-                      alt={cast.name}
+                      alt={cast.name ?? ''}
                       fill
                       className="object-cover transition-transform duration-700 group-hover/card:scale-105"
                       sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"

--- a/frontend/src/_pages/store-site/templates/_sections/CastSection.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/CastSection.tsx
@@ -4,17 +4,7 @@ import { useRef } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
-
-interface Cast {
-  id: string;
-  name: string;
-  photo_url?: string;
-  age?: number;
-  height?: number;
-  bust?: number;
-  waist?: number;
-  hip?: number;
-}
+import { Cast } from '../../model/types';
 
 interface CastSectionProps {
   casts?: Cast[];
@@ -101,7 +91,7 @@ export default function CastSection({ casts }: CastSectionProps) {
                   {cast.photo_url ? (
                     <Image
                       src={cast.photo_url}
-                      alt={cast.name}
+                      alt={cast.name ?? ''}
                       fill
                       className="object-cover transition-transform duration-700 group-hover/card:scale-105"
                       sizes="(max-width: 640px) 144px, (max-width: 768px) 160px, 192px"

--- a/frontend/src/_pages/store-site/templates/_sections/Footer.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/Footer.tsx
@@ -86,7 +86,7 @@ export default function Footer({ storeName, partnerLinks, snsLinks }: FooterProp
                     className="text-[color-mix(in_srgb,var(--storefront-fg)_25%,transparent)] hover:text-[color-mix(in_srgb,var(--storefront-accent)_70%,transparent)] transition-colors duration-200"
                     aria-label={item.platform}
                   >
-                    {getSnsIcon(item.platform ?? '')}
+                    {getSnsIcon(item.platform)}
                   </a>
                 ))}
               </div>

--- a/frontend/src/_pages/store-site/templates/_sections/Footer.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/Footer.tsx
@@ -86,7 +86,7 @@ export default function Footer({ storeName, partnerLinks, snsLinks }: FooterProp
                     className="text-[color-mix(in_srgb,var(--storefront-fg)_25%,transparent)] hover:text-[color-mix(in_srgb,var(--storefront-accent)_70%,transparent)] transition-colors duration-200"
                     aria-label={item.platform}
                   >
-                    {getSnsIcon(item.platform)}
+                    {getSnsIcon(item.platform ?? '')}
                   </a>
                 ))}
               </div>

--- a/frontend/src/_pages/store-site/templates/_sections/ScheduleSection.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/ScheduleSection.tsx
@@ -7,11 +7,11 @@ interface ScheduleSectionProps {
 }
 
 /** "HH:mm(:ss)" → "HH:mm" 表示。 */
-const formatTime = (t: string) => t.slice(0, 5);
+const formatTime = (t: string | undefined) => (t ?? '').slice(0, 5);
 
 /** 終了時刻の表示。00:00 終了は跨夜の連続表記として 24:00 と表示する。 */
-const formatEndTime = (t: string) => {
-  const hm = t.slice(0, 5);
+const formatEndTime = (t: string | undefined) => {
+  const hm = (t ?? '').slice(0, 5);
   return hm === '00:00' ? '24:00' : hm;
 };
 
@@ -66,7 +66,7 @@ export default function ScheduleSection({ shifts }: ScheduleSectionProps) {
                 {shift.cast_photo_url ? (
                   <Image
                     src={shift.cast_photo_url}
-                    alt={shift.cast_name}
+                    alt={shift.cast_name ?? ''}
                     fill
                     className="object-cover transition-transform duration-700 group-hover/card:scale-105"
                     sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"

--- a/frontend/src/_pages/store-site/templates/classic/cast-detail.tsx
+++ b/frontend/src/_pages/store-site/templates/classic/cast-detail.tsx
@@ -33,7 +33,7 @@ export default async function ClassicCastDetailPage({ castId }: ClassicCastDetai
       <AgeGate storeName={storeName} />
       <Header storeName={storeName} logoUrl={siteConfig.logo_url} />
       <main className="grow">
-        <PageHero title={cast.name} />
+        <PageHero title={cast.name ?? ''} />
         <CastDetailSection cast={cast} />
       </main>
       <Footer

--- a/frontend/src/_pages/store-site/templates/default/cast-detail.tsx
+++ b/frontend/src/_pages/store-site/templates/default/cast-detail.tsx
@@ -33,7 +33,7 @@ export default async function DefaultCastDetailPage({ castId }: DefaultCastDetai
       <AgeGate storeName={storeName} />
       <Header storeName={storeName} logoUrl={siteConfig.logo_url} />
       <main className="grow">
-        <PageHero title={cast.name} />
+        <PageHero title={cast.name ?? ''} />
         <CastDetailSection cast={cast} />
       </main>
       <Footer

--- a/frontend/src/_pages/store-site/templates/modern/cast-detail.tsx
+++ b/frontend/src/_pages/store-site/templates/modern/cast-detail.tsx
@@ -33,7 +33,7 @@ export default async function ModernCastDetailPage({ castId }: ModernCastDetailP
       <AgeGate storeName={storeName} />
       <Header storeName={storeName} logoUrl={siteConfig.logo_url} />
       <main className="grow">
-        <PageHero title={cast.name} />
+        <PageHero title={cast.name ?? ''} />
         <CastDetailSection cast={cast} />
       </main>
       <Footer

--- a/frontend/src/entities/cast/model/invitationStatusLabel.ts
+++ b/frontend/src/entities/cast/model/invitationStatusLabel.ts
@@ -1,7 +1,7 @@
 import { CastInvitationStatus } from './types';
 
 /** 招待状態の表示ラベルと配色（DESIGN.md Status pill の tint レシピ）を返す。 */
-export function castInvitationStatusLabel(status: CastInvitationStatus): {
+export function castInvitationStatusLabel(status: CastInvitationStatus | undefined): {
   text: string;
   color: string;
 } {

--- a/frontend/src/entities/cast/model/types.ts
+++ b/frontend/src/entities/cast/model/types.ts
@@ -3,9 +3,9 @@ export type CastInvitationStatus = 'NOT_INVITED' | 'INVITED' | 'EXPIRED' | 'LINK
 
 // キャスト（Cast）レスポンス
 export interface CastResponse {
-  id: string;
-  name: string;
-  status: string;
+  id?: string;
+  name?: string;
+  status?: string;
   photo_url?: string;
   introduction?: string;
   age?: number;
@@ -14,25 +14,26 @@ export interface CastResponse {
   waist?: number;
   hip?: number;
   display_order?: number;
-  invitation_status: CastInvitationStatus;
+  // 作成・更新の応答では招待状態を載せないため、一覧・詳細以外では欠落する
+  invitation_status?: CastInvitationStatus;
   custom_fields?: Record<string, string>;
-  created_at: string;
-  updated_at: string;
+  created_at?: string;
+  updated_at?: string;
 }
 
 // 公開カスタムフィールド1件（表示順どおりに整形済み）
 export interface CastCustomFieldView {
-  key: string;
-  label: string;
-  value: string;
+  key?: string;
+  label?: string;
+  value?: string;
 }
 
 // 公開キャスト詳細レスポンス（GET /store/casts/public）。管理用 CastResponse と異なり
 // invitation_status を持たず、custom_fields は公開・生存・値ありの定義のみを表示順に整形した配列。
 export interface CastPublicResponse {
-  id: string;
-  name: string;
-  status: string;
+  id?: string;
+  name?: string;
+  status?: string;
   photo_url?: string;
   introduction?: string;
   age?: number;
@@ -41,9 +42,9 @@ export interface CastPublicResponse {
   waist?: number;
   hip?: number;
   display_order?: number;
-  custom_fields: CastCustomFieldView[];
-  created_at: string;
-  updated_at: string;
+  custom_fields?: CastCustomFieldView[];
+  created_at?: string;
+  updated_at?: string;
 }
 
 // キャスト作成リクエスト
@@ -78,13 +79,13 @@ export interface CastUpdateRequest {
 
 // カスタムフィールド定義レスポンス
 export interface CastFieldDefinitionResponse {
-  id: string;
-  key: string;
-  label: string;
-  display_order: number;
-  is_public: boolean;
-  created_at: string;
-  updated_at: string;
+  id?: string;
+  key?: string;
+  label?: string;
+  display_order?: number;
+  is_public?: boolean;
+  created_at?: string;
+  updated_at?: string;
 }
 
 // カスタムフィールド定義作成リクエスト（key は不変のため作成時のみ指定）
@@ -103,8 +104,8 @@ export interface CastFieldDefinitionUpdateRequest {
 
 // キャスト招待発行レスポンス
 export interface CastInvitationIssueResponse {
-  token: string;
-  expires_at: string;
+  token?: string;
+  expires_at?: string;
 }
 
 // 招待照会（公開ランディング）の受諾可否状態
@@ -112,10 +113,10 @@ export type CastInvitationViewStatus = 'VALID' | 'EXPIRED' | 'USED';
 
 // 招待照会（公開ランディング）レスポンス
 export interface CastInvitationDetailResponse {
-  store_name: string;
-  cast_name: string;
-  status: CastInvitationViewStatus;
-  expires_at: string;
+  store_name?: string;
+  cast_name?: string;
+  status?: CastInvitationViewStatus;
+  expires_at?: string;
 }
 
 // 招待の新規登録受諾リクエスト
@@ -127,5 +128,5 @@ export interface CastInvitationAcceptRequest {
 
 // 招待受諾の完了応答
 export interface CastAcceptanceResponse {
-  store_name: string;
+  store_name?: string;
 }

--- a/frontend/src/entities/customer/model/types.ts
+++ b/frontend/src/entities/customer/model/types.ts
@@ -1,7 +1,7 @@
 // 顧客（Customer）レスポンス
 export interface CustomerResponse {
-  id: string;
-  name: string;
+  id?: string;
+  name?: string;
   phone_number?: string;
   phone_number2?: string;
   address?: string;

--- a/frontend/src/entities/menu/model/types.ts
+++ b/frontend/src/entities/menu/model/types.ts
@@ -1,5 +1,5 @@
 export interface MenuVO {
-  name: string;
+  name?: string;
   path?: string;
   icon?: string;
   items?: MenuVO[];

--- a/frontend/src/entities/order/model/types.ts
+++ b/frontend/src/entities/order/model/types.ts
@@ -1,51 +1,56 @@
-// バックエンド API の JSON キーに一致（Jackson グローバル SNAKE_CASE）
+// バックエンド API の JSON キーに一致（Jackson グローバル SNAKE_CASE）。
+// 応答の任意性は Java 側の可空性が正本。wrapper 型のフィールドは
+// default-property-inclusion: non_null によりキーごと応答から消えるため optional にする。
 export interface Order {
-  id: string;
-  receptionist_id?: string;
+  id?: string;
+  receptionist_id?: number;
   receptionist_name?: string;
-  business_date: string;
+  business_date?: string;
   arrival_scheduled_start_time?: string;
   arrival_scheduled_end_time?: string;
   customer_id?: string;
   customer_name?: string;
   cast_id?: string;
   cast_name?: string;
-  course_minutes: number;
-  extension_minutes: number;
-  option_codes: string[];
+  course_minutes?: number;
+  extension_minutes?: number;
+  option_codes?: string[];
   discount_name?: string;
-  manual_discount: number;
+  manual_discount?: number;
   carrier?: string;
   media_name?: string;
-  used_points: number;
-  manual_grant_points: number;
+  used_points?: number;
+  manual_grant_points?: number;
   remarks?: string;
   cast_driver_message?: string;
-  status: string;
+  status?: string;
+  location_address?: string;
+  location_building?: string;
 }
 
 export interface OrderReceptionist {
-  id: number;
-  display_name: string;
+  id?: number;
+  display_name?: string;
 }
 
 export interface OrderCreateRequest {
-  receptionist_id?: string;
+  // 受付とキャストは Java 側が @NotNull / @NotBlank のため必須
+  receptionist_id: number;
   business_date: string;
   arrival_scheduled_start_time?: string;
   arrival_scheduled_end_time?: string;
   customer_id?: string;
   customer_name?: string;
-  cast_id?: string;
-  course_minutes: number;
-  extension_minutes: number;
-  option_codes: string[];
+  cast_id: string;
+  course_minutes?: number;
+  extension_minutes?: number;
+  option_codes?: string[];
   discount_name?: string;
-  manual_discount: number;
+  manual_discount?: number;
   carrier?: string;
   media_name?: string;
-  used_points: number;
-  manual_grant_points: number;
+  used_points?: number;
+  manual_grant_points?: number;
   remarks?: string;
   cast_driver_message?: string;
   // Customer Creation Fields

--- a/frontend/src/entities/shift/model/types.ts
+++ b/frontend/src/entities/shift/model/types.ts
@@ -1,13 +1,13 @@
 // シフト（Shift）レスポンス。時刻は ISO 文字列（work_date=yyyy-MM-dd / start_time・end_time=HH:mm:ss）。
 export interface ShiftResponse {
-  id: string;
-  cast_id: string;
-  work_date: string;
-  start_time: string;
-  end_time: string;
-  status: string;
-  created_at: string;
-  updated_at: string;
+  id?: string;
+  cast_id?: string;
+  work_date?: string;
+  start_time?: string;
+  end_time?: string;
+  status?: string;
+  created_at?: string;
+  updated_at?: string;
 }
 
 // シフト作成リクエスト（status 省略時はサーバ側で TENTATIVE）
@@ -30,12 +30,12 @@ export interface ShiftUpdateRequest {
 
 // 本人（キャスト）ポータル週間スケジュールの1件（GET /platform/me/schedule）。店舗名を内联する。
 export interface CastScheduleItem {
-  work_date: string;
-  start_time: string;
-  end_time: string;
-  status: string;
-  store_id: number;
-  store_name: string;
+  work_date?: string;
+  start_time?: string;
+  end_time?: string;
+  status?: string;
+  store_id?: number;
+  store_name?: string;
 }
 
 // 出勤希望のステータス。PENDING=受付済み/APPROVED=確定済み/DECLINED=却下。
@@ -52,42 +52,43 @@ export interface ShiftRequestCreateRequest {
 
 // 出勤希望提出の応答（本人ポータル）。
 export interface ShiftRequestResponse {
-  id: string;
-  store_id: number;
-  work_date: string;
-  start_time: string;
-  end_time: string;
-  note: string | null;
-  status: ShiftRequestStatus;
-  created_at: string;
+  id?: string;
+  store_id?: number;
+  work_date?: string;
+  start_time?: string;
+  end_time?: string;
+  // 未入力はキーごと応答から消えるため undefined であって null ではない
+  note?: string;
+  status?: ShiftRequestStatus;
+  created_at?: string;
 }
 
 // 本人（キャスト）の出勤希望履歴の1件（GET /platform/me/shift-requests）。店舗名を埋め込む。
 export interface CastShiftRequestItem {
-  id: string;
-  work_date: string;
-  start_time: string;
-  end_time: string;
-  note: string | null;
-  status: ShiftRequestStatus;
-  store_id: number;
-  store_name: string;
-  created_at: string;
+  id?: string;
+  work_date?: string;
+  start_time?: string;
+  end_time?: string;
+  note?: string;
+  status?: ShiftRequestStatus;
+  store_id?: number;
+  store_name?: string;
+  created_at?: string;
 }
 
 // 本人（キャスト）所属店舗セレクタの1件（GET /platform/me/stores）。
 export interface CastStoreItem {
-  store_id: number;
-  store_name: string;
+  store_id?: number;
+  store_name?: string;
 }
 
 // 店舗側 inbox の出勤希望1件（GET /store/shift-requests）。
 export interface StoreShiftRequestItem {
-  id: string;
-  cast_id: string;
-  work_date: string;
-  start_time: string;
-  end_time: string;
-  note: string | null;
-  status: ShiftRequestStatus;
+  id?: string;
+  cast_id?: string;
+  work_date?: string;
+  start_time?: string;
+  end_time?: string;
+  note?: string;
+  status?: ShiftRequestStatus;
 }

--- a/frontend/src/entities/store-profile/model/types.ts
+++ b/frontend/src/entities/store-profile/model/types.ts
@@ -1,14 +1,15 @@
-// SNSリンク
+// SNSリンク。更新リクエストの入れ子でもあり、Java 側は platform・url とも @NotBlank。
+// 同じ型を請求と応答の双方で使うため、厳しい側（請求）の必須性を採る。
 export interface SnsLink {
-  platform?: string;
-  url?: string;
+  platform: string;
+  url: string;
   label?: string;
 }
 
-// パートナーリンク
+// パートナーリンク。更新リクエストの入れ子でもあり、Java 側は name・url とも @NotBlank。
 export interface PartnerLink {
-  name?: string;
-  url?: string;
+  name: string;
+  url: string;
   logo_url?: string;
 }
 

--- a/frontend/src/entities/store-profile/model/types.ts
+++ b/frontend/src/entities/store-profile/model/types.ts
@@ -1,25 +1,25 @@
 // SNSリンク
 export interface SnsLink {
-  platform: string;
-  url: string;
+  platform?: string;
+  url?: string;
   label?: string;
 }
 
 // パートナーリンク
 export interface PartnerLink {
-  name: string;
-  url: string;
+  name?: string;
+  url?: string;
   logo_url?: string;
 }
 
 // 店舗サイト設定レスポンス
 export interface StoreProfileResponse {
-  id: string;
-  template_key: string;
+  id?: string;
+  template_key?: string;
   logo_url?: string;
   banner_url?: string;
   mv_url?: string;
-  mv_type: string;
+  mv_type?: string;
   description?: string;
   catch_copy?: string;
   address?: string;
@@ -27,10 +27,10 @@ export interface StoreProfileResponse {
   business_hours?: string;
   pricing_description?: string;
   custom_texts?: Record<string, string>;
-  sns_links: SnsLink[];
-  partner_links: PartnerLink[];
-  created_at: string;
-  updated_at: string;
+  sns_links?: SnsLink[];
+  partner_links?: PartnerLink[];
+  created_at?: string;
+  updated_at?: string;
 }
 
 // 店舗サイト設定更新リクエスト

--- a/frontend/src/entities/store/api/platform.ts
+++ b/frontend/src/entities/store/api/platform.ts
@@ -17,13 +17,13 @@ export const platformStoreApi = {
     const response = await apiClient.get(`/platform/stores/${id}`);
     return response.data;
   },
-  create: async (data: CreateStoreRequest): Promise<Store> => {
-    const response = await apiClient.post('/platform/stores', data);
-    return response.data;
+  /** 端点は 204 No Content。body は返らない。 */
+  create: async (data: CreateStoreRequest): Promise<void> => {
+    await apiClient.post('/platform/stores', data);
   },
-  update: async (id: string, data: UpdateStoreRequest): Promise<Store> => {
-    const response = await apiClient.put(`/platform/stores/${id}`, data);
-    return response.data;
+  /** 端点は 204 No Content。body は返らない。 */
+  update: async (id: string, data: UpdateStoreRequest): Promise<void> => {
+    await apiClient.put(`/platform/stores/${id}`, data);
   },
   delete: async (id: string): Promise<void> => {
     await apiClient.delete(`/platform/stores/${id}`);

--- a/frontend/src/entities/store/model/types.ts
+++ b/frontend/src/entities/store/model/types.ts
@@ -1,11 +1,10 @@
 // 店舗
 export interface Store {
-  id: string;
-  name: string;
-  email: string;
-  domain: string;
-  created_at: string;
-  updated_at?: string;
+  id?: string;
+  name?: string;
+  email?: string;
+  domain?: string;
+  created_at?: string;
 }
 
 // 店舗作成リクエスト
@@ -23,5 +22,6 @@ export interface UpdateStoreRequest {
 
 // 店舗統計データ
 export interface StoreStats {
+  // Java 側が primitive の long のため、キーは必ず応答に含まれる
   total: number;
 }

--- a/frontend/src/entities/system-config/model/types.ts
+++ b/frontend/src/entities/system-config/model/types.ts
@@ -1,19 +1,20 @@
 // システム設定レスポンス
 export interface SystemConfigResponse {
-  id: number;
-  config_key: string;
+  id?: number;
+  config_key?: string;
   // 秘匿設定はバックエンドでマスクされ JSON に含まれないため optional
   config_value?: string;
-  value_type: 'STRING' | 'NUMBER' | 'BOOLEAN';
-  secret: boolean;
-  category: string;
+  value_type?: 'STRING' | 'NUMBER' | 'BOOLEAN';
+  secret?: boolean;
+  category?: string;
   description?: string;
-  created_at: string;
-  updated_at: string;
+  created_at?: string;
+  updated_at?: string;
 }
 
 // システム設定更新リクエスト
 export interface SystemConfigUpdateRequest {
   config_key: string;
-  config_value: string;
+  // Java 側に必須注解が無い
+  config_value?: string;
 }

--- a/frontend/src/entities/user/model/types.ts
+++ b/frontend/src/entities/user/model/types.ts
@@ -6,7 +6,8 @@ export interface PasswordChangeRequest {
 
 // 認証レスポンス
 export interface LoginResponse {
-  token: string;
+  token?: string;
+  // Java 側が primitive の long のため、キーは必ず応答に含まれる
   expires_at: number;
 }
 
@@ -48,15 +49,16 @@ export interface PlatformLoginRequest {
 
 // 平台 /me レスポンス
 export interface PlatformMeResponse {
-  email: string;
-  display_name: string;
-  user_type: PlatformUserType;
-  permissions: PlatformPermission[];
-  console: PlatformConsole;
+  email?: string;
+  display_name?: string;
+  user_type?: PlatformUserType;
+  permissions?: PlatformPermission[];
+  console?: PlatformConsole;
   // 店舗文脈（X-Store-ID）を確立できるか。JWT storeBridge claim と同源でサーバ側が権限目録から導出する。
+  // Java 側が primitive の boolean のため、キーは必ず応答に含まれる。
   store_bridge: boolean;
-  store_scope_type: PlatformStoreScopeType;
-  store_ids: number[];
+  store_scope_type?: PlatformStoreScopeType;
+  store_ids?: number[];
 }
 
 // 平台自己プロフィール更新リクエスト
@@ -66,8 +68,8 @@ export interface PlatformMeUpdateRequest {
 
 // 平台の授権店舗一覧の1件
 export interface PlatformStore {
-  id: number;
-  name: string;
+  id?: number;
+  name?: string;
 }
 
 // 権限目録（/platform/permissions）の所属コンソール。大文字 3 値で、
@@ -76,24 +78,25 @@ export type PermissionConsole = 'PLATFORM' | 'STORE' | 'SHARED';
 
 // 権限目録の1件（ロール編集 UI の選択肢）
 export interface PermissionResponse {
-  code: PlatformPermission;
-  console: PermissionConsole;
+  code?: PlatformPermission;
+  console?: PermissionConsole;
 }
 
 // ロールへの参照（スタッフ応答の埋め込み）。
 // name はサーバの non_null 方針でキーごと欠落しうるため任意扱いにする。
 export interface RoleRef {
-  id: number;
+  id?: number;
   name?: string;
 }
 
 // ロール一覧の1件
 export interface RoleResponse {
-  id: number;
-  name: string;
+  id?: number;
+  name?: string;
   // 平台既定ロール。改名・権限変更・削除がいずれも拒否される。
+  // system と version は Java 側が primitive のため、キーは必ず応答に含まれる。
   system: boolean;
-  permissions: PlatformPermission[];
+  permissions?: PlatformPermission[];
   // 楽観ロック用バージョン（更新リクエストへそのまま往復する）
   version: number;
 }
@@ -115,13 +118,14 @@ export interface RoleUpdateRequest {
 // スタッフ（ロール×店舗集合）の応答。
 // リクエストは role_ids（id の配列）なのに応答は roles（id と名称の対）という非対称に注意。
 export interface PlatformStaffResponse {
-  id: number;
-  email: string;
-  display_name: string;
+  id?: number;
+  email?: string;
+  display_name?: string;
+  // enabled と version は Java 側が primitive のため、キーは必ず応答に含まれる。
   enabled: boolean;
-  roles: RoleRef[];
-  store_scope_type: PlatformStoreScopeType;
-  store_ids: number[];
+  roles?: RoleRef[];
+  store_scope_type?: PlatformStoreScopeType;
+  store_ids?: number[];
   // 楽観ロック用バージョン（更新リクエストへそのまま往復する）
   version: number;
 }
@@ -133,14 +137,16 @@ export interface PlatformStaffCreateRequest {
   display_name: string;
   role_ids: number[];
   store_scope_type: PlatformStoreScopeType;
-  store_ids: number[];
+  // Java 側に必須注解が無い（ALL_STORES のときは送らなくてよい）
+  store_ids?: number[];
 }
 
 // スタッフ授権編集リクエスト（enabled: 未指定=現状維持、false=停止、true=再開）
 export interface PlatformStaffUpdateRequest {
   role_ids: number[];
   store_scope_type: PlatformStoreScopeType;
-  store_ids: number[];
+  // Java 側に必須注解が無い（ALL_STORES のときは送らなくてよい）
+  store_ids?: number[];
   enabled?: boolean;
   // 楽観ロック用バージョン（応答の version をそのまま返送。不一致は 409）
   version: number;

--- a/frontend/src/features/cast-invitation/ui/InvitationButton.tsx
+++ b/frontend/src/features/cast-invitation/ui/InvitationButton.tsx
@@ -12,8 +12,8 @@ export interface IssuedInvitation {
 }
 
 interface InvitationButtonProps {
-  castId: string;
-  status: CastInvitationStatus;
+  castId: string | undefined;
+  status: CastInvitationStatus | undefined;
   /**
    * 発行成功後に呼ばれる。モーダル表示は呼び出し元（ページ層）の責務 ——
    * 一覧の再取得（onIssued 内で行われる想定）は isLoading を伴い、それに連動して
@@ -31,8 +31,8 @@ export function InvitationButton({ castId, status, onIssued }: InvitationButtonP
   const handleIssue = async () => {
     setIssuing(true);
     try {
-      const response = await castApi.issueInvitation(castId);
-      onIssued({ token: response.token, expiresAt: response.expires_at });
+      const response = await castApi.issueInvitation(castId ?? '');
+      onIssued({ token: response.token ?? '', expiresAt: response.expires_at ?? '' });
     } catch (error) {
       toast.error(getApiErrorMessage(error, '招待の発行に失敗しました'));
     } finally {

--- a/frontend/src/features/cast-invite-accept/ui/ExistingLoginForm.tsx
+++ b/frontend/src/features/cast-invite-accept/ui/ExistingLoginForm.tsx
@@ -47,7 +47,7 @@ export function ExistingLoginForm({ token, onSuccess, onBack }: ExistingLoginFor
       // 招待を開く前に別ロールで平台にログイン済みだった場合、旧セッションの platform-role/platform-store-id が
       // 残ったままだと apiClient やルート遷移が旧ロールの文脈を CAST の token に対して使ってしまう。
       clearPlatformSession();
-      Cookies.set('token', authToken, { expires: new Date(expires_at) });
+      Cookies.set('token', authToken ?? '', { expires: new Date(expires_at) });
       newTokenWritten = true;
       const response = await castInvitationAcceptanceApi.acceptAsExistingUser(token);
       // 受諾はここで完了し、ポータルセッションは開始しない。一時的に張った CAST token を

--- a/frontend/src/features/platform-login/ui/PlatformLoginForm.tsx
+++ b/frontend/src/features/platform-login/ui/PlatformLoginForm.tsx
@@ -26,13 +26,14 @@ export default function PlatformLoginForm() {
     try {
       const { token, expires_at } = await platformAuthApi.login(data);
       // epoch millis を Date に変換する（expires_at をそのまま日数として解釈すると不正な有効期限になる）
-      Cookies.set('token', token, { expires: new Date(expires_at) });
+      Cookies.set('token', token ?? '', { expires: new Date(expires_at) });
 
       const me = await platformAuthApi.me();
-      const destination = resolvePlatformDestination(me.console);
+      const activeConsole = me.console ?? 'none';
+      const destination = resolvePlatformDestination(activeConsole);
 
       if (destination === 'platform') {
-        startPlatformSession(me.console, expires_at);
+        startPlatformSession(activeConsole, expires_at);
         router.push('/platform/dashboard/');
         return;
       }
@@ -40,7 +41,7 @@ export default function PlatformLoginForm() {
       if (destination === 'store') {
         // 着地方針（授権店舗の選択とメニュー由来の着地先解決）は StoreEntryPage 一箇所に集約する。
         // ログインフォームは無条件に入口へ渡し、店舗の解決には関与しない。
-        startPlatformSession(me.console, expires_at);
+        startPlatformSession(activeConsole, expires_at);
         router.push(storeEntryPath());
         return;
       }

--- a/frontend/src/features/staff-management/lib/roleSetLabel.ts
+++ b/frontend/src/features/staff-management/lib/roleSetLabel.ts
@@ -5,6 +5,8 @@ import { RoleRef } from '@/entities/user';
  * name はサーバの non_null 方針でキーごと欠落しうるため、欠けた場合は id を代替表示する
  * （素直に name を並べると undefined が画面に出る）。
  */
-export function roleSetLabel(roles: RoleRef[]): string {
-  return roles.length > 0 ? roles.map(role => role.name ?? String(role.id)).join('・') : '未選択';
+export function roleSetLabel(roles: RoleRef[] | undefined): string {
+  return roles && roles.length > 0
+    ? roles.map(role => role.name ?? String(role.id)).join('・')
+    : '未選択';
 }

--- a/frontend/src/features/staff-management/lib/storeSetLabel.ts
+++ b/frontend/src/features/staff-management/lib/storeSetLabel.ts
@@ -2,11 +2,15 @@ import { PlatformStore, PlatformStoreScopeType } from '@/entities/user';
 
 /** 担当店舗の表示文字列（「全店舗」または店舗名をカンマ区切り）。 */
 export function storeSetLabel(
-  storeScopeType: PlatformStoreScopeType,
-  storeIds: number[],
+  storeScopeType: PlatformStoreScopeType | undefined,
+  storeIds: number[] | undefined,
   stores: PlatformStore[]
 ): string {
   if (storeScopeType === 'ALL_STORES') return '全店舗';
-  const names = stores.filter(store => storeIds.includes(store.id)).map(store => store.name);
+  const selected = storeIds ?? [];
+  const names = stores
+    .filter(store => store.id !== undefined && selected.includes(store.id))
+    // name も non_null 方針で欠けうるため、欠けた場合は id を代替表示する
+    .map(store => store.name ?? String(store.id));
   return names.length > 0 ? names.join('・') : '未選択';
 }

--- a/frontend/src/features/staff-management/ui/RolePicker.tsx
+++ b/frontend/src/features/staff-management/ui/RolePicker.tsx
@@ -26,16 +26,16 @@ export function RolePicker({ roles, isLoading, roleIds, onChange }: RolePickerPr
         {isLoading ? (
           <p className="text-sm text-muted-foreground">読み込み中...</p>
         ) : (
-          roles.map(role => (
-            <Label key={role.id} className="font-normal">
-              <input
-                type="checkbox"
-                checked={roleIds.includes(role.id)}
-                onChange={() => toggle(role.id)}
-              />
-              {role.name}
-            </Label>
-          ))
+          roles.map(role => {
+            const id = role.id;
+            if (id === undefined) return null;
+            return (
+              <Label key={id} className="font-normal">
+                <input type="checkbox" checked={roleIds.includes(id)} onChange={() => toggle(id)} />
+                {role.name}
+              </Label>
+            );
+          })
         )}
       </div>
       <p className="mt-1 text-xs text-muted-foreground">

--- a/frontend/src/features/staff-management/ui/StaffEditModal.tsx
+++ b/frontend/src/features/staff-management/ui/StaffEditModal.tsx
@@ -46,7 +46,9 @@ export function StaffEditModal({ open, onClose, staff, onUpdated }: StaffEditMod
   useEffect(() => {
     if (!open || !staff) return;
     setRoleIds((staff.roles ?? []).flatMap(role => (role.id === undefined ? [] : [role.id])));
-    setStoreScopeType(staff.store_scope_type ?? 'ALL_STORES');
+    // 欠落時は全店舗ではなく個別店舗（storeIds 空 = どの店舗にも及ばない）へ倒す。
+    // 既定を全店舗にすると、保存操作がそのまま作用域の拡大になる。
+    setStoreScopeType(staff.store_scope_type ?? 'SPECIFIC_STORES');
     setStoreIds(staff.store_ids ?? []);
     setEnabled(staff.enabled);
   }, [open, staff]);

--- a/frontend/src/features/staff-management/ui/StaffEditModal.tsx
+++ b/frontend/src/features/staff-management/ui/StaffEditModal.tsx
@@ -45,15 +45,15 @@ export function StaffEditModal({ open, onClose, staff, onUpdated }: StaffEditMod
 
   useEffect(() => {
     if (!open || !staff) return;
-    setRoleIds(staff.roles.map(role => role.id));
-    setStoreScopeType(staff.store_scope_type);
-    setStoreIds(staff.store_ids);
+    setRoleIds((staff.roles ?? []).flatMap(role => (role.id === undefined ? [] : [role.id])));
+    setStoreScopeType(staff.store_scope_type ?? 'ALL_STORES');
+    setStoreIds(staff.store_ids ?? []);
     setEnabled(staff.enabled);
   }, [open, staff]);
 
   const summary = useMemo(() => {
     const scopeLabel = storeSetLabel(storeScopeType, storeIds, stores);
-    const selectedRoles = roles.filter(role => roleIds.includes(role.id));
+    const selectedRoles = roles.filter(role => role.id !== undefined && roleIds.includes(role.id));
     return `${staff?.display_name ?? ''}さんは ${roleSetLabel(selectedRoles)} として ${scopeLabel} のデータにアクセスできます`;
   }, [roles, roleIds, storeScopeType, storeIds, stores, staff]);
 
@@ -65,7 +65,7 @@ export function StaffEditModal({ open, onClose, staff, onUpdated }: StaffEditMod
     }
     setIsSubmitting(true);
     try {
-      await platformStaffApi.update(staff.id, {
+      await platformStaffApi.update(staff.id ?? 0, {
         role_ids: roleIds,
         store_scope_type: storeScopeType,
         store_ids: storeIds,

--- a/frontend/src/features/staff-management/ui/StoreSetPicker.tsx
+++ b/frontend/src/features/staff-management/ui/StoreSetPicker.tsx
@@ -51,16 +51,20 @@ export function StoreSetPicker({ storeScopeType, storeIds, onChange }: StoreSetP
             {isLoading ? (
               <p className="text-sm text-muted-foreground">読み込み中...</p>
             ) : (
-              stores.map(store => (
-                <Label key={store.id} className="font-normal">
-                  <input
-                    type="checkbox"
-                    checked={storeIds.includes(store.id)}
-                    onChange={() => toggleStore(store.id)}
-                  />
-                  {store.name}
-                </Label>
-              ))
+              stores.map(store => {
+                const id = store.id;
+                if (id === undefined) return null;
+                return (
+                  <Label key={id} className="font-normal">
+                    <input
+                      type="checkbox"
+                      checked={storeIds.includes(id)}
+                      onChange={() => toggleStore(id)}
+                    />
+                    {store.name}
+                  </Label>
+                );
+              })
             )}
           </div>
         )}

--- a/frontend/src/shared/api/types.ts
+++ b/frontend/src/shared/api/types.ts
@@ -17,7 +17,8 @@ export interface Page<T> {
 
 // ファイルアップロードレスポンス
 export interface FileUploadResponse {
-  url: string;
-  original_name: string;
+  url?: string;
+  original_name?: string;
+  // Java 側が primitive の long のため、キーは必ず応答に含まれる
   size: number;
 }

--- a/frontend/src/shared/ui/image-upload.tsx
+++ b/frontend/src/shared/ui/image-upload.tsx
@@ -41,7 +41,7 @@ export default function ImageUpload({
     try {
       setIsUploading(true);
       const response = await fileApi.upload(file, bucket);
-      onChange(response.url);
+      onChange(response.url ?? '');
       toast.success('画像をアップロードしました');
     } catch {
       toast.error('画像のアップロードに失敗しました');

--- a/frontend/src/widgets/header/ui/Header.tsx
+++ b/frontend/src/widgets/header/ui/Header.tsx
@@ -58,11 +58,15 @@ export function Header() {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" sideOffset={8} className="w-56">
-              {stores.map(store => (
-                <DropdownMenuItem key={store.id} onSelect={() => switchStore(store.id)}>
-                  {store.name}
-                </DropdownMenuItem>
-              ))}
+              {stores.map(store => {
+                const id = store.id;
+                if (id === undefined) return null;
+                return (
+                  <DropdownMenuItem key={id} onSelect={() => switchStore(id)}>
+                    {store.name}
+                  </DropdownMenuItem>
+                );
+              })}
             </DropdownMenuContent>
           </DropdownMenu>
         )}


### PR DESCRIPTION
## 概要

#537 の裁定を実装した。対外 wire 面 54 対を controller 署名から導出して全量照合し、応答の可空性と請求の必須性を Java 側の宣言へ揃えたうえで、`fail-on-unknown-properties` を `true` に切替えて請求側の静默棄却を閉じた。契約を守ると称していた偽テスト 2 件は降格した。

実施順序は #539 の指示どおり **照合・修理 → 切替**を厳守している（逆順にすると潜在不一致が一斉に本番 400 になる）。

Closes #539

## 変更内容

- **応答型**: wrapper 型のフィールドを対応する TS 型で optional にした（primitive の `int`/`long`/`boolean` のみ必須のまま据え置き）。既知の不一致 6 件はすべて解消
- **請求型**: `@NotNull`/`@NotBlank` の有無と TS の必須性を一致させた。`OrderCreateRequest.receptionist_id` は `string?` → `number`（必須）、`cast_id` も必須へ
- **応答形の嘘**: `platformStoreApi.create` / `update` を `Promise<void>` にした（端点は 204）
- **フォーム**: 受付・キャストが Java 側で必須なのに空のまま送れていたため、送信前に止めて理由を表示するようにした
- **設定**: `application.yml` の `fail-on-unknown-properties` を `true` へ
- **偽テスト 2 件の降格**: `OrdersPage.test.tsx` から `as never` と「バックエンドの実形状を検証する」旨の主張を外し、`platform-store-api.test.ts` は 204 の端点に合わせて `undefined` を断言する形へ
- **統合テスト 1 件の修正**: `OrderCrossStoreIT` が作成用の要求体を PUT に流用していた

### 判定規則の適用範囲

裁定の判定規則（**応答: Java が wrapper 型なら TS は optional。primitive のみ必須を名乗れる**）は
保守的な上界であり、実際には never-null のフィールド（PK 等）にも optional を課す。
既知の不一致 6 件だけなら十数項目だが、規則を全対に適用すると **約 145 項目**が optional になる。

これは受け入れ基準「応答 DTO が wrapper 型のフィールドは、対応する TS 型で optional になっている」の
文面どおりであり、将来 A-2（跨ツリー fitness test）を採る際の判定式とも一致するため、
**規則どおり全量に適用した**。消費点の波及は tsc で実測して 113 箇所、うち大半は 1 トークンの
`?? ''` / `?? []` で閉じた。識別子系（PK・キー）は「欠落しうるが実際には来る」ため、
分岐を増やさない終端の既定値で受けている。

例外は `Page<T>` 封筒のみ。Spring の `PageImpl` は `getTotalPages()`=`int` / `getTotalElements()`=`long` /
`getSize()`・`getNumber()`=`int` / `getContent()`=非 null `List` で、**規則自身の primitive 例外**に該当する。

### 実測で裏付けた挙動

```
# course_minutes を送らずに作成した受注の応答 — キーごと消える（「undefined 分」の原因そのもの）
{"id":"870580625990488064","receptionist_id":7,"receptionist_name":"…","business_date":"2026-07-30",
 "cast_id":"…","cast_name":"test","status":"CREATED"}

# DTO に無い項目を送ると 400（従来は静默に捨てられていた = #521 の形）
PUT /platform/stores/1 {"name":…,"email":…,"domain":"evil.test"} → 400
POST /store/orders {"…","courseMinutes":60}                      → 400
```

画面側も起動して確認した（下記「検証」）。

## 逐フィールド照合結果（54 対）

射程の正本は controller 署名（応答型 30 + `@RequestBody` 24 = 54）。
判定規則: **Java 側の可空性を正本とし、TS 側を合わせる。**

- 応答: Java が wrapper 型（`Integer` / `String` / `List` 等）なら TS は optional。primitive（`int` / `long` / `boolean`）のみ TS 必須を名乗れる。
- 請求: Java 側に `@NotNull` / `@NotBlank` / `@NotEmpty` があれば TS も必須、無ければ optional。

凡例: ✅ 一致（修正不要） / 🔧 修正した / ➖ TS 側対応型なし（frontend 未使用）

---

### 応答型 30 対

| # | 端点 | Java | TS | 判定 | 不一致の内容と処置 |
|---|---|---|---|---|---|
| R1 | `GET /platform/stores`(Page) `/{id}` `/lookup` | `StoreVO` | `Store` | 🔧 | `updated_at` が TS のみに存在する死フィールド（既知5）→ 削除。`id`/`name`/`domain`/`email`/`created_at` はすべて `String`・`OffsetDateTime` → optional 化 |
| R2 | `GET /platform/stores/me` | `PlatformStoreResponse` | `PlatformStore` | 🔧 | 項目は一致。`Long id`/`String name` → optional 化 |
| R3 | `GET /platform/stores/stats` | `StoreStatusVO` | `StoreStats` | ✅ | `long total` は primitive → `total: number` 必須のまま正しい |
| R4 | `GET /platform/orders`(Page) | `PlatformOrderResponse` | ➖ | ➖ | frontend は `/platform/orders` を呼んでいない（対応型なし） |
| R5 | `POST /platform/orders`, `GET/POST/PUT /store/orders` | `OrderResponse` | `Order` | 🔧 | **既知1**: `course_minutes`/`extension_minutes`/`option_codes`/`manual_discount`/`used_points`/`manual_grant_points` が TS 必須 → optional。**既知2**: `receptionist_id?: string` → `number`。**既知4**: `location_address`/`location_building` が TS に無い → 追加。`id`/`business_date`/`status` も wrapper → optional |
| R6 | `GET /store/orders/receptionists` | `OrderReceptionistResponse` | `OrderReceptionist` | 🔧 | 項目一致。`Long id`/`String display_name` → optional 化 |
| R7 | `GET/PUT /platform/configs` | `SystemConfigResponse` | `SystemConfigResponse` | 🔧 | 項目一致。`secret` は `Boolean`（wrapper）で TS 必須だった → optional。`id`/`config_key`/`value_type`/`category`/`created_at`/`updated_at` も optional |
| R8 | `GET/PUT /store/config`, `GET /store/config/public` | `StoreProfileResponse` | `StoreProfileResponse` | 🔧 | 項目一致。`id`/`template_key`/`mv_type`/`sns_links`/`partner_links`/`created_at`/`updated_at` → optional |
| R8b | `GET /store/config/public` | `StoreProfileResponse` | `_pages/store-site` `SiteConfig` | 🔧 | 同一端点の別（部分）ビュー型。`id`/`template_key`/`created_at`/`updated_at` を持たない narrowing で正しい。`mv_type` → optional |
| R9 | `POST /platform/login` | `Token` | `LoginResponse` | 🔧 | `long expiresAt` は primitive → `expires_at: number` 必須のまま正しい。`String token` → optional |
| R10 | `POST /platform/logout` | `ResponseEntity<?>`（実体は 204 no content） | `Promise<void>` | ✅ | `platformAuthApi.logout` は戻り値を返さない宣言で正しい |
| R11 | `GET/PUT /platform/me` | `PlatformMeResponse` | `PlatformMeResponse` | 🔧 | 項目一致。`boolean storeBridge` は primitive → `store_bridge` 必須のまま正しい。他 7 項目 → optional |
| R12 | `GET /platform/me/stores` | `CastStoreResponse` | `CastStoreItem` | 🔧 | 項目一致。2 項目 → optional |
| R13 | `GET /platform/cast-invitations/{token}` | `CastInvitationDetailResponse` | `CastInvitationDetailResponse` | 🔧 | 項目一致。4 項目 → optional |
| R14 | `POST .../acceptance`, `.../acceptance/existing` | `CastAcceptanceResponse` | `CastAcceptanceResponse` | 🔧 | 項目一致。`store_name` → optional |
| R15 | `GET/POST/PUT /store/casts/fields` | `CastFieldDefinitionResponse` | `CastFieldDefinitionResponse` | 🔧 | 項目一致（`Boolean isPublic` の Jackson 名は `isPublic` → `is_public` で一致）。7 項目 → optional |
| R16 | `GET/POST/PUT /store/casts` | `CastResponse` | `CastResponse` | 🔧 | 項目一致。**新規発見**: `invitation_status` が TS 必須だが、`CastService.create/update` は `invitationStatus` を無視する mapper overload を使うため応答から**必ず消える**。→ optional。他 5 項目も optional |
| R17 | `POST /store/casts/{id}/invitation` | `CastInvitationResponse` | `CastInvitationIssueResponse` | 🔧 | 項目一致。2 項目 → optional |
| R18 | `GET /store/casts/public` | `CastPublicResponse` | `CastPublicResponse` | 🔧 | 項目一致。6 項目 → optional |
| R18b | 同上 | `CastPublicResponse` | `_pages/store-site` `Cast` | 🔧 | 部分ビュー型（`status`/`display_order`/`created_at`/`updated_at` を持たない narrowing で正しい）。`id`/`name` → optional |
| R18c | 同上 | `CastPublicResponse` | `templates/_sections/CastSection.tsx` の手書き `interface Cast` | 🔧 | **新規発見**: 断面が wire 形を自前で再宣言していた（スライスの正本と二重管理）→ `model/types` の `Cast` を使うよう寄せる |
| R19 | `GET /platform/me/schedule` | `CastScheduleResponse` | `CastScheduleItem` | 🔧 | 項目一致。6 項目 → optional |
| R20 | `POST /platform/me/shift-requests` | `ShiftRequestResponse` | `ShiftRequestResponse` | 🔧 | 項目一致。**新規発見**: `note: string \| null` は誤り — `non_null` によりキーごと消えるので値は `undefined` であって `null` ではない → `note?: string`。他 7 項目 → optional |
| R21 | `GET /platform/me/shift-requests` | `CastShiftRequestResponse` | `CastShiftRequestItem` | 🔧 | 項目一致。`note` の `\| null` 同上。9 項目 → optional |
| R22 | `GET /store/shift-requests`, `POST /{id}/approval` `/decline` | `StoreShiftRequestResponse` | `StoreShiftRequestItem` | 🔧 | 項目一致。`note` の `\| null` 同上。7 項目 → optional |
| R23 | `GET/POST/PUT /store/shifts` | `ShiftResponse` | `ShiftResponse` | 🔧 | 項目一致。8 項目 → optional |
| R24 | `GET /store/shifts/public` | `PublicShiftResponse` | `PublicShift` | 🔧 | 項目一致。4 項目 → optional |
| R25 | `GET/POST/PUT /platform/staff` | `PlatformStaffResponse` | `PlatformStaffResponse` | 🔧 | 項目一致。`boolean enabled` / `long version` は primitive → 必須のまま正しい。他 6 項目 → optional |
| R26 | （R25 入れ子） | `PlatformStaffResponse.RoleRef` | `RoleRef` | 🔧 | `name?` は既に optional で正しい。`id` → optional |
| R27 | `GET/POST/PUT /platform/roles` | `RoleResponse` | `RoleResponse` | 🔧 | 項目一致。`boolean system` / `long version` は primitive → 必須のまま正しい。`id`/`name`/`permissions` → optional |
| R28 | `GET /platform/permissions` | `PermissionResponse` | `PermissionResponse` | 🔧 | 項目一致。2 項目 → optional |
| R29 | `POST /files/upload` | `FileUploadResponse` | `FileUploadResponse` | 🔧 | 項目一致。`long size` は primitive → 必須のまま正しい。`url`/`original_name` → optional |
| R30 | `GET /platform/menus/me` | `MenuVO` | `MenuVO` | 🔧 | 項目一致。`name` → optional |
| R31 | （R18 入れ子） | `CastCustomFieldView` | `CastCustomFieldView` | 🔧 | 項目一致。3 項目 → optional |
| R32 | （R8 入れ子） | `SnsLink` / `PartnerLink` | `SnsLink` / `PartnerLink` | ✅ | 項目一致。**この 2 型は Q7（更新リクエスト）の入れ子でもあり、Java 側は `platform`/`url`/`name` が `@NotBlank`。同じ TS 型が請求と応答の双方で使われるため、厳しい側（請求の必須）を採り必須のまま据え置く**。`label`/`logo_url` は注解が無く optional |

#### 応答側の対象外（射程の境界を明示する）

- **`ResponseEntity<Void>` の 10 端点**（`DELETE` 各種 / `PUT /platform/password` / `POST`・`PUT`・`DELETE /platform/stores`）: body が無い。TS 側はすべて `Promise<void>` 宣言。**既知3** の `platformStoreApi.create` / `update` のみ `Promise<Store>` を名乗っていた → `Promise<void>` に修正。
- **`Page<T>` 封筒**: Spring の `PageImpl` が正本で、`getTotalPages()`=`int` / `getTotalElements()`=`long` / `getSize()`・`getNumber()`=`int` / `getContent()`=非 null `List`。すべて primitive・非 null なので**判定規則の primitive 例外に該当し、TS 側は必須のまま正しい**。#509 / #511 で `fromSpringPage` に寄せ済み。

---

### 請求型 24 対

| # | 端点 | Java | TS | 判定 | 不一致の内容と処置 |
|---|---|---|---|---|---|
| Q1 | `POST /platform/stores` | `StoreCreateDTO` | `CreateStoreRequest` | ✅ | `name`/`domain`/`email` すべて `@NotBlank` ⟺ TS 必須。逆方向の欠落なし（`StoreCreatePage` の `useState<CreateStoreRequest>` が 3 項目とも送信） |
| Q2 | `PUT /platform/stores/{id}` | `StoreUpdateDTO` | `UpdateStoreRequest` | ✅ | `name`/`email` とも `@NotBlank` ⟺ TS 必須。`StoreEditPage` が両方送信（#521 修理済みの状態を確認） |
| Q3 | `POST /store/orders` | `OrderCreateRequest` | `OrderCreateRequest` | 🔧 | **既知6**: `receptionistId` は `Long`+`@NotNull` だが TS は `receptionist_id?: string` → `receptionist_id: number`（必須）。`castId` は `@NotBlank` だが TS `cast_id?` → 必須。`course_minutes` 他 5 項目は注解無し ⟺ optional 化。逆方向の欠落なし（Java 27 項目すべて TS に存在） |
| Q4 | `PUT /store/orders/{id}` | `OrderUpdateRequest` | ➖ | ➖ | frontend は `PUT /store/orders/{id}` を呼んでいない（`OrderEditPage` は mock 実装で API 未接続）。対応型なし |
| Q5 | `POST /platform/orders` | `PlatformOrderCreateRequest` | ➖ | ➖ | frontend 未使用（R4 と同じ端点群） |
| Q6 | `PUT /platform/configs` | `SystemConfigUpdateRequest` | `SystemConfigUpdateRequest` | 🔧 | **新規発見**: `configValue` に注解が無いのに TS は `config_value: string` 必須 → optional |
| Q7 | `PUT /store/config` | `StoreProfileUpdateRequest` | `StoreProfileUpdateRequest` | ✅ | 全 15 項目とも注解無し ⟺ TS 全 optional。逆方向の欠落なし（`StoreProfileForm` が全項目を送信） |
| Q8 | `POST /platform/login` | `PlatformLoginRequest` | `PlatformLoginRequest` | ✅ | `email`/`password` とも `@NotBlank` ⟺ 必須 |
| Q9 | `PUT /platform/me` | `PlatformMeUpdateRequest` | `PlatformMeUpdateRequest` | ✅ | `displayName` `@NotBlank` ⟺ 必須 |
| Q10 | `PUT /platform/password` | `PasswordChangeRequest` | `PasswordChangeRequest` | ✅ | 両項目 `@NotBlank` ⟺ 必須 |
| Q11 | `POST /platform/cast-invitations/{token}/acceptance` | `CastInvitationAcceptRequest` | `CastInvitationAcceptRequest` | ✅ | 3 項目とも `@NotBlank` ⟺ 必須。`RegisterFormValues` が 3 項目ちょうど |
| Q12 | `POST /store/casts/fields` | `CastFieldDefinitionCreateRequest` | `CastFieldDefinitionCreateRequest` | ✅ | `key`/`label` `@NotBlank` ⟺ 必須、`isPublic` 注解無し ⟺ `is_public?` |
| Q13 | `PUT /store/casts/fields/{id}` | `CastFieldDefinitionUpdateRequest` | `CastFieldDefinitionUpdateRequest` | ✅ | 全項目注解無し（`label` は `@Pattern`+`@Size` のみで必須ではない）⟺ TS 全 optional |
| Q14 | `POST /store/casts` | `CastCreateRequest` | `CastCreateRequest` | ✅ | `name` `@NotBlank` ⟺ 必須、他 9 項目 optional。逆方向の欠落なし |
| Q15 | `PUT /store/casts/{id}` | `CastUpdateRequest` | `CastUpdateRequest` | ✅ | 全 11 項目注解無し ⟺ 全 optional。`CastEditPage` が全項目を送信 |
| Q16 | `POST /store/customers` | `CustomerCreateRequest` | `CustomerCreateRequest` | ✅ | `name` `@NotBlank` ⟺ 必須、他 11 項目 optional。`toCustomerRequest` が全項目を送信 |
| Q17 | `PUT /store/customers/{id}` | `CustomerUpdateRequest` | `CustomerUpdateRequest` | ✅ | 全 12 項目注解無し ⟺ 全 optional。`toCustomerRequest` が全項目を送信 |
| Q18 | `POST /store/shifts` | `ShiftCreateRequest` | `ShiftCreateRequest` | ✅ | `castId`/`workDate`/`startTime`/`endTime` が `@NotBlank`・`@NotNull` ⟺ 必須、`status` optional |
| Q19 | `PUT /store/shifts/{id}` | `ShiftUpdateRequest` | `ShiftUpdateRequest` | ✅ | 全 5 項目注解無し ⟺ 全 optional。`ShiftFormModal` が全 5 項目を送信 |
| Q20 | `POST /platform/me/shift-requests` | `ShiftRequestCreateRequest` | `ShiftRequestCreateRequest` | ✅ | 4 項目 `@NotNull` ⟺ 必須、`note` optional |
| Q21 | `POST /platform/staff` | `PlatformStaffCreateRequest` | `PlatformStaffCreateRequest` | 🔧 | `storeIds` に注解が無いのに TS は `store_ids: number[]` 必須 → optional。他は一致 |
| Q22 | `PUT /platform/staff/{id}` | `PlatformStaffUpdateRequest` | `PlatformStaffUpdateRequest` | 🔧 | 同上（`store_ids` → optional）。`roleIds` `@NotEmpty` / `storeScopeType` `@NotNull` / `version` `@NotNull` ⟺ 必須、`enabled` optional は一致 |
| Q23 | `POST /platform/roles` | `RoleCreateRequest` | `RoleCreateRequest` | ✅ | `name` `@NotBlank` / `permissions` `@NotEmpty` ⟺ 必須 |
| Q24 | `PUT /platform/roles/{id}` | `RoleUpdateRequest` | `RoleUpdateRequest` | ✅ | 3 項目とも必須注解あり ⟺ TS 必須 |

#### 逆方向（PUT の null 上書き）の確認結果

全 PUT 端点について「Java の請求 DTO にあって TS 側が送らない項目」を消費点まで追った。

| PUT 端点 | Java の項目数 | フォームが実際に送る項目 | 結果 |
|---|---|---|---|
| `PUT /platform/stores/{id}` | 2 | `StoreEditPage` の `useState<UpdateStoreRequest>` が `name`/`email` | 欠落なし |
| `PUT /store/config` | 15 | `StoreProfileForm` の `StoreProfileFormData` が 14 項目 + `custom_texts` マージ | 欠落なし |
| `PUT /store/casts/{id}` | 11 | `CastEditPage` の `requestData` が 11 項目 | 欠落なし |
| `PUT /store/customers/{id}` | 12 | `toCustomerRequest` が 12 項目 | 欠落なし |
| `PUT /store/shifts/{id}` | 5 | `ShiftFormModal` の `payload` が 5 項目 | 欠落なし |
| `PUT /platform/staff/{id}` | 5 | `StaffEditModal` が 5 項目 | 欠落なし |
| `PUT /platform/roles/{id}` | 3 | `RoleFormModal` が 3 項目 | 欠落なし |
| `PUT /platform/configs` | 2 | `SettingsPage` が 2 項目 | 欠落なし |
| `PUT /platform/me` | 1 | `AccountPage` が 1 項目 | 欠落なし |
| `PUT /store/orders/{id}` | 15 | — | frontend 未接続（Q4） |

#### `fail-on-unknown-properties: true` の安全性確認

「TS 型に無い項目をフォームが送る」経路が無いことを、請求を組み立てる全 18 箇所について確認した。
TypeScript の余剰プロパティ検査は**変数渡しと spread では効かない**ため、その 3 経路は個別に中身を読んで確認した。

- `StaffCreateModal`: `{...values, ...}` の `values` は `StaffCreateFormValues = {email, password, display_name}` → Java 側に全項目存在
- `StoreProfileForm`: `{...data, custom_texts}` の `data` は `StoreProfileFormData` 14 項目 → Java 側に全項目存在
- `StoreCreatePage` / `StoreEditPage` / `RegisterForm` / `PlatformLoginForm` / `ExistingLoginForm`: `useState<T>` / `useForm<T>` で型そのものが状態の形 → 余剰キーが構造的に発生しない

### 照合で新たに出た不一致

0. **入れ子型は「入れ子型なし」という前提が誤りだった** — `SnsLink` / `PartnerLink` は
   `StoreProfileUpdateRequest` の `@Valid List<...>` として**請求側にも現れる**（`RoleRef` は応答側の入れ子）。
   一度は応答側の規則だけを当てて optional にしたが、請求側の `@NotBlank` と矛盾するため必須へ戻した。
   同一の TS 型が両方向で使われる場合は**厳しい側の規則を採る**。
1. **`CastResponse.invitation_status`** — `CastService.create/update` は招待状態を無視する mapper
   overload を使うため、作成・更新の応答からは**必ず**欠落する。TS は必須を名乗っていた。
2. **出勤希望 3 型の `note`** — `string | null` は誤り。`non_null` によりキーごと消えるため
   値は `undefined` であって `null` ではなく、`note === null` の判定は成立しない。
3. **`CastSection.tsx` の手書き wire 型** — 公開サイトの断面がスライスの正本とは別に
   `interface Cast` を再宣言していた。正本へ寄せた。
4. **`OrderCrossStoreIT` が作成用の要求体を PUT に流用していた** — `OrderUpdateRequest` は
   `business_date` を持たないため、切替後に 400 になって発覚した。従来は静默に捨てられており、
   営業日を送ったつもりの更新が実際には無視されていた。**切替が実際に欠陥を捕まえた 1 件目**。
5. **`cast_id` の必須性がフォームに無かった** — `@NotBlank` なのに空文字で送れていた。受付と
   同じ根因の変種であり、受付だけ直すと後から別項目として出てくるため同時に閉じた。

## 検証

- [x] `task lint` exit 0（backend / frontend 双方）
- [x] `task test` exit 0（frontend 517 件、backend unit、`task test-integration` は単独実行で 153 件）
- [x] `task build` exit 0（backend / frontend 双方）
- [x] `task e2e` exit 0（実行シナリオ: 全 22 件 — platform-login / staff-management / roles / sidebar-menus / hybrid-console-access / cast-portal）
- [x] ローカルで code-review 実施済み（Standards / Spec 二軸）

補足:

- **偽テストの赤転確認**: `as never` を外したことで fixture と `Order` 型の照合が復活していることを、未知キー（`customer_nmae` → 「`Order` に存在しません」）と型違い（`business_date: 20260703`）の双方で tsc が赤くなることを確認した。**jest は SWC で型検査しないため、この照合が効くのは `tsc` / `next build` の側である**（jest が緑でも照合の担保にはならない）
- **統合テストは単独で実行**した（並行して lint/build を回すと tmpfs の postgres が落ちる）

### 視覚確認（UI 変更時）

`task build` + `task up` の実機で確認した（スクリーンショットは Playwright MCP がホスト側にファイルを書けなかったため、確認内容を記す）。

| 画面 | 確認内容 |
| --- | --- |
| 店舗一覧 | 登録日が `2026/7/29` と表示される（`Invalid Date` 無し = #515 再発なし）。※ 受け入れ基準の「有効/無効バッジ」は `is_active` が TS 側のみの項目として #515 で削除済みのため、現在この列は存在しない |
| 店舗編集 | 店舗名・連絡用メールが読み込まれ、関連ドメインが表示される（#516 / #521 再発なし）。`PUT` 後に `GET` してドメインが保持されていることも API で確認 |
| オーダー一覧 | `course_minutes` を持つ行は `60 分`、持たない行は `-`（`undefined 分` 無し） |
| オーダー作成 | 受付・キャスト未選択で送信を止め理由を表示。両方選択すれば `fail-on-unknown-properties: true` の下で登録が成功し一覧へ戻る |
| 店舗サイト設定 | SNS リンク・パートナーリンクを追加して保存し、**送信ペイロードを実際に読んで**余剰キー（react-hook-form の内部 id 等）が混じっていないことを確認（このフォームは spread で組み立てるため TS の余剰プロパティ検査が効かない唯一の経路） |
| 公開サイト | `store1.kizuna.test` が 200 で描画される |

## 決定ログ

### 採った判定：規則を字面どおり全量に当てる

裁定の判定規則（**応答: Java が wrapper 型なら TS は optional。primitive のみ必須を名乗れる**）は
保守的な上界であり、実際には never-null のフィールド（PK 等）にも optional を課す。
既知の不一致 6 件だけなら十数項目だが、規則を全対に適用すると **約 145 項目**が optional になる。

これは受け入れ基準「応答 DTO が wrapper 型のフィールドは、対応する TS 型で optional になっている」の
文面どおりであり、将来 A-2（跨ツリー fitness test）を採る際の判定式とも一致するため、
**規則どおり全量に適用した**。消費点の波及は tsc で実測して 113 箇所、うち大半は 1 トークンの
`?? ''` / `?? []` で閉じた。識別子系（PK・キー）は「欠落しうるが実際には来る」ため、
分岐を増やさない終端の既定値で受けている。

例外は `Page<T>` 封筒のみ。Spring の `PageImpl` は `getTotalPages()`=`int` / `getTotalElements()`=`long` /
`getSize()`・`getNumber()`=`int` / `getContent()`=非 null `List` で、**規則自身の primitive 例外**に該当する。

### 見送った代替案

- **A-1〜A-4 の写像機構**: #537 で裁定済み（採らない）。本 PR は掃討のみ
- **DB を締める方向**（NOT NULL 付与 + 既存 null 行の埋め戻し + 請求 DTO の primitive 化）: 既存 null 行に何を入れるかは業務判断であり、請求 DTO の primitive 化は「キー欠落が静默に 0 になる」欠陥を招く（`course_minutes` の欠落が 0 分として通る）
- **PATCH セマンティクス化**: 全 API 面の意味変更であり、「明示的に空にする」が表現できなくなる

### 挙動変更

- **`fail-on-unknown-properties: true` は本番設定の変更**。前後端は同一 compose で同時配備され、
  第三者クライアントも無いため寛容性の損失は本仓では成立しない（#537 の確認事実）。
  請求を組み立てる全 18 経路の送信ペイロードを消費点まで追い、DTO に無い項目を送る経路が
  無いことを確認済み（TypeScript の余剰プロパティ検査は変数渡しと spread では効かないため、
  該当 3 経路は個別に中身を読んだ）。
- **オーダー作成フォームで受付・キャストが必須になった**。従来は未選択のまま送れて 400 の
  toast が出るだけだった。ラベルに必須印を付け、`FormMessage` で理由を出す。
- **`StaffEditModal` の `store_scope_type` 既定を `SPECIFIC_STORES` にした**（fail-closed）。
  `ALL_STORES` を既定にすると、キーが欠けた状態で保存操作がそのまま作用域の拡大になる。

### `/code-review` 二軸で出た指摘の処置

修正した 4 件:

- **入れ子請求型の必須性**（上記 0）
- **`ShiftFormModal` の `SelectItem` に `value=""` が渡りうる形** — Radix Select が唯一許容しない値で、
  同ファイルが `SELECT_NONE` を持つ理由そのもの。id を持たない行は描かないよう改めた
- **`castName` の照合が `undefined` 同士で一致しうる** — id 未指定のとき、id を持たないキャストと
  一致して別人の名前を出す形だった
- **変更の経緯を語る注釈**（Comment Policy 違反）を現在の不変条件の記述へ改めた

謝絶した 1 件（理由を記す）:

- **識別子の終端既定値（`?? ''` / `?? 0`）が約 13 箇所ある**という指摘。判定規則が PK にも optional を
  課すため生じたもので、値が欠けた場合の帰結は `/platform/staff/0` のような**404（大声の失敗）**であり、
  データを取り違えたり黙って壊したりはしない。13 箇所を早期 return へ書き換えると、規約の
  「起こりえない異常を扱わない」に照らして逆に分岐が増えるため、一貫した終端既定値のまま据え置いた。
  一方、**選択肢の描画側**（Radix の value、チェックボックスの id）は空値が実際に壊れるため、
  そちらは行を描かない形に統一してある。

## 備考 / レビュー観点

### 対象外

- **`OrderEditPage` は API 未接続の mock 実装**（`setTimeout` + `console.log` で、
  `PUT /store/orders/{id}` を呼んでいない）。`OrderUpdateRequest` に TS 側対応型が無いのはこのため。
  照合表の Q4 / R4 / Q5 が ➖ なのも同じ理由。#539 の射程外だが、掃討で判明したので記録する。
- A-2 の写像機構（#537 の延期項。引き金は「掃討完了後に wire 形状起因の事故が再発したら採る」）

### 本 PR の範囲外で見つかった既存不具合（別 issue 化を推奨）

店舗サイト設定の保存は、**SNS リンクかパートナーリンクを 1 件でも含むと 500 になる**。
`fail-on-unknown-properties` とは無関係で、`master` 時点から存在する。

```
NonSerializableObjectException: ... the [[PartnerLink(...)]] Object ... is not Serializable
```

`StoreProfile` の当該 3 列は `@Type(JsonBinaryType.class)`（hypersistence-utils）で、
この型は dirty check の複製のため要素型が `java.io.Serializable` であることを要求するが、
`SnsLink` / `PartnerLink` のいずれも実装していない。本 PR の backend 差分は
`application.yml` と統合テスト 1 本のみで、この経路には触れていない。

上記のペイロード確認は 500 の手前（送信内容）まで到達しており、**wire 形としては正しい**ことは
確認できている。500 の修理は別 issue とする。

Closes #539

