### PR TITLE
fix(storeprofile): jsonb 要素を Serializable にして店舗設定更新の 500 を止める

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/storeprofile/StoreProfileRoundtripIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/storeprofile/StoreProfileRoundtripIT.java
@@ -63,4 +63,49 @@ class StoreProfileRoundtripIT extends CrossStoreTestSupport {
     assertThat(reget.getBody().path("catch_copy").asString()).isEqualTo(unique);
     assertThat(reget.getBody().path("id").asString()).as("id は更新後も不変であること").isEqualTo(id);
   }
+
+  /**
+   * jsonb コレクション（sns_links・partner_links）を含む更新経路を固定する。
+   *
+   * <p>要素型が Serializable でないと hypersistence-utils の深いコピーが実行時に失敗し 500 になる。空配列では深いコピーが走らないため、 要素が 1
+   * 件以上あるペイロードでなければこの経路は検証できない。
+   */
+  @Test
+  @DisplayName("/store/config は要素を持つ sns_links・partner_links を含む PUT を永続化できること")
+  void configPutPersistsNonEmptyJsonbCollections() {
+    String label = "IT_sns_" + System.nanoTime();
+    String partner = "IT_partner_" + System.nanoTime();
+    String body =
+        """
+        {"sns_links": [{"platform": "x", "url": "https://example.com/sns", "label": "%s"}],
+         "partner_links": [{"name": "%s", "url": "https://example.com/partner", "logo_url": ""}]}
+        """
+            .formatted(label, partner);
+
+    ResponseEntity<JsonNode> put =
+        rest.exchange(
+            "/store/config",
+            HttpMethod.PUT,
+            new HttpEntity<>(body, storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(put.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(put.getBody().path("sns_links").path(0).path("label").asString()).isEqualTo(label);
+    assertThat(put.getBody().path("partner_links").path(0).path("name").asString())
+        .isEqualTo(partner);
+
+    ResponseEntity<JsonNode> reget =
+        rest.exchange(
+            "/store/config",
+            HttpMethod.GET,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(reget.getStatusCode()).isEqualTo(HttpStatus.OK);
+    JsonNode snsLink = reget.getBody().path("sns_links").path(0);
+    assertThat(snsLink.path("platform").asString()).isEqualTo("x");
+    assertThat(snsLink.path("url").asString()).isEqualTo("https://example.com/sns");
+    assertThat(snsLink.path("label").asString()).isEqualTo(label);
+    JsonNode partnerLink = reget.getBody().path("partner_links").path(0);
+    assertThat(partnerLink.path("name").asString()).isEqualTo(partner);
+    assertThat(partnerLink.path("url").asString()).isEqualTo("https://example.com/partner");
+  }
 }

--- a/backend/src/main/java/com/kizuna/storeprofile/domain/PartnerLink.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/domain/PartnerLink.java
@@ -1,17 +1,28 @@
 package com.kizuna.storeprofile.domain;
 
 import jakarta.validation.constraints.NotBlank;
+import java.io.Serial;
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.URL;
 
+/**
+ * jsonb 列 {@code t_store_profiles.partner_links} の要素。
+ *
+ * <p>hypersistence-utils は dirty checking 用の深いコピーを Java 直列化で作る。要素型が Serializable
+ * でないと、空でない配列の書き込みが実行時に失敗する。
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class PartnerLink {
+public class PartnerLink implements Serializable {
+
+  @Serial private static final long serialVersionUID = 1L;
+
   @NotBlank(message = "名前は必須です")
   private String name;
 

--- a/backend/src/main/java/com/kizuna/storeprofile/domain/SnsLink.java
+++ b/backend/src/main/java/com/kizuna/storeprofile/domain/SnsLink.java
@@ -1,17 +1,28 @@
 package com.kizuna.storeprofile.domain;
 
 import jakarta.validation.constraints.NotBlank;
+import java.io.Serial;
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.URL;
 
+/**
+ * jsonb 列 {@code t_store_profiles.sns_links} の要素。
+ *
+ * <p>hypersistence-utils は dirty checking 用の深いコピーを Java 直列化で作る。要素型が Serializable
+ * でないと、空でない配列の書き込みが実行時に失敗する。
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class SnsLink {
+public class SnsLink implements Serializable {
+
+  @Serial private static final long serialVersionUID = 1L;
+
   @NotBlank(message = "プラットフォームは必須です")
   private String platform;
 

--- a/backend/src/test/java/com/kizuna/JsonbSerializableTests.java
+++ b/backend/src/test/java/com/kizuna/JsonbSerializableTests.java
@@ -1,0 +1,91 @@
+package com.kizuna;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
+import jakarta.persistence.Entity;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+
+/**
+ * jsonb 属性（{@code @Type(JsonBinaryType.class)}）の Java 直列化可能性を機械検証する。
+ *
+ * <p>hypersistence-utils の既定 clone 実装（ObjectMapperJsonSerializer）は、dirty checking 用の深いコピーを Java
+ * 直列化で作る。要素型が {@link Serializable} でないと、値が空でない限り実行時に NonSerializableObjectException となり書き込みが 500
+ * になる。 空コレクションでは走らないため、この欠陥は普通のテストや手動確認をすり抜ける。
+ *
+ * <p>走査対象は {@code @Entity}（とその継承元）に宣言された属性のみ。現在の jsonb 属性はすべてエンティティ側にあるが、{@code @Embeddable} に置かれた
+ * jsonb 属性はこの検証を素通りする。
+ */
+class JsonbSerializableTests {
+
+  @Test
+  @DisplayName("jsonb 属性の要素型がすべて Serializable であること")
+  void allJsonbAttributeTypesAreSerializable() throws Exception {
+    ClassPathScanningCandidateComponentProvider scanner =
+        new ClassPathScanningCandidateComponentProvider(false);
+    scanner.addIncludeFilter(new AnnotationTypeFilter(Entity.class));
+
+    List<String> offenders = new ArrayList<>();
+    List<String> scanned = new ArrayList<>();
+    for (var candidate : scanner.findCandidateComponents("com.kizuna")) {
+      Class<?> entity = Class.forName(candidate.getBeanClassName());
+      for (Class<?> c = entity; c != null && c != Object.class; c = c.getSuperclass()) {
+        for (Field field : c.getDeclaredFields()) {
+          // org.hibernate.annotations.Type は java.lang.reflect.Type と名前が衝突するため FQCN で参照する。
+          org.hibernate.annotations.Type type =
+              field.getAnnotation(org.hibernate.annotations.Type.class);
+          if (type == null || !JsonBinaryType.class.equals(type.value())) {
+            continue;
+          }
+          String attribute = entity.getSimpleName() + "#" + field.getName();
+          scanned.add(attribute);
+          collectNonSerializable(field.getGenericType(), attribute, offenders);
+        }
+      }
+    }
+
+    assertThat(scanned).isNotEmpty();
+    assertThat(offenders).as("Java 直列化できない型を含む jsonb 属性").isEmpty();
+  }
+
+  /**
+   * jsonb 属性の型を走査し、Java 直列化できない型を offenders へ積む。
+   *
+   * <p>{@link Collection} / {@link Map} インターフェース自体は Serializable ではないが、実体は Jackson が生成する ArrayList
+   * / HashMap なので違反としない。判定対象はその型引数（要素型）である。
+   */
+  private static void collectNonSerializable(Type type, String attribute, List<String> offenders) {
+    if (type instanceof ParameterizedType parameterized) {
+      Class<?> raw = (Class<?>) parameterized.getRawType();
+      if (!Collection.class.isAssignableFrom(raw) && !Map.class.isAssignableFrom(raw)) {
+        requireSerializable(raw, attribute, offenders);
+      }
+      for (Type argument : parameterized.getActualTypeArguments()) {
+        collectNonSerializable(argument, attribute, offenders);
+      }
+    } else if (type instanceof Class<?> clazz) {
+      // 生の List / Map はここで違反となる（要素型が静的に分からず、判定を素通りさせられない）。
+      requireSerializable(clazz, attribute, offenders);
+    } else {
+      offenders.add(attribute + " -> 型を静的に解決できません: " + type);
+    }
+  }
+
+  private static void requireSerializable(
+      Class<?> clazz, String attribute, List<String> offenders) {
+    if (!Serializable.class.isAssignableFrom(clazz)) {
+      offenders.add(attribute + " -> " + clazz.getName());
+    }
+  }
+}


### PR DESCRIPTION
## 概要

要素を持つ `sns_links` / `partner_links` を含む `PUT /store/config` が 500 になっていたのを直す。jsonb 列の要素型（`SnsLink` / `PartnerLink`）が `Serializable` でないため、hypersistence-utils が dirty checking 用に作る深いコピー（Java 直列化）が実行時に失敗していた。

対応 issue なし（#539 の手動 QA 中に見つけた master 既存の不具合。#539 の変更とは無関係）。

## 変更内容

- `SnsLink` / `PartnerLink` を `Serializable` 化（`@Serial serialVersionUID`、既存 `StoreVO` と同じ流儀）
- `JsonbSerializableTests` を追加。全 `@Entity`（とその継承元）の `@Type(JsonBinaryType.class)` 属性を走査し、型引数まで再帰的に直列化可能性を機械検証する（同根因の他実例を残さないため）
- `StoreProfileRoundtripIT` に、要素を 1 件以上持つ `sns_links`・`partner_links` の往復テストを追加

## 検証

<!-- 合否はすべて exit code で判定（出力は日本語ロケールのことがある） -->

- [x] `task lint` exit 0（差分は backend のみのため `task -d backend lint`）
- [x] `task test` exit 0（`task -d backend test-unit` = 単体 + coverage gate、`task -d backend test-integration` = 統合 154 tests / 24 classes / 失敗 0）
- [x] `task build` exit 0（`task -d backend build`）
- [x] `task e2e` exit 0（実行シナリオ: 全 22 シナリオ / 22 passed・4.3m）
- [ ] ローカルで code-review 実施済み（未実施）

赤→緑の両向を確認済み。

- 赤（修正前）: IT が `expected 200 but was 500`、スタック頂点は `StoreProfileController.update`（報告と同一）。単体守衛は `StoreProfile#snsLinks` / `#partnerLinks` の 2 件だけを違反として挙げた
- 緑（修正後）: 上記すべて exit 0。単体門禁は buildx の陳腐 COPY キャッシュを避けるため `--no-cache-filter test` で実走させ、イメージ内に新テストファイルが入っていることも確認した

## 決定ログ

- **採用**: 要素型の `Serializable` 化。既存 `StoreVO` に前例があり、変更が 2 クラスに閉じる。
- **見送り**: `ObjectMapperWrapper#setJsonSerializer` で Jackson ベースの clone を全域に差し替える案。全 jsonb 属性の複製経路を一度に変えることになり、2 クラスの不備に対して影響範囲が過大。
- **単体テストを足した理由**: 統合テストは CI では走らない（PR 作成者のローカル責務）ため、IT だけでは同種の回帰に対する CI 側の防波堤が無い。機構検証の流儀は既存の `StoreIsolationTests` に合わせた。

## 備考 / レビュー観点

- **潜伏していた理由**: 深いコピーは値が空だと走らない。そのため空配列では 200 が返り、スカラー項目しか触っていなかった既存 IT と手動確認の両方をすり抜けていた。
- **同根因の掃討は実測済み（推測ではない）**: 守衛テストが走査した jsonb 属性は 5 件（`Cast#customFields` / `Order#optionCodes` / `StoreProfile#customTexts` / `#snsLinks` / `#partnerLinks`）。一覧を実際に出力して確認した。前 3 件は要素型が `String` で元から安全なため変更していない。
- **守衛テストの限界**: 走査面は `@Entity`（とその継承元）に宣言された属性のみ。`@Embeddable` に置かれた jsonb 属性は素通りする。現状そのような属性は無く、走査面はテストの javadoc に明記した。
- **code-review は未実施**。必要であれば実施する。
