### PR TITLE
fix(validation): 招待受諾とスタッフ作成の email に @Size(max=255) を課し列長違反の 500・誤帰属 400 を防ぐ

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/cast/PlatformCastInvitationAcceptanceIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/cast/PlatformCastInvitationAcceptanceIT.java
@@ -167,6 +167,24 @@ class PlatformCastInvitationAcceptanceIT extends CrossStoreTestSupport {
   }
 
   @Test
+  @DisplayName("列長(255)を超えるメールでの新規登録受諾は 400 で拒否され、副作用がないこと")
+  void tooLongEmailRegistrationIsRejected() {
+    String castId = createCast(STORE_A, "長すぎメール受諾テスト");
+    String token = issue(castId, STORE_A);
+    // t_users.email は VARCHAR(255)。@Email は形式のみで長さを見ないため、@Size が無いと列長超過の生 DB エラー(500)になる。
+    // ローカル部は @Email の上限 64 文字、ドメインはラベル 63 文字以内で組み、形式は合法のまま 255 字を超える。
+    String label = "a".repeat(63);
+    String email = "b".repeat(64) + "@" + label + "." + label + "." + label + ".kizuna.test";
+    long before = platformUserRepository.count();
+
+    ResponseEntity<JsonNode> res = acceptNewUser(token, email, "password1234", "花子");
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(platformUserRepository.count()).isEqualTo(before);
+    assertThat(platformUserRepository.findByEmail(email)).isEmpty();
+  }
+
+  @Test
   @DisplayName("既存 CAST アカウントの受諾で所属店舗が追加され、档案に紐づくこと")
   void existingCastAcceptanceAddsStoreAndLinks() {
     PlatformUser castUser = ensureExistingCastUser();

--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -281,6 +281,30 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
   }
 
   @Test
+  @DisplayName("列長(255)を超えるメールでの作成は email 由来の 400 で拒否され、副作用がないこと")
+  void tooLongEmailCreateIsRejected() {
+    String hq = platformToken(SEED_EMAIL, PASSWORD);
+    // t_users.email は VARCHAR(255)。@Email は形式のみで長さを見ないため、@Size が無いと列長違反が
+    // 保存時の DataIntegrityViolationException 変換に吸われ「指定された店舗が存在しません」へ誤帰属する。
+    // ローカル部は @Email の上限 64 文字、ドメインはラベル 63 文字以内で組み、形式は合法のまま 255 字を超える。
+    String label = "a".repeat(63);
+    String email = "b".repeat(64) + "@" + label + "." + label + "." + label + ".kizuna.test";
+
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/platform/staff",
+            new HttpEntity<>(
+                createBody(email, rolesJson("店舗スタッフ"), "ALL_STORES", "[]"), bearerJson(hq)),
+            JsonNode.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(res.getBody().path("details").has("email"))
+        .as("列長超過は email 由来の検証エラーとして返ること（店舗エラーへの誤帰属でないこと）")
+        .isTrue();
+    assertThat(platformUserRepository.findByEmail(email)).isEmpty();
+  }
+
+  @Test
   @DisplayName("存在しない能力束 id での作成は 400 で拒否")
   void unknownRoleRejected() {
     String hq = platformToken(SEED_EMAIL, PASSWORD);

--- a/backend/src/main/java/com/kizuna/cast/api/dto/CastInvitationAcceptRequest.java
+++ b/backend/src/main/java/com/kizuna/cast/api/dto/CastInvitationAcceptRequest.java
@@ -11,6 +11,7 @@ public class CastInvitationAcceptRequest {
 
   @NotBlank(message = "email is required")
   @Email(message = "email format is invalid")
+  @Size(max = 255)
   private String email;
 
   @NotBlank(message = "password is required")

--- a/backend/src/main/java/com/kizuna/user/api/dto/PlatformStaffCreateRequest.java
+++ b/backend/src/main/java/com/kizuna/user/api/dto/PlatformStaffCreateRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.Set;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +22,7 @@ public class PlatformStaffCreateRequest {
 
   @NotBlank(message = "email is required")
   @Email(message = "email format is invalid")
+  @Size(max = 255)
   private String email;
 
   @NotBlank(message = "password is required")

--- a/frontend/src/features/cast-invite-accept/ui/RegisterForm.tsx
+++ b/frontend/src/features/cast-invite-accept/ui/RegisterForm.tsx
@@ -52,6 +52,7 @@ export function RegisterForm({ token, initialDisplayName, onSuccess, onBack }: R
           type="email"
           autoComplete="email"
           required
+          maxLength={255}
           className="auth-field__input"
           placeholder="example@mail.com"
           {...register('email', { required: true })}

--- a/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
+++ b/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
@@ -89,7 +89,12 @@ export function StaffCreateModal({ open, onClose, onCreated }: StaffCreateModalP
         <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
           <div className="grid gap-1">
             <Label htmlFor="staff-email">メールアドレス</Label>
-            <Input id="staff-email" type="email" {...register('email', { required: true })} />
+            <Input
+              id="staff-email"
+              type="email"
+              maxLength={255}
+              {...register('email', { required: true })}
+            />
           </div>
           <div className="grid gap-1">
             <Label htmlFor="staff-password">初期パスワード</Label>


### PR DESCRIPTION
## 概要

#544 の codex 指摘（@Email は形式のみで長さを検証しない）と同根因の既存 2 経路を修理する。255 字を超える合法形式のメールが `t_users.email VARCHAR(255)` の列長違反まで到達し、招待受諾では生の DB エラー（500）、スタッフ作成では保存時の例外変換に吸われ「指定された店舗が存在しません」への誤帰属 400 になっていた。

## 変更内容

- `CastInvitationAcceptRequest.email` / `PlatformStaffCreateRequest.email` に `@Size(max = 255)` を追加（#544 の member 側と同型）
- 統合テスト各 1 件追加: 超長メールが 400 かつ副作用なし
  - `PlatformCastInvitationAcceptanceIT.tooLongEmailRegistrationIsRejected`
  - `PlatformStaffManagementIT.tooLongEmailCreateIsRejected`（誤帰属を検出するため「エラーが `details.email` に帰属すること」まで断言）
- 前端の対応フォーム（招待受諾 `RegisterForm` / スタッフ追加 `StaffCreateModal`）のメール入力に `maxLength={255}`

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task test-unit` と `task test-integration` を個別に実行、いずれも exit 0。統合は単独実行）
- [x] `task build` exit 0
- [ ] `task e2e` 未実行（検証注釈のみの変更で、既存 e2e シナリオに 255 字超メールの経路はない）
- [ ] ローカルで code-review 実施済み

新テスト 2 件は赤→緑を両方向で実証済み: `@Size` を外した状態で cast 側は 500（AssertionFailedError）、スタッフ側は誤帰属 400 の検出で赤になり、修正を戻すと緑。

## 決定ログ

- **テストメールの構成**: Hibernate の `@Email` 自体にローカル部 ≤64 字・ドメインラベル ≤63 字の制限があるため、単純な `"a".repeat(300)+"@x.com"` は形式検証で弾かれ `@Size` の証明にならない。「64 字ローカル部 + 63 字ラベル ×3 のドメイン」（計 268 字）で形式合法のまま 255 字を超える構成にした。
- **スタッフ側の断言強化**: 修正前でも `PlatformStaffService.save` の `DataIntegrityViolationException` 変換が列長違反を吸って 400 を返すため、ステータスだけの断言では修正の有無で赤緑が変わらない。エラーの帰属先（`details.email`）まで断言して初めて赤になることを確認した。
- **`PlatformLoginRequest` は対象外**: 参照（検索）のみで INSERT に到達しないため。

## 備考 / レビュー観点

- ローカル code-review は未実施。必要ならレビュー後に対応する。
- UI 変更は `maxLength` 属性のみで見た目の変化はないため、視覚確認スクリーンショットは省略。

🤖 Generated with [Claude Code](https://claude.com/claude-code)