### PR TITLE
feat(shift): 確定シフトの変更申請と店舗側受理を実装

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/shift/ShiftRequestScopeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/shift/ShiftRequestScopeIT.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.kizuna.cast.domain.Cast;
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.CrossStoreTestSupport;
+import com.kizuna.shift.domain.Shift;
 import com.kizuna.shift.domain.ShiftRepository;
 import com.kizuna.shift.domain.ShiftRequest;
 import com.kizuna.shift.domain.ShiftRequestRepository;
@@ -176,6 +177,48 @@ class ShiftRequestScopeIT extends CrossStoreTestSupport {
         "/platform/me/shift-requests", new HttpEntity<>(body, bearer(token)), JsonNode.class);
   }
 
+  private String changeBody(
+      String targetShiftId, String workDate, String start, String end, String note) {
+    return "{\"target_shift_id\": \""
+        + targetShiftId
+        + "\", \"work_date\": \""
+        + workDate
+        + "\", \"start_time\": \""
+        + start
+        + "\", \"end_time\": \""
+        + end
+        + "\", \"note\": \""
+        + note
+        + "\"}";
+  }
+
+  private ResponseEntity<JsonNode> submitChange(String token, String body) {
+    return rest.postForEntity(
+        "/platform/me/shift-requests/changes",
+        new HttpEntity<>(body, bearer(token)),
+        JsonNode.class);
+  }
+
+  /** 対象シフトをリポジトリ直挿しで用意する（テストスレッドは storeFilter を経由しない）。 */
+  private Shift saveShift(String castId, long storeId, LocalDate workDate, String status) {
+    return saveShift(castId, storeId, workDate, status, true);
+  }
+
+  private Shift saveShift(
+      String castId, long storeId, LocalDate workDate, String status, boolean publicVisible) {
+    Shift shift =
+        Shift.builder()
+            .castId(castId)
+            .workDate(workDate)
+            .startTime(LocalTime.of(18, 0))
+            .endTime(LocalTime.of(23, 0))
+            .status(status)
+            .publicVisible(publicVisible)
+            .build();
+    shift.setStoreId(storeId);
+    return shiftRepository.save(shift);
+  }
+
   private ResponseEntity<JsonNode> getHistory(String token) {
     return rest.exchange(
         "/platform/me/shift-requests",
@@ -339,9 +382,13 @@ class ShiftRequestScopeIT extends CrossStoreTestSupport {
     ResponseEntity<JsonNode> approved = approve(STORE_A, id);
     assertThat(approved.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(approved.getBody().path("status").asString()).isEqualTo("APPROVED");
+    assertThat(approved.getBody().path("decided_by").asString())
+        .isEqualTo("yamada.jiro@kizuna.test");
+    assertThat(approved.getBody().path("decided_at").asString()).isNotBlank();
 
     ShiftRequest reloaded = shiftRequestRepository.findById(id).orElseThrow();
     assertThat(reloaded.getStatus()).isEqualTo(ShiftRequestStatus.APPROVED);
+    assertThat(reloaded.getTargetShiftId()).isNotBlank();
 
     // 本人スケジュール（cast_id 単層自限）に確定シフトとして反映される。
     ResponseEntity<JsonNode> schedule =
@@ -379,6 +426,21 @@ class ShiftRequestScopeIT extends CrossStoreTestSupport {
       }
     }
     assertThat(publicHasIt).as("公開出勤表に確定シフトが反映されること").isTrue();
+
+    ResponseEntity<JsonNode> hidden =
+        rest.exchange(
+            "/store/shifts/" + reloaded.getTargetShiftId(),
+            HttpMethod.PUT,
+            new HttpEntity<>("{\"public_visible\": false}", storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(hidden.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(hidden.getBody().path("status").asString()).isEqualTo("CONFIRMED");
+    assertThat(hidden.getBody().path("public_visible").asBoolean()).isFalse();
+
+    ResponseEntity<String> publicAfterHide =
+        rest.exchange(
+            "/store/shifts/public", HttpMethod.GET, new HttpEntity<>(publicHeaders), String.class);
+    assertThat(publicAfterHide.getBody()).doesNotContain(myCastId);
   }
 
   @Test
@@ -541,6 +603,218 @@ class ShiftRequestScopeIT extends CrossStoreTestSupport {
         submit(castToken, submitBody(STORE_A, yesterday, "18:00:00", "20:00:00", "境界確認"));
 
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
+  // ---- 確定シフトの変更申請（#330） ----
+
+  @Test
+  @DisplayName("確定済みシフトへの変更申請が受理され、履歴に変更申請(CHANGE)の受付済みとして現れること")
+  void submitChange_onConfirmedShift_isAcceptedAndAppearsInHistoryAsChange() {
+    Shift target = saveShift(myCastId, STORE_A, LocalDate.of(2999, 6, 1), "CONFIRMED");
+
+    ResponseEntity<JsonNode> created =
+        submitChange(
+            castToken, changeBody(target.getId(), tomorrow(), "20:00:00", "23:30:00", "遅めに変更したい"));
+
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(created.getBody().path("kind").asString()).isEqualTo("CHANGE");
+    assertThat(created.getBody().path("status").asString()).isEqualTo("PENDING");
+    // 店舗は本文で名乗らず、対象シフトの帰属から導出される。
+    assertThat(created.getBody().path("store_id").asLong()).isEqualTo(STORE_A);
+
+    String id = created.getBody().path("id").asString();
+    ResponseEntity<JsonNode> history = getHistory(castToken);
+    assertThat(history.getStatusCode()).isEqualTo(HttpStatus.OK);
+    JsonNode item = null;
+    for (JsonNode node : history.getBody()) {
+      if (id.equals(node.path("id").asString())) {
+        item = node;
+      }
+    }
+    assertThat(item).as("提出履歴に変更申請が現れること").isNotNull();
+    assertThat(item.path("kind").asString()).isEqualTo("CHANGE");
+    assertThat(item.path("status").asString()).isEqualTo("PENDING");
+  }
+
+  @Test
+  @DisplayName("確定済みでないシフトへの変更申請は 400 で拒否され、行が増えないこと")
+  void submitChange_onTentativeShift_isRejected() {
+    Shift tentative = saveShift(myCastId, STORE_A, LocalDate.of(2999, 6, 2), "TENTATIVE");
+    long before = shiftRequestRepository.count();
+
+    ResponseEntity<JsonNode> res =
+        submitChange(
+            castToken,
+            changeBody(tentative.getId(), tomorrow(), "20:00:00", "23:00:00", "仮シフトへの申請"));
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(shiftRequestRepository.count()).isEqualTo(before);
+  }
+
+  @Test
+  @DisplayName("他キャストの確定シフトへの変更申請は 404 で拒否され、行が増えないこと")
+  void submitChange_onAnotherCastShift_isRejected() {
+    String otherCastId = createCast(STORE_A, "変更申請IT別キャスト", null);
+    Shift foreign = saveShift(otherCastId, STORE_A, LocalDate.of(2999, 6, 3), "CONFIRMED");
+    long before = shiftRequestRepository.count();
+
+    ResponseEntity<JsonNode> res =
+        submitChange(
+            castToken, changeBody(foreign.getId(), tomorrow(), "20:00:00", "23:00:00", "他人のシフト"));
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(shiftRequestRepository.count()).isEqualTo(before);
+  }
+
+  @Test
+  @DisplayName("変更申請の承認で対象シフトが同一行のまま更新され、申請が持たない属性は保たれること")
+  void approveChange_updatesTargetShiftInPlaceAndPreservesUnrelatedAttributes() {
+    Shift target = saveShift(myCastId, STORE_A, LocalDate.of(2999, 6, 4), "CONFIRMED", false);
+    long shiftCountBefore = shiftRepository.count();
+
+    ResponseEntity<JsonNode> created =
+        submitChange(
+            castToken, changeBody(target.getId(), "2999-06-05", "20:00:00", "23:30:00", "変更承認確認"));
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    String id = created.getBody().path("id").asString();
+
+    ResponseEntity<JsonNode> approved = approve(STORE_A, id);
+
+    assertThat(approved.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(approved.getBody().path("status").asString()).isEqualTo("APPROVED");
+    assertThat(approved.getBody().path("kind").asString()).isEqualTo("CHANGE");
+
+    Shift reloaded = shiftRepository.findById(target.getId()).orElseThrow();
+    assertThat(reloaded.getWorkDate()).isEqualTo(LocalDate.of(2999, 6, 5));
+    assertThat(reloaded.getStartTime()).isEqualTo(LocalTime.of(20, 0));
+    assertThat(reloaded.getEndTime()).isEqualTo(LocalTime.of(23, 30));
+    // 更新であって作り直しではないため、申請が持たない属性は元のまま残る。
+    assertThat(reloaded.getStatus()).isEqualTo("CONFIRMED");
+    assertThat(reloaded.getCastId()).isEqualTo(myCastId);
+    assertThat(reloaded.getStoreId()).isEqualTo(STORE_A);
+    assertThat(reloaded.isPublicVisible()).as("変更承認後も公開可否が保持されること").isFalse();
+    assertThat(shiftRepository.count()).as("変更承認でシフトが増えないこと").isEqualTo(shiftCountBefore);
+  }
+
+  @Test
+  @DisplayName("変更申請の謝絶で元の確定シフトが維持されること")
+  void declineChange_leavesOriginalShiftIntact() {
+    Shift target = saveShift(myCastId, STORE_A, LocalDate.of(2999, 6, 6), "CONFIRMED");
+
+    ResponseEntity<JsonNode> created =
+        submitChange(
+            castToken, changeBody(target.getId(), "2999-06-07", "10:00:00", "12:00:00", "謝絶確認"));
+    String id = created.getBody().path("id").asString();
+
+    ResponseEntity<JsonNode> declined = decline(STORE_A, id);
+
+    assertThat(declined.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(declined.getBody().path("status").asString()).isEqualTo("DECLINED");
+    Shift reloaded = shiftRepository.findById(target.getId()).orElseThrow();
+    assertThat(reloaded.getWorkDate()).isEqualTo(LocalDate.of(2999, 6, 6));
+    assertThat(reloaded.getStartTime()).isEqualTo(LocalTime.of(18, 0));
+    assertThat(reloaded.getEndTime()).isEqualTo(LocalTime.of(23, 0));
+  }
+
+  @Test
+  @DisplayName("店舗 inbox が新規希望と変更申請を種別で区別し、変更申請には変更前の値が添うこと")
+  void storeInbox_distinguishesKindAndCarriesCurrentShiftValues() {
+    Shift target = saveShift(myCastId, STORE_A, LocalDate.of(2999, 6, 8), "CONFIRMED");
+    String newNote = "inbox種別_新規_" + UUID.randomUUID();
+    String changeNote = "inbox種別_変更_" + UUID.randomUUID();
+
+    ResponseEntity<JsonNode> newRequest =
+        submit(castToken, submitBody(STORE_A, tomorrow(), "18:00:00", "23:00:00", newNote));
+    assertThat(newRequest.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    ResponseEntity<JsonNode> changeRequest =
+        submitChange(
+            castToken,
+            changeBody(target.getId(), "2999-06-09", "21:00:00", "23:30:00", changeNote));
+    assertThat(changeRequest.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+    ResponseEntity<JsonNode> inbox =
+        rest.exchange(
+            "/store/shift-requests?status=PENDING",
+            HttpMethod.GET,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+
+    assertThat(inbox.getStatusCode()).isEqualTo(HttpStatus.OK);
+    JsonNode newNode = null;
+    JsonNode changeNode = null;
+    for (JsonNode node : inbox.getBody()) {
+      if (newNote.equals(node.path("note").asString())) {
+        newNode = node;
+      }
+      if (changeNote.equals(node.path("note").asString())) {
+        changeNode = node;
+      }
+    }
+    assertThat(newNode).isNotNull();
+    assertThat(newNode.path("kind").asString()).isEqualTo("NEW");
+    assertThat(newNode.has("current_work_date")).as("新規希望に変更前は無い").isFalse();
+
+    assertThat(changeNode).isNotNull();
+    assertThat(changeNode.path("kind").asString()).isEqualTo("CHANGE");
+    assertThat(changeNode.path("target_shift_id").asString()).isEqualTo(target.getId());
+    // 申請された値（変更後）と対象シフトの現在値（変更前）が並ぶ。
+    assertThat(changeNode.path("work_date").asString()).isEqualTo("2999-06-09");
+    assertThat(changeNode.path("current_work_date").asString()).isEqualTo("2999-06-08");
+    assertThat(changeNode.path("current_start_time").asString()).isEqualTo("18:00:00");
+  }
+
+  @Test
+  @DisplayName("本人スケジュールが変更申請の対象に使えるシフト id を返すこと")
+  void mySchedule_exposesShiftId() {
+    saveShift(myCastId, STORE_A, LocalDate.of(2999, 6, 10), "CONFIRMED");
+
+    ResponseEntity<JsonNode> schedule =
+        rest.exchange(
+            "/platform/me/schedule?from=2999-06-10&to=2999-06-10",
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(castToken)),
+            JsonNode.class);
+
+    assertThat(schedule.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(schedule.getBody()).isNotEmpty();
+    for (JsonNode node : schedule.getBody()) {
+      assertThat(node.path("id").asString()).as("シフト id が露出すること").isNotBlank();
+    }
+  }
+
+  @Test
+  @DisplayName("当日実績が予定と別に記録され、店舗・キャスト双方から照会できること")
+  void actualAttendance_isRecordedSeparatelyAndQueryable() {
+    Shift target = saveShift(myCastId, STORE_A, LocalDate.of(2999, 6, 11), "CONFIRMED");
+
+    ResponseEntity<JsonNode> recorded =
+        rest.exchange(
+            "/store/shifts/" + target.getId() + "/actual",
+            HttpMethod.PUT,
+            new HttpEntity<>(
+                "{\"start_time\": \"18:05:00\", \"end_time\": \"23:10:00\"}",
+                storeHeaders(STORE_A)),
+            JsonNode.class);
+
+    assertThat(recorded.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(recorded.getBody().path("start_time").asString()).isEqualTo("18:00:00");
+    assertThat(recorded.getBody().path("end_time").asString()).isEqualTo("23:00:00");
+    assertThat(recorded.getBody().path("attendance_confirmed").asBoolean()).isTrue();
+    assertThat(recorded.getBody().path("actual_start_time").asString()).isEqualTo("18:05:00");
+    assertThat(recorded.getBody().path("actual_end_time").asString()).isEqualTo("23:10:00");
+    assertThat(recorded.getBody().path("actual_recorded_by").asString())
+        .isEqualTo("yamada.jiro@kizuna.test");
+    assertThat(recorded.getBody().path("actual_recorded_at").asString()).isNotBlank();
+
+    ResponseEntity<JsonNode> schedule =
+        rest.exchange(
+            "/platform/me/schedule?from=2999-06-11&to=2999-06-11",
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(castToken)),
+            JsonNode.class);
+    assertThat(schedule.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(schedule.getBody().get(0).path("actual_start_time").asString())
+        .isEqualTo("18:05:00");
   }
 
   @Test

--- a/backend/src/integrationTest/java/com/kizuna/shift/ShiftRequestScopeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/shift/ShiftRequestScopeIT.java
@@ -785,7 +785,8 @@ class ShiftRequestScopeIT extends CrossStoreTestSupport {
   @Test
   @DisplayName("当日実績が予定と別に記録され、店舗・キャスト双方から照会できること")
   void actualAttendance_isRecordedSeparatelyAndQueryable() {
-    Shift target = saveShift(myCastId, STORE_A, LocalDate.of(2999, 6, 11), "CONFIRMED");
+    String workDate = today();
+    Shift target = saveShift(myCastId, STORE_A, LocalDate.parse(workDate), "CONFIRMED", false);
 
     ResponseEntity<JsonNode> recorded =
         rest.exchange(
@@ -808,7 +809,7 @@ class ShiftRequestScopeIT extends CrossStoreTestSupport {
 
     ResponseEntity<JsonNode> schedule =
         rest.exchange(
-            "/platform/me/schedule?from=2999-06-11&to=2999-06-11",
+            "/platform/me/schedule?from=" + workDate + "&to=" + workDate,
             HttpMethod.GET,
             new HttpEntity<>(bearer(castToken)),
             JsonNode.class);

--- a/backend/src/main/java/com/kizuna/shift/api/dto/CastScheduleResponse.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/CastScheduleResponse.java
@@ -2,6 +2,7 @@ package com.kizuna.shift.api.dto;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,10 +14,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CastScheduleResponse {
+  private String id;
   private LocalDate workDate;
   private LocalTime startTime;
   private LocalTime endTime;
   private String status;
+  private boolean attendanceConfirmed;
+  private LocalTime actualStartTime;
+  private LocalTime actualEndTime;
+  private String actualRecordedBy;
+  private OffsetDateTime actualRecordedAt;
   private Long storeId;
   private String storeName;
 }

--- a/backend/src/main/java/com/kizuna/shift/api/dto/CastShiftRequestResponse.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/CastShiftRequestResponse.java
@@ -20,6 +20,10 @@ public class CastShiftRequestResponse {
   private LocalTime endTime;
   private String note;
   private String status;
+  private String kind;
+  private String targetShiftId;
+  private String decidedBy;
+  private OffsetDateTime decidedAt;
   private Long storeId;
   private String storeName;
   private OffsetDateTime createdAt;

--- a/backend/src/main/java/com/kizuna/shift/api/dto/ShiftActualRequest.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/ShiftActualRequest.java
@@ -1,0 +1,12 @@
+package com.kizuna.shift.api.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalTime;
+import lombok.Data;
+
+/** 当日実績の記録。予定時刻とは別に保持する。 */
+@Data
+public class ShiftActualRequest {
+  @NotNull private LocalTime startTime;
+  @NotNull private LocalTime endTime;
+}

--- a/backend/src/main/java/com/kizuna/shift/api/dto/ShiftChangeRequestCreateRequest.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/ShiftChangeRequestCreateRequest.java
@@ -1,0 +1,25 @@
+package com.kizuna.shift.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Data;
+
+/**
+ * 確定済みシフトへの変更申請（本人・cast）。
+ *
+ * <p>店舗は対象シフトから導出するため store_id は受け取らない — 申請者が名乗った店舗を信じると、対象シフトと別店舗の 帰属を主張できてしまう。所属判定も対象シフトの cast_id
+ * が本人のものかで行う。
+ */
+@Data
+public class ShiftChangeRequestCreateRequest {
+  @NotBlank private String targetShiftId;
+  @NotNull private LocalDate workDate;
+  @NotNull private LocalTime startTime;
+  @NotNull private LocalTime endTime;
+
+  @Size(max = 500, message = "備考は500文字以内で入力してください")
+  private String note;
+}

--- a/backend/src/main/java/com/kizuna/shift/api/dto/ShiftCreateRequest.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/ShiftCreateRequest.java
@@ -13,4 +13,5 @@ public class ShiftCreateRequest {
   @NotNull private LocalTime startTime;
   @NotNull private LocalTime endTime;
   private String status;
+  private Boolean publicVisible;
 }

--- a/backend/src/main/java/com/kizuna/shift/api/dto/ShiftMapper.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/ShiftMapper.java
@@ -12,6 +12,14 @@ public interface ShiftMapper {
   ShiftResponse toResponse(Shift shift);
 
   @Mapping(target = "status", defaultValue = "TENTATIVE")
+  @Mapping(target = "publicVisible", defaultValue = "true")
+  @Mapping(target = "approvedBy", ignore = true)
+  @Mapping(target = "approvedAt", ignore = true)
+  @Mapping(target = "attendanceConfirmed", ignore = true)
+  @Mapping(target = "actualStartTime", ignore = true)
+  @Mapping(target = "actualEndTime", ignore = true)
+  @Mapping(target = "actualRecordedBy", ignore = true)
+  @Mapping(target = "actualRecordedAt", ignore = true)
   Shift toEntity(ShiftCreateRequest request);
 
   /** 更新リクエストをドメインの部分更新コマンドに変換します。null フィールドは「変更しない」。 */

--- a/backend/src/main/java/com/kizuna/shift/api/dto/ShiftRequestMapper.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/ShiftRequestMapper.java
@@ -3,6 +3,7 @@ package com.kizuna.shift.api.dto;
 import com.kizuna.shift.domain.CastShiftRequestView;
 import com.kizuna.shift.domain.ShiftRequest;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface ShiftRequestMapper {
@@ -10,7 +11,10 @@ public interface ShiftRequestMapper {
   /** 本人ポータルの提出応答へ変換します。 */
   ShiftRequestResponse toResponse(ShiftRequest request);
 
-  /** 店舗側 inbox 応答へ変換します。 */
+  /** 店舗側 inbox 応答へ変換します。current_* は対象シフトの現在値なので、application 層が別途埋めます。 */
+  @Mapping(target = "currentWorkDate", ignore = true)
+  @Mapping(target = "currentStartTime", ignore = true)
+  @Mapping(target = "currentEndTime", ignore = true)
   StoreShiftRequestResponse toStoreResponse(ShiftRequest request);
 
   /** 本人ポータル履歴の読み側 projection を応答 DTO に変換します。 */

--- a/backend/src/main/java/com/kizuna/shift/api/dto/ShiftRequestResponse.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/ShiftRequestResponse.java
@@ -21,5 +21,9 @@ public class ShiftRequestResponse {
   private LocalTime endTime;
   private String note;
   private String status;
+  private String kind;
+  private String targetShiftId;
+  private String decidedBy;
+  private OffsetDateTime decidedAt;
   private OffsetDateTime createdAt;
 }

--- a/backend/src/main/java/com/kizuna/shift/api/dto/ShiftResponse.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/ShiftResponse.java
@@ -19,6 +19,14 @@ public class ShiftResponse {
   private LocalTime startTime;
   private LocalTime endTime;
   private String status;
+  private boolean publicVisible;
+  private String approvedBy;
+  private OffsetDateTime approvedAt;
+  private boolean attendanceConfirmed;
+  private LocalTime actualStartTime;
+  private LocalTime actualEndTime;
+  private String actualRecordedBy;
+  private OffsetDateTime actualRecordedAt;
   private OffsetDateTime createdAt;
   private OffsetDateTime updatedAt;
 }

--- a/backend/src/main/java/com/kizuna/shift/api/dto/ShiftUpdateRequest.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/ShiftUpdateRequest.java
@@ -11,4 +11,5 @@ public class ShiftUpdateRequest {
   private LocalTime startTime;
   private LocalTime endTime;
   private String status;
+  private Boolean publicVisible;
 }

--- a/backend/src/main/java/com/kizuna/shift/api/dto/StoreShiftRequestResponse.java
+++ b/backend/src/main/java/com/kizuna/shift/api/dto/StoreShiftRequestResponse.java
@@ -2,12 +2,18 @@ package com.kizuna.shift.api.dto;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/** 店舗側 inbox の出勤希望1件。JSON キーはグローバルの snake_case 設定に従う。 */
+/**
+ * 店舗側 inbox の出勤希望1件。JSON キーはグローバルの snake_case 設定に従う。
+ *
+ * <p>work_date / start_time / end_time は申請された内容。変更申請（kind=CHANGE）では current_* に対象シフトの現在値が入り、
+ * 店舗は変更前後を並べて判断できる。対象シフトが既に削除されている場合は target_shift_id ごと null になる。
+ */
 @Data
 @Builder
 @NoArgsConstructor
@@ -20,4 +26,11 @@ public class StoreShiftRequestResponse {
   private LocalTime endTime;
   private String note;
   private String status;
+  private String kind;
+  private String targetShiftId;
+  private String decidedBy;
+  private OffsetDateTime decidedAt;
+  private LocalDate currentWorkDate;
+  private LocalTime currentStartTime;
+  private LocalTime currentEndTime;
 }

--- a/backend/src/main/java/com/kizuna/shift/api/platform/PlatformShiftRequestController.java
+++ b/backend/src/main/java/com/kizuna/shift/api/platform/PlatformShiftRequestController.java
@@ -1,6 +1,7 @@
 package com.kizuna.shift.api.platform;
 
 import com.kizuna.shift.api.dto.CastShiftRequestResponse;
+import com.kizuna.shift.api.dto.ShiftChangeRequestCreateRequest;
 import com.kizuna.shift.api.dto.ShiftRequestCreateRequest;
 import com.kizuna.shift.api.dto.ShiftRequestResponse;
 import com.kizuna.shift.application.CastShiftRequestService;
@@ -31,6 +32,15 @@ public class PlatformShiftRequestController {
       Principal principal, @Valid @RequestBody ShiftRequestCreateRequest request) {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(castShiftRequestService.submit(principal.getName(), request));
+  }
+
+  /** 確定済みシフトへの変更申請。対象店舗は対象シフトから導出するため、本文に店舗は含めない。 */
+  @PostMapping("/changes")
+  @PreAuthorize("hasRole('CAST')")
+  public ResponseEntity<ShiftRequestResponse> submitChange(
+      Principal principal, @Valid @RequestBody ShiftChangeRequestCreateRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(castShiftRequestService.submitChange(principal.getName(), request));
   }
 
   @GetMapping

--- a/backend/src/main/java/com/kizuna/shift/api/store/ShiftController.java
+++ b/backend/src/main/java/com/kizuna/shift/api/store/ShiftController.java
@@ -1,12 +1,14 @@
 package com.kizuna.shift.api.store;
 
 import com.kizuna.shift.api.dto.PublicShiftResponse;
+import com.kizuna.shift.api.dto.ShiftActualRequest;
 import com.kizuna.shift.api.dto.ShiftCreateRequest;
 import com.kizuna.shift.api.dto.ShiftResponse;
 import com.kizuna.shift.api.dto.ShiftUpdateRequest;
 import com.kizuna.shift.application.ShiftService;
 import jakarta.annotation.security.PermitAll;
 import jakarta.validation.Valid;
+import java.security.Principal;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +52,15 @@ public class ShiftController {
   public ResponseEntity<ShiftResponse> update(
       @PathVariable String id, @Valid @RequestBody ShiftUpdateRequest request) {
     return ResponseEntity.ok(shiftService.update(id, request));
+  }
+
+  @PutMapping("/{id}/actual")
+  @PreAuthorize("hasAuthority('PERM_SHIFT_MANAGE')")
+  public ResponseEntity<ShiftResponse> recordActual(
+      Principal principal,
+      @PathVariable String id,
+      @Valid @RequestBody ShiftActualRequest request) {
+    return ResponseEntity.ok(shiftService.recordActual(id, request, principal.getName()));
   }
 
   @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/kizuna/shift/api/store/ShiftRequestController.java
+++ b/backend/src/main/java/com/kizuna/shift/api/store/ShiftRequestController.java
@@ -2,6 +2,7 @@ package com.kizuna.shift.api.store;
 
 import com.kizuna.shift.api.dto.StoreShiftRequestResponse;
 import com.kizuna.shift.application.ShiftRequestService;
+import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -30,13 +31,15 @@ public class ShiftRequestController {
 
   @PostMapping("/{id}/approval")
   @PreAuthorize("hasAuthority('PERM_SHIFT_MANAGE')")
-  public ResponseEntity<StoreShiftRequestResponse> approve(@PathVariable String id) {
-    return ResponseEntity.ok(shiftRequestService.approve(id));
+  public ResponseEntity<StoreShiftRequestResponse> approve(
+      Principal principal, @PathVariable String id) {
+    return ResponseEntity.ok(shiftRequestService.approve(id, principal.getName()));
   }
 
   @PostMapping("/{id}/decline")
   @PreAuthorize("hasAuthority('PERM_SHIFT_MANAGE')")
-  public ResponseEntity<StoreShiftRequestResponse> decline(@PathVariable String id) {
-    return ResponseEntity.ok(shiftRequestService.decline(id));
+  public ResponseEntity<StoreShiftRequestResponse> decline(
+      Principal principal, @PathVariable String id) {
+    return ResponseEntity.ok(shiftRequestService.decline(id, principal.getName()));
   }
 }

--- a/backend/src/main/java/com/kizuna/shift/application/CastShiftRequestService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/CastShiftRequestService.java
@@ -2,16 +2,22 @@ package com.kizuna.shift.application;
 
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.config.AppProperties;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.exception.StaleSessionException;
 import com.kizuna.shift.api.dto.CastShiftRequestResponse;
+import com.kizuna.shift.api.dto.ShiftChangeRequestCreateRequest;
 import com.kizuna.shift.api.dto.ShiftRequestCreateRequest;
 import com.kizuna.shift.api.dto.ShiftRequestMapper;
 import com.kizuna.shift.api.dto.ShiftRequestResponse;
+import com.kizuna.shift.domain.Shift;
+import com.kizuna.shift.domain.ShiftRepository;
 import com.kizuna.shift.domain.ShiftRequest;
+import com.kizuna.shift.domain.ShiftRequestKind;
 import com.kizuna.shift.domain.ShiftRequestRepository;
 import com.kizuna.user.domain.PlatformUserRepository;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -29,21 +35,18 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CastShiftRequestService {
 
+  private static final String CONFIRMED_STATUS = "CONFIRMED";
+
   private final PlatformUserRepository platformUserRepository;
   private final CastRepository castRepository;
   private final ShiftRequestRepository shiftRequestRepository;
+  private final ShiftRepository shiftRepository;
   private final ShiftRequestMapper shiftRequestMapper;
   private final AppProperties appProperties;
 
   @Transactional
   public ShiftRequestResponse submit(String email, ShiftRequestCreateRequest request) {
-    if (request.getStartTime().equals(request.getEndTime())) {
-      throw new ServiceException("開始時刻と終了時刻が同一です");
-    }
-    LocalDate today = LocalDate.now(ZoneId.of(appProperties.getTimezone()));
-    if (request.getWorkDate().isBefore(today)) {
-      throw new ServiceException("勤務日は本日以降を指定してください");
-    }
+    validateSchedule(request.getWorkDate(), request.getStartTime(), request.getEndTime());
 
     Long userId = resolveUserId(email);
     // 同一店舗に本人の档案が複数並存し得るため、最古の档案 id を決定的に選ぶ（リポジトリが古い順で返す）。
@@ -64,6 +67,41 @@ public class CastShiftRequestService {
     return shiftRequestMapper.toResponse(shiftRequestRepository.save(entity));
   }
 
+  /**
+   * 確定済みシフトへの変更申請を提出する。
+   *
+   * <p>対象シフトの所有は「その cast_id が本人の档案集合に含まれること」で判定し、店舗は対象シフトから導出する — 本人ポータルは StoreContext
+   * を持たず、リクエスト側が名乗る店舗を検証する手段が無いため。 存在しないシフトと他人のシフトはどちらも同じ NotFound として扱い、id の実在を漏らさない。
+   */
+  @Transactional
+  public ShiftRequestResponse submitChange(String email, ShiftChangeRequestCreateRequest request) {
+    validateSchedule(request.getWorkDate(), request.getStartTime(), request.getEndTime());
+
+    Long userId = resolveUserId(email);
+    List<String> castIds = castRepository.findIdsByPlatformUserId(userId);
+    Shift target =
+        shiftRepository
+            .findById(request.getTargetShiftId())
+            .filter(shift -> castIds.contains(shift.getCastId()))
+            .orElseThrow(() -> new NotFoundException("対象のシフトが見つかりません"));
+    if (!CONFIRMED_STATUS.equals(target.getStatus())) {
+      throw new ServiceException("確定済みのシフトにのみ変更申請できます");
+    }
+
+    ShiftRequest entity =
+        ShiftRequest.builder()
+            .castId(target.getCastId())
+            .kind(ShiftRequestKind.CHANGE)
+            .targetShiftId(target.getId())
+            .workDate(request.getWorkDate())
+            .startTime(request.getStartTime())
+            .endTime(request.getEndTime())
+            .note(request.getNote())
+            .build();
+    entity.setStoreId(target.getStoreId());
+    return shiftRequestMapper.toResponse(shiftRequestRepository.save(entity));
+  }
+
   @Transactional(readOnly = true)
   public List<CastShiftRequestResponse> history(String email) {
     Long userId = resolveUserId(email);
@@ -74,6 +112,17 @@ public class CastShiftRequestService {
     return shiftRequestRepository.findHistoryByCastIds(castIds).stream()
         .map(shiftRequestMapper::toHistoryResponse)
         .toList();
+  }
+
+  /** 新規希望・変更申請に共通する日時の妥当性検査。 */
+  private void validateSchedule(LocalDate workDate, LocalTime startTime, LocalTime endTime) {
+    if (startTime.equals(endTime)) {
+      throw new ServiceException("開始時刻と終了時刻が同一です");
+    }
+    LocalDate today = LocalDate.now(ZoneId.of(appProperties.getTimezone()));
+    if (workDate.isBefore(today)) {
+      throw new ServiceException("勤務日は本日以降を指定してください");
+    }
   }
 
   private Long resolveUserId(String email) {

--- a/backend/src/main/java/com/kizuna/shift/application/ShiftRequestService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ShiftRequestService.java
@@ -85,17 +85,21 @@ public class ShiftRequestService {
   /**
    * 変更申請の対象シフトを更新する。
    *
-   * <p>対象は @StoreScoped の storeFilter 下で引くが、id 検索はフィルタを迂回し得るため、店舗帰属を申請と突き合わせて明示的に 確認する —
-   * 他店のシフトを指した申請 id で越境更新されないことを、フィルタの適用有無に依存せず保証する。 対象が既に削除されている場合（FK は SET
-   * NULL）は更新すべき正本が無いため拒否する。
+   * <p>対象は @StoreScoped の storeFilter 下で引くが、店舗・キャスト帰属を申請と突き合わせて明示的に確認する。申請後に対象が別キャストへ
+   * 付け替えられた場合や、確定済みでなくなった場合も古い申請を適用しない。対象が既に削除されている場合（FK は SET NULL）は更新すべき正本が 無いため拒否する。
    */
   private void updateTargetShift(ShiftRequest request) {
     Shift target =
         request.getTargetShiftId() == null
             ? null
             : shiftRepository.findById(request.getTargetShiftId()).orElse(null);
-    if (target == null || !request.getStoreId().equals(target.getStoreId())) {
+    if (target == null
+        || !Objects.equals(request.getStoreId(), target.getStoreId())
+        || !Objects.equals(request.getCastId(), target.getCastId())) {
       throw new NotFoundException("変更対象のシフトが見つかりません");
+    }
+    if (!"CONFIRMED".equals(target.getStatus())) {
+      throw new ServiceException("変更対象のシフトは確定済みではありません");
     }
     target.apply(request.toShiftPatch());
     shiftRepository.save(target);

--- a/backend/src/main/java/com/kizuna/shift/application/ShiftRequestService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ShiftRequestService.java
@@ -8,9 +8,14 @@ import com.kizuna.shift.api.dto.StoreShiftRequestResponse;
 import com.kizuna.shift.domain.Shift;
 import com.kizuna.shift.domain.ShiftRepository;
 import com.kizuna.shift.domain.ShiftRequest;
+import com.kizuna.shift.domain.ShiftRequestKind;
 import com.kizuna.shift.domain.ShiftRequestRepository;
 import com.kizuna.shift.domain.ShiftRequestStatus;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,39 +36,104 @@ public class ShiftRequestService {
         status == null
             ? shiftRequestRepository.findAllByOrderByCreatedAtAsc()
             : shiftRequestRepository.findByStatusOrderByCreatedAtAsc(parseStatus(status));
-    return requests.stream().map(shiftRequestMapper::toStoreResponse).toList();
+    Map<String, Shift> targets = loadTargetShifts(requests);
+    return requests.stream().map(request -> toStoreResponse(request, targets)).toList();
   }
 
   /**
-   * 出勤希望を承認する。request の (cast_id, store_id, work_date, start_time, end_time) を原様に CONFIRMED Shift
-   * として新規作成する（同一トランザクション）。時刻調整は承認後の既存シフト編集で行う。
+   * 出勤希望を承認する。
+   *
+   * <p>新規希望（NEW）は request の (cast_id, store_id, work_date, start_time, end_time) を原様に CONFIRMED
+   * Shift として新規作成する（同一トランザクション）。時刻調整は承認後の既存シフト編集で行う。
+   *
+   * <p>変更申請（CHANGE）は対象シフトの行をその場で更新する。作り直しではないので、シフト側にだけ載っている設定は 申請が持つ日付・時刻の外側で保たれる（{@link
+   * ShiftRequest#toShiftPatch} が構造で担保する）。
    */
   @StoreScoped
   @Transactional
-  public StoreShiftRequestResponse approve(String id) {
+  public StoreShiftRequestResponse approve(String id, String actor) {
     ShiftRequest request = findOwnRequest(id);
-    request.approve();
+    request.approve(actor);
 
-    // store_id は StoreScopeStampListener が @PrePersist で採番する
-    Shift shift =
-        Shift.builder()
-            .castId(request.getCastId())
-            .workDate(request.getWorkDate())
-            .startTime(request.getStartTime())
-            .endTime(request.getEndTime())
-            .status("CONFIRMED")
-            .build();
-    shiftRepository.save(shift);
+    if (request.getKind() == ShiftRequestKind.CHANGE) {
+      updateTargetShift(request);
+    } else {
+      // store_id は StoreScopeStampListener が @PrePersist で採番する
+      Shift shift =
+          Shift.builder()
+              .castId(request.getCastId())
+              .workDate(request.getWorkDate())
+              .startTime(request.getStartTime())
+              .endTime(request.getEndTime())
+              .status("CONFIRMED")
+              .build();
+      shift.markApproved(actor);
+      request.linkToShift(shiftRepository.save(shift).getId());
+    }
 
-    return shiftRequestMapper.toStoreResponse(shiftRequestRepository.save(request));
+    return respond(shiftRequestRepository.save(request));
   }
 
   @StoreScoped
   @Transactional
-  public StoreShiftRequestResponse decline(String id) {
+  public StoreShiftRequestResponse decline(String id, String actor) {
     ShiftRequest request = findOwnRequest(id);
-    request.decline();
-    return shiftRequestMapper.toStoreResponse(shiftRequestRepository.save(request));
+    request.decline(actor);
+    return respond(shiftRequestRepository.save(request));
+  }
+
+  /**
+   * 変更申請の対象シフトを更新する。
+   *
+   * <p>対象は @StoreScoped の storeFilter 下で引くが、id 検索はフィルタを迂回し得るため、店舗帰属を申請と突き合わせて明示的に 確認する —
+   * 他店のシフトを指した申請 id で越境更新されないことを、フィルタの適用有無に依存せず保証する。 対象が既に削除されている場合（FK は SET
+   * NULL）は更新すべき正本が無いため拒否する。
+   */
+  private void updateTargetShift(ShiftRequest request) {
+    Shift target =
+        request.getTargetShiftId() == null
+            ? null
+            : shiftRepository.findById(request.getTargetShiftId()).orElse(null);
+    if (target == null || !request.getStoreId().equals(target.getStoreId())) {
+      throw new NotFoundException("変更対象のシフトが見つかりません");
+    }
+    target.apply(request.toShiftPatch());
+    shiftRepository.save(target);
+  }
+
+  /** 変更申請が指す対象シフトをまとめて引く（一覧で 1 件ずつ引かないため）。自店に属さないものは落とす。 */
+  private Map<String, Shift> loadTargetShifts(List<ShiftRequest> requests) {
+    List<String> targetIds =
+        requests.stream()
+            .filter(request -> request.getKind() == ShiftRequestKind.CHANGE)
+            .map(ShiftRequest::getTargetShiftId)
+            .filter(Objects::nonNull)
+            .toList();
+    if (targetIds.isEmpty()) {
+      return Map.of();
+    }
+    return shiftRepository.findAllById(targetIds).stream()
+        .collect(Collectors.toMap(Shift::getId, Function.identity()));
+  }
+
+  private StoreShiftRequestResponse respond(ShiftRequest request) {
+    return toStoreResponse(request, loadTargetShifts(List.of(request)));
+  }
+
+  /** inbox 応答へ変換し、変更申請には対象シフトの現在値（変更前）を添える。 */
+  private StoreShiftRequestResponse toStoreResponse(
+      ShiftRequest request, Map<String, Shift> targets) {
+    StoreShiftRequestResponse response = shiftRequestMapper.toStoreResponse(request);
+    if (request.getKind() != ShiftRequestKind.CHANGE || request.getTargetShiftId() == null) {
+      return response;
+    }
+    Shift target = targets.get(request.getTargetShiftId());
+    if (target != null && request.getStoreId().equals(target.getStoreId())) {
+      response.setCurrentWorkDate(target.getWorkDate());
+      response.setCurrentStartTime(target.getStartTime());
+      response.setCurrentEndTime(target.getEndTime());
+    }
+    return response;
   }
 
   private ShiftRequest findOwnRequest(String id) {

--- a/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
@@ -107,6 +107,11 @@ public class ShiftService {
     Shift shift =
         shiftRepository.findById(id).orElseThrow(() -> new NotFoundException("シフトが見つかりません: " + id));
 
+    if (shift.isAttendanceConfirmed()
+        && request.getCastId() != null
+        && !Objects.equals(request.getCastId(), shift.getCastId())) {
+      throw new ServiceException("実績記録済みのシフトはキャストを変更できません");
+    }
     validateStatus(request.getStatus());
     if (request.getCastId() != null && !castService.existsForCurrentStore(request.getCastId())) {
       throw new NotFoundException("キャストが見つかりません: " + request.getCastId());
@@ -139,6 +144,10 @@ public class ShiftService {
             .orElseThrow(() -> new NotFoundException("シフトが見つかりません: " + id));
     if (!"CONFIRMED".equals(shift.getStatus())) {
       throw new ServiceException("確定済みのシフトにのみ当日実績を記録できます");
+    }
+    LocalDate today = LocalDate.now(ZoneId.of(appProperties.getTimezone()));
+    if (shift.getWorkDate().isAfter(today)) {
+      throw new ServiceException("未来のシフトには当日実績を記録できません");
     }
     shift.recordActual(request.getStartTime(), request.getEndTime(), actor);
     return shiftMapper.toResponse(shiftRepository.save(shift));

--- a/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
@@ -112,6 +112,9 @@ public class ShiftService {
         && !Objects.equals(request.getCastId(), shift.getCastId())) {
       throw new ServiceException("実績記録済みのシフトはキャストを変更できません");
     }
+    if (shift.isAttendanceConfirmed() && "TENTATIVE".equals(request.getStatus())) {
+      throw new ServiceException("実績記録済みのシフトは未確定に戻せません");
+    }
     validateStatus(request.getStatus());
     if (request.getCastId() != null && !castService.existsForCurrentStore(request.getCastId())) {
       throw new NotFoundException("キャストが見つかりません: " + request.getCastId());

--- a/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ShiftService.java
@@ -6,8 +6,10 @@ import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.config.AppProperties;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.shared.storescope.StoreScoped;
 import com.kizuna.shift.api.dto.PublicShiftResponse;
+import com.kizuna.shift.api.dto.ShiftActualRequest;
 import com.kizuna.shift.api.dto.ShiftCreateRequest;
 import com.kizuna.shift.api.dto.ShiftMapper;
 import com.kizuna.shift.api.dto.ShiftResponse;
@@ -19,6 +21,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -37,6 +40,7 @@ public class ShiftService {
   private final CastService castService;
   private final CastRepository castRepository;
   private final AppProperties appProperties;
+  private final StoreContext storeContext;
 
   @StoreScoped
   @Transactional(readOnly = true)
@@ -57,7 +61,8 @@ public class ShiftService {
   public List<PublicShiftResponse> listPublicToday() {
     LocalDate today = LocalDate.now(ZoneId.of(appProperties.getTimezone()));
     List<Shift> shifts =
-        shiftRepository.findByWorkDateAndStatusOrderByStartTimeAsc(today, "CONFIRMED");
+        shiftRepository.findByWorkDateAndStatusAndPublicVisibleTrueOrderByStartTimeAsc(
+            today, "CONFIRMED");
     if (shifts.isEmpty()) {
       return List.of();
     }
@@ -118,6 +123,24 @@ public class ShiftService {
 
     shift.apply(shiftMapper.toPatch(request));
 
+    return shiftMapper.toResponse(shiftRepository.save(shift));
+  }
+
+  @StoreScoped
+  @Transactional
+  public ShiftResponse recordActual(String id, ShiftActualRequest request, String actor) {
+    if (request.getStartTime().equals(request.getEndTime())) {
+      throw new ServiceException("実績の開始時刻と終了時刻が同一です");
+    }
+    Shift shift =
+        shiftRepository
+            .findById(id)
+            .filter(found -> Objects.equals(found.getStoreId(), storeContext.getStoreId()))
+            .orElseThrow(() -> new NotFoundException("シフトが見つかりません: " + id));
+    if (!"CONFIRMED".equals(shift.getStatus())) {
+      throw new ServiceException("確定済みのシフトにのみ当日実績を記録できます");
+    }
+    shift.recordActual(request.getStartTime(), request.getEndTime(), actor);
     return shiftMapper.toResponse(shiftRepository.save(shift));
   }
 

--- a/backend/src/main/java/com/kizuna/shift/domain/CastScheduleView.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/CastScheduleView.java
@@ -2,6 +2,7 @@ package com.kizuna.shift.domain;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 
 /**
  * 本人（キャスト）ポータル週間スケジュールの読み側 projection。
@@ -10,6 +11,9 @@ import java.time.LocalTime;
  */
 public interface CastScheduleView {
 
+  /** シフト id。本人が確定済みシフトを指して変更申請を出すために必要。 */
+  String getId();
+
   LocalDate getWorkDate();
 
   LocalTime getStartTime();
@@ -17,6 +21,16 @@ public interface CastScheduleView {
   LocalTime getEndTime();
 
   String getStatus();
+
+  boolean isAttendanceConfirmed();
+
+  LocalTime getActualStartTime();
+
+  LocalTime getActualEndTime();
+
+  String getActualRecordedBy();
+
+  OffsetDateTime getActualRecordedAt();
 
   Long getStoreId();
 

--- a/backend/src/main/java/com/kizuna/shift/domain/CastShiftRequestView.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/CastShiftRequestView.java
@@ -23,6 +23,14 @@ public interface CastShiftRequestView {
 
   ShiftRequestStatus getStatus();
 
+  ShiftRequestKind getKind();
+
+  String getTargetShiftId();
+
+  String getDecidedBy();
+
+  OffsetDateTime getDecidedAt();
+
   Long getStoreId();
 
   String getStoreName();

--- a/backend/src/main/java/com/kizuna/shift/domain/Shift.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/Shift.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,6 +39,33 @@ public class Shift extends StoreScopedEntity {
   @Column(name = "status", nullable = false, length = 20)
   private String status;
 
+  /** 承認状態とは独立した公開可否。既存挙動を保つため既定は公開可。 */
+  @Column(name = "public_visible", nullable = false)
+  @Builder.Default
+  private boolean publicVisible = true;
+
+  @Column(name = "approved_by", length = 255)
+  private String approvedBy;
+
+  @Column(name = "approved_at")
+  private OffsetDateTime approvedAt;
+
+  @Column(name = "attendance_confirmed", nullable = false)
+  @Builder.Default
+  private boolean attendanceConfirmed = false;
+
+  @Column(name = "actual_start_time")
+  private LocalTime actualStartTime;
+
+  @Column(name = "actual_end_time")
+  private LocalTime actualEndTime;
+
+  @Column(name = "actual_recorded_by", length = 255)
+  private String actualRecordedBy;
+
+  @Column(name = "actual_recorded_at")
+  private OffsetDateTime actualRecordedAt;
+
   /** 部分更新コマンドを適用する。null のフィールドは変更しない。 */
   public void apply(ShiftPatch patch) {
     if (patch.castId() != null) {
@@ -55,6 +83,23 @@ public class Shift extends StoreScopedEntity {
     if (patch.status() != null) {
       this.status = patch.status();
     }
+    if (patch.publicVisible() != null) {
+      this.publicVisible = patch.publicVisible();
+    }
+  }
+
+  public void markApproved(String actor) {
+    this.approvedBy = actor;
+    this.approvedAt = OffsetDateTime.now();
+  }
+
+  /** 予定を変更せず、当日実績だけを記録する。 */
+  public void recordActual(LocalTime startTime, LocalTime endTime, String actor) {
+    this.attendanceConfirmed = true;
+    this.actualStartTime = startTime;
+    this.actualEndTime = endTime;
+    this.actualRecordedBy = actor;
+    this.actualRecordedAt = OffsetDateTime.now();
   }
 
   @Override
@@ -71,6 +116,8 @@ public class Shift extends StoreScopedEntity {
         + endTime
         + ", status="
         + status
+        + ", publicVisible="
+        + publicVisible
         + ")";
   }
 }

--- a/backend/src/main/java/com/kizuna/shift/domain/Shift.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/Shift.java
@@ -1,5 +1,6 @@
 package com.kizuna.shift.domain;
 
+import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.persistence.StoreScopedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -7,6 +8,7 @@ import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -68,6 +70,12 @@ public class Shift extends StoreScopedEntity {
 
   /** 部分更新コマンドを適用する。null のフィールドは変更しない。 */
   public void apply(ShiftPatch patch) {
+    if (attendanceConfirmed
+        && ((patch.workDate() != null && !Objects.equals(patch.workDate(), workDate))
+            || (patch.startTime() != null && !Objects.equals(patch.startTime(), startTime))
+            || (patch.endTime() != null && !Objects.equals(patch.endTime(), endTime)))) {
+      throw new ServiceException("実績記録済みのシフトは予定日時を変更できません");
+    }
     if (patch.castId() != null) {
       this.castId = patch.castId();
     }

--- a/backend/src/main/java/com/kizuna/shift/domain/ShiftPatch.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/ShiftPatch.java
@@ -5,4 +5,9 @@ import java.time.LocalTime;
 
 /** シフトの部分更新コマンド。null のフィールドは「変更しない」を意味する（CastPatch と同じ意味論）。 */
 public record ShiftPatch(
-    String castId, LocalDate workDate, LocalTime startTime, LocalTime endTime, String status) {}
+    String castId,
+    LocalDate workDate,
+    LocalTime startTime,
+    LocalTime endTime,
+    String status,
+    Boolean publicVisible) {}

--- a/backend/src/main/java/com/kizuna/shift/domain/ShiftRepository.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/ShiftRepository.java
@@ -12,7 +12,8 @@ public interface ShiftRepository
 
   List<Shift> findByWorkDateBetween(LocalDate from, LocalDate to);
 
-  List<Shift> findByWorkDateAndStatusOrderByStartTimeAsc(LocalDate workDate, String status);
+  List<Shift> findByWorkDateAndStatusAndPublicVisibleTrueOrderByStartTimeAsc(
+      LocalDate workDate, String status);
 
   /**
    * 本人（cast_id 集合、跨店）の週間確定シフトを店名内联で返す。where 句に店舗の絞りは書かない — cast_id は当人が所属する店にしか 存在しないため、cast_id
@@ -20,8 +21,11 @@ public interface ShiftRepository
    */
   @Query(
       """
-      select s.workDate as workDate, s.startTime as startTime, s.endTime as endTime,
-             s.status as status, s.storeId as storeId, st.name as storeName
+      select s.id as id, s.workDate as workDate, s.startTime as startTime, s.endTime as endTime,
+             s.status as status, s.attendanceConfirmed as attendanceConfirmed,
+             s.actualStartTime as actualStartTime, s.actualEndTime as actualEndTime,
+             s.actualRecordedBy as actualRecordedBy, s.actualRecordedAt as actualRecordedAt,
+             s.storeId as storeId, st.name as storeName
       from Shift s join com.kizuna.store.domain.Store st on st.id = s.storeId
       where s.castId in :castIds and s.status = 'CONFIRMED'
         and s.workDate between :from and :to

--- a/backend/src/main/java/com/kizuna/shift/domain/ShiftRequest.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/ShiftRequest.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,9 +16,10 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Filter;
 
 /**
- * 出勤希望集約。キャストが所属店舗を指定して提出する勤務希望。
+ * 出勤希望集約。キャストが所属店舗を指定して提出する勤務希望と、確定済みシフトへの変更申請を単一の状態系列で表す。
  *
- * <p>承認で確定（CONFIRMED）Shift を新規作成する。希望自体は Shift へ変化せず、申請の履歴として残る。
+ * <p>NEW の承認は確定（CONFIRMED）Shift を新規作成し、CHANGE の承認は {@link #targetShiftId} のシフトを更新する。 いずれも希望自体は
+ * Shift へ変化せず、申請の履歴として残る。
  */
 @Entity
 @Table(name = "t_shift_requests")
@@ -50,16 +52,53 @@ public class ShiftRequest extends StoreScopedEntity {
   @Builder.Default
   private ShiftRequestStatus status = ShiftRequestStatus.PENDING;
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "kind", nullable = false, length = 20)
+  @Builder.Default
+  private ShiftRequestKind kind = ShiftRequestKind.NEW;
+
+  /** 変更申請（CHANGE）が対象とする確定済みシフトの id。新規希望（NEW）では null。 */
+  @Column(name = "target_shift_id", length = 64)
+  private String targetShiftId;
+
+  @Column(name = "decided_by", length = 255)
+  private String decidedBy;
+
+  @Column(name = "decided_at")
+  private OffsetDateTime decidedAt;
+
+  /**
+   * 変更申請の内容を、対象シフトへの部分更新コマンドへ写す。
+   *
+   * <p>載せるのは申請が持つ日付・時刻だけで、他の成分は null（＝変更しない）に固定する。申請が持たない属性 — 担当キャスト・確定ステータス、および将来シフト側に増える設定 —
+   * を承認が巻き込んで書き換えないことを、 判断ではなく構造で保証するための写像。
+   */
+  public ShiftPatch toShiftPatch() {
+    if (kind != ShiftRequestKind.CHANGE) {
+      throw new ShiftRequestStateException("変更申請ではないためシフトを更新できません");
+    }
+    return new ShiftPatch(null, workDate, startTime, endTime, null, null);
+  }
+
   /** PENDING の希望のみ承認できる。それ以外は状態例外を投げる（処理済みへの再処理を拒否）。 */
-  public void approve() {
+  public void approve(String actor) {
     requirePending();
     this.status = ShiftRequestStatus.APPROVED;
+    this.decidedBy = actor;
+    this.decidedAt = OffsetDateTime.now();
   }
 
   /** PENDING の希望のみ却下できる。それ以外は状態例外を投げる。 */
-  public void decline() {
+  public void decline(String actor) {
     requirePending();
     this.status = ShiftRequestStatus.DECLINED;
+    this.decidedBy = actor;
+    this.decidedAt = OffsetDateTime.now();
+  }
+
+  /** NEW の承認後も、希望から確定シフトへ同じ正本系列を辿れるように関連付ける。 */
+  public void linkToShift(String shiftId) {
+    this.targetShiftId = shiftId;
   }
 
   private void requirePending() {
@@ -82,6 +121,10 @@ public class ShiftRequest extends StoreScopedEntity {
         + endTime
         + ", status="
         + status
+        + ", kind="
+        + kind
+        + ", targetShiftId="
+        + targetShiftId
         + ")";
   }
 }

--- a/backend/src/main/java/com/kizuna/shift/domain/ShiftRequestKind.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/ShiftRequestKind.java
@@ -1,0 +1,7 @@
+package com.kizuna.shift.domain;
+
+/** 出勤希望の種別。NEW=新規希望 / CHANGE=確定済みシフトへの変更申請。状態系列（PENDING→APPROVED/DECLINED）は両者で共通。 */
+public enum ShiftRequestKind {
+  NEW,
+  CHANGE
+}

--- a/backend/src/main/java/com/kizuna/shift/domain/ShiftRequestRepository.java
+++ b/backend/src/main/java/com/kizuna/shift/domain/ShiftRequestRepository.java
@@ -18,8 +18,9 @@ public interface ShiftRequestRepository extends JpaRepository<ShiftRequest, Stri
   @Query(
       """
       select r.id as id, r.workDate as workDate, r.startTime as startTime, r.endTime as endTime,
-             r.note as note, r.status as status, r.storeId as storeId, st.name as storeName,
-             r.createdAt as createdAt
+             r.note as note, r.status as status, r.kind as kind, r.storeId as storeId,
+             r.targetShiftId as targetShiftId, r.decidedBy as decidedBy, r.decidedAt as decidedAt,
+             st.name as storeName, r.createdAt as createdAt
       from ShiftRequest r join com.kizuna.store.domain.Store st on st.id = r.storeId
       where r.castId in :castIds
       order by r.createdAt desc

--- a/backend/src/main/resources/db/changelog/releases/v0.4.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.4.0/master.yaml
@@ -1,6 +1,9 @@
-# v0.4.0 = Order の店舗帰属を store_id に一本化する。
+# v0.4.0 = Order の店舗帰属を store_id に一本化し、出勤希望に変更申請の種別を足す。
 # 構成は v0.1.0 / v0.2.0 / v0.3.0 と同じ platform / store / seed の 3 層のうち store のみ。
 databaseChangeLog:
   - include:
       file: store/01-order-drop-store-name.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: store/02-shift-request-change.yaml
       relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.4.0/store/02-shift-request-change.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.4.0/store/02-shift-request-change.yaml
@@ -1,0 +1,82 @@
+databaseChangeLog:
+  - changeSet:
+      id: store-v0400-002-shift-request-change
+      author: kanghouchao
+      # 確定済みシフトへの変更申請を、新規希望と同じ t_shift_requests の状態系列で扱う。
+      # 種別（kind）と対象シフト（target_shift_id）を足すのみで、別テーブルには分けない。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - addColumn:
+            tableName: t_shift_requests
+            columns:
+              - column:
+                  name: kind
+                  type: VARCHAR(20)
+                  defaultValue: NEW
+                  constraints:
+                    nullable: false
+                  remarks: 種別（NEW=新規希望/CHANGE=確定済みシフトへの変更申請）
+              - column:
+                  name: target_shift_id
+                  type: VARCHAR(64)
+                  remarks: 同一正本系列の確定シフト（CHANGE は申請時、NEW は承認時に設定）
+              - column:
+                  name: decided_by
+                  type: VARCHAR(255)
+                  remarks: 承認・謝絶の実行主体
+              - column:
+                  name: decided_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  remarks: 承認・謝絶の実行日時
+        - addColumn:
+            tableName: t_shifts
+            columns:
+              - column:
+                  name: public_visible
+                  type: BOOLEAN
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+                  remarks: 承認状態とは独立した公開可否
+              - column:
+                  name: approved_by
+                  type: VARCHAR(255)
+                  remarks: 希望を承認して確定した実行主体
+              - column:
+                  name: approved_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  remarks: 希望を承認して確定した日時
+              - column:
+                  name: attendance_confirmed
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+                  remarks: 当日実績が記録済みか
+              - column:
+                  name: actual_start_time
+                  type: TIME
+                  remarks: 実際の開始時刻
+              - column:
+                  name: actual_end_time
+                  type: TIME
+                  remarks: 実際の終了時刻
+              - column:
+                  name: actual_recorded_by
+                  type: VARCHAR(255)
+                  remarks: 当日実績の記録主体
+              - column:
+                  name: actual_recorded_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  remarks: 当日実績の記録日時
+        # シフトが削除されても申請の履歴（キャストへ返す結果状態）は残す必要があるため CASCADE ではなく SET NULL。
+        # 対象を失った申請の承認は、アプリケーション側が対象不在として拒否する。
+        - addForeignKeyConstraint:
+            constraintName: fk_t_shift_requests_target_shift
+            baseTableName: t_shift_requests
+            baseColumnNames: target_shift_id
+            referencedTableName: t_shifts
+            referencedColumnNames: id
+            onDelete: SET NULL

--- a/backend/src/test/java/com/kizuna/shift/application/CastShiftRequestServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/CastShiftRequestServiceTest.java
@@ -11,14 +11,20 @@ import static org.mockito.Mockito.when;
 
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.config.AppProperties;
+import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.exception.StaleSessionException;
 import com.kizuna.shift.api.dto.CastShiftRequestResponse;
+import com.kizuna.shift.api.dto.ShiftChangeRequestCreateRequest;
 import com.kizuna.shift.api.dto.ShiftRequestCreateRequest;
 import com.kizuna.shift.api.dto.ShiftRequestMapper;
 import com.kizuna.shift.api.dto.ShiftRequestResponse;
 import com.kizuna.shift.domain.CastShiftRequestView;
+import com.kizuna.shift.domain.Shift;
+import com.kizuna.shift.domain.ShiftPatch;
+import com.kizuna.shift.domain.ShiftRepository;
 import com.kizuna.shift.domain.ShiftRequest;
+import com.kizuna.shift.domain.ShiftRequestKind;
 import com.kizuna.shift.domain.ShiftRequestRepository;
 import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
@@ -39,6 +45,7 @@ class CastShiftRequestServiceTest {
   @Mock private PlatformUserRepository platformUserRepository;
   @Mock private CastRepository castRepository;
   @Mock private ShiftRequestRepository shiftRequestRepository;
+  @Mock private ShiftRepository shiftRepository;
   @Mock private ShiftRequestMapper shiftRequestMapper;
   @Mock private AppProperties appProperties;
 
@@ -157,6 +164,120 @@ class CastShiftRequestServiceTest {
     ArgumentCaptor<ShiftRequest> captor = ArgumentCaptor.forClass(ShiftRequest.class);
     verify(shiftRequestRepository).save(captor.capture());
     assertThat(captor.getValue().getCastId()).isEqualTo("cast-old");
+  }
+
+  // ---- 変更申請（kind=CHANGE） ----
+
+  private ShiftChangeRequestCreateRequest validChangeRequest() {
+    ShiftChangeRequestCreateRequest req = new ShiftChangeRequestCreateRequest();
+    req.setTargetShiftId("shift-1");
+    req.setWorkDate(LocalDate.of(2999, 8, 2));
+    req.setStartTime(LocalTime.of(19, 0));
+    req.setEndTime(LocalTime.of(22, 0));
+    return req;
+  }
+
+  private Shift confirmedShift(String castId, long storeId) {
+    Shift shift =
+        Shift.builder()
+            .castId(castId)
+            .workDate(LocalDate.of(2999, 8, 1))
+            .startTime(LocalTime.of(18, 0))
+            .endTime(LocalTime.of(23, 0))
+            .status("CONFIRMED")
+            .build();
+    shift.setId("shift-1");
+    shift.setStoreId(storeId);
+    return shift;
+  }
+
+  @Test
+  void submitChange_savesChangeRequestWithStoreDerivedFromTargetShift() {
+    ShiftChangeRequestCreateRequest req = validChangeRequest();
+    when(appProperties.getTimezone()).thenReturn("Asia/Tokyo");
+    PlatformUser user = userWithId(42L);
+    when(platformUserRepository.findByEmail(EMAIL)).thenReturn(Optional.of(user));
+    when(castRepository.findIdsByPlatformUserId(42L)).thenReturn(List.of("cast-1"));
+    when(shiftRepository.findById("shift-1")).thenReturn(Optional.of(confirmedShift("cast-1", 7L)));
+    when(shiftRequestRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+    when(shiftRequestMapper.toResponse(any()))
+        .thenReturn(ShiftRequestResponse.builder().id("sr1").build());
+
+    service.submitChange(EMAIL, req);
+
+    ArgumentCaptor<ShiftRequest> captor = ArgumentCaptor.forClass(ShiftRequest.class);
+    verify(shiftRequestRepository).save(captor.capture());
+    ShiftRequest saved = captor.getValue();
+    assertThat(saved.getKind()).isEqualTo(ShiftRequestKind.CHANGE);
+    assertThat(saved.getTargetShiftId()).isEqualTo("shift-1");
+    assertThat(saved.getCastId()).isEqualTo("cast-1");
+    // 店舗は申請者の申告ではなく対象シフトの帰属から決まる。
+    assertThat(saved.getStoreId()).isEqualTo(7L);
+    assertThat(saved.getWorkDate()).isEqualTo(LocalDate.of(2999, 8, 2));
+  }
+
+  @Test
+  void submitChange_rejectsShiftOfAnotherCast() {
+    ShiftChangeRequestCreateRequest req = validChangeRequest();
+    when(appProperties.getTimezone()).thenReturn("Asia/Tokyo");
+    PlatformUser user = userWithId(42L);
+    when(platformUserRepository.findByEmail(EMAIL)).thenReturn(Optional.of(user));
+    when(castRepository.findIdsByPlatformUserId(42L)).thenReturn(List.of("cast-1"));
+    when(shiftRepository.findById("shift-1"))
+        .thenReturn(Optional.of(confirmedShift("someone-else", 7L)));
+
+    assertThatThrownBy(() -> service.submitChange(EMAIL, req))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("対象のシフトが見つかりません");
+
+    verify(shiftRequestRepository, never()).save(any());
+  }
+
+  @Test
+  void submitChange_rejectsShiftThatIsNotConfirmed() {
+    ShiftChangeRequestCreateRequest req = validChangeRequest();
+    Shift tentative = confirmedShift("cast-1", 7L);
+    tentative.apply(new ShiftPatch(null, null, null, null, "TENTATIVE", null));
+    when(appProperties.getTimezone()).thenReturn("Asia/Tokyo");
+    PlatformUser user = userWithId(42L);
+    when(platformUserRepository.findByEmail(EMAIL)).thenReturn(Optional.of(user));
+    when(castRepository.findIdsByPlatformUserId(42L)).thenReturn(List.of("cast-1"));
+    when(shiftRepository.findById("shift-1")).thenReturn(Optional.of(tentative));
+
+    assertThatThrownBy(() -> service.submitChange(EMAIL, req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("確定済みのシフトにのみ変更申請できます");
+
+    verify(shiftRequestRepository, never()).save(any());
+  }
+
+  @Test
+  void submitChange_rejectsMissingShift() {
+    ShiftChangeRequestCreateRequest req = validChangeRequest();
+    when(appProperties.getTimezone()).thenReturn("Asia/Tokyo");
+    PlatformUser user = userWithId(42L);
+    when(platformUserRepository.findByEmail(EMAIL)).thenReturn(Optional.of(user));
+    when(castRepository.findIdsByPlatformUserId(42L)).thenReturn(List.of("cast-1"));
+    when(shiftRepository.findById("shift-1")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.submitChange(EMAIL, req))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("対象のシフトが見つかりません");
+
+    verify(shiftRequestRepository, never()).save(any());
+  }
+
+  @Test
+  void submitChange_rejectsPastWorkDateBeforeTouchingTheShift() {
+    ShiftChangeRequestCreateRequest req = validChangeRequest();
+    req.setWorkDate(LocalDate.of(2000, 1, 1));
+    when(appProperties.getTimezone()).thenReturn("Asia/Tokyo");
+
+    assertThatThrownBy(() -> service.submitChange(EMAIL, req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("本日以降");
+
+    verifyNoInteractions(platformUserRepository, castRepository, shiftRepository);
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftRequestServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftRequestServiceTest.java
@@ -189,13 +189,17 @@ class ShiftRequestServiceTest {
   }
 
   private Shift targetShift() {
+    return targetShift("c1", "CONFIRMED");
+  }
+
+  private Shift targetShift(String castId, String status) {
     Shift shift =
         Shift.builder()
-            .castId("c1")
+            .castId(castId)
             .workDate(LocalDate.of(2999, 8, 1))
             .startTime(LocalTime.of(18, 0))
             .endTime(LocalTime.of(23, 0))
-            .status("CONFIRMED")
+            .status(status)
             .publicVisible(false)
             .build();
     shift.setId("s1");
@@ -244,6 +248,38 @@ class ShiftRequestServiceTest {
     verify(shiftRepository, never()).save(any());
     verify(shiftRequestRepository, never()).save(any());
     assertThat(foreign.getWorkDate()).isEqualTo(LocalDate.of(2999, 8, 1));
+  }
+
+  @Test
+  void approveChange_whenTargetShiftWasReassigned_isRejectedAndLeavesItUntouched() {
+    ShiftRequest request = pendingChangeRequest();
+    Shift reassigned = targetShift("c2", "CONFIRMED");
+    when(shiftRequestRepository.findById("sr1")).thenReturn(Optional.of(request));
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(reassigned));
+
+    assertThatThrownBy(() -> shiftRequestService.approve("sr1", STAFF))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("変更対象のシフトが見つかりません");
+
+    verify(shiftRepository, never()).save(any());
+    verify(shiftRequestRepository, never()).save(any());
+    assertThat(reassigned.getWorkDate()).isEqualTo(LocalDate.of(2999, 8, 1));
+  }
+
+  @Test
+  void approveChange_whenTargetShiftIsNoLongerConfirmed_isRejectedAndLeavesItUntouched() {
+    ShiftRequest request = pendingChangeRequest();
+    Shift tentative = targetShift("c1", "TENTATIVE");
+    when(shiftRequestRepository.findById("sr1")).thenReturn(Optional.of(request));
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(tentative));
+
+    assertThatThrownBy(() -> shiftRequestService.approve("sr1", STAFF))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("確定済み");
+
+    verify(shiftRepository, never()).save(any());
+    verify(shiftRequestRepository, never()).save(any());
+    assertThat(tentative.getWorkDate()).isEqualTo(LocalDate.of(2999, 8, 1));
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftRequestServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftRequestServiceTest.java
@@ -14,6 +14,7 @@ import com.kizuna.shift.api.dto.StoreShiftRequestResponse;
 import com.kizuna.shift.domain.Shift;
 import com.kizuna.shift.domain.ShiftRepository;
 import com.kizuna.shift.domain.ShiftRequest;
+import com.kizuna.shift.domain.ShiftRequestKind;
 import com.kizuna.shift.domain.ShiftRequestRepository;
 import com.kizuna.shift.domain.ShiftRequestStateException;
 import com.kizuna.shift.domain.ShiftRequestStatus;
@@ -30,6 +31,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ShiftRequestServiceTest {
+
+  private static final String STAFF = "staff@kizuna.test";
 
   @Mock private ShiftRequestRepository shiftRequestRepository;
   @Mock private ShiftRepository shiftRepository;
@@ -86,7 +89,7 @@ class ShiftRequestServiceTest {
   void approve_throwsWhenNotFound() {
     when(shiftRequestRepository.findById("missing")).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> shiftRequestService.approve("missing"))
+    assertThatThrownBy(() -> shiftRequestService.approve("missing", STAFF))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("出勤希望が見つかりません");
 
@@ -101,7 +104,15 @@ class ShiftRequestServiceTest {
     when(shiftRequestMapper.toStoreResponse(request))
         .thenReturn(StoreShiftRequestResponse.builder().id("sr1").status("APPROVED").build());
 
-    StoreShiftRequestResponse result = shiftRequestService.approve("sr1");
+    when(shiftRepository.save(any()))
+        .thenAnswer(
+            invocation -> {
+              Shift shift = invocation.getArgument(0);
+              shift.setId("s1");
+              return shift;
+            });
+
+    StoreShiftRequestResponse result = shiftRequestService.approve("sr1", STAFF);
 
     assertThat(result.getStatus()).isEqualTo("APPROVED");
     assertThat(request.getStatus()).isEqualTo(ShiftRequestStatus.APPROVED);
@@ -114,15 +125,20 @@ class ShiftRequestServiceTest {
     assertThat(shift.getStartTime()).isEqualTo(request.getStartTime());
     assertThat(shift.getEndTime()).isEqualTo(request.getEndTime());
     assertThat(shift.getStatus()).isEqualTo("CONFIRMED");
+    assertThat(shift.getApprovedBy()).isEqualTo(STAFF);
+    assertThat(shift.getApprovedAt()).isNotNull();
+    assertThat(request.getTargetShiftId()).isEqualTo("s1");
+    assertThat(request.getDecidedBy()).isEqualTo(STAFF);
+    assertThat(request.getDecidedAt()).isNotNull();
   }
 
   @Test
   void approve_whenAlreadyProcessed_throwsStateExceptionAndCreatesNoShift() {
     ShiftRequest request = pendingRequest();
-    request.approve();
+    request.approve(STAFF);
     when(shiftRequestRepository.findById("sr1")).thenReturn(Optional.of(request));
 
-    assertThatThrownBy(() -> shiftRequestService.approve("sr1"))
+    assertThatThrownBy(() -> shiftRequestService.approve("sr1", STAFF))
         .isInstanceOf(ShiftRequestStateException.class);
 
     verify(shiftRepository, never()).save(any());
@@ -137,10 +153,12 @@ class ShiftRequestServiceTest {
     when(shiftRequestMapper.toStoreResponse(request))
         .thenReturn(StoreShiftRequestResponse.builder().id("sr1").status("DECLINED").build());
 
-    StoreShiftRequestResponse result = shiftRequestService.decline("sr1");
+    StoreShiftRequestResponse result = shiftRequestService.decline("sr1", STAFF);
 
     assertThat(result.getStatus()).isEqualTo("DECLINED");
     assertThat(request.getStatus()).isEqualTo(ShiftRequestStatus.DECLINED);
+    assertThat(request.getDecidedBy()).isEqualTo(STAFF);
+    assertThat(request.getDecidedAt()).isNotNull();
     verify(shiftRepository, never()).save(any());
   }
 
@@ -148,8 +166,134 @@ class ShiftRequestServiceTest {
   void decline_throwsWhenNotFound() {
     when(shiftRequestRepository.findById("missing")).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> shiftRequestService.decline("missing"))
+    assertThatThrownBy(() -> shiftRequestService.decline("missing", STAFF))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("出勤希望が見つかりません");
+  }
+
+  // ---- 変更申請（kind=CHANGE） ----
+
+  private ShiftRequest pendingChangeRequest() {
+    ShiftRequest request =
+        ShiftRequest.builder()
+            .castId("c1")
+            .kind(ShiftRequestKind.CHANGE)
+            .targetShiftId("s1")
+            .workDate(LocalDate.of(2999, 8, 2))
+            .startTime(LocalTime.of(19, 0))
+            .endTime(LocalTime.of(22, 0))
+            .build();
+    request.setId("sr1");
+    request.setStoreId(1L);
+    return request;
+  }
+
+  private Shift targetShift() {
+    Shift shift =
+        Shift.builder()
+            .castId("c1")
+            .workDate(LocalDate.of(2999, 8, 1))
+            .startTime(LocalTime.of(18, 0))
+            .endTime(LocalTime.of(23, 0))
+            .status("CONFIRMED")
+            .publicVisible(false)
+            .build();
+    shift.setId("s1");
+    shift.setStoreId(1L);
+    return shift;
+  }
+
+  @Test
+  void approveChange_updatesTargetShiftInPlaceWithoutCreatingANewOne() {
+    ShiftRequest request = pendingChangeRequest();
+    Shift target = targetShift();
+    when(shiftRequestRepository.findById("sr1")).thenReturn(Optional.of(request));
+    when(shiftRequestRepository.save(request)).thenReturn(request);
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(target));
+    when(shiftRepository.findAllById(List.of("s1"))).thenReturn(List.of(target));
+    when(shiftRequestMapper.toStoreResponse(request))
+        .thenReturn(StoreShiftRequestResponse.builder().id("sr1").status("APPROVED").build());
+
+    StoreShiftRequestResponse result = shiftRequestService.approve("sr1", STAFF);
+
+    assertThat(request.getStatus()).isEqualTo(ShiftRequestStatus.APPROVED);
+    // 既存の行が更新される（新規作成ではない）ので、シフト側だけが持つ属性は申請の外側で保たれる。
+    verify(shiftRepository).save(target);
+    assertThat(target.getWorkDate()).isEqualTo(LocalDate.of(2999, 8, 2));
+    assertThat(target.getStartTime()).isEqualTo(LocalTime.of(19, 0));
+    assertThat(target.getEndTime()).isEqualTo(LocalTime.of(22, 0));
+    assertThat(target.getStatus()).isEqualTo("CONFIRMED");
+    assertThat(target.getCastId()).isEqualTo("c1");
+    assertThat(target.isPublicVisible()).isFalse();
+    // 応答には変更後の対象シフトの現在値が添う。
+    assertThat(result.getCurrentStartTime()).isEqualTo(LocalTime.of(19, 0));
+  }
+
+  @Test
+  void approveChange_whenTargetShiftBelongsToAnotherStore_isRejectedAndLeavesItUntouched() {
+    ShiftRequest request = pendingChangeRequest();
+    Shift foreign = targetShift();
+    foreign.setStoreId(2L);
+    when(shiftRequestRepository.findById("sr1")).thenReturn(Optional.of(request));
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(foreign));
+
+    assertThatThrownBy(() -> shiftRequestService.approve("sr1", STAFF))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("変更対象のシフトが見つかりません");
+
+    verify(shiftRepository, never()).save(any());
+    verify(shiftRequestRepository, never()).save(any());
+    assertThat(foreign.getWorkDate()).isEqualTo(LocalDate.of(2999, 8, 1));
+  }
+
+  @Test
+  void approveChange_whenTargetShiftIsGone_isRejected() {
+    ShiftRequest request = pendingChangeRequest();
+    when(shiftRequestRepository.findById("sr1")).thenReturn(Optional.of(request));
+    when(shiftRepository.findById("s1")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> shiftRequestService.approve("sr1", STAFF))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("変更対象のシフトが見つかりません");
+
+    verify(shiftRequestRepository, never()).save(any());
+  }
+
+  @Test
+  void declineChange_leavesTargetShiftUnchanged() {
+    ShiftRequest request = pendingChangeRequest();
+    Shift target = targetShift();
+    when(shiftRequestRepository.findById("sr1")).thenReturn(Optional.of(request));
+    when(shiftRequestRepository.save(request)).thenReturn(request);
+    when(shiftRepository.findAllById(List.of("s1"))).thenReturn(List.of(target));
+    when(shiftRequestMapper.toStoreResponse(request))
+        .thenReturn(StoreShiftRequestResponse.builder().id("sr1").status("DECLINED").build());
+
+    StoreShiftRequestResponse result = shiftRequestService.decline("sr1", STAFF);
+
+    assertThat(request.getStatus()).isEqualTo(ShiftRequestStatus.DECLINED);
+    verify(shiftRepository, never()).save(any());
+    assertThat(target.getWorkDate()).isEqualTo(LocalDate.of(2999, 8, 1));
+    assertThat(target.getStartTime()).isEqualTo(LocalTime.of(18, 0));
+    assertThat(target.getEndTime()).isEqualTo(LocalTime.of(23, 0));
+    // 謝絶の応答でも、元のシフトの現在値が変更前のまま添う。
+    assertThat(result.getCurrentStartTime()).isEqualTo(LocalTime.of(18, 0));
+  }
+
+  @Test
+  void list_attachesCurrentShiftValuesToChangeRequests() {
+    ShiftRequest request = pendingChangeRequest();
+    when(shiftRequestRepository.findByStatusOrderByCreatedAtAsc(ShiftRequestStatus.PENDING))
+        .thenReturn(List.of(request));
+    when(shiftRepository.findAllById(List.of("s1"))).thenReturn(List.of(targetShift()));
+    when(shiftRequestMapper.toStoreResponse(request))
+        .thenReturn(StoreShiftRequestResponse.builder().id("sr1").kind("CHANGE").build());
+
+    List<StoreShiftRequestResponse> result = shiftRequestService.list("PENDING");
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getCurrentWorkDate()).isEqualTo(LocalDate.of(2999, 8, 1));
+    assertThat(result.get(0).getCurrentStartTime()).isEqualTo(LocalTime.of(18, 0));
+    assertThat(result.get(0).getCurrentEndTime()).isEqualTo(LocalTime.of(23, 0));
   }
 }

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftRequestServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftRequestServiceTest.java
@@ -283,6 +283,25 @@ class ShiftRequestServiceTest {
   }
 
   @Test
+  void approveChange_whenTargetShiftHasActual_isRejectedAndLeavesItUntouched() {
+    ShiftRequest request = pendingChangeRequest();
+    Shift target = targetShift();
+    target.recordActual(LocalTime.of(18, 5), LocalTime.of(23, 10), STAFF);
+    when(shiftRequestRepository.findById("sr1")).thenReturn(Optional.of(request));
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(target));
+
+    assertThatThrownBy(() -> shiftRequestService.approve("sr1", STAFF))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("実績記録済み");
+
+    verify(shiftRepository, never()).save(any());
+    verify(shiftRequestRepository, never()).save(any());
+    assertThat(target.getWorkDate()).isEqualTo(LocalDate.of(2999, 8, 1));
+    assertThat(target.getStartTime()).isEqualTo(LocalTime.of(18, 0));
+    assertThat(target.getEndTime()).isEqualTo(LocalTime.of(23, 0));
+  }
+
+  @Test
   void approveChange_whenTargetShiftIsGone_isRejected() {
     ShiftRequest request = pendingChangeRequest();
     when(shiftRequestRepository.findById("sr1")).thenReturn(Optional.of(request));

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
@@ -298,6 +298,33 @@ class ShiftServiceTest {
   }
 
   @Test
+  void update_rejectsPlannedTimeChangeAfterActualWasRecorded() {
+    Shift shift =
+        Shift.builder()
+            .castId("c1")
+            .workDate(LocalDate.of(2026, 7, 8))
+            .startTime(LocalTime.of(18, 0))
+            .endTime(LocalTime.of(23, 0))
+            .status("CONFIRMED")
+            .build();
+    shift.setId("s1");
+    shift.recordActual(LocalTime.of(18, 5), LocalTime.of(23, 10), "staff@kizuna.test");
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(shift));
+
+    ShiftUpdateRequest request = new ShiftUpdateRequest();
+    request.setStartTime(LocalTime.of(19, 0));
+    when(shiftMapper.toPatch(request))
+        .thenReturn(new ShiftPatch(null, null, LocalTime.of(19, 0), null, null, null));
+
+    assertThatThrownBy(() -> shiftService.update("s1", request))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("実績記録済み");
+
+    verify(shiftRepository, never()).save(any());
+    assertThat(shift.getStartTime()).isEqualTo(LocalTime.of(18, 0));
+  }
+
+  @Test
   void recordActual_tracksActualTimesAndActorWithoutChangingPlan() {
     when(appProperties.getTimezone()).thenReturn("Asia/Tokyo");
     Shift shift =

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
@@ -273,6 +273,31 @@ class ShiftServiceTest {
   }
 
   @Test
+  void update_rejectsStatusDowngradeAfterActualWasRecorded() {
+    Shift shift =
+        Shift.builder()
+            .castId("c1")
+            .workDate(LocalDate.of(2026, 7, 8))
+            .startTime(LocalTime.of(18, 0))
+            .endTime(LocalTime.of(23, 0))
+            .status("CONFIRMED")
+            .build();
+    shift.setId("s1");
+    shift.recordActual(LocalTime.of(18, 5), LocalTime.of(23, 10), "staff@kizuna.test");
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(shift));
+
+    ShiftUpdateRequest request = new ShiftUpdateRequest();
+    request.setStatus("TENTATIVE");
+
+    assertThatThrownBy(() -> shiftService.update("s1", request))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("実績記録済み");
+
+    verify(shiftRepository, never()).save(any());
+    assertThat(shift.getStatus()).isEqualTo("CONFIRMED");
+  }
+
+  @Test
   void recordActual_tracksActualTimesAndActorWithoutChangingPlan() {
     when(appProperties.getTimezone()).thenReturn("Asia/Tokyo");
     Shift shift =

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
@@ -3,6 +3,7 @@ package com.kizuna.shift.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -12,7 +13,9 @@ import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.config.AppProperties;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.shift.api.dto.PublicShiftResponse;
+import com.kizuna.shift.api.dto.ShiftActualRequest;
 import com.kizuna.shift.api.dto.ShiftCreateRequest;
 import com.kizuna.shift.api.dto.ShiftMapper;
 import com.kizuna.shift.api.dto.ShiftResponse;
@@ -40,6 +43,7 @@ class ShiftServiceTest {
   @Mock private CastService castService;
   @Mock private CastRepository castRepository;
   @Mock private AppProperties appProperties;
+  @Mock private StoreContext storeContext;
 
   @InjectMocks private ShiftService shiftService;
 
@@ -124,7 +128,8 @@ class ShiftServiceTest {
 
     ShiftUpdateRequest req = new ShiftUpdateRequest();
     req.setStatus("CONFIRMED");
-    when(shiftMapper.toPatch(req)).thenReturn(new ShiftPatch(null, null, null, null, "CONFIRMED"));
+    when(shiftMapper.toPatch(req))
+        .thenReturn(new ShiftPatch(null, null, null, null, "CONFIRMED", null));
 
     ShiftResponse resp = new ShiftResponse();
     resp.setStatus("CONFIRMED");
@@ -214,6 +219,111 @@ class ShiftServiceTest {
   }
 
   @Test
+  void update_changesPublicationWithoutChangingConfirmationOrPlannedTimes() {
+    Shift shift =
+        Shift.builder()
+            .castId("c1")
+            .workDate(LocalDate.of(2026, 7, 8))
+            .startTime(LocalTime.of(18, 0))
+            .endTime(LocalTime.of(23, 0))
+            .status("CONFIRMED")
+            .publicVisible(true)
+            .build();
+    shift.setId("s1");
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(shift));
+    when(shiftRepository.save(shift)).thenReturn(shift);
+
+    ShiftUpdateRequest request = new ShiftUpdateRequest();
+    request.setPublicVisible(false);
+    when(shiftMapper.toPatch(request))
+        .thenReturn(new ShiftPatch(null, null, null, null, null, false));
+    when(shiftMapper.toResponse(shift)).thenReturn(new ShiftResponse());
+
+    shiftService.update("s1", request);
+
+    assertThat(shift.isPublicVisible()).isFalse();
+    assertThat(shift.getStatus()).isEqualTo("CONFIRMED");
+    assertThat(shift.getStartTime()).isEqualTo(LocalTime.of(18, 0));
+    assertThat(shift.getEndTime()).isEqualTo(LocalTime.of(23, 0));
+  }
+
+  @Test
+  void recordActual_tracksActualTimesAndActorWithoutChangingPlan() {
+    Shift shift =
+        Shift.builder()
+            .castId("c1")
+            .workDate(LocalDate.of(2026, 7, 8))
+            .startTime(LocalTime.of(18, 0))
+            .endTime(LocalTime.of(23, 0))
+            .status("CONFIRMED")
+            .build();
+    shift.setId("s1");
+    shift.setStoreId(1L);
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(shift));
+    when(storeContext.getStoreId()).thenReturn(1L);
+    when(shiftRepository.save(shift)).thenReturn(shift);
+    when(shiftMapper.toResponse(shift)).thenReturn(new ShiftResponse());
+    ShiftActualRequest request = new ShiftActualRequest();
+    request.setStartTime(LocalTime.of(18, 5));
+    request.setEndTime(LocalTime.of(23, 10));
+
+    shiftService.recordActual("s1", request, "staff@kizuna.test");
+
+    assertThat(shift.isAttendanceConfirmed()).isTrue();
+    assertThat(shift.getActualStartTime()).isEqualTo(LocalTime.of(18, 5));
+    assertThat(shift.getActualEndTime()).isEqualTo(LocalTime.of(23, 10));
+    assertThat(shift.getActualRecordedBy()).isEqualTo("staff@kizuna.test");
+    assertThat(shift.getActualRecordedAt()).isNotNull();
+    assertThat(shift.getStartTime()).isEqualTo(LocalTime.of(18, 0));
+    assertThat(shift.getEndTime()).isEqualTo(LocalTime.of(23, 0));
+  }
+
+  @Test
+  void recordActual_rejectsTentativeShift() {
+    Shift shift =
+        Shift.builder()
+            .castId("c1")
+            .startTime(LocalTime.of(18, 0))
+            .endTime(LocalTime.of(23, 0))
+            .status("TENTATIVE")
+            .build();
+    shift.setId("s1");
+    shift.setStoreId(1L);
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(shift));
+    when(storeContext.getStoreId()).thenReturn(1L);
+    ShiftActualRequest request = new ShiftActualRequest();
+    request.setStartTime(LocalTime.of(18, 5));
+    request.setEndTime(LocalTime.of(23, 10));
+
+    assertThatThrownBy(() -> shiftService.recordActual("s1", request, "staff@kizuna.test"))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("確定済み");
+  }
+
+  @Test
+  void recordActual_rejectsShiftFromAnotherStoreEvenWhenDirectIdLoadFindsIt() {
+    Shift shift =
+        Shift.builder()
+            .castId("c1")
+            .startTime(LocalTime.of(18, 0))
+            .endTime(LocalTime.of(23, 0))
+            .status("CONFIRMED")
+            .build();
+    shift.setId("s1");
+    shift.setStoreId(2L);
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(shift));
+    when(storeContext.getStoreId()).thenReturn(1L);
+    ShiftActualRequest request = new ShiftActualRequest();
+    request.setStartTime(LocalTime.of(18, 5));
+    request.setEndTime(LocalTime.of(23, 10));
+
+    assertThatThrownBy(() -> shiftService.recordActual("s1", request, "staff@kizuna.test"))
+        .isInstanceOf(NotFoundException.class);
+
+    verify(shiftRepository, never()).save(any());
+  }
+
+  @Test
   void delete_removes() {
     when(shiftRepository.existsById("s1")).thenReturn(true);
     shiftService.delete("s1");
@@ -250,7 +360,8 @@ class ShiftServiceTest {
             .startTime(LocalTime.of(21, 0))
             .endTime(LocalTime.of(23, 0))
             .build();
-    when(shiftRepository.findByWorkDateAndStatusOrderByStartTimeAsc(any(), any()))
+    when(shiftRepository.findByWorkDateAndStatusAndPublicVisibleTrueOrderByStartTimeAsc(
+            any(), any()))
         .thenReturn(List.of(first, second));
     when(castRepository.findByStatusOrderByDisplayOrderAsc("ACTIVE"))
         .thenReturn(List.of(activeCast("cA", "キャストA", "urlA"), activeCast("cB", "キャストB", "urlB")));
@@ -272,7 +383,8 @@ class ShiftServiceTest {
   void listPublicToday_queriesTodayInConfiguredTimezoneWithConfirmedStatus() {
     when(appProperties.getTimezone()).thenReturn("Asia/Tokyo");
     LocalDate expectedToday = LocalDate.now(ZoneId.of("Asia/Tokyo"));
-    when(shiftRepository.findByWorkDateAndStatusOrderByStartTimeAsc(any(), any()))
+    when(shiftRepository.findByWorkDateAndStatusAndPublicVisibleTrueOrderByStartTimeAsc(
+            any(), any()))
         .thenReturn(List.of());
 
     shiftService.listPublicToday();
@@ -280,7 +392,8 @@ class ShiftServiceTest {
     ArgumentCaptor<LocalDate> dateCaptor = ArgumentCaptor.forClass(LocalDate.class);
     ArgumentCaptor<String> statusCaptor = ArgumentCaptor.forClass(String.class);
     verify(shiftRepository)
-        .findByWorkDateAndStatusOrderByStartTimeAsc(dateCaptor.capture(), statusCaptor.capture());
+        .findByWorkDateAndStatusAndPublicVisibleTrueOrderByStartTimeAsc(
+            dateCaptor.capture(), statusCaptor.capture());
     assertThat(dateCaptor.getValue()).isEqualTo(expectedToday);
     assertThat(statusCaptor.getValue()).isEqualTo("CONFIRMED");
   }
@@ -300,7 +413,8 @@ class ShiftServiceTest {
             .startTime(LocalTime.of(19, 0))
             .endTime(LocalTime.of(21, 0))
             .build();
-    when(shiftRepository.findByWorkDateAndStatusOrderByStartTimeAsc(any(), any()))
+    when(shiftRepository.findByWorkDateAndStatusAndPublicVisibleTrueOrderByStartTimeAsc(
+            any(), any()))
         .thenReturn(List.of(active, orphan));
     when(castRepository.findByStatusOrderByDisplayOrderAsc("ACTIVE"))
         .thenReturn(List.of(activeCast("cA", "キャストA", "urlA")));
@@ -314,7 +428,8 @@ class ShiftServiceTest {
   @Test
   void listPublicToday_returnsEmptyWhenNoConfirmedShifts() {
     when(appProperties.getTimezone()).thenReturn("Asia/Tokyo");
-    when(shiftRepository.findByWorkDateAndStatusOrderByStartTimeAsc(any(), any()))
+    when(shiftRepository.findByWorkDateAndStatusAndPublicVisibleTrueOrderByStartTimeAsc(
+            any(), any()))
         .thenReturn(List.of());
 
     assertThat(shiftService.listPublicToday()).isEmpty();

--- a/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
+++ b/backend/src/test/java/com/kizuna/shift/application/ShiftServiceTest.java
@@ -248,7 +248,33 @@ class ShiftServiceTest {
   }
 
   @Test
+  void update_rejectsCastReassignmentAfterActualWasRecorded() {
+    Shift shift =
+        Shift.builder()
+            .castId("c1")
+            .workDate(LocalDate.of(2026, 7, 8))
+            .startTime(LocalTime.of(18, 0))
+            .endTime(LocalTime.of(23, 0))
+            .status("CONFIRMED")
+            .build();
+    shift.setId("s1");
+    shift.recordActual(LocalTime.of(18, 5), LocalTime.of(23, 10), "staff@kizuna.test");
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(shift));
+
+    ShiftUpdateRequest request = new ShiftUpdateRequest();
+    request.setCastId("c2");
+
+    assertThatThrownBy(() -> shiftService.update("s1", request))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("実績記録済み");
+
+    verify(shiftRepository, never()).save(any());
+    assertThat(shift.getCastId()).isEqualTo("c1");
+  }
+
+  @Test
   void recordActual_tracksActualTimesAndActorWithoutChangingPlan() {
+    when(appProperties.getTimezone()).thenReturn("Asia/Tokyo");
     Shift shift =
         Shift.builder()
             .castId("c1")
@@ -276,6 +302,33 @@ class ShiftServiceTest {
     assertThat(shift.getActualRecordedAt()).isNotNull();
     assertThat(shift.getStartTime()).isEqualTo(LocalTime.of(18, 0));
     assertThat(shift.getEndTime()).isEqualTo(LocalTime.of(23, 0));
+  }
+
+  @Test
+  void recordActual_rejectsFutureShift() {
+    when(appProperties.getTimezone()).thenReturn("Asia/Tokyo");
+    Shift shift =
+        Shift.builder()
+            .castId("c1")
+            .workDate(LocalDate.now(ZoneId.of("Asia/Tokyo")).plusDays(1))
+            .startTime(LocalTime.of(18, 0))
+            .endTime(LocalTime.of(23, 0))
+            .status("CONFIRMED")
+            .build();
+    shift.setId("s1");
+    shift.setStoreId(1L);
+    when(shiftRepository.findById("s1")).thenReturn(Optional.of(shift));
+    when(storeContext.getStoreId()).thenReturn(1L);
+    ShiftActualRequest request = new ShiftActualRequest();
+    request.setStartTime(LocalTime.of(18, 5));
+    request.setEndTime(LocalTime.of(23, 10));
+
+    assertThatThrownBy(() -> shiftService.recordActual("s1", request, "staff@kizuna.test"))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("未来");
+
+    verify(shiftRepository, never()).save(any());
+    assertThat(shift.isAttendanceConfirmed()).isFalse();
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/shift/domain/ShiftRequestTest.java
+++ b/backend/src/test/java/com/kizuna/shift/domain/ShiftRequestTest.java
@@ -18,35 +18,97 @@ class ShiftRequestTest {
         .build();
   }
 
+  private ShiftRequest pendingChangeRequest() {
+    return ShiftRequest.builder()
+        .castId("c1")
+        .kind(ShiftRequestKind.CHANGE)
+        .targetShiftId("s1")
+        .workDate(LocalDate.of(2999, 8, 2))
+        .startTime(LocalTime.of(19, 0))
+        .endTime(LocalTime.of(22, 0))
+        .build();
+  }
+
   @Test
   void builder_defaultsStatusToPending() {
     assertThat(pendingRequest().getStatus()).isEqualTo(ShiftRequestStatus.PENDING);
   }
 
   @Test
+  void builder_defaultsKindToNew() {
+    assertThat(pendingRequest().getKind()).isEqualTo(ShiftRequestKind.NEW);
+  }
+
+  @Test
+  void toShiftPatch_carriesOnlyRequestedDateAndTimes() {
+    ShiftPatch patch = pendingChangeRequest().toShiftPatch();
+
+    assertThat(patch.workDate()).isEqualTo(LocalDate.of(2999, 8, 2));
+    assertThat(patch.startTime()).isEqualTo(LocalTime.of(19, 0));
+    assertThat(patch.endTime()).isEqualTo(LocalTime.of(22, 0));
+    // 申請が持たない属性は「変更しない」に固定される。承認が担当キャストや確定状態を巻き込まないことの担保。
+    assertThat(patch.castId()).isNull();
+    assertThat(patch.status()).isNull();
+    assertThat(patch.publicVisible()).isNull();
+  }
+
+  @Test
+  void toShiftPatch_leavesUnrelatedShiftAttributesUntouched() {
+    Shift shift =
+        Shift.builder()
+            .castId("c1")
+            .workDate(LocalDate.of(2999, 8, 1))
+            .startTime(LocalTime.of(18, 0))
+            .endTime(LocalTime.of(23, 0))
+            .status("CONFIRMED")
+            .publicVisible(false)
+            .build();
+
+    shift.apply(pendingChangeRequest().toShiftPatch());
+
+    assertThat(shift.getWorkDate()).isEqualTo(LocalDate.of(2999, 8, 2));
+    assertThat(shift.getStartTime()).isEqualTo(LocalTime.of(19, 0));
+    assertThat(shift.getEndTime()).isEqualTo(LocalTime.of(22, 0));
+    assertThat(shift.getCastId()).isEqualTo("c1");
+    assertThat(shift.getStatus()).isEqualTo("CONFIRMED");
+    assertThat(shift.isPublicVisible()).isFalse();
+  }
+
+  @Test
+  void toShiftPatch_onNewRequest_throwsStateException() {
+    assertThatThrownBy(pendingRequest()::toShiftPatch)
+        .isInstanceOf(ShiftRequestStateException.class)
+        .hasMessageContaining("変更申請");
+  }
+
+  @Test
   void approve_fromPending_transitionsToApproved() {
     ShiftRequest request = pendingRequest();
 
-    request.approve();
+    request.approve("staff@kizuna.test");
 
     assertThat(request.getStatus()).isEqualTo(ShiftRequestStatus.APPROVED);
+    assertThat(request.getDecidedBy()).isEqualTo("staff@kizuna.test");
+    assertThat(request.getDecidedAt()).isNotNull();
   }
 
   @Test
   void decline_fromPending_transitionsToDeclined() {
     ShiftRequest request = pendingRequest();
 
-    request.decline();
+    request.decline("staff@kizuna.test");
 
     assertThat(request.getStatus()).isEqualTo(ShiftRequestStatus.DECLINED);
+    assertThat(request.getDecidedBy()).isEqualTo("staff@kizuna.test");
+    assertThat(request.getDecidedAt()).isNotNull();
   }
 
   @Test
   void approve_whenAlreadyApproved_throwsStateException() {
     ShiftRequest request = pendingRequest();
-    request.approve();
+    request.approve("staff@kizuna.test");
 
-    assertThatThrownBy(request::approve)
+    assertThatThrownBy(() -> request.approve("staff@kizuna.test"))
         .isInstanceOf(ShiftRequestStateException.class)
         .hasMessageContaining("処理済み");
   }
@@ -54,9 +116,9 @@ class ShiftRequestTest {
   @Test
   void approve_whenAlreadyDeclined_throwsStateException() {
     ShiftRequest request = pendingRequest();
-    request.decline();
+    request.decline("staff@kizuna.test");
 
-    assertThatThrownBy(request::approve)
+    assertThatThrownBy(() -> request.approve("staff@kizuna.test"))
         .isInstanceOf(ShiftRequestStateException.class)
         .hasMessageContaining("処理済み");
   }
@@ -64,9 +126,9 @@ class ShiftRequestTest {
   @Test
   void decline_whenAlreadyApproved_throwsStateException() {
     ShiftRequest request = pendingRequest();
-    request.approve();
+    request.approve("staff@kizuna.test");
 
-    assertThatThrownBy(request::decline)
+    assertThatThrownBy(() -> request.decline("staff@kizuna.test"))
         .isInstanceOf(ShiftRequestStateException.class)
         .hasMessageContaining("処理済み");
   }
@@ -74,10 +136,19 @@ class ShiftRequestTest {
   @Test
   void decline_whenAlreadyDeclined_throwsStateException() {
     ShiftRequest request = pendingRequest();
-    request.decline();
+    request.decline("staff@kizuna.test");
 
-    assertThatThrownBy(request::decline)
+    assertThatThrownBy(() -> request.decline("staff@kizuna.test"))
         .isInstanceOf(ShiftRequestStateException.class)
         .hasMessageContaining("処理済み");
+  }
+
+  @Test
+  void linkToShift_connectsApprovedNewRequestToTheShiftSourceOfTruth() {
+    ShiftRequest request = pendingRequest();
+
+    request.linkToShift("s1");
+
+    assertThat(request.getTargetShiftId()).isEqualTo("s1");
   }
 }

--- a/backend/src/test/java/com/kizuna/shift/domain/ShiftTest.java
+++ b/backend/src/test/java/com/kizuna/shift/domain/ShiftTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Test;
 
 class ShiftTest {
@@ -22,7 +23,7 @@ class ShiftTest {
   void apply_updatesOnlyNonNullFields() {
     Shift shift = baseShift();
 
-    shift.apply(new ShiftPatch(null, null, null, LocalTime.of(1, 0), "CONFIRMED"));
+    shift.apply(new ShiftPatch(null, null, null, LocalTime.of(1, 0), "CONFIRMED", null));
 
     // null のフィールドは変更されない
     assertThat(shift.getCastId()).isEqualTo("c1");
@@ -39,25 +40,48 @@ class ShiftTest {
 
     shift.apply(
         new ShiftPatch(
-            "c2", LocalDate.of(2026, 7, 9), LocalTime.of(19, 0), LocalTime.of(2, 0), "CONFIRMED"));
+            "c2",
+            LocalDate.of(2026, 7, 9),
+            LocalTime.of(19, 0),
+            LocalTime.of(2, 0),
+            "CONFIRMED",
+            false));
 
     assertThat(shift.getCastId()).isEqualTo("c2");
     assertThat(shift.getWorkDate()).isEqualTo(LocalDate.of(2026, 7, 9));
     assertThat(shift.getStartTime()).isEqualTo(LocalTime.of(19, 0));
     assertThat(shift.getEndTime()).isEqualTo(LocalTime.of(2, 0));
     assertThat(shift.getStatus()).isEqualTo("CONFIRMED");
+    assertThat(shift.isPublicVisible()).isFalse();
   }
 
   @Test
   void apply_withEmptyPatch_changesNothing() {
     Shift shift = baseShift();
 
-    shift.apply(new ShiftPatch(null, null, null, null, null));
+    shift.apply(new ShiftPatch(null, null, null, null, null, null));
 
     assertThat(shift.getCastId()).isEqualTo("c1");
     assertThat(shift.getWorkDate()).isEqualTo(LocalDate.of(2026, 7, 8));
     assertThat(shift.getStartTime()).isEqualTo(LocalTime.of(18, 0));
     assertThat(shift.getEndTime()).isEqualTo(LocalTime.of(23, 0));
     assertThat(shift.getStatus()).isEqualTo("TENTATIVE");
+    assertThat(shift.isPublicVisible()).isTrue();
+  }
+
+  @Test
+  void recordActual_keepsPlannedTimesAndTracksRecorder() {
+    Shift shift = baseShift();
+    OffsetDateTime before = OffsetDateTime.now();
+
+    shift.recordActual(LocalTime.of(18, 5), LocalTime.of(23, 10), "staff@kizuna.test");
+
+    assertThat(shift.isAttendanceConfirmed()).isTrue();
+    assertThat(shift.getActualStartTime()).isEqualTo(LocalTime.of(18, 5));
+    assertThat(shift.getActualEndTime()).isEqualTo(LocalTime.of(23, 10));
+    assertThat(shift.getActualRecordedBy()).isEqualTo("staff@kizuna.test");
+    assertThat(shift.getActualRecordedAt()).isAfterOrEqualTo(before);
+    assertThat(shift.getStartTime()).isEqualTo(LocalTime.of(18, 0));
+    assertThat(shift.getEndTime()).isEqualTo(LocalTime.of(23, 0));
   }
 }

--- a/frontend/src/_pages/cast-portal/ui/CastRequestsPage.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastRequestsPage.tsx
@@ -274,6 +274,12 @@ export function CastRequestsPage() {
                       {item.work_date} {item.start_time?.slice(0, 5)}–{item.end_time?.slice(0, 5)}
                     </p>
                     {item.note && <p className="mt-1 text-xs text-muted-foreground">{item.note}</p>}
+                    {item.status !== 'PENDING' && item.decided_by && item.decided_at && (
+                      <div className="mt-1 text-xs text-muted-foreground">
+                        <p>判断者: {item.decided_by}</p>
+                        <p>判断日時: {new Date(item.decided_at).toLocaleString('ja-JP')}</p>
+                      </div>
+                    )}
                   </CardContent>
                 </Card>
               </li>

--- a/frontend/src/_pages/cast-portal/ui/CastRequestsPage.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastRequestsPage.tsx
@@ -51,6 +51,12 @@ const STATUS_PILL_CLASS: Record<ShiftRequestStatus, string> = {
   DECLINED: 'border-transparent bg-destructive/10 text-destructive-strong',
 };
 
+const CHANGE_STATUS_LABELS: Record<ShiftRequestStatus, string> = {
+  PENDING: '変更受付済み',
+  APPROVED: '変更承認済み',
+  DECLINED: '謝絶',
+};
+
 /** 本日の 'yyyy-MM-dd' を返す（過去日拒否の下限。当日の出勤希望は許容する）。 */
 function todayStr(): string {
   return toDateStr(new Date());
@@ -249,12 +255,20 @@ export function CastRequestsPage() {
                   <CardContent className="px-3">
                     <div className="flex items-center justify-between">
                       <span className="text-sm font-medium text-foreground">{item.store_name}</span>
-                      <Badge
-                        variant="outline"
-                        className={item.status && STATUS_PILL_CLASS[item.status]}
-                      >
-                        {item.status && STATUS_LABELS[item.status]}
-                      </Badge>
+                      <div className="flex gap-1">
+                        <Badge variant="outline">
+                          {item.kind === 'CHANGE' ? '変更申請' : '新規希望'}
+                        </Badge>
+                        <Badge
+                          variant="outline"
+                          className={item.status && STATUS_PILL_CLASS[item.status]}
+                        >
+                          {item.status &&
+                            (item.kind === 'CHANGE'
+                              ? CHANGE_STATUS_LABELS[item.status]
+                              : STATUS_LABELS[item.status])}
+                        </Badge>
+                      </div>
                     </div>
                     <p className="mt-1 text-xs text-muted-foreground">
                       {item.work_date} {item.start_time?.slice(0, 5)}–{item.end_time?.slice(0, 5)}

--- a/frontend/src/_pages/cast-portal/ui/CastSchedulePage.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastSchedulePage.tsx
@@ -152,6 +152,12 @@ export function CastSchedulePage() {
                           </Button>
                         )}
                       </div>
+                      {item.attendance_confirmed && (
+                        <p className="mt-1 text-right text-xs text-success-strong">
+                          実績記録済み {formatTime(item.actual_start_time)}–
+                          {formatEndTime(item.actual_end_time)}
+                        </p>
+                      )}
                       {change && change.id === item.id && (
                         <form className="mt-3 grid gap-3" onSubmit={submitChange}>
                           <div className="grid gap-1">

--- a/frontend/src/_pages/cast-portal/ui/CastSchedulePage.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastSchedulePage.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { toast } from 'react-hot-toast';
 import { CastScheduleItem, shiftApi } from '@/entities/shift';
-import { Badge, Button, Card, CardContent } from '@/shared/ui';
+import { Badge, Button, Card, CardContent, Input, Label, Textarea } from '@/shared/ui';
 import { groupByWorkDate } from '../lib/groupSchedule';
 import {
   formatEndTime,
@@ -27,6 +28,14 @@ export function CastSchedulePage() {
   const [currentWeekStart, setCurrentWeekStart] = useState(() => weekStart(new Date()));
   const [items, setItems] = useState<CastScheduleItem[] | null>(null);
   const [hasError, setHasError] = useState(false);
+  const [change, setChange] = useState<{
+    id: string;
+    workDate: string;
+    startTime: string;
+    endTime: string;
+    note: string;
+  } | null>(null);
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -58,6 +67,38 @@ export function CastSchedulePage() {
     });
   };
 
+  const openChange = (item: CastScheduleItem) => {
+    if (!item.id) return;
+    setChange({
+      id: item.id,
+      workDate: item.work_date ?? '',
+      startTime: item.start_time?.slice(0, 5) ?? '',
+      endTime: item.end_time?.slice(0, 5) ?? '',
+      note: '',
+    });
+  };
+
+  const submitChange = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!change) return;
+    setSubmitting(true);
+    try {
+      await shiftApi.submitShiftChange({
+        target_shift_id: change.id,
+        work_date: change.workDate,
+        start_time: `${change.startTime}:00`,
+        end_time: `${change.endTime}:00`,
+        note: change.note || undefined,
+      });
+      toast.success('変更申請を提出しました');
+      setChange(null);
+    } catch {
+      toast.error('変更申請の提出に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   return (
     <div className="p-4">
       <div className="mb-4 flex items-center justify-between">
@@ -87,18 +128,89 @@ export function CastSchedulePage() {
                 <ul className="space-y-2">
                   {group.items.map(item => (
                     <li
-                      key={`${item.store_id}-${item.start_time}-${item.end_time}`}
-                      className="flex items-center justify-between text-sm text-muted-foreground"
+                      key={item.id ?? `${item.store_id}-${item.start_time}-${item.end_time}`}
+                      className="text-sm text-muted-foreground"
                     >
-                      <Badge
-                        variant="outline"
-                        className="border-transparent bg-primary/10 text-primary-strong"
-                      >
-                        {item.store_name}
-                      </Badge>
-                      <span>
-                        {formatTime(item.start_time)}–{formatEndTime(item.end_time)}
-                      </span>
+                      <div className="flex items-center justify-between">
+                        <Badge
+                          variant="outline"
+                          className="border-transparent bg-primary/10 text-primary-strong"
+                        >
+                          {item.store_name}
+                        </Badge>
+                        <span>
+                          {formatTime(item.start_time)}–{formatEndTime(item.end_time)}
+                        </span>
+                        {item.id && (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => openChange(item)}
+                          >
+                            変更申請
+                          </Button>
+                        )}
+                      </div>
+                      {change && change.id === item.id && (
+                        <form className="mt-3 grid gap-3" onSubmit={submitChange}>
+                          <div className="grid gap-1">
+                            <Label htmlFor={`change-date-${item.id}`}>変更後の日付</Label>
+                            <Input
+                              id={`change-date-${item.id}`}
+                              type="date"
+                              value={change.workDate}
+                              onChange={event =>
+                                setChange({ ...change, workDate: event.target.value })
+                              }
+                              required
+                            />
+                          </div>
+                          <div className="grid grid-cols-2 gap-3">
+                            <div className="grid gap-1">
+                              <Label htmlFor={`change-start-${item.id}`}>変更後の開始</Label>
+                              <Input
+                                id={`change-start-${item.id}`}
+                                type="time"
+                                value={change.startTime}
+                                onChange={event =>
+                                  setChange({ ...change, startTime: event.target.value })
+                                }
+                                required
+                              />
+                            </div>
+                            <div className="grid gap-1">
+                              <Label htmlFor={`change-end-${item.id}`}>変更後の終了</Label>
+                              <Input
+                                id={`change-end-${item.id}`}
+                                type="time"
+                                value={change.endTime}
+                                onChange={event =>
+                                  setChange({ ...change, endTime: event.target.value })
+                                }
+                                required
+                              />
+                            </div>
+                          </div>
+                          <div className="grid gap-1">
+                            <Label htmlFor={`change-note-${item.id}`}>備考</Label>
+                            <Textarea
+                              id={`change-note-${item.id}`}
+                              value={change.note}
+                              onChange={event => setChange({ ...change, note: event.target.value })}
+                              maxLength={500}
+                            />
+                          </div>
+                          <div className="flex justify-end gap-2">
+                            <Button type="button" variant="outline" onClick={() => setChange(null)}>
+                              キャンセル
+                            </Button>
+                            <Button type="submit" disabled={submitting}>
+                              {submitting ? '申請中...' : '変更を申請する'}
+                            </Button>
+                          </div>
+                        </form>
+                      )}
                     </li>
                   ))}
                 </ul>

--- a/frontend/src/_pages/cast-portal/ui/__tests__/CastRequestsPage.test.tsx
+++ b/frontend/src/_pages/cast-portal/ui/__tests__/CastRequestsPage.test.tsx
@@ -176,6 +176,31 @@ describe('CastRequestsPage', () => {
     expect(screen.getAllByText('変更申請')).toHaveLength(2);
   });
 
+  it('処理済みの履歴に判断者と判断日時を表示すること', async () => {
+    const decidedAt = '2026-07-31T02:18:29Z';
+    mockedMyShiftRequests.mockResolvedValue([
+      {
+        id: 'sr-approved',
+        kind: 'CHANGE',
+        work_date: '2026-08-02',
+        start_time: '19:00:00',
+        end_time: '23:00:00',
+        status: 'APPROVED',
+        decided_by: 'staff@kizuna.test',
+        decided_at: decidedAt,
+        store_id: 1,
+        store_name: '店舗A',
+      },
+    ]);
+
+    render(<CastRequestsPage />);
+
+    expect(await screen.findByText('判断者: staff@kizuna.test')).toBeInTheDocument();
+    expect(
+      screen.getByText(`判断日時: ${new Date(decidedAt).toLocaleString('ja-JP')}`)
+    ).toBeInTheDocument();
+  });
+
   it('取得に失敗した場合はエラー文言を表示すること', async () => {
     mockedMyShiftRequests.mockRejectedValue(new Error('network error'));
 

--- a/frontend/src/_pages/cast-portal/ui/__tests__/CastRequestsPage.test.tsx
+++ b/frontend/src/_pages/cast-portal/ui/__tests__/CastRequestsPage.test.tsx
@@ -145,6 +145,37 @@ describe('CastRequestsPage', () => {
     expect(screen.getByText('却下')).toBeInTheDocument();
   });
 
+  it('変更申請の結果は変更承認済み・謝絶として区別して表示すること', async () => {
+    mockedMyShiftRequests.mockResolvedValue([
+      {
+        id: 'sr-change-approved',
+        kind: 'CHANGE',
+        work_date: '2026-08-02',
+        start_time: '19:00:00',
+        end_time: '23:00:00',
+        status: 'APPROVED',
+        store_id: 1,
+        store_name: '店舗A',
+      },
+      {
+        id: 'sr-change-declined',
+        kind: 'CHANGE',
+        work_date: '2026-08-03',
+        start_time: '19:00:00',
+        end_time: '23:00:00',
+        status: 'DECLINED',
+        store_id: 1,
+        store_name: '店舗A',
+      },
+    ]);
+
+    render(<CastRequestsPage />);
+
+    expect(await screen.findByText('変更承認済み')).toBeInTheDocument();
+    expect(screen.getByText('謝絶')).toBeInTheDocument();
+    expect(screen.getAllByText('変更申請')).toHaveLength(2);
+  });
+
   it('取得に失敗した場合はエラー文言を表示すること', async () => {
     mockedMyShiftRequests.mockRejectedValue(new Error('network error'));
 

--- a/frontend/src/_pages/cast-portal/ui/__tests__/CastSchedulePage.test.tsx
+++ b/frontend/src/_pages/cast-portal/ui/__tests__/CastSchedulePage.test.tsx
@@ -3,10 +3,11 @@ import { CastSchedulePage } from '../CastSchedulePage';
 import { shiftApi } from '@/entities/shift';
 
 jest.mock('@/entities/shift', () => ({
-  shiftApi: { mySchedule: jest.fn() },
+  shiftApi: { mySchedule: jest.fn(), submitShiftChange: jest.fn() },
 }));
 
 const mockedMySchedule = shiftApi.mySchedule as jest.Mock;
+const mockedSubmitShiftChange = shiftApi.submitShiftChange as jest.Mock;
 
 function daysBetween(fromStr: string, toStr: string): number {
   const from = new Date(fromStr);
@@ -73,6 +74,39 @@ describe('CastSchedulePage', () => {
     expect(screen.getByText('18:00–20:00')).toBeInTheDocument();
     expect(screen.getByText('店舗B')).toBeInTheDocument();
     expect(screen.getByText('10:00–12:00')).toBeInTheDocument();
+  });
+
+  it('確定シフトから変更申請を提出する', async () => {
+    mockedMySchedule.mockResolvedValue([
+      {
+        id: 's1',
+        work_date: '2999-07-20',
+        start_time: '18:00:00',
+        end_time: '20:00:00',
+        status: 'CONFIRMED',
+        store_id: 1,
+        store_name: '店舗A',
+      },
+    ]);
+    mockedSubmitShiftChange.mockResolvedValue({ id: 'sr1', kind: 'CHANGE', status: 'PENDING' });
+
+    render(<CastSchedulePage />);
+
+    fireEvent.click(await screen.findByRole('button', { name: '変更申請' }));
+    fireEvent.change(screen.getByLabelText('変更後の開始'), { target: { value: '19:00' } });
+    fireEvent.change(screen.getByLabelText('変更後の終了'), { target: { value: '21:30' } });
+    fireEvent.change(screen.getByLabelText('備考'), { target: { value: '開始を遅らせたい' } });
+    fireEvent.click(screen.getByRole('button', { name: '変更を申請する' }));
+
+    await waitFor(() =>
+      expect(mockedSubmitShiftChange).toHaveBeenCalledWith({
+        target_shift_id: 's1',
+        work_date: '2999-07-20',
+        start_time: '19:00:00',
+        end_time: '21:30:00',
+        note: '開始を遅らせたい',
+      })
+    );
   });
 
   it('次週ボタンで7日後の範囲を再取得する', async () => {

--- a/frontend/src/_pages/cast-portal/ui/__tests__/CastSchedulePage.test.tsx
+++ b/frontend/src/_pages/cast-portal/ui/__tests__/CastSchedulePage.test.tsx
@@ -76,6 +76,28 @@ describe('CastSchedulePage', () => {
     expect(screen.getByText('10:00–12:00')).toBeInTheDocument();
   });
 
+  it('記録済みの当日実績を予定時間と分けて表示する', async () => {
+    mockedMySchedule.mockResolvedValue([
+      {
+        id: 's1',
+        work_date: '2026-07-20',
+        start_time: '18:00:00',
+        end_time: '20:00:00',
+        status: 'CONFIRMED',
+        attendance_confirmed: true,
+        actual_start_time: '18:05:00',
+        actual_end_time: '20:10:00',
+        store_id: 1,
+        store_name: '店舗A',
+      },
+    ]);
+
+    render(<CastSchedulePage />);
+
+    expect(await screen.findByText('18:00–20:00')).toBeInTheDocument();
+    expect(screen.getByText('実績記録済み 18:05–20:10')).toBeInTheDocument();
+  });
+
   it('確定シフトから変更申請を提出する', async () => {
     mockedMySchedule.mockResolvedValue([
       {

--- a/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
@@ -32,6 +32,7 @@ interface ShiftFormValues {
   start_time: string;
   end_time: string;
   status: string;
+  public_visible: boolean;
 }
 
 interface ShiftFormModalProps {
@@ -71,6 +72,7 @@ export function ShiftFormModal({
       start_time: '',
       end_time: '',
       status: 'TENTATIVE',
+      public_visible: true,
     },
   });
   const {
@@ -81,6 +83,9 @@ export function ShiftFormModal({
     formState: { isSubmitting },
   } = form;
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [actualStartTime, setActualStartTime] = useState('');
+  const [actualEndTime, setActualEndTime] = useState('');
+  const [recordingActual, setRecordingActual] = useState(false);
 
   useEffect(() => {
     if (!open) return;
@@ -91,7 +96,10 @@ export function ShiftFormModal({
         start_time: (editing.start_time ?? '').slice(0, 5),
         end_time: (editing.end_time ?? '').slice(0, 5),
         status: editing.status ?? '',
+        public_visible: editing.public_visible ?? true,
       });
+      setActualStartTime((editing.actual_start_time ?? '').slice(0, 5));
+      setActualEndTime((editing.actual_end_time ?? '').slice(0, 5));
     } else {
       reset({
         cast_id: casts[0]?.id ?? '',
@@ -99,6 +107,7 @@ export function ShiftFormModal({
         start_time: '18:00',
         end_time: '23:00',
         status: 'TENTATIVE',
+        public_visible: true,
       });
     }
   }, [open, editing, defaultDate, casts, reset]);
@@ -110,6 +119,7 @@ export function ShiftFormModal({
       start_time: `${values.start_time}:00`,
       end_time: `${values.end_time}:00`,
       status: values.status,
+      public_visible: values.public_visible,
     };
     try {
       if (editing) {
@@ -123,6 +133,23 @@ export function ShiftFormModal({
       onClose();
     } catch (error) {
       toast.error(getApiErrorMessage(error, 'シフトの保存に失敗しました'));
+    }
+  };
+
+  const recordActual = async () => {
+    if (!editing || !actualStartTime || !actualEndTime) return;
+    setRecordingActual(true);
+    try {
+      await shiftApi.recordActual(editing.id ?? '', {
+        start_time: `${actualStartTime}:00`,
+        end_time: `${actualEndTime}:00`,
+      });
+      toast.success('当日実績を記録しました');
+      onSaved();
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, '当日実績の記録に失敗しました'));
+    } finally {
+      setRecordingActual(false);
     }
   };
 
@@ -233,6 +260,43 @@ export function ShiftFormModal({
                 </FormItem>
               )}
             />
+            <label className="flex items-center gap-2 text-sm text-foreground">
+              <input type="checkbox" {...register('public_visible')} />
+              公開出勤表に表示する
+            </label>
+            {editing && (
+              <div className="space-y-3 border-t pt-4">
+                <p className="text-sm font-medium text-foreground">当日実績</p>
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="grid gap-2">
+                    <Label htmlFor="actual_start_time">実績開始</Label>
+                    <Input
+                      id="actual_start_time"
+                      type="time"
+                      value={actualStartTime}
+                      onChange={event => setActualStartTime(event.target.value)}
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="actual_end_time">実績終了</Label>
+                    <Input
+                      id="actual_end_time"
+                      type="time"
+                      value={actualEndTime}
+                      onChange={event => setActualEndTime(event.target.value)}
+                    />
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={!actualStartTime || !actualEndTime || recordingActual}
+                  onClick={() => void recordActual()}
+                >
+                  {recordingActual ? '記録中...' : '実績を記録'}
+                </Button>
+              </div>
+            )}
             <div className="flex items-center justify-between border-t pt-4">
               <div>
                 {editing && (

--- a/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
@@ -25,6 +25,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/shared/ui';
+import { toDateStr } from '../lib/datetime';
 
 interface ShiftFormValues {
   cast_id: string;
@@ -86,6 +87,12 @@ export function ShiftFormModal({
   const [actualStartTime, setActualStartTime] = useState('');
   const [actualEndTime, setActualEndTime] = useState('');
   const [recordingActual, setRecordingActual] = useState(false);
+  const actualUnavailableMessage =
+    editing?.status !== 'CONFIRMED'
+      ? '未確定のシフトには実績を記録できません'
+      : (editing.work_date ?? '') > toDateStr(new Date())
+        ? '未来のシフトには実績を記録できません'
+        : null;
 
   useEffect(() => {
     if (!open) return;
@@ -274,6 +281,7 @@ export function ShiftFormModal({
                       id="actual_start_time"
                       type="time"
                       value={actualStartTime}
+                      disabled={actualUnavailableMessage !== null}
                       onChange={event => setActualStartTime(event.target.value)}
                     />
                   </div>
@@ -283,14 +291,23 @@ export function ShiftFormModal({
                       id="actual_end_time"
                       type="time"
                       value={actualEndTime}
+                      disabled={actualUnavailableMessage !== null}
                       onChange={event => setActualEndTime(event.target.value)}
                     />
                   </div>
                 </div>
+                {actualUnavailableMessage && (
+                  <p className="text-xs text-muted-foreground">{actualUnavailableMessage}</p>
+                )}
                 <Button
                   type="button"
                   variant="outline"
-                  disabled={!actualStartTime || !actualEndTime || recordingActual}
+                  disabled={
+                    actualUnavailableMessage !== null ||
+                    !actualStartTime ||
+                    !actualEndTime ||
+                    recordingActual
+                  }
                   onClick={() => void recordActual()}
                 >
                   {recordingActual ? '記録中...' : '実績を記録'}

--- a/frontend/src/_pages/store-shifts/ui/ShiftRequestInbox.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftRequestInbox.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { CastResponse } from '@/entities/cast';
 import { StoreShiftRequestItem, shiftApi } from '@/entities/shift';
-import { Button } from '@/shared/ui';
+import { Badge, Button } from '@/shared/ui';
 
 interface ShiftRequestInboxProps {
   casts: CastResponse[];
@@ -77,10 +77,27 @@ export function ShiftRequestInbox({ casts, onApproved }: ShiftRequestInboxProps)
           className="flex items-center justify-between rounded-[10px] border bg-card p-4 shadow-sm"
         >
           <div>
-            <p className="text-sm font-medium text-foreground">{castName(request.cast_id)}</p>
-            <p className="text-sm text-muted-foreground">
-              {request.work_date} {request.start_time?.slice(0, 5)}–{request.end_time?.slice(0, 5)}
-            </p>
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-medium text-foreground">{castName(request.cast_id)}</p>
+              <Badge variant="outline">{request.kind === 'CHANGE' ? '変更申請' : '新規希望'}</Badge>
+            </div>
+            {request.kind === 'CHANGE' ? (
+              <>
+                <p className="text-sm text-muted-foreground">
+                  {request.current_work_date} {request.current_start_time?.slice(0, 5)}–
+                  {request.current_end_time?.slice(0, 5)}
+                </p>
+                <p className="text-sm font-medium text-foreground">
+                  {request.work_date} {request.start_time?.slice(0, 5)}–
+                  {request.end_time?.slice(0, 5)}
+                </p>
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                {request.work_date} {request.start_time?.slice(0, 5)}–
+                {request.end_time?.slice(0, 5)}
+              </p>
+            )}
             {request.note && <p className="mt-1 text-xs text-muted-foreground">{request.note}</p>}
           </div>
           <div className="flex gap-2">
@@ -91,7 +108,7 @@ export function ShiftRequestInbox({ casts, onApproved }: ShiftRequestInboxProps)
               onClick={() => decline(request.id ?? '')}
               disabled={processingId === request.id}
             >
-              辞退
+              {request.kind === 'CHANGE' ? '謝絶' : '辞退'}
             </Button>
             <Button
               type="button"
@@ -99,7 +116,7 @@ export function ShiftRequestInbox({ casts, onApproved }: ShiftRequestInboxProps)
               onClick={() => approve(request.id ?? '')}
               disabled={processingId === request.id}
             >
-              承認
+              {request.kind === 'CHANGE' ? '承認してシフト更新' : '承認'}
             </Button>
           </div>
         </li>

--- a/frontend/src/_pages/store-shifts/ui/ShiftRequestInbox.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftRequestInbox.tsx
@@ -81,7 +81,9 @@ export function ShiftRequestInbox({ casts, onApproved }: ShiftRequestInboxProps)
               <p className="text-sm font-medium text-foreground">{castName(request.cast_id)}</p>
               <Badge variant="outline">{request.kind === 'CHANGE' ? '変更申請' : '新規希望'}</Badge>
             </div>
-            {request.kind === 'CHANGE' ? (
+            {request.kind === 'CHANGE' && !request.target_shift_id ? (
+              <p className="text-sm text-destructive-strong">対象シフトは削除されました</p>
+            ) : request.kind === 'CHANGE' ? (
               <>
                 <p className="text-sm text-muted-foreground">
                   {request.current_work_date} {request.current_start_time?.slice(0, 5)}–
@@ -110,14 +112,16 @@ export function ShiftRequestInbox({ casts, onApproved }: ShiftRequestInboxProps)
             >
               {request.kind === 'CHANGE' ? '謝絶' : '辞退'}
             </Button>
-            <Button
-              type="button"
-              size="sm"
-              onClick={() => approve(request.id ?? '')}
-              disabled={processingId === request.id}
-            >
-              {request.kind === 'CHANGE' ? '承認してシフト更新' : '承認'}
-            </Button>
+            {(request.kind !== 'CHANGE' || request.target_shift_id) && (
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => approve(request.id ?? '')}
+                disabled={processingId === request.id}
+              >
+                {request.kind === 'CHANGE' ? '承認してシフト更新' : '承認'}
+              </Button>
+            )}
           </div>
         </li>
       ))}

--- a/frontend/src/_pages/store-shifts/ui/__tests__/ShiftFormModal.test.tsx
+++ b/frontend/src/_pages/store-shifts/ui/__tests__/ShiftFormModal.test.tsx
@@ -223,7 +223,7 @@ describe('シフトフォームのセレクト配線と送信ペイロード', (
   });
 
   it('当日実績は予定と別の API へ送ること', async () => {
-    renderModal({ editing: EDITING });
+    renderModal({ editing: { ...EDITING, work_date: '2000-08-02' } });
 
     fireEvent.change(await screen.findByLabelText('実績開始'), {
       target: { value: '19:35' },
@@ -238,6 +238,21 @@ describe('シフトフォームのセレクト配線と送信ペイロード', (
       })
     );
     expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [{ ...EDITING, work_date: '2999-08-02' }, '未来のシフトには実績を記録できません'],
+    [
+      { ...EDITING, work_date: '2000-08-02', status: 'TENTATIVE' },
+      '未確定のシフトには実績を記録できません',
+    ],
+  ])('記録できないシフトでは実績入力を無効にすること', async (editing, message) => {
+    renderModal({ editing });
+
+    expect(await screen.findByLabelText('実績開始')).toBeDisabled();
+    expect(screen.getByLabelText('実績終了')).toBeDisabled();
+    expect(screen.getByRole('button', { name: '実績を記録' })).toBeDisabled();
+    expect(screen.getByText(message)).toBeInTheDocument();
   });
 
   it('一覧に無いキャストを編集しても別のキャストが表示されないこと', async () => {

--- a/frontend/src/_pages/store-shifts/ui/__tests__/ShiftFormModal.test.tsx
+++ b/frontend/src/_pages/store-shifts/ui/__tests__/ShiftFormModal.test.tsx
@@ -8,6 +8,7 @@ jest.mock('@/entities/shift', () => ({
     create: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),
+    recordActual: jest.fn(),
   },
 }));
 
@@ -18,6 +19,7 @@ jest.mock('react-hot-toast', () => ({
 const mockedCreate = shiftApi.create as jest.Mock;
 const mockedUpdate = shiftApi.update as jest.Mock;
 const mockedDelete = shiftApi.delete as jest.Mock;
+const mockedRecordActual = shiftApi.recordActual as jest.Mock;
 
 const cast = (id: string, name: string): CastResponse => ({
   id,
@@ -37,6 +39,7 @@ const EDITING: ShiftResponse = {
   start_time: '19:30:00',
   end_time: '01:00:00',
   status: 'CONFIRMED',
+  public_visible: true,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 };
@@ -102,6 +105,7 @@ describe('シフトフォームのセレクト配線と送信ペイロード', (
     mockedCreate.mockResolvedValue({});
     mockedUpdate.mockResolvedValue({});
     mockedDelete.mockResolvedValue(undefined);
+    mockedRecordActual.mockResolvedValue({});
   });
 
   it('新規作成の既定値が先頭キャスト・未確定・秒付き時刻で送られること', async () => {
@@ -117,11 +121,13 @@ describe('シフトフォームのセレクト配線と送信ペイロード', (
       start_time: '18:00:00',
       end_time: '23:00:00',
       status: 'TENTATIVE',
+      public_visible: true,
     });
     // キー集合そのものが移行で増減しないことを固定する
     expect(Object.keys(payload).sort()).toEqual([
       'cast_id',
       'end_time',
+      'public_visible',
       'start_time',
       'status',
       'work_date',
@@ -175,6 +181,7 @@ describe('シフトフォームのセレクト配線と送信ペイロード', (
       start_time: '19:30:00',
       end_time: '01:00:00',
       status: 'CONFIRMED',
+      public_visible: true,
     });
     expect(mockedCreate).not.toHaveBeenCalled();
     await waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1));
@@ -201,6 +208,36 @@ describe('シフトフォームのセレクト配線と送信ペイロード', (
 
     await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(1));
     expect(mockedUpdate.mock.calls[0][1].cast_id).toBe('cast-1');
+  });
+
+  it('公開可否だけを切り替えて保存できること', async () => {
+    renderModal({ editing: EDITING });
+
+    const checkbox = await screen.findByRole('checkbox', { name: '公開出勤表に表示する' });
+    expect(checkbox).toBeChecked();
+    fireEvent.click(checkbox);
+    submit();
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(1));
+    expect(mockedUpdate.mock.calls[0][1].public_visible).toBe(false);
+  });
+
+  it('当日実績は予定と別の API へ送ること', async () => {
+    renderModal({ editing: EDITING });
+
+    fireEvent.change(await screen.findByLabelText('実績開始'), {
+      target: { value: '19:35' },
+    });
+    fireEvent.change(screen.getByLabelText('実績終了'), { target: { value: '01:10' } });
+    fireEvent.click(screen.getByRole('button', { name: '実績を記録' }));
+
+    await waitFor(() =>
+      expect(mockedRecordActual).toHaveBeenCalledWith('shift-1', {
+        start_time: '19:35:00',
+        end_time: '01:10:00',
+      })
+    );
+    expect(mockedUpdate).not.toHaveBeenCalled();
   });
 
   it('一覧に無いキャストを編集しても別のキャストが表示されないこと', async () => {

--- a/frontend/src/_pages/store-shifts/ui/__tests__/ShiftRequestInbox.test.tsx
+++ b/frontend/src/_pages/store-shifts/ui/__tests__/ShiftRequestInbox.test.tsx
@@ -88,6 +88,24 @@ describe('ShiftRequestInbox', () => {
     expect(screen.getByRole('button', { name: '謝絶' })).toBeInTheDocument();
   });
 
+  it('対象シフトが削除済みの変更申請は謝絶のみ操作できる', async () => {
+    mockedList.mockResolvedValue([
+      {
+        ...REQUEST,
+        kind: 'CHANGE',
+        work_date: '2026-08-02',
+        start_time: '19:00:00',
+        end_time: '23:30:00',
+      },
+    ]);
+
+    render(<ShiftRequestInbox casts={CASTS} onApproved={jest.fn()} />);
+
+    expect(await screen.findByText('対象シフトは削除されました')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '承認してシフト更新' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '謝絶' })).toBeInTheDocument();
+  });
+
   it('承認すると一覧とシフトを再取得すること', async () => {
     mockedList.mockResolvedValue([REQUEST]);
     mockedApprove.mockResolvedValue({ ...REQUEST, status: 'APPROVED' });

--- a/frontend/src/_pages/store-shifts/ui/__tests__/ShiftRequestInbox.test.tsx
+++ b/frontend/src/_pages/store-shifts/ui/__tests__/ShiftRequestInbox.test.tsx
@@ -64,6 +64,30 @@ describe('ShiftRequestInbox', () => {
     expect(mockedList).toHaveBeenCalledWith({ status: 'PENDING' });
   });
 
+  it('変更申請は種別と変更前後を表示し、承認操作の意味を区別する', async () => {
+    mockedList.mockResolvedValue([
+      {
+        ...REQUEST,
+        kind: 'CHANGE',
+        target_shift_id: 's1',
+        work_date: '2026-08-02',
+        start_time: '19:00:00',
+        end_time: '23:30:00',
+        current_work_date: '2026-08-01',
+        current_start_time: '18:00:00',
+        current_end_time: '23:00:00',
+      },
+    ]);
+
+    render(<ShiftRequestInbox casts={CASTS} onApproved={jest.fn()} />);
+
+    expect(await screen.findByText('変更申請')).toBeInTheDocument();
+    expect(screen.getByText('2026-08-01 18:00–23:00')).toBeInTheDocument();
+    expect(screen.getByText('2026-08-02 19:00–23:30')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '承認してシフト更新' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '謝絶' })).toBeInTheDocument();
+  });
+
   it('承認すると一覧とシフトを再取得すること', async () => {
     mockedList.mockResolvedValue([REQUEST]);
     mockedApprove.mockResolvedValue({ ...REQUEST, status: 'APPROVED' });

--- a/frontend/src/entities/shift/__tests__/shift-api.test.ts
+++ b/frontend/src/entities/shift/__tests__/shift-api.test.ts
@@ -52,6 +52,16 @@ describe('shiftApi', () => {
       })
     ).toEqual({ ok: true, url: '/platform/me/shift-requests' });
   });
+  it('submitShiftChange は /platform/me/shift-requests/changes を POST する', async () => {
+    expect(
+      await shiftApi.submitShiftChange({
+        target_shift_id: 's1',
+        work_date: '2026-07-25',
+        start_time: '19:00:00',
+        end_time: '23:30:00',
+      })
+    ).toEqual({ ok: true, url: '/platform/me/shift-requests/changes' });
+  });
   it('myShiftRequests は /platform/me/shift-requests を GET する', async () => {
     expect(await shiftApi.myShiftRequests()).toEqual({
       ok: true,
@@ -77,6 +87,17 @@ describe('shiftApi', () => {
     expect(await shiftApi.declineShiftRequest('sr1')).toEqual({
       ok: true,
       url: '/store/shift-requests/sr1/decline',
+    });
+  });
+  it('recordActual は /store/shifts/:id/actual を PUT する', async () => {
+    expect(
+      await shiftApi.recordActual('s1', {
+        start_time: '18:05:00',
+        end_time: '23:10:00',
+      })
+    ).toEqual({
+      ok: true,
+      url: '/store/shifts/s1/actual',
     });
   });
 });

--- a/frontend/src/entities/shift/api/shift.ts
+++ b/frontend/src/entities/shift/api/shift.ts
@@ -3,6 +3,8 @@ import {
   CastScheduleItem,
   CastShiftRequestItem,
   CastStoreItem,
+  ShiftActualRequest,
+  ShiftChangeRequestCreateRequest,
   ShiftCreateRequest,
   ShiftRequestCreateRequest,
   ShiftRequestResponse,
@@ -41,6 +43,13 @@ export const shiftApi = {
     const response = await apiClient.post('/platform/me/shift-requests', data);
     return response.data;
   },
+  /** 確定シフトへの変更申請を提出する。 */
+  submitShiftChange: async (
+    data: ShiftChangeRequestCreateRequest
+  ): Promise<ShiftRequestResponse> => {
+    const response = await apiClient.post('/platform/me/shift-requests/changes', data);
+    return response.data;
+  },
   /** 本人（キャスト）の出勤希望履歴を取得する（全所属店横断・全量・新しい順）。 */
   myShiftRequests: async (): Promise<CastShiftRequestItem[]> => {
     const response = await apiClient.get('/platform/me/shift-requests');
@@ -64,6 +73,11 @@ export const shiftApi = {
   /** 出勤希望を辞退する。 */
   declineShiftRequest: async (id: string): Promise<StoreShiftRequestItem> => {
     const response = await apiClient.post(`/store/shift-requests/${id}/decline`);
+    return response.data;
+  },
+  /** 予定時刻とは別に当日実績を記録する。 */
+  recordActual: async (id: string, data: ShiftActualRequest): Promise<ShiftResponse> => {
+    const response = await apiClient.put(`/store/shifts/${id}/actual`, data);
     return response.data;
   },
 };

--- a/frontend/src/entities/shift/model/types.ts
+++ b/frontend/src/entities/shift/model/types.ts
@@ -6,6 +6,14 @@ export interface ShiftResponse {
   start_time?: string;
   end_time?: string;
   status?: string;
+  public_visible?: boolean;
+  approved_by?: string;
+  approved_at?: string;
+  attendance_confirmed?: boolean;
+  actual_start_time?: string;
+  actual_end_time?: string;
+  actual_recorded_by?: string;
+  actual_recorded_at?: string;
   created_at?: string;
   updated_at?: string;
 }
@@ -17,6 +25,7 @@ export interface ShiftCreateRequest {
   start_time: string;
   end_time: string;
   status?: string;
+  public_visible?: boolean;
 }
 
 // シフト更新リクエスト
@@ -26,20 +35,28 @@ export interface ShiftUpdateRequest {
   start_time?: string;
   end_time?: string;
   status?: string;
+  public_visible?: boolean;
 }
 
 // 本人（キャスト）ポータル週間スケジュールの1件（GET /platform/me/schedule）。店舗名を内联する。
 export interface CastScheduleItem {
+  id?: string;
   work_date?: string;
   start_time?: string;
   end_time?: string;
   status?: string;
+  attendance_confirmed?: boolean;
+  actual_start_time?: string;
+  actual_end_time?: string;
+  actual_recorded_by?: string;
+  actual_recorded_at?: string;
   store_id?: number;
   store_name?: string;
 }
 
 // 出勤希望のステータス。PENDING=受付済み/APPROVED=確定済み/DECLINED=却下。
 export type ShiftRequestStatus = 'PENDING' | 'APPROVED' | 'DECLINED';
+export type ShiftRequestKind = 'NEW' | 'CHANGE';
 
 // 出勤希望の提出リクエスト（本人・cast）。work_date は 'yyyy-MM-dd'、時刻は 'HH:mm:ss'。
 export interface ShiftRequestCreateRequest {
@@ -48,6 +65,19 @@ export interface ShiftRequestCreateRequest {
   start_time: string;
   end_time: string;
   note?: string;
+}
+
+export interface ShiftChangeRequestCreateRequest {
+  target_shift_id: string;
+  work_date: string;
+  start_time: string;
+  end_time: string;
+  note?: string;
+}
+
+export interface ShiftActualRequest {
+  start_time: string;
+  end_time: string;
 }
 
 // 出勤希望提出の応答（本人ポータル）。
@@ -60,6 +90,10 @@ export interface ShiftRequestResponse {
   // 未入力はキーごと応答から消えるため undefined であって null ではない
   note?: string;
   status?: ShiftRequestStatus;
+  kind?: ShiftRequestKind;
+  target_shift_id?: string;
+  decided_by?: string;
+  decided_at?: string;
   created_at?: string;
 }
 
@@ -71,6 +105,10 @@ export interface CastShiftRequestItem {
   end_time?: string;
   note?: string;
   status?: ShiftRequestStatus;
+  kind?: ShiftRequestKind;
+  target_shift_id?: string;
+  decided_by?: string;
+  decided_at?: string;
   store_id?: number;
   store_name?: string;
   created_at?: string;
@@ -91,4 +129,11 @@ export interface StoreShiftRequestItem {
   end_time?: string;
   note?: string;
   status?: ShiftRequestStatus;
+  kind?: ShiftRequestKind;
+  target_shift_id?: string;
+  decided_by?: string;
+  decided_at?: string;
+  current_work_date?: string;
+  current_start_time?: string;
+  current_end_time?: string;
 }

--- a/frontend/src/features/cast-invitation/ui/InvitationModal.tsx
+++ b/frontend/src/features/cast-invitation/ui/InvitationModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRef } from 'react';
 import { toast } from 'react-hot-toast';
 import { Button, Dialog, DialogContent, DialogTitle, Input, Label } from '@/shared/ui';
 
@@ -14,12 +15,19 @@ interface InvitationModalProps {
 
 /** 招待発行モーダル（リンク+コピー+有効期限+跨店注記のみ。LINE送信ボタンは付けない。裁定10）。 */
 export function InvitationModal({ open, link, expiresAt, onClose }: InvitationModalProps) {
+  const linkInputRef = useRef<HTMLInputElement>(null);
+
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(link);
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(link);
+      } else {
+        linkInputRef.current?.select();
+        if (!document.execCommand('copy')) throw new Error('copy failed');
+      }
       toast.success('リンクをコピーしました');
     } catch {
-      toast.error('リンクのコピーに失敗しました');
+      toast.error('リンクをコピーできませんでした。招待リンクを選択して手動でコピーしてください。');
     }
   };
 
@@ -42,6 +50,7 @@ export function InvitationModal({ open, link, expiresAt, onClose }: InvitationMo
           <div className="grid gap-1">
             <Label htmlFor="cast-invitation-link">招待リンク</Label>
             <Input
+              ref={linkInputRef}
               id="cast-invitation-link"
               type="text"
               readOnly

--- a/frontend/src/features/cast-invitation/ui/__tests__/InvitationModal.test.tsx
+++ b/frontend/src/features/cast-invitation/ui/__tests__/InvitationModal.test.tsx
@@ -8,6 +8,7 @@ jest.mock('react-hot-toast', () => ({
 
 const mockedToast = toast as jest.Mocked<typeof toast>;
 const writeText = jest.fn();
+const execCommand = jest.fn();
 
 const LINK = 'https://store.example.com/cast/invite/abc';
 
@@ -19,6 +20,11 @@ describe('キャスト招待リンクのモーダル', () => {
       configurable: true,
       value: { writeText },
     });
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    });
+    execCommand.mockReturnValue(true);
   });
 
   it('閉じているときは何も描画しない', () => {
@@ -44,6 +50,22 @@ describe('キャスト招待リンクのモーダル', () => {
     expect(mockedToast.success).toHaveBeenCalledWith('リンクをコピーしました');
   });
 
+  it('Clipboard API が使えない場合は入力欄を選択してコピーする', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+    render(<InvitationModal open link={LINK} expiresAt={null} onClose={jest.fn()} />);
+    const input = screen.getByLabelText('招待リンク') as HTMLInputElement;
+    const select = jest.spyOn(input, 'select');
+
+    fireEvent.click(screen.getByRole('button', { name: 'コピー' }));
+
+    await waitFor(() => expect(execCommand).toHaveBeenCalledWith('copy'));
+    expect(select).toHaveBeenCalled();
+    expect(mockedToast.success).toHaveBeenCalledWith('リンクをコピーしました');
+  });
+
   it('コピー失敗は失敗トーストを出す', async () => {
     writeText.mockRejectedValue(new Error('denied'));
     render(<InvitationModal open link={LINK} expiresAt={null} onClose={jest.fn()} />);
@@ -51,7 +73,9 @@ describe('キャスト招待リンクのモーダル', () => {
     fireEvent.click(screen.getByRole('button', { name: 'コピー' }));
 
     await waitFor(() =>
-      expect(mockedToast.error).toHaveBeenCalledWith('リンクのコピーに失敗しました')
+      expect(mockedToast.error).toHaveBeenCalledWith(
+        'リンクをコピーできませんでした。招待リンクを選択して手動でコピーしてください。'
+      )
     );
   });
 


### PR DESCRIPTION
## 概要

確定済みシフトに対するキャストの変更申請から、店舗での承認・謝絶、キャスト側の結果確認までを実装します。
あわせて #379 の補足要件に基づき、公開可否・承認記録・当日実績を単一のシフト系列上で独立して管理します。

Closes #330

## 変更内容

- キャストの確定シフト画面に変更申請フォームを追加
- 新規希望と変更申請を同じ申請系列で管理し、店舗 inbox で種別と変更前後を表示
- 変更申請の承認時は対象シフトを同一行のまま更新し、謝絶時は元シフトを維持
- キャストの申請履歴に申請種別、承認・謝絶結果、判断者と判断日時を追加
- シフトの公開可否を確定状態から分離し、公開出勤表は公開中の確定シフトのみ返却
- 予定時刻と分離した当日実績、記録者、記録日時を追加
- 変更申請と実績用の API、DTO、DB migration を追加
- 店舗スコープ外のシフトを直接 ID 指定して操作できないことを検証
- code review 対応として、承認前の対象キャスト・確定状態の再検証、実績記録後のキャスト改派禁止、未来班次の実績記録拒否を追加

## 検証

<!-- 合否はすべて exit code で判定（出力は日本語ロケールのことがある） -->

- [ ] `task lint` exit 0（未実行。変更 frontend ファイルの ESLint / Prettier は個別に exit 0）
- [ ] `task test` exit 0（未実行。下記の backend / frontend テストは個別に exit 0）
- [ ] `task build` exit 0（未実行）
- [ ] `task e2e` exit 0（未実行）
- [x] ローカルで code-review 実施済み
- [x] `cd backend && ./gradlew --no-daemon spotlessCheck test compileIntegrationTestJava` exit 0
- [x] `task test-integration` exit 0（162 tests）
- [x] `cd frontend && npm test -- --runInBand` exit 0（79 suites / 524 tests）
- [x] `git diff --check` exit 0

### 視覚確認（UI 変更時）

未実施（スクリーンショット未添付）。変更対象はキャストの週間シフト・申請履歴と、店舗の出勤希望 inbox・シフト編集モーダルです。

## 決定ログ

- 変更申請専用の別集約は作らず、既存 `t_shift_requests` に `NEW` / `CHANGE` の種別と対象シフト ID を追加しました。申請状態遷移と履歴を一本化するためです。
- 変更承認では新しいシフトを作らず、対象シフトの日付・予定時刻だけを部分更新します。公開可否、実績、元の承認情報を保持するためです。
- 公開可否は確定状態から分離しました。承認と公開を同一操作にすると、内部確定後に公開時期だけを調整できないためです。
- 当日実績は予定時刻を上書きせず、専用 API と列で記録します。予定と実績の双方を監査可能にするためです。
- code review 後は新しい状態機械や追加テーブルを導入せず、既存サービス入口で不変条件を再検証する最小修正を選びました。

## 備考 / レビュー観点

- 変更申請の提出後、対象シフトが別キャストへ改派または未確定へ戻された場合に承認を拒否する境界を重点的に確認してください。
- 実績記録後のキャスト改派禁止と、アプリケーション timezone 基準の未来日拒否を重点的に確認してください。
- `frontend/src/shared/api/__tests__/file.test.ts` の既存 TypeScript 型エラーは本変更外です。
- `npm run lint:fsd` はローカル環境のファイルディスクリプタ上限により `EMFILE` で停止しました。