### PR TITLE
perf(roles): ロール一覧を権限個数の要約にし、権限の列挙は編集時の詳細取得へ分離する

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -739,11 +739,15 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
   void roleListingRequiresStaffManage() {
     String hq = platformToken(SEED_EMAIL, PASSWORD);
 
-    ResponseEntity<String> roles =
+    ResponseEntity<JsonNode> roles =
         rest.exchange(
-            "/platform/roles", HttpMethod.GET, new HttpEntity<>(bearer(hq)), String.class);
+            "/platform/roles", HttpMethod.GET, new HttpEntity<>(bearer(hq)), JsonNode.class);
     assertThat(roles.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(roles.getBody()).contains("HQ管理者").contains("店長").contains("店舗スタッフ");
+    assertThat(roles.getBody().toString()).contains("HQ管理者").contains("店長").contains("店舗スタッフ");
+    // 一覧は要約のみ：権限は個数で返し、コードの列挙（permissions）は詳細取得に委ねる。
+    JsonNode firstRole = roles.getBody().get(0);
+    assertThat(firstRole.path("permission_count").asLong()).isPositive();
+    assertThat(firstRole.has("permissions")).isFalse();
 
     String nonHq = platformToken(NON_HQ_EMAIL, PASSWORD);
     ResponseEntity<String> forbidden =
@@ -782,6 +786,17 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
     long roleId = created.getBody().path("id").asLong();
     assertThat(created.getBody().path("system").asBoolean()).isFalse();
     assertThat(created.getBody().path("permissions").get(0).asString()).isEqualTo("ORDER_MANAGE");
+
+    // 詳細は編集フォーム向けに権限コードの列挙と version を返す。
+    ResponseEntity<JsonNode> detail =
+        rest.exchange(
+            "/platform/roles/" + roleId,
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(hq)),
+            JsonNode.class);
+    assertThat(detail.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(detail.getBody().path("permissions").get(0).asString()).isEqualTo("ORDER_MANAGE");
+    assertThat(detail.getBody().has("version")).isTrue();
 
     // 存在しない権限コードは 400。
     ResponseEntity<String> unknownPermission =

--- a/backend/src/main/java/com/kizuna/user/api/dto/RoleSummaryResponse.java
+++ b/backend/src/main/java/com/kizuna/user/api/dto/RoleSummaryResponse.java
@@ -1,0 +1,7 @@
+package com.kizuna.user.api.dto;
+
+/**
+ * ロール一覧 1 件の要約応答。権限は個数（permission_count）のみで、権限コードの列挙と楽観ロック用 version は詳細（GET
+ * /platform/roles/{id}）が持つ。system は平台既定ロール（変更・削除不可）。
+ */
+public record RoleSummaryResponse(Long id, String name, boolean system, long permissionCount) {}

--- a/backend/src/main/java/com/kizuna/user/api/platform/RoleController.java
+++ b/backend/src/main/java/com/kizuna/user/api/platform/RoleController.java
@@ -2,6 +2,7 @@ package com.kizuna.user.api.platform;
 
 import com.kizuna.user.api.dto.RoleCreateRequest;
 import com.kizuna.user.api.dto.RoleResponse;
+import com.kizuna.user.api.dto.RoleSummaryResponse;
 import com.kizuna.user.api.dto.RoleUpdateRequest;
 import com.kizuna.user.application.RoleService;
 import jakarta.validation.Valid;
@@ -26,10 +27,17 @@ public class RoleController {
 
   private final RoleService roleService;
 
+  /** 一覧は権限個数までの要約。編集フォームが要る権限コードの列挙は {@link #get(Long)} で個別に取得する。 */
   @GetMapping
   @PreAuthorize("hasAuthority('PERM_STAFF_MANAGE')")
-  public ResponseEntity<List<RoleResponse>> list() {
+  public ResponseEntity<List<RoleSummaryResponse>> list() {
     return ResponseEntity.ok(roleService.list());
+  }
+
+  @GetMapping("/{id}")
+  @PreAuthorize("hasAuthority('PERM_STAFF_MANAGE')")
+  public ResponseEntity<RoleResponse> get(@PathVariable Long id) {
+    return ResponseEntity.ok(roleService.get(id));
   }
 
   @PostMapping

--- a/backend/src/main/java/com/kizuna/user/application/RoleService.java
+++ b/backend/src/main/java/com/kizuna/user/application/RoleService.java
@@ -4,6 +4,7 @@ import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.api.dto.RoleCreateRequest;
 import com.kizuna.user.api.dto.RoleResponse;
+import com.kizuna.user.api.dto.RoleSummaryResponse;
 import com.kizuna.user.api.dto.RoleUpdateRequest;
 import com.kizuna.user.domain.Permission;
 import com.kizuna.user.domain.PermissionRepository;
@@ -19,7 +20,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,15 +39,24 @@ public class RoleService {
   private final PermissionRepository permissionRepository;
   private final PlatformUserRepository platformUserRepository;
 
+  /** 一覧は権限の個数だけを返す要約。権限コードの列挙が要るのは編集時のみで、それは {@link #get(Long)} が担う。 */
   @Transactional(readOnly = true)
-  public List<RoleResponse> list() {
-    List<Role> roles = roleRepository.findAll(Sort.by("name"));
-    Set<Long> permissionIds =
-        roles.stream()
-            .flatMap(role -> role.getPermissionIds().stream())
-            .collect(Collectors.toSet());
-    Map<Long, String> codesById = codesById(permissionIds);
-    return roles.stream().map(role -> toResponse(role, codesById)).toList();
+  public List<RoleSummaryResponse> list() {
+    return roleRepository.findAllSummaries().stream()
+        .map(
+            summary ->
+                new RoleSummaryResponse(
+                    summary.getId(),
+                    summary.getName(),
+                    Boolean.TRUE.equals(summary.getSystemRole()),
+                    summary.getPermissionCount()))
+        .toList();
+  }
+
+  @Transactional(readOnly = true)
+  public RoleResponse get(Long id) {
+    Role role = roleRepository.findById(id).orElseThrow(() -> notFound(id));
+    return toResponse(role, codesById(role.getPermissionIds()));
   }
 
   @Transactional

--- a/backend/src/main/java/com/kizuna/user/domain/RoleRepository.java
+++ b/backend/src/main/java/com/kizuna/user/domain/RoleRepository.java
@@ -1,5 +1,6 @@
 package com.kizuna.user.domain;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,18 @@ import org.springframework.data.repository.query.Param;
 public interface RoleRepository extends JpaRepository<Role, Long> {
 
   Optional<Role> findByName(String name);
+
+  /**
+   * 一覧用の要約（名称昇順）。集約を経由すると EAGER の権限集合が全ロール分ロードされるため、権限は group by の件数集計だけで済ませる。
+   *
+   * <p>権限なしのロールは不変条件上存在しないが、行を落とさないよう left join にしておく。
+   */
+  @Query(
+      "select r.id as id, r.name as name, r.systemRole as systemRole,"
+          + " count(pid) as permissionCount"
+          + " from com.kizuna.user.domain.Role r left join r.permissionIds pid"
+          + " group by r.id, r.name, r.systemRole order by r.name")
+  List<RoleSummary> findAllSummaries();
 
   /**
    * 指定した権限コードを含むロールの id 集合。呼び出し側はユーザーのロール集合とこの集合の共通部分の有無で権限保持を判定する。

--- a/backend/src/main/java/com/kizuna/user/domain/RoleSummary.java
+++ b/backend/src/main/java/com/kizuna/user/domain/RoleSummary.java
@@ -1,0 +1,13 @@
+package com.kizuna.user.domain;
+
+/** ロール一覧の読み側 projection。権限は個数だけを集計し、権限集合そのものは取得しない。 */
+public interface RoleSummary {
+
+  Long getId();
+
+  String getName();
+
+  Boolean getSystemRole();
+
+  long getPermissionCount();
+}

--- a/backend/src/test/java/com/kizuna/user/application/RoleServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/RoleServiceTest.java
@@ -12,6 +12,7 @@ import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.api.dto.RoleCreateRequest;
 import com.kizuna.user.api.dto.RoleResponse;
+import com.kizuna.user.api.dto.RoleSummaryResponse;
 import com.kizuna.user.api.dto.RoleUpdateRequest;
 import com.kizuna.user.domain.Permission;
 import com.kizuna.user.domain.PermissionCode;
@@ -20,6 +21,7 @@ import com.kizuna.user.domain.PlatformUserRepository;
 import com.kizuna.user.domain.Role;
 import com.kizuna.user.domain.RoleInUseException;
 import com.kizuna.user.domain.RoleRepository;
+import com.kizuna.user.domain.RoleSummary;
 import com.kizuna.user.domain.StaleRoleUpdateException;
 import com.kizuna.user.domain.SystemRoleImmutableException;
 import java.util.List;
@@ -33,7 +35,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -79,22 +80,67 @@ class RoleServiceTest {
     return req;
   }
 
+  private RoleSummary summary(long id, String name, boolean systemRole, long permissionCount) {
+    return new RoleSummary() {
+      @Override
+      public Long getId() {
+        return id;
+      }
+
+      @Override
+      public String getName() {
+        return name;
+      }
+
+      @Override
+      public Boolean getSystemRole() {
+        return systemRole;
+      }
+
+      @Override
+      public long getPermissionCount() {
+        return permissionCount;
+      }
+    };
+  }
+
   @Test
-  void list_resolvesPermissionCodesSorted() {
-    when(roleRepository.findAll(Sort.by("name")))
-        .thenReturn(List.of(role(1L, "受付", false, Set.of(ORDER_MANAGE_ID, CUSTOMER_MANAGE_ID))));
+  void list_returnsSummariesWithoutTouchingPermissionCatalog() {
+    when(roleRepository.findAllSummaries()).thenReturn(List.of(summary(1L, "受付", false, 2L)));
+
+    List<RoleSummaryResponse> res = service.list();
+
+    assertThat(res).hasSize(1);
+    assertThat(res.get(0).name()).isEqualTo("受付");
+    assertThat(res.get(0).system()).isFalse();
+    assertThat(res.get(0).permissionCount()).isEqualTo(2L);
+    // 一覧は件数集計だけで完結する — 権限目録の解決（編集時の詳細取得の仕事）が混ざらないこと
+    verify(permissionRepository, never()).findAllById(any());
+  }
+
+  @Test
+  void get_resolvesPermissionCodesSorted() {
+    when(roleRepository.findById(1L))
+        .thenReturn(
+            Optional.of(role(1L, "受付", false, Set.of(ORDER_MANAGE_ID, CUSTOMER_MANAGE_ID))));
     when(permissionRepository.findAllById(Set.of(ORDER_MANAGE_ID, CUSTOMER_MANAGE_ID)))
         .thenReturn(
             List.of(
                 permission(ORDER_MANAGE_ID, PermissionCode.ORDER_MANAGE),
                 permission(CUSTOMER_MANAGE_ID, PermissionCode.CUSTOMER_MANAGE)));
 
-    List<RoleResponse> res = service.list();
+    RoleResponse res = service.get(1L);
 
-    assertThat(res).hasSize(1);
-    assertThat(res.get(0).name()).isEqualTo("受付");
-    assertThat(res.get(0).system()).isFalse();
-    assertThat(res.get(0).permissions()).containsExactly("CUSTOMER_MANAGE", "ORDER_MANAGE");
+    assertThat(res.name()).isEqualTo("受付");
+    assertThat(res.system()).isFalse();
+    assertThat(res.permissions()).containsExactly("CUSTOMER_MANAGE", "ORDER_MANAGE");
+  }
+
+  @Test
+  void get_unknownId_throwsNotFound() {
+    when(roleRepository.findById(404L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.get(404L)).isInstanceOf(NotFoundException.class);
   }
 
   @Test

--- a/frontend/src/_pages/platform-roles/__tests__/RolesPage.test.tsx
+++ b/frontend/src/_pages/platform-roles/__tests__/RolesPage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { RoleResponse, platformRoleApi } from '@/entities/user';
+import { RoleSummaryResponse, platformRoleApi } from '@/entities/user';
 import RolesPage from '../ui/RolesPage';
 
 jest.mock('@/entities/user', () => ({
@@ -9,8 +9,8 @@ jest.mock('@/entities/user', () => ({
 jest.mock('../ui/RoleFormModal', () => {
   const React = require('react');
   return {
-    RoleFormModal: ({ open }: { open: boolean }) =>
-      open ? React.createElement('div', null, 'ロールモーダル表示中') : null,
+    // 実体は開いたときだけ mount される。mock はマーカーだけ出す。
+    RoleFormModal: () => React.createElement('div', null, 'ロールモーダル表示中'),
   };
 });
 
@@ -20,12 +20,11 @@ jest.mock('react-hot-toast', () => ({
 
 const mockedRoleApi = platformRoleApi as jest.Mocked<typeof platformRoleApi>;
 
-const role = (override: Partial<RoleResponse>): RoleResponse => ({
+const role = (override: Partial<RoleSummaryResponse>): RoleSummaryResponse => ({
   id: 1,
   name: '店長',
-  permissions: [],
+  permission_count: 3,
   system: false,
-  version: 0,
   ...override,
 });
 
@@ -34,8 +33,27 @@ describe('ロール一覧ページ', () => {
     jest.clearAllMocks();
     mockedRoleApi.list.mockResolvedValue([
       role({ id: 1, name: '店長' }),
-      role({ id: 2, name: '受付担当' }),
+      role({ id: 2, name: '受付担当', permission_count: 1 }),
     ]);
+  });
+
+  // 一覧は権限個数までの要約で描画する（権限コードの列挙は編集モーダルが個別取得する）
+  it('権限数は一覧応答の permission_count をそのまま表示すること', async () => {
+    render(<RolesPage />);
+    await screen.findByText('店長');
+
+    expect(screen.getByText('3 件')).toBeInTheDocument();
+    expect(screen.getByText('1 件')).toBeInTheDocument();
+  });
+
+  it('モーダルは開くまで mount しないこと（権限目録の先読みを防ぐ）', async () => {
+    render(<RolesPage />);
+    await screen.findByText('店長');
+
+    expect(screen.queryByText('ロールモーダル表示中')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'ロールを追加' }));
+    expect(screen.getByText('ロールモーダル表示中')).toBeInTheDocument();
   });
 
   // ロールは全量取得のため絞り込みは取得済み配列に対して行う。再取得は走らない。

--- a/frontend/src/_pages/platform-roles/ui/RoleFormModal.tsx
+++ b/frontend/src/_pages/platform-roles/ui/RoleFormModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import {
@@ -81,17 +81,25 @@ export function RoleFormModal({ onClose, editingId, onSaved }: RoleFormModalProp
     '権限目録の取得に失敗しました'
   );
 
+  // 再試行の連打などで取得が並行しても、最新のリクエストだけがフォームを更新する
+  const requestIdRef = useRef(0);
+
   // 編集対象の詳細取得。409 の後にも呼び、最新の name / permissions / version でフォームを
-  // 初期化し直す（version 固着で再試行が同じ 409 を繰り返さないように）。
+  // 初期化し直す（version 固着で再試行が同じ 409 を繰り返さないように）。取り直し中は
+  // editingRole を空にして保存を止める — 残したままだと完了前の再送が陳腐な version で走る。
   const reloadEditingRole = useCallback(async () => {
     if (editingId === null) return;
+    const requestId = ++requestIdRef.current;
+    setEditingRole(null);
     setDetailLoadFailed(false);
     try {
       const role = await platformRoleApi.get(editingId);
+      if (requestId !== requestIdRef.current) return;
       setEditingRole(role);
       reset({ name: role.name ?? '' });
       setPermissions(role.permissions ?? []);
     } catch (error) {
+      if (requestId !== requestIdRef.current) return;
       toast.error(getApiErrorMessage(error, 'ロール情報の取得に失敗しました'));
       setDetailLoadFailed(true);
     }
@@ -173,13 +181,15 @@ export function RoleFormModal({ onClose, editingId, onSaved }: RoleFormModalProp
               id="role-name"
               type="text"
               maxLength={100}
+              // 詳細が届く前に入力させると、到着時の reset が入力を黙って上書きする
+              disabled={editingLoading}
               {...register('name', { required: true })}
             />
           </div>
           <div>
             <span className="mb-1 block text-sm font-medium text-foreground">権限</span>
-            {/* 初回の詳細取得失敗は「読み込み中」に固着させず、ダイアログ内で再試行できるようにする
-                （409 後の取り直し失敗は editingRole が残るためここには来ない — フォームはそのまま使える） */}
+            {/* 詳細取得の失敗（初回・409 後の取り直しとも）は「読み込み中」に固着させず、
+                ダイアログ内で再試行できるようにする */}
             {editingLoading && detailLoadFailed ? (
               <div className="space-y-2 rounded-md border p-3">
                 <p className="text-sm text-destructive-strong">ロール情報の取得に失敗しました</p>

--- a/frontend/src/_pages/platform-roles/ui/RoleFormModal.tsx
+++ b/frontend/src/_pages/platform-roles/ui/RoleFormModal.tsx
@@ -74,6 +74,8 @@ export function RoleFormModal({ onClose, editingId, onSaved }: RoleFormModalProp
   } = useForm<RoleFormValues>({ defaultValues: { name: '' } });
   const [permissions, setPermissions] = useState<PlatformPermission[]>([]);
   const [editingRole, setEditingRole] = useState<RoleResponse | null>(null);
+  // 初回の詳細取得に失敗したときの再試行導線用。閉じて開き直す以外の回復手段を残す。
+  const [detailLoadFailed, setDetailLoadFailed] = useState(false);
   const { items: catalog, isLoading: catalogLoading } = useManagedList<PermissionResponse>(
     () => platformRoleApi.permissions(),
     '権限目録の取得に失敗しました'
@@ -83,6 +85,7 @@ export function RoleFormModal({ onClose, editingId, onSaved }: RoleFormModalProp
   // 初期化し直す（version 固着で再試行が同じ 409 を繰り返さないように）。
   const reloadEditingRole = useCallback(async () => {
     if (editingId === null) return;
+    setDetailLoadFailed(false);
     try {
       const role = await platformRoleApi.get(editingId);
       setEditingRole(role);
@@ -90,6 +93,7 @@ export function RoleFormModal({ onClose, editingId, onSaved }: RoleFormModalProp
       setPermissions(role.permissions ?? []);
     } catch (error) {
       toast.error(getApiErrorMessage(error, 'ロール情報の取得に失敗しました'));
+      setDetailLoadFailed(true);
     }
   }, [editingId, reset]);
 
@@ -174,7 +178,16 @@ export function RoleFormModal({ onClose, editingId, onSaved }: RoleFormModalProp
           </div>
           <div>
             <span className="mb-1 block text-sm font-medium text-foreground">権限</span>
-            {catalogLoading || editingLoading ? (
+            {/* 初回の詳細取得失敗は「読み込み中」に固着させず、ダイアログ内で再試行できるようにする
+                （409 後の取り直し失敗は editingRole が残るためここには来ない — フォームはそのまま使える） */}
+            {editingLoading && detailLoadFailed ? (
+              <div className="space-y-2 rounded-md border p-3">
+                <p className="text-sm text-destructive-strong">ロール情報の取得に失敗しました</p>
+                <Button type="button" variant="outline" onClick={() => void reloadEditingRole()}>
+                  再試行
+                </Button>
+              </div>
+            ) : catalogLoading || editingLoading ? (
               <p className="text-sm text-muted-foreground">読み込み中...</p>
             ) : (
               <div className="space-y-4 rounded-md border p-3">

--- a/frontend/src/_pages/platform-roles/ui/RoleFormModal.tsx
+++ b/frontend/src/_pages/platform-roles/ui/RoleFormModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import {
@@ -18,10 +18,9 @@ interface RoleFormValues {
 }
 
 interface RoleFormModalProps {
-  open: boolean;
   onClose: () => void;
-  /** 編集対象。null なら新規作成。 */
-  editing: RoleResponse | null;
+  /** 編集対象のロール id。null なら新規作成。 */
+  editingId: number | null;
   /** 保存成功後に呼ばれる（一覧の再取得用）。 */
   onSaved: () => void;
 }
@@ -60,25 +59,46 @@ function groupByConsole(
     }));
 }
 
-/** ロールの新規作成・編集モーダル（名称 + 権限の複数選択）。 */
-export function RoleFormModal({ open, onClose, editing, onSaved }: RoleFormModalProps) {
+/**
+ * ロールの新規作成・編集モーダル（名称 + 権限の複数選択）。
+ * 開いたときだけ mount される前提。一覧は権限個数までの要約しか持たないため、編集フォームの
+ * 中身（権限コードと楽観ロック用 version）は mount 時に id で個別取得する。権限目録の取得も
+ * mount 時 = 開いた時点に遅延される。
+ */
+export function RoleFormModal({ onClose, editingId, onSaved }: RoleFormModalProps) {
   const {
     register,
     handleSubmit,
     reset,
     formState: { isSubmitting },
-  } = useForm<RoleFormValues>();
+  } = useForm<RoleFormValues>({ defaultValues: { name: '' } });
   const [permissions, setPermissions] = useState<PlatformPermission[]>([]);
+  const [editingRole, setEditingRole] = useState<RoleResponse | null>(null);
   const { items: catalog, isLoading: catalogLoading } = useManagedList<PermissionResponse>(
     () => platformRoleApi.permissions(),
     '権限目録の取得に失敗しました'
   );
 
+  // 編集対象の詳細取得。409 の後にも呼び、最新の name / permissions / version でフォームを
+  // 初期化し直す（version 固着で再試行が同じ 409 を繰り返さないように）。
+  const reloadEditingRole = useCallback(async () => {
+    if (editingId === null) return;
+    try {
+      const role = await platformRoleApi.get(editingId);
+      setEditingRole(role);
+      reset({ name: role.name ?? '' });
+      setPermissions(role.permissions ?? []);
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, 'ロール情報の取得に失敗しました'));
+    }
+  }, [editingId, reset]);
+
   useEffect(() => {
-    if (!open) return;
-    reset({ name: editing?.name ?? '' });
-    setPermissions(editing?.permissions ?? []);
-  }, [open, editing, reset]);
+    void reloadEditingRole();
+  }, [reloadEditingRole]);
+
+  // 編集モードで詳細が未着のうちは保存させない（version 無しで送る事故を防ぐ）
+  const editingLoading = editingId !== null && editingRole === null;
 
   const toggle = (code: PlatformPermission) => {
     setPermissions(current =>
@@ -92,12 +112,13 @@ export function RoleFormModal({ open, onClose, editing, onSaved }: RoleFormModal
       return;
     }
     try {
-      if (editing) {
-        await platformRoleApi.update(editing.id ?? 0, {
+      if (editingId !== null) {
+        if (editingRole === null) return;
+        await platformRoleApi.update(editingId, {
           name: values.name,
           permissions,
-          // 楽観ロック用バージョン（応答の version をそのまま往復する）
-          version: editing.version,
+          // 楽観ロック用バージョン（詳細応答の version をそのまま往復する）
+          version: editingRole.version,
         });
         toast.success('ロールを更新しました');
       } else {
@@ -108,22 +129,27 @@ export function RoleFormModal({ open, onClose, editing, onSaved }: RoleFormModal
       onClose();
     } catch (error) {
       if (isConflict(error)) {
-        // 楽観ロック競合。ここで再取得しないと editing が古い version を抱えたままになり、
-        // 再試行はもちろん閉じて開き直しても同じ 409 を繰り返す（一覧から導出しているため）。
-        // 一覧を取り直すと editing prop が入れ替わり useEffect が最新値で再初期化する。
+        // 楽観ロック競合。詳細を取り直さないと古い version を抱えたままになり、
+        // 再試行が同じ 409 を繰り返す。一覧側も権限数・名称が変わりうるので再取得する。
         toast.error('他の管理者が更新しました。最新の内容を確認してください');
         onSaved();
+        void reloadEditingRole();
       } else {
         toast.error(getApiErrorMessage(error, 'ロールの保存に失敗しました'));
       }
     }
   };
 
-  const title = editing ? `${editing.name} を編集` : 'ロールを追加';
+  const title =
+    editingId !== null
+      ? editingRole !== null
+        ? `${editingRole.name} を編集`
+        : 'ロールを編集'
+      : 'ロールを追加';
 
   return (
     <Dialog
-      open={open}
+      open
       onOpenChange={next => {
         if (!next) onClose();
       }}
@@ -148,7 +174,7 @@ export function RoleFormModal({ open, onClose, editing, onSaved }: RoleFormModal
           </div>
           <div>
             <span className="mb-1 block text-sm font-medium text-foreground">権限</span>
-            {catalogLoading ? (
+            {catalogLoading || editingLoading ? (
               <p className="text-sm text-muted-foreground">読み込み中...</p>
             ) : (
               <div className="space-y-4 rounded-md border p-3">
@@ -184,7 +210,7 @@ export function RoleFormModal({ open, onClose, editing, onSaved }: RoleFormModal
             <Button type="button" variant="outline" onClick={onClose}>
               キャンセル
             </Button>
-            <Button type="submit" disabled={isSubmitting}>
+            <Button type="submit" disabled={isSubmitting || editingLoading}>
               {isSubmitting ? '保存中...' : '保存する'}
             </Button>
           </div>

--- a/frontend/src/_pages/platform-roles/ui/RoleFormModal.tsx
+++ b/frontend/src/_pages/platform-roles/ui/RoleFormModal.tsx
@@ -174,7 +174,9 @@ export function RoleFormModal({ onClose, editingId, onSaved }: RoleFormModalProp
         <DialogTitle className="border-b px-6 py-4 text-lg font-semibold text-foreground">
           {title}
         </DialogTitle>
-        <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
+        {/* submit は取り直し（requestIdRef を読む）へ繋がるため、handleSubmit の適用を
+            イベント時まで遅らせる — 描画中の適用は react-hooks/refs が ref 読みとして拒む */}
+        <form onSubmit={event => void handleSubmit(submit)(event)} className="space-y-4 px-6 py-5">
           <div className="grid gap-1">
             <Label htmlFor="role-name">ロール名</Label>
             <Input

--- a/frontend/src/_pages/platform-roles/ui/RolesPage.tsx
+++ b/frontend/src/_pages/platform-roles/ui/RolesPage.tsx
@@ -2,7 +2,7 @@
 
 import { PlusIcon } from 'lucide-react';
 import { useState } from 'react';
-import { RoleResponse, platformRoleApi } from '@/entities/user';
+import { RoleSummaryResponse, platformRoleApi } from '@/entities/user';
 import { useDeleteAction, useManagedList } from '@/shared/lib';
 import { ListPage } from '@/widgets/list-page';
 import {
@@ -25,7 +25,10 @@ export default function RolesPage() {
     items: allRoles,
     isLoading,
     refetch,
-  } = useManagedList<RoleResponse>(() => platformRoleApi.list(), 'ロール一覧の取得に失敗しました');
+  } = useManagedList<RoleSummaryResponse>(
+    () => platformRoleApi.list(),
+    'ロール一覧の取得に失敗しました'
+  );
   const [searchTerm, setSearchTerm] = useState('');
   // ロールは定義数が限られ、GET /platform/roles も全量を返す（付与 UI のロール目録が同じ端点を
   // 使うため分頁できない）。絞り込みは取得済みの配列に対して行い、送信で確定させる。
@@ -33,18 +36,11 @@ export default function RolesPage() {
   const roles = appliedSearch
     ? allRoles.filter(role => (role.name ?? '').toLowerCase().includes(appliedSearch.toLowerCase()))
     : allRoles;
-  // フォームは 1 つだけ開く。新規と編集で実体を分けると権限目録の取得が二重に走るため、
-  // 「閉じている / 新規 / 既存の編集」を 1 つの状態で表す。
-  // 編集対象は id で保持し、role オブジェクトは現在の一覧から導出する。
-  // これにより refetch がそのままモーダル内容の最新化になる（409 リフレッシュ）。
-  // 導出元は絞り込み前の allRoles。roles から引くと、409 の再取得で他の管理者による改名が
-  // 入った瞬間に絞り込みから外れ、最新値を見せるはずのモーダルが黙って閉じてしまう。
+  // フォームは 1 つだけ開く（閉じている / 新規 / 既存 id の編集）。一覧は権限個数までの要約しか
+  // 持たないため、編集フォームの中身（権限コードと version）はモーダル側が id で個別取得する。
   const [formTarget, setFormTarget] = useState<'closed' | 'create' | number>('closed');
-  const editingRole =
-    typeof formTarget === 'number' ? (allRoles.find(role => role.id === formTarget) ?? null) : null;
-  const formOpen = formTarget === 'create' || editingRole !== null;
   // 授与中のロール削除は 409、平台既定ロールは 400。文言はサーバ側が持つ。
-  const deletion = useDeleteAction<RoleResponse>({
+  const deletion = useDeleteAction<RoleSummaryResponse>({
     remove: role => platformRoleApi.remove(role.id ?? 0),
     successMessage: 'ロールを削除しました',
     errorMessage: 'ロールの削除に失敗しました',
@@ -115,9 +111,7 @@ export default function RolesPage() {
             {roles.map(role => (
               <TableRow key={role.id}>
                 <TableCell className="font-medium text-foreground">{role.name}</TableCell>
-                <TableCell className="text-muted-foreground">
-                  {role.permissions?.length ?? 0} 件
-                </TableCell>
+                <TableCell className="text-muted-foreground">{role.permission_count} 件</TableCell>
                 <TableCell>
                   {role.system ? (
                     <Badge
@@ -163,13 +157,15 @@ export default function RolesPage() {
         </Table>
       </ListPage>
 
-      {/* モーダルは一覧の loading / empty に連動して消えないよう外殻の外に置く */}
-      <RoleFormModal
-        open={formOpen}
-        editing={editingRole}
-        onClose={() => setFormTarget('closed')}
-        onSaved={refetch}
-      />
+      {/* モーダルは一覧の loading / empty に連動して消えないよう外殻の外に置く。
+          開くまで mount しないことで、権限目録とロール詳細の取得を必要になった時点まで遅延させる */}
+      {formTarget !== 'closed' && (
+        <RoleFormModal
+          editingId={typeof formTarget === 'number' ? formTarget : null}
+          onClose={() => setFormTarget('closed')}
+          onSaved={refetch}
+        />
+      )}
       <ConfirmDialog
         open={deletion.target !== null}
         title={`${deletion.target?.name ?? ''} を削除しますか？`}

--- a/frontend/src/_pages/platform-roles/ui/__tests__/RoleFormModal.test.tsx
+++ b/frontend/src/_pages/platform-roles/ui/__tests__/RoleFormModal.test.tsx
@@ -116,9 +116,7 @@ describe('ロール編集モーダル', () => {
     fireEvent.click(screen.getByRole('button', { name: '保存する' }));
 
     await waitFor(() => expect(mockedRoleApi.update).toHaveBeenCalledTimes(2));
-    expect(mockedRoleApi.update.mock.calls[1][1]).toEqual(
-      expect.objectContaining({ version: 4 })
-    );
+    expect(mockedRoleApi.update.mock.calls[1][1]).toEqual(expect.objectContaining({ version: 4 }));
   });
 
   it('権限目録を console ごとに見出し付きで並べる', async () => {

--- a/frontend/src/_pages/platform-roles/ui/__tests__/RoleFormModal.test.tsx
+++ b/frontend/src/_pages/platform-roles/ui/__tests__/RoleFormModal.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { toast } from 'react-hot-toast';
 import type { PermissionResponse, RoleResponse } from '@/entities/user';
 import { platformRoleApi } from '@/entities/user';
@@ -72,6 +72,53 @@ describe('ロール編集モーダル', () => {
     expect(await screen.findByLabelText('ORDER_MANAGE')).toBeChecked();
     expect(screen.getByLabelText('ロール名')).toHaveValue('受付担当');
     expect(screen.getByRole('button', { name: '保存する' })).toBeEnabled();
+  });
+
+  it('詳細が届くまで名称入力を無効化する（到着時の reset が入力を上書きしないように）', async () => {
+    let resolveGet: (r: RoleResponse) => void = () => {};
+    mockedRoleApi.get.mockImplementationOnce(
+      () =>
+        new Promise<RoleResponse>(resolve => {
+          resolveGet = resolve;
+        })
+    );
+    renderModal();
+
+    expect(screen.getByLabelText('ロール名')).toBeDisabled();
+
+    await act(async () => resolveGet(role()));
+
+    expect(screen.getByLabelText('ロール名')).toBeEnabled();
+    expect(screen.getByLabelText('ロール名')).toHaveValue('受付担当');
+  });
+
+  it('409 の取り直し中は保存を無効化し、完了後は新しい version で送る', async () => {
+    // 取り直し完了前に保存が押せると、陳腐な version の再送で同じ 409 を繰り返す
+    mockedRoleApi.update.mockRejectedValueOnce({ response: { status: 409 } });
+    let resolveReload: (r: RoleResponse) => void = () => {};
+    mockedRoleApi.get.mockResolvedValueOnce(role()).mockImplementationOnce(
+      () =>
+        new Promise<RoleResponse>(resolve => {
+          resolveReload = resolve;
+        })
+    );
+    renderModal();
+    await screen.findByLabelText('ORDER_MANAGE');
+
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(mockedRoleApi.get).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole('button', { name: '保存する' })).toBeDisabled();
+
+    await act(async () => resolveReload(role({ version: 4 })));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: '保存する' })).toBeEnabled());
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(mockedRoleApi.update).toHaveBeenCalledTimes(2));
+    expect(mockedRoleApi.update.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ version: 4 })
+    );
   });
 
   it('権限目録を console ごとに見出し付きで並べる', async () => {

--- a/frontend/src/_pages/platform-roles/ui/__tests__/RoleFormModal.test.tsx
+++ b/frontend/src/_pages/platform-roles/ui/__tests__/RoleFormModal.test.tsx
@@ -58,6 +58,22 @@ describe('ロール編集モーダル', () => {
     expect(screen.getByLabelText('ロール名')).toHaveValue('受付担当');
   });
 
+  it('詳細取得に失敗したら読み込み中に固着せず、再試行で回復できる', async () => {
+    // 失敗のまま「読み込み中...」を出し続けると、閉じて開き直す以外の回復手段が無くなる
+    mockedRoleApi.get.mockRejectedValueOnce({ response: { status: 500 } });
+    renderModal();
+
+    expect(await screen.findByText('ロール情報の取得に失敗しました')).toBeInTheDocument();
+    expect(screen.queryByText('読み込み中...')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '保存する' })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: '再試行' }));
+
+    expect(await screen.findByLabelText('ORDER_MANAGE')).toBeChecked();
+    expect(screen.getByLabelText('ロール名')).toHaveValue('受付担当');
+    expect(screen.getByRole('button', { name: '保存する' })).toBeEnabled();
+  });
+
   it('権限目録を console ごとに見出し付きで並べる', async () => {
     renderModal();
 

--- a/frontend/src/_pages/platform-roles/ui/__tests__/RoleFormModal.test.tsx
+++ b/frontend/src/_pages/platform-roles/ui/__tests__/RoleFormModal.test.tsx
@@ -6,7 +6,7 @@ import { RoleFormModal } from '../RoleFormModal';
 
 jest.mock('@/entities/user', () => ({
   platformRoleApi: {
-    list: jest.fn(),
+    get: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
     permissions: jest.fn(),
@@ -32,7 +32,7 @@ const role = (override: Partial<RoleResponse> = {}): RoleResponse => ({
 const renderModal = (props: Partial<React.ComponentProps<typeof RoleFormModal>> = {}) => {
   const onClose = jest.fn();
   const onSaved = jest.fn();
-  render(<RoleFormModal open editing={role()} onClose={onClose} onSaved={onSaved} {...props} />);
+  render(<RoleFormModal editingId={5} onClose={onClose} onSaved={onSaved} {...props} />);
   return { onClose, onSaved };
 };
 
@@ -44,8 +44,18 @@ describe('ロール編集モーダル', () => {
       { code: 'CUSTOMER_MANAGE', console: 'STORE' },
       { code: 'STAFF_MANAGE', console: 'PLATFORM' },
     ]);
+    mockedRoleApi.get.mockResolvedValue(role());
     mockedRoleApi.update.mockResolvedValue({} as never);
     mockedRoleApi.create.mockResolvedValue({} as never);
+  });
+
+  // 一覧は権限個数までの要約しか持たないため、編集の中身は id での個別取得が正
+  it('編集は詳細を id で取得してフォームを初期化する', async () => {
+    renderModal();
+
+    expect(await screen.findByLabelText('ORDER_MANAGE')).toBeChecked();
+    expect(mockedRoleApi.get).toHaveBeenCalledWith(5);
+    expect(screen.getByLabelText('ロール名')).toHaveValue('受付担当');
   });
 
   it('権限目録を console ごとに見出し付きで並べる', async () => {
@@ -72,7 +82,7 @@ describe('ロール編集モーダル', () => {
     expect(screen.getByText('BILLING')).toBeInTheDocument();
   });
 
-  it('編集保存は楽観ロックの version を往復する', async () => {
+  it('編集保存は詳細応答の version を往復する', async () => {
     renderModal();
     await screen.findByLabelText('ORDER_MANAGE');
 
@@ -87,8 +97,8 @@ describe('ロール編集モーダル', () => {
     });
   });
 
-  it('新規作成は version を送らない', async () => {
-    renderModal({ editing: null });
+  it('新規作成は詳細を取得せず、version も送らない', async () => {
+    renderModal({ editingId: null });
     await screen.findByLabelText('ORDER_MANAGE');
 
     fireEvent.change(screen.getByLabelText('ロール名'), { target: { value: '新ロール' } });
@@ -100,6 +110,7 @@ describe('ロール編集モーダル', () => {
       name: '新ロール',
       permissions: ['CUSTOMER_MANAGE'],
     });
+    expect(mockedRoleApi.get).not.toHaveBeenCalled();
   });
 
   it('権限を全て外すと保存 API を呼ばず警告する', async () => {
@@ -115,8 +126,8 @@ describe('ロール編集モーダル', () => {
     expect(mockedRoleApi.update).not.toHaveBeenCalled();
   });
 
-  it('409 は一覧を再取得してモーダルを開いたままにする（version 固着で詰まないこと）', async () => {
-    // 再取得しないと editing が古い version を抱えたままになり、再試行も開き直しも同じ 409 を繰り返す。
+  it('409 は詳細と一覧を取り直してモーダルを開いたままにする（version 固着で詰まないこと）', async () => {
+    // 詳細を取り直さないと古い version を抱えたままになり、再試行が同じ 409 を繰り返す。
     mockedRoleApi.update.mockRejectedValue({ response: { status: 409 } });
     const { onClose, onSaved } = renderModal();
     await screen.findByLabelText('ORDER_MANAGE');
@@ -129,6 +140,7 @@ describe('ロール編集モーダル', () => {
       )
     );
     expect(onSaved).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedRoleApi.get).toHaveBeenCalledTimes(2));
     expect(onClose).not.toHaveBeenCalled();
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });

--- a/frontend/src/entities/user/__tests__/platform-staff-api.test.ts
+++ b/frontend/src/entities/user/__tests__/platform-staff-api.test.ts
@@ -67,6 +67,10 @@ describe('platformRoleApi', () => {
     const res = await platformRoleApi.list();
     expect(res).toEqual({ ok: true, url: '/platform/roles' });
   });
+  it('get は /platform/roles/{id} を GET する', async () => {
+    const res = await platformRoleApi.get(5);
+    expect(res).toEqual({ ok: true, url: '/platform/roles/5' });
+  });
   it('create は /platform/roles を POST する', async () => {
     const res = await platformRoleApi.create({
       name: '受付担当',

--- a/frontend/src/entities/user/api/platform-staff.ts
+++ b/frontend/src/entities/user/api/platform-staff.ts
@@ -6,6 +6,7 @@ import {
   PlatformStaffUpdateRequest,
   RoleCreateRequest,
   RoleResponse,
+  RoleSummaryResponse,
   RoleUpdateRequest,
 } from '../model/types';
 
@@ -37,8 +38,13 @@ export const platformStaffApi = {
 };
 
 export const platformRoleApi = {
-  list: async (): Promise<RoleResponse[]> => {
+  /** 一覧は権限個数までの要約。編集フォームが要る権限コードの列挙は get で個別に取得する。 */
+  list: async (): Promise<RoleSummaryResponse[]> => {
     const response = await apiClient.get('/platform/roles');
+    return response.data;
+  },
+  get: async (id: number): Promise<RoleResponse> => {
+    const response = await apiClient.get(`/platform/roles/${id}`);
     return response.data;
   },
   create: async (data: RoleCreateRequest): Promise<RoleResponse> => {

--- a/frontend/src/entities/user/model/types.ts
+++ b/frontend/src/entities/user/model/types.ts
@@ -89,7 +89,17 @@ export interface RoleRef {
   name?: string;
 }
 
-// ロール一覧の1件
+// ロール一覧の1件（要約）。権限は個数のみで、コードの列挙は詳細（RoleResponse）が持つ。
+export interface RoleSummaryResponse {
+  id?: number;
+  name?: string;
+  // 平台既定ロール。改名・権限変更・削除がいずれも拒否される。
+  // system と permission_count は Java 側が primitive のため、キーは必ず応答に含まれる。
+  system: boolean;
+  permission_count: number;
+}
+
+// ロール詳細（GET /platform/roles/{id} と作成・更新の応答）
 export interface RoleResponse {
   id?: number;
   name?: string;

--- a/frontend/src/features/staff-management/ui/RolePicker.tsx
+++ b/frontend/src/features/staff-management/ui/RolePicker.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { RoleResponse } from '@/entities/user';
+import { RoleSummaryResponse } from '@/entities/user';
 import { Label } from '@/shared/ui';
 
 interface RolePickerProps {
-  roles: RoleResponse[];
+  roles: RoleSummaryResponse[];
   isLoading: boolean;
   roleIds: number[];
   onChange: (roleIds: number[]) => void;

--- a/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
+++ b/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import {
   PlatformStoreScopeType,
-  RoleResponse,
+  RoleSummaryResponse,
   platformRoleApi,
   platformStaffApi,
 } from '@/entities/user';
@@ -38,7 +38,7 @@ export function StaffCreateModal({ open, onClose, onCreated }: StaffCreateModalP
   const [roleIds, setRoleIds] = useState<number[]>([]);
   const [storeScopeType, setStoreScopeType] = useState<PlatformStoreScopeType>('ALL_STORES');
   const [storeIds, setStoreIds] = useState<number[]>([]);
-  const { items: roles, isLoading: rolesLoading } = useManagedList<RoleResponse>(
+  const { items: roles, isLoading: rolesLoading } = useManagedList<RoleSummaryResponse>(
     () => platformRoleApi.list(),
     'ロール一覧の取得に失敗しました'
   );

--- a/frontend/src/features/staff-management/ui/StaffEditModal.tsx
+++ b/frontend/src/features/staff-management/ui/StaffEditModal.tsx
@@ -6,7 +6,7 @@ import {
   PlatformStaffResponse,
   PlatformStore,
   PlatformStoreScopeType,
-  RoleResponse,
+  RoleSummaryResponse,
   platformAuthApi,
   platformRoleApi,
   platformStaffApi,
@@ -38,7 +38,7 @@ export function StaffEditModal({ open, onClose, staff, onUpdated }: StaffEditMod
     () => platformAuthApi.stores(),
     '店舗一覧の取得に失敗しました'
   );
-  const { items: roles, isLoading: rolesLoading } = useManagedList<RoleResponse>(
+  const { items: roles, isLoading: rolesLoading } = useManagedList<RoleSummaryResponse>(
     () => platformRoleApi.list(),
     'ロール一覧の取得に失敗しました'
   );

--- a/frontend/src/features/staff-management/ui/__tests__/StaffCreateModal.test.tsx
+++ b/frontend/src/features/staff-management/ui/__tests__/StaffCreateModal.test.tsx
@@ -31,8 +31,8 @@ describe('スタッフ新規作成モーダル', () => {
     jest.clearAllMocks();
     mockedAuthApi.stores.mockResolvedValue([{ id: 9, name: '店舗A' }]);
     mockedRoleApi.list.mockResolvedValue([
-      { id: 3, name: '店長', system: true, permissions: [], version: 0 },
-      { id: 4, name: '経理', system: false, permissions: [], version: 0 },
+      { id: 3, name: '店長', system: true, permission_count: 0 },
+      { id: 4, name: '経理', system: false, permission_count: 0 },
     ]);
     mockedStaffApi.create.mockResolvedValue({} as never);
   });

--- a/frontend/src/features/staff-management/ui/__tests__/StaffEditModal.test.tsx
+++ b/frontend/src/features/staff-management/ui/__tests__/StaffEditModal.test.tsx
@@ -45,8 +45,8 @@ describe('スタッフ授権編集モーダル', () => {
     jest.clearAllMocks();
     mockedAuthApi.stores.mockResolvedValue([]);
     mockedRoleApi.list.mockResolvedValue([
-      { id: 3, name: '店長', system: true, permissions: [], version: 0 },
-      { id: 4, name: '経理', system: false, permissions: [], version: 0 },
+      { id: 3, name: '店長', system: true, permission_count: 0 },
+      { id: 4, name: '経理', system: false, permission_count: 0 },
     ]);
     mockedStaffApi.update.mockResolvedValue({} as never);
   });


### PR DESCRIPTION
## 概要

ロール一覧を開くたびに全ロールの権限集合と権限目録（/platform/permissions）まで読み込んでいたのを、一覧は group by 集計の権限個数だけを返す要約に置き換え、権限コードの列挙は編集モーダルを開いた時点の詳細取得へ分離した。

## 変更内容

- バックエンド: `GET /platform/roles` を要約応答（`permission_count`）へ変更。`RoleSummary` projection（JPQL group by）で集約を経由せず件数を集計し、EAGER の権限集合ロードを排除
- バックエンド: `GET /platform/roles/{id}` を新設。編集フォーム向けに権限コードの列挙と楽観ロック用 `version` を返す
- フロント: ロール編集モーダルを開くまで mount しない構造にし、権限目録とロール詳細の取得を編集時点まで遅延。409 競合時は詳細を取り直して version 固着を防ぐ
- フロント: スタッフ管理のロール選択（RolePicker / Staff*Modal）は要約型（id/name のみ使用）へ型を差し替え

## 検証

- [x] `task lint` exit 0
- [x] `task test-unit` 相当（backend `./gradlew test` exit 0 / frontend Jest 79 suites 521 tests 全緑）
- [ ] `task build`（CI の Lint and Test ジョブで実行される）
- [ ] `task e2e`（ローカルで複数セッションの docker が並行しており実行不能。roles.feature は本変更で断言対象の画面要素が変わらないことを確認済み）
- [ ] ローカルで code-review 実施済み

統合テスト: `task test-integration` を 2 回実行し、本変更が触る `PlatformStaffManagementIT` は 19/19 緑（一覧の permission_count / permissions 非列挙 / GET /{id} の新断言を含む）。`PlatformStoreApiIT.updateInvalidatesDomainLookupCache`（店舗ドメイン照会キャッシュ失効）だけが全量実行時に落ちるが、単独実行では緑で、本変更とは無関係（ローカルで複数セッションの compose が同一プロジェクト名を共有して干渉している疑い）。CI での確認を根拠とする。

## 決定ログ

- 一覧応答から `version` も落とした。楽観ロックの往復は詳細（GET /{id}）が担うため、一覧に残すと陳腐な version を掴む経路が復活する
- 件数集計は domain 層の interface projection（`RoleSummary`）+ JPQL `group by`。`OrderView` の既存読み側 projection パターンに合わせた。left join にしたのは、権限ゼロのロール（不変条件上は存在しない）が行ごと消えるのを防ぐ保険
- モーダルは常駐 mount + open prop から「開いたときだけ mount」へ変更。これにより権限目録（/platform/permissions）の取得もページ表示時から編集時へ自然に遅延する
- 409 時のフォーム最新化は「一覧から編集対象を導出して refetch で入れ替える」旧方式から「モーダル自身が詳細を取り直す」方式へ。一覧が要約になったため旧方式は成立しない

## 備考 / レビュー観点

- 応答形状の変更（一覧から `permissions` が消え `permission_count` が入る）はワイヤ契約変更。フロントの消費箇所は全て追随済み（RolesPage / RolePicker / Staff*Modal）
- `PlatformStoreApiIT` の flaky はこの PR とは別件。再現条件（全量実行時のみ）が安定しているため、必要なら別 issue に切り出す

🤖 Generated with [Claude Code](https://claude.com/claude-code)