### PR TITLE
fix(cache): キャッシュ書き込みを即時化し、失効前の値を読める競合窓を閉じる

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/shared/CacheTransactionAwarenessIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/shared/CacheTransactionAwarenessIT.java
@@ -8,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.transaction.TransactionAwareCacheDecorator;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * キャッシュが事務対応で組み上がっていることを固定する IT。
@@ -29,5 +31,21 @@ class CacheTransactionAwarenessIT {
     assertThat(cacheManager.getCache("systemConfigValues"))
         .as("システム設定のキャッシュ（装飾は CacheManager 単位なので全キャッシュに効く）")
         .isInstanceOf(TransactionAwareCacheDecorator.class);
+  }
+
+  // Spring Data Redis 4 の RedisCacheWriter は Lettuce 環境で書き込み（put/evict/clear）を
+  // 非同期 fire-and-forget で行うのが既定。失効の完了を待たずに応答が返るため、
+  // 「更新 204 → 公開照会」の順で叩いても照会が失効前の値を読める競合窓が開く。
+  // immediateWrites の配線が外れると全 @CacheEvict がこの競合に戻るので、内部フラグで固定する。
+  // （競合自体は負荷依存で決定的に再現できないため、断言面は挙動でなく配線に置く）
+  @Test
+  @DisplayName("キャッシュ書き込みは即時（同期）であること — 失効完了前に応答が返らない")
+  void cacheWritesAreImmediate() {
+    assertThat(cacheManager).isInstanceOf(RedisCacheManager.class);
+    Object writer = ReflectionTestUtils.getField(cacheManager, "cacheWriter");
+    assertThat(writer).as("既定の DefaultRedisCacheWriter 構成であること").isNotNull();
+    assertThat(ReflectionTestUtils.getField(writer, "asynchronousWrites"))
+        .as("非同期書き込みが無効化されていること（immediateWrites）")
+        .isEqualTo(false);
   }
 }

--- a/backend/src/main/java/com/kizuna/shared/config/CacheConfig.java
+++ b/backend/src/main/java/com/kizuna/shared/config/CacheConfig.java
@@ -4,6 +4,8 @@ import org.springframework.boot.cache.autoconfigure.RedisCacheManagerBuilderCust
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheWriter;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 
 /** キャッシュ設定クラス。実体は Redis（{@code spring.cache.type: redis}）。 */
 @Configuration
@@ -20,5 +22,24 @@ public class CacheConfig {
   @Bean
   RedisCacheManagerBuilderCustomizer transactionAwareCacheManagerCustomizer() {
     return builder -> builder.transactionAware();
+  }
+
+  /**
+   * キャッシュ書き込み（put / evict / clear）を即時＝同期にする。
+   *
+   * <p>Spring Data Redis 4 の既定は Lettuce 環境で非同期 fire-and-forget：{@code @CacheEvict} の失効が Redis
+   * へ届くのを待たずに応答が返るため、「更新の成功応答を受けてから照会する」クライアントでも失効前の 値を読める競合窓が開く（失効の read-your-writes
+   * が壊れる）。書き込みを同期へ戻してこの窓を閉じる。
+   *
+   * <p>{@code immediateWrites(true)} 以外の構成（非ロック・KEYS バッチ・統計なし）は既定 writer と同一。 配線は {@code
+   * CacheTransactionAwarenessIT} が固定する。
+   */
+  @Bean
+  RedisCacheManagerBuilderCustomizer immediateCacheWritesCustomizer(
+      RedisConnectionFactory connectionFactory) {
+    return builder ->
+        builder.cacheWriter(
+            RedisCacheWriter.create(
+                connectionFactory, configurer -> configurer.immediateWrites(true)));
   }
 }


### PR DESCRIPTION
## 概要

`PlatformStoreApiIT.updateInvalidatesDomainLookupCache` がスイート全量実行でのみ落ちる順序依存 flaky の根因を特定し修正した。Spring Data Redis 4 はキャッシュ書き込み（put / evict / clear）を非同期 fire-and-forget で行うのが既定（[spring-data-redis#3348](https://github.com/spring-projects/spring-data-redis/issues/3348)）で、`@CacheEvict` の失効（KEYS+UNLINK）の完了を待たずに 204 が返るため、更新の成功応答後の公開照会が失効前の値を読める競合窓が開いていた。書き込みを `immediateWrites(true)` で同期へ戻して窓を閉じる。

## 変更内容

- `CacheConfig`: `RedisCacheWriter.create(factory, c -> c.immediateWrites(true))` の writer へ差し替える customizer を追加（同期化以外の構成 — 非ロック・KEYS バッチ・統計なし — は既定 writer と同一）
- `CacheTransactionAwarenessIT`: 書き込みが即時（`asynchronousWrites=false`）であることを反射で固定する断言を追加（競合自体は負荷依存で決定的に再現できないため、断言面は挙動でなく配線に置く）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task -d backend test-unit` 相当の `./gradlew test` + `task test-integration` 全量 25 クラス 0 失敗）
- [x] `task build` exit 0（service=backend）
- [ ] `task e2e` 未実施（バックエンドのキャッシュ配線のみで UI 変更なし）
- [x] 回帰断言の紅緑双方向検証済み（修正前: `expected: false but was: true` で紅 / 修正後: 緑）

## 決定ログ

- **根因の実測**: 失敗運転の JUnit XML（SQL 轨跡: `update t_stores` 後に照会クエリなし＝キャッシュヒット）→ `redis-cli monitor` で `KEYS → GET（陳腐値ヒット）→ UNLINK` の順序を捕捉（UNLINK が GET より 13μs 遅い）→ 4.1.0 の `DefaultRedisCacheWriter.clear()` バイトコードで `thenAccept(...)` により future が破棄されることを確認、の三段で特定。再現率は ZZZ 前綴の反復テスト（update→lookup ×150）で 1/6 → 2/3 まで引き上げて検証した（診断用のため commit には含めない）。
- **断言面を配線に置いた理由**: 競合は負荷依存で、行動断言では「修正と無関係に緑」になり得るため。装飾の実在を固定する既存 `CacheTransactionAwarenessIT` の流儀に揃えた。
- **見送った代替案**: `@CacheEvict(allEntries)` をキー単位 evict へ変える案は、非同期書き込みが残る限り同じ競合が残るため不採用。transactionAware() の撤去は（cache interceptor が事務の外側で走るため実際には介入しない死配線と判明したが）本修正と独立の意思決定なので触れていない。

## 備考 / レビュー観点

- 反射断言（`cacheWriter` / `asynchronousWrites` フィールド名）は Spring Data Redis のアップグレードで NoSuchField として大声で壊れる想定 — その時点で同期性の再検証を強制する意図的な設計。
- transactionAware() が実際には介入していない件は将来の整理候補（本 PR の範囲外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)