### PR TITLE
fix(validation): email の @Size 上限を小文字化伸長を見込んだ 127 に統一する

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/cast/PlatformCastInvitationAcceptanceIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/cast/PlatformCastInvitationAcceptanceIT.java
@@ -185,6 +185,23 @@ class PlatformCastInvitationAcceptanceIT extends CrossStoreTestSupport {
   }
 
   @Test
+  @DisplayName("小文字化で列長(255)を超えるメールでの新規登録受諾は 400 で拒否され、副作用がないこと")
+  void lowercaseExpandingEmailRegistrationIsRejected() {
+    String castId = createCast(STORE_A, "伸長メール受諾テスト");
+    String token = issue(castId, STORE_A);
+    // U+0130 は永続化前の小文字化で 2 文字に伸長する。原文 146 字は @Email を通過するが
+    // 小文字化後は 280 字となり VARCHAR(255) を超えるため、@Size は伸長を見込んだ上限で拒否する必要がある。
+    String label = "İ".repeat(10);
+    String email = "İ".repeat(64) + "@" + (label + ".").repeat(7) + "test";
+    long before = platformUserRepository.count();
+
+    ResponseEntity<JsonNode> res = acceptNewUser(token, email, "password1234", "花子");
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(platformUserRepository.count()).isEqualTo(before);
+  }
+
+  @Test
   @DisplayName("既存 CAST アカウントの受諾で所属店舗が追加され、档案に紐づくこと")
   void existingCastAcceptanceAddsStoreAndLinks() {
     PlatformUser castUser = ensureExistingCastUser();

--- a/backend/src/integrationTest/java/com/kizuna/member/PlatformMemberRegistrationIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/member/PlatformMemberRegistrationIT.java
@@ -9,6 +9,7 @@ import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
+import java.util.Locale;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -116,6 +117,20 @@ class PlatformMemberRegistrationIT extends CrossStoreTestSupport {
 
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     assertThat(platformUserRepository.findByEmail(email)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("小文字化で列長(255)を超えるメールアドレスでの登録は 400 で拒否され、副作用がないこと")
+  void lowercaseExpandingEmailRegistrationIsRejected() {
+    // U+0130 は永続化前の小文字化で 2 文字に伸長する。原文 146 字は @Email を通過するが
+    // 小文字化後は 280 字となり VARCHAR(255) を超えるため、@Size は伸長を見込んだ上限で拒否する必要がある。
+    String label = "İ".repeat(10);
+    String email = "İ".repeat(64) + "@" + (label + ".").repeat(7) + "test";
+
+    ResponseEntity<JsonNode> res = register(email, PASSWORD, "伸長メール花子");
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(platformUserRepository.findByEmail(email.toLowerCase(Locale.ROOT))).isEmpty();
   }
 
   @Test

--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -10,6 +10,7 @@ import com.kizuna.user.domain.PlatformUserRepository;
 import com.kizuna.user.domain.RoleRepository;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
+import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -302,6 +303,29 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
         .as("列長超過は email 由来の検証エラーとして返ること（店舗エラーへの誤帰属でないこと）")
         .isTrue();
     assertThat(platformUserRepository.findByEmail(email)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("小文字化で列長(255)を超えるメールでの作成は email 由来の 400 で拒否され、副作用がないこと")
+  void lowercaseExpandingEmailCreateIsRejected() {
+    String hq = platformToken(SEED_EMAIL, PASSWORD);
+    // U+0130 は永続化前の小文字化で 2 文字に伸長する。原文 146 字は @Email を通過するが
+    // 小文字化後は 280 字となり VARCHAR(255) を超えるため、@Size は伸長を見込んだ上限で拒否する必要がある。
+    String label = "İ".repeat(10);
+    String email = "İ".repeat(64) + "@" + (label + ".").repeat(7) + "test";
+
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/platform/staff",
+            new HttpEntity<>(
+                createBody(email, rolesJson("店舗スタッフ"), "ALL_STORES", "[]"), bearerJson(hq)),
+            JsonNode.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(res.getBody().path("details").has("email"))
+        .as("伸長超過は email 由来の検証エラーとして返ること（店舗エラーへの誤帰属でないこと）")
+        .isTrue();
+    assertThat(platformUserRepository.findByEmail(email.toLowerCase(Locale.ROOT))).isEmpty();
   }
 
   @Test

--- a/backend/src/main/java/com/kizuna/cast/api/dto/CastInvitationAcceptRequest.java
+++ b/backend/src/main/java/com/kizuna/cast/api/dto/CastInvitationAcceptRequest.java
@@ -11,7 +11,8 @@ public class CastInvitationAcceptRequest {
 
   @NotBlank(message = "email is required")
   @Email(message = "email format is invalid")
-  @Size(max = 255)
+  // 永続化前の小文字化で最大2倍に伸長する文字(U+0130 等)があっても t_users.email VARCHAR(255) に収まる上限。
+  @Size(max = 127)
   private String email;
 
   @NotBlank(message = "password is required")

--- a/backend/src/main/java/com/kizuna/member/api/dto/MemberRegistrationRequest.java
+++ b/backend/src/main/java/com/kizuna/member/api/dto/MemberRegistrationRequest.java
@@ -11,7 +11,8 @@ public class MemberRegistrationRequest {
 
   @NotBlank(message = "email is required")
   @Email(message = "email format is invalid")
-  @Size(max = 255)
+  // 永続化前の小文字化で最大2倍に伸長する文字(U+0130 等)があっても t_users.email VARCHAR(255) に収まる上限。
+  @Size(max = 127)
   private String email;
 
   @NotBlank(message = "password is required")

--- a/backend/src/main/java/com/kizuna/user/api/dto/PlatformStaffCreateRequest.java
+++ b/backend/src/main/java/com/kizuna/user/api/dto/PlatformStaffCreateRequest.java
@@ -22,7 +22,8 @@ public class PlatformStaffCreateRequest {
 
   @NotBlank(message = "email is required")
   @Email(message = "email format is invalid")
-  @Size(max = 255)
+  // 永続化前の小文字化で最大2倍に伸長する文字(U+0130 等)があっても t_users.email VARCHAR(255) に収まる上限。
+  @Size(max = 127)
   private String email;
 
   @NotBlank(message = "password is required")

--- a/frontend/src/features/cast-invite-accept/ui/RegisterForm.tsx
+++ b/frontend/src/features/cast-invite-accept/ui/RegisterForm.tsx
@@ -52,7 +52,7 @@ export function RegisterForm({ token, initialDisplayName, onSuccess, onBack }: R
           type="email"
           autoComplete="email"
           required
-          maxLength={255}
+          maxLength={127}
           className="auth-field__input"
           placeholder="example@mail.com"
           {...register('email', { required: true })}

--- a/frontend/src/features/member-register/ui/MemberRegisterForm.tsx
+++ b/frontend/src/features/member-register/ui/MemberRegisterForm.tsx
@@ -60,10 +60,10 @@ export function MemberRegisterForm() {
           type="email"
           autoComplete="email"
           required
-          maxLength={255}
+          maxLength={127}
           className="auth-field__input"
           placeholder="example@mail.com"
-          {...register('email', { required: true, maxLength: 255 })}
+          {...register('email', { required: true, maxLength: 127 })}
         />
         <span className="auth-field__accent" />
       </div>

--- a/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
+++ b/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
@@ -92,7 +92,7 @@ export function StaffCreateModal({ open, onClose, onCreated }: StaffCreateModalP
             <Input
               id="staff-email"
               type="email"
-              maxLength={255}
+              maxLength={127}
               {...register('email', { required: true })}
             />
           </div>


### PR DESCRIPTION
## 概要

#549 への codex 指摘（P2）の対応。`@Size(max=255)` は原文の文字数しか見ないため、小文字化で 2 文字に伸長する文字（U+0130 等）を含む合法形式のメールが検証を通過し、依然として `t_users.email VARCHAR(255)` の列長違反へ到達していた。上限を伸長を見込んだ 127 に下げ、email を INSERT に用いる全 3 経路（会員登録・招待受諾・スタッフ作成）で統一する。

## 変更内容

- 3 DTO の email を `@Size(max = 255)` → `@Size(max = 127)`（`MemberRegistrationRequest` / `CastInvitationAcceptRequest` / `PlatformStaffCreateRequest`、上限根拠のコメント付き）
- 各統合テストに U+0130 伸長ケースを追加（原文 146 字 → 小文字化後 280 字のメールが 400 かつ副作用なし）
- 前端 3 フォーム（会員登録・招待受諾・スタッフ追加）の email `maxLength` を 127 に同期

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task test-unit` と `task test-integration` を個別に実行、いずれも exit 0。統合は単独実行）
- [x] `task build` exit 0
- [ ] `task e2e` 未実行（検証注釈と maxLength のみの変更で、既存 e2e シナリオに該当経路の変化はない）
- [ ] ローカルで code-review 実施済み

新テスト 3 件は赤→緑を両方向で実証済み: `@Size(max=255)` に戻すと 3 件とも AssertionFailedError で赤（会員・招待は 500、スタッフは店舗エラーへの誤帰属 400）、127 に戻すと 3 クラス全緑。

## 決定ログ

- **なぜ 150 ではなく 127 か**: Hibernate の `@Email` はドメインラベルにも伸長文字を受理する（実証プローブ: `İ×10` ラベルは受理、punycode 換算で上限判定）。このため「ローカル部 64 字だけが伸長する」前提は成立せず、原文 146 字で小文字化後 280 字という反例が構成できる（150 上限では素通り）。伸長は最大 2 倍なので、2×127=254 ≤ 255 が成り立つ 127 を上限とした。実在のメールアドレスは実務上 127 字を超えないため運用上の制約にはならない。
- **正規化（小文字化）を DTO で行い 255 を維持する案は見送り**: 3 DTO に変換ロジックが重複し、検証と永続化の二重責務になる。単純な上限で最悪ケースを機械的に排除する方が保守が軽い。
- **displayName は対象外**: 永続化前の変換が存在せず（lowercase は email のみ）、Java の `@Size`（UTF-16 単位）は PostgreSQL の文字数（コードポイント）以上を数えるため常に安全側。

## 備考 / レビュー観点

- #549 の上に積んだスタックド PR（base = `claude/wonderful-hugle-3d35a1`）。#549 の合併後に base が master へ自動付け替えされる想定。マージ順は #549 → 本 PR。
- 検証時の変換位置は `PlatformUser#setEmail`（永続化側の一括 lowercase）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)