### PR TITLE
feat(auth): LINE ログイン/登録/連携をプラットフォーム認証手段として追加

### DIFF
--- a/backend/docs/modulith/components.puml
+++ b/backend/docs/modulith/components.puml
@@ -45,6 +45,8 @@ Rel(Application.Application.Customer, Application.Application.Shared, "depends o
 Rel(Application.Application.Auth, Application.Application.User, "listens to", $techn="", $tags="", $link="")
 Rel(Application.Application.Auth, Application.Application.User, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Auth, Application.Application.Shared, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Auth, Application.Application.Member, "uses", $techn="", $tags="", $link="")
+Rel(Application.Application.Auth, Application.Application.Settings, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Notification, Application.Application.Settings, "uses", $techn="", $tags="", $link="")
 Rel(Application.Application.Member, Application.Application.Shared, "depends on", $techn="", $tags="", $link="")
 Rel(Application.Application.Member, Application.Application.User, "uses", $techn="", $tags="", $link="")

--- a/backend/docs/modulith/module-auth.adoc
+++ b/backend/docs/modulith/module-auth.adoc
@@ -4,9 +4,11 @@
 |`com.kizuna.auth`
 |Bean references
 |* `c.k.u.domain.PlatformUserRepository` (in User)
+* `c.k.m.application.MemberRegistrationService` (in Member)
 * `c.k.u.domain.RoleRepository` (in User)
 * `c.k.u.domain.PermissionRepository` (in User)
 * `c.k.s.config.AppProperties` (in Shared)
+* `c.k.s.application.SystemConfigService` (in Settings)
 |Events listened to
 |* `c.k.u.domain.PlatformUserResumed` 
 * `c.k.u.domain.PlatformUserStopped` 

--- a/backend/docs/modulith/module-member.adoc
+++ b/backend/docs/modulith/module-member.adoc
@@ -2,6 +2,11 @@
 |===
 |Base package
 |`com.kizuna.member`
+|Spring components
+|_Services_
+
+* `c.k.m.application.MemberRegistrationService`
+* `c.k.m.application.MemberSelfService`
 |Bean references
 |* `c.k.u.domain.PlatformUserRepository` (in User)
 |===

--- a/backend/src/integrationTest/java/com/kizuna/auth/PlatformLineAuthIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/auth/PlatformLineAuthIT.java
@@ -1,0 +1,428 @@
+package com.kizuna.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kizuna.member.domain.Member;
+import com.kizuna.member.domain.MemberRepository;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import com.kizuna.user.domain.StoreScopeType;
+import com.kizuna.user.domain.UserType;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * LINE を認証手段とするログイン・登録・連携の統合テスト。実チャネルは存在しないため、LINE プラットフォーム API を ループバックのスタブへ差し替える（{@code
+ * app.line.api-base-url}）。
+ *
+ * <p>スタブはクラスロード時（Spring の文脈生成より前）に起動し、確定したポートを {@code @DynamicPropertySource} が読む — {@code
+ * AppProperties} は文脈初期化時に束縛されるため、後から決まる値は使えない。
+ *
+ * <p>本テストが固定する受入条件のうち中核は「なりすまし不能」: LINE 側が検証したメールアドレスが既存アカウントと一致しても、 未知の LINE ユーザー ID
+ * は必ず登録チケット経路へ落ち、既存アカウントのトークンは決して発行されない。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestRestTemplate
+class PlatformLineAuthIT {
+
+  private static final String MEMBER_PASSWORD = "password1234";
+
+  /** スタブが返す検証済み同一性。各テストが自分の筋書きに合わせて差し替える。 */
+  private static volatile String stubSub = "U-line-default";
+
+  private static volatile String stubName = "LINE太郎";
+
+  private static volatile String stubEmail = "line-default@kizuna.test";
+
+  private static final HttpServer LINE_STUB = startLineStub();
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private PlatformUserRepository platformUserRepository;
+  @Autowired private MemberRepository memberRepository;
+
+  private static HttpServer startLineStub() {
+    try {
+      HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+      server.createContext("/oauth2/v2.1/token", exchange -> respond(exchange, tokenBody()));
+      server.createContext("/oauth2/v2.1/verify", exchange -> respond(exchange, verifyBody()));
+      server.start();
+      return server;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static String tokenBody() {
+    return "{\"id_token\": \"stub-id-token\"}";
+  }
+
+  private static String verifyBody() {
+    return String.format(
+        "{\"sub\": \"%s\", \"name\": \"%s\", \"email\": \"%s\"}", stubSub, stubName, stubEmail);
+  }
+
+  private static void respond(HttpExchange exchange, String body) throws IOException {
+    try (InputStream in = exchange.getRequestBody()) {
+      in.readAllBytes();
+    }
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().add("Content-Type", "application/json");
+    exchange.sendResponseHeaders(200, bytes.length);
+    exchange.getResponseBody().write(bytes);
+    exchange.close();
+  }
+
+  @DynamicPropertySource
+  static void lineProperties(DynamicPropertyRegistry registry) {
+    registry.add(
+        "app.line.api-base-url", () -> "http://127.0.0.1:" + LINE_STUB.getAddress().getPort());
+    registry.add("app.line.channel-id", () -> "it-channel-id");
+    registry.add("app.line.channel-secret", () -> "it-channel-secret");
+  }
+
+  private static String uniqueSub(String prefix) {
+    return "U-" + prefix + "-" + System.nanoTime();
+  }
+
+  private static String uniqueEmail(String prefix) {
+    return prefix + "-line-it-" + System.nanoTime() + "@kizuna.test";
+  }
+
+  private void stubIdentity(String sub, String name, String email) {
+    stubSub = sub;
+    stubName = name;
+    stubEmail = email;
+  }
+
+  private static HttpHeaders jsonHeaders() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+
+  private static HttpHeaders bearer(String token) {
+    HttpHeaders headers = jsonHeaders();
+    headers.setBearerAuth(token);
+    return headers;
+  }
+
+  private static String authorizationBody() {
+    return "{\"code\": \"stub-auth-code\", \"redirect_uri\": \"https://app.test/line/callback\","
+        + " \"code_verifier\": \"stub-code-verifier\"}";
+  }
+
+  private ResponseEntity<JsonNode> lineLogin() {
+    return rest.postForEntity(
+        "/platform/line/login",
+        new HttpEntity<>(authorizationBody(), jsonHeaders()),
+        JsonNode.class);
+  }
+
+  private ResponseEntity<JsonNode> lineRegister(String ticket, String displayName, String email) {
+    String body =
+        String.format(
+            "{\"registration_ticket\": \"%s\", \"display_name\": \"%s\", \"email\": \"%s\"}",
+            ticket, displayName, email);
+    return rest.postForEntity(
+        "/platform/line/register", new HttpEntity<>(body, jsonHeaders()), JsonNode.class);
+  }
+
+  private ResponseEntity<JsonNode> linkLine(HttpHeaders headers) {
+    return rest.exchange(
+        "/platform/me/line",
+        HttpMethod.POST,
+        new HttpEntity<>(authorizationBody(), headers),
+        JsonNode.class);
+  }
+
+  private ResponseEntity<JsonNode> getMe(String token) {
+    return rest.exchange(
+        "/platform/me", HttpMethod.GET, new HttpEntity<>(bearer(token)), JsonNode.class);
+  }
+
+  /** メール + パスワードで会員を登録し、そのトークンを返す（連携の前提となる既存身分の用意）。 */
+  private String registerMemberAndLogin(String email, String displayName) {
+    String body =
+        String.format(
+            "{\"email\": \"%s\", \"password\": \"%s\", \"display_name\": \"%s\"}",
+            email, MEMBER_PASSWORD, displayName);
+    ResponseEntity<JsonNode> registered =
+        rest.postForEntity(
+            "/platform/members", new HttpEntity<>(body, jsonHeaders()), JsonNode.class);
+    assertThat(registered.getStatusCode()).as("前提: 会員登録が成功すること").isEqualTo(HttpStatus.CREATED);
+    ResponseEntity<JsonNode> login =
+        rest.postForEntity(
+            "/platform/login",
+            new HttpEntity<>(
+                String.format("{\"email\": \"%s\", \"password\": \"%s\"}", email, MEMBER_PASSWORD),
+                jsonHeaders()),
+            JsonNode.class);
+    assertThat(login.getStatusCode()).as("前提: 平台ログインが成功すること").isEqualTo(HttpStatus.OK);
+    return login.getBody().path("token").asString();
+  }
+
+  /** 未登録の LINE アカウントでログインし、登録チケットを取り出す。 */
+  private String ticketForUnknownSub(String sub, String name, String email) {
+    stubIdentity(sub, name, email);
+    ResponseEntity<JsonNode> login = lineLogin();
+    assertThat(login.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(login.getBody().path("registered").asBoolean()).isFalse();
+    String ticket = login.getBody().path("registration_ticket").asString();
+    assertThat(ticket).isNotBlank();
+    return ticket;
+  }
+
+  @Test
+  @DisplayName("チャネル設定済みなら config は enabled=true とチャネル ID を返す（前端が認可要求を組み立てられる）")
+  void configExposesChannelId() {
+    ResponseEntity<JsonNode> res = rest.getForEntity("/platform/line/config", JsonNode.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(res.getBody().path("enabled").asBoolean()).isTrue();
+    assertThat(res.getBody().path("channel_id").asString()).isEqualTo("it-channel-id");
+  }
+
+  @Test
+  @DisplayName("未登録 LINE アカウントは登録チケット経由で MEMBER 身分と会員コードを得て、そのままログイン状態になる")
+  void unknownLineUserRegistersAndLogsIn() {
+    String sub = uniqueSub("new");
+    String email = uniqueEmail("line-new");
+    String ticket = ticketForUnknownSub(sub, "LINE花子", email);
+
+    ResponseEntity<JsonNode> registered = lineRegister(ticket, "会員花子", email);
+
+    assertThat(registered.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    String token = registered.getBody().path("token").asString();
+    assertThat(token).isNotBlank();
+    assertThat(registered.getBody().path("expires_at").asLong()).isPositive();
+
+    PlatformUser user = platformUserRepository.findByEmail(email).orElseThrow();
+    assertThat(user.getUserType()).isEqualTo(UserType.MEMBER);
+    assertThat(user.getLineUserId()).isEqualTo(sub);
+    assertThat(user.getRoleIds()).isEmpty();
+    assertThat(user.getStoreScopeType()).isEqualTo(StoreScopeType.SPECIFIC_STORES);
+    assertThat(user.getStoreIds()).isEmpty();
+    Member member = memberRepository.findByPlatformUserId(user.getId()).orElseThrow();
+    assertThat(member.getMemberCode()).matches("\\d{12}");
+
+    // 発行トークンは会員端点で通用する（パスワードログインと同じ claim が載っている）。
+    ResponseEntity<JsonNode> home =
+        rest.exchange(
+            "/platform/me/member", HttpMethod.GET, new HttpEntity<>(bearer(token)), JsonNode.class);
+    assertThat(home.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(home.getBody().path("member_code").asString()).isEqualTo(member.getMemberCode());
+  }
+
+  @Test
+  @DisplayName("連携済み LINE アカウントのログインは登録を挟まずトークンを返す")
+  void knownLineUserLogsInDirectly() {
+    String sub = uniqueSub("known");
+    String email = uniqueEmail("line-known");
+    lineRegister(ticketForUnknownSub(sub, "LINE次郎", email), "会員次郎", email);
+
+    ResponseEntity<JsonNode> login = lineLogin();
+
+    assertThat(login.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(login.getBody().path("registered").asBoolean()).isTrue();
+    assertThat(login.getBody().has("registration_ticket")).isFalse();
+    String token = login.getBody().path("token").asString();
+    ResponseEntity<JsonNode> me = getMe(token);
+    assertThat(me.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(me.getBody().path("email").asString()).isEqualTo(email);
+    assertThat(me.getBody().path("user_type").asString()).isEqualTo("MEMBER");
+    assertThat(me.getBody().path("line_linked").asBoolean()).isTrue();
+  }
+
+  @Test
+  @DisplayName("LINE 側のメールが既存アカウントと一致しても、未知の LINE ID では既存アカウントのトークンを発行しない（なりすまし防止）")
+  void matchingEmailNeverAutoLinksExistingAccount() {
+    String existingEmail = uniqueEmail("line-impersonation");
+    registerMemberAndLogin(existingEmail, "既存花子");
+    PlatformUser before = platformUserRepository.findByEmail(existingEmail).orElseThrow();
+    assertThat(before.getLineUserId()).as("前提: 既存アカウントは未連携").isNull();
+
+    // LINE 側は「この既存アカウントと同じメール」を検証済みとして返すが、LINE ユーザー ID は未知。
+    stubIdentity(uniqueSub("impersonator"), "なりすまし花子", existingEmail);
+    ResponseEntity<JsonNode> login = lineLogin();
+
+    assertThat(login.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(login.getBody().path("registered").asBoolean()).isFalse();
+    assertThat(login.getBody().has("token")).as("既存アカウントのトークンを返さないこと").isFalse();
+    assertThat(login.getBody().path("registration_ticket").asString()).isNotBlank();
+
+    // 登録確定でも既存メールは奪えず、既存アカウントは未連携のまま。
+    ResponseEntity<JsonNode> registered =
+        lineRegister(
+            login.getBody().path("registration_ticket").asString(), "なりすまし花子", existingEmail);
+
+    assertThat(registered.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    PlatformUser after = platformUserRepository.findByEmail(existingEmail).orElseThrow();
+    assertThat(after.getLineUserId()).isNull();
+    assertThat(after.getId()).isEqualTo(before.getId());
+  }
+
+  @Test
+  @DisplayName("認証済み本人への連携は 204 で、以後その LINE アカウントで本人としてログインできる")
+  void linkAttachesLineAccountToAuthenticatedUser() {
+    String email = uniqueEmail("line-link");
+    String token = registerMemberAndLogin(email, "連携花子");
+    String sub = uniqueSub("link");
+    stubIdentity(sub, "LINE花子", uniqueEmail("line-other"));
+
+    assertThat(linkLine(bearer(token)).getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+    assertThat(getMe(token).getBody().path("line_linked").asBoolean()).isTrue();
+    ResponseEntity<JsonNode> login = lineLogin();
+    assertThat(login.getBody().path("registered").asBoolean()).isTrue();
+    assertThat(getMe(login.getBody().path("token").asString()).getBody().path("email").asString())
+        .isEqualTo(email);
+  }
+
+  @Test
+  @DisplayName("Bearer なしの連携要求は 401（匿名で他人のアカウントへ結び付けられない）")
+  void linkWithoutBearerIsUnauthorized() {
+    stubIdentity(uniqueSub("anon"), "匿名花子", uniqueEmail("line-anon"));
+
+    ResponseEntity<JsonNode> res = linkLine(jsonHeaders());
+
+    assertThat(res.getStatusCode().value()).isIn(401, 403);
+  }
+
+  @Test
+  @DisplayName("他の身分が連携済みの LINE アカウントへの連携は 409 で、要求者は未連携のまま")
+  void linkWithLineAccountBoundToAnotherUserIsConflict() {
+    String ownerEmail = uniqueEmail("line-owner");
+    String ownerToken = registerMemberAndLogin(ownerEmail, "先着花子");
+    String sub = uniqueSub("taken");
+    stubIdentity(sub, "LINE花子", uniqueEmail("line-taken"));
+    assertThat(linkLine(bearer(ownerToken)).getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+    String otherEmail = uniqueEmail("line-other-user");
+    String otherToken = registerMemberAndLogin(otherEmail, "後着次郎");
+    ResponseEntity<JsonNode> res = linkLine(bearer(otherToken));
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(platformUserRepository.findByEmail(otherEmail).orElseThrow().getLineUserId())
+        .isNull();
+    assertThat(platformUserRepository.findByEmail(ownerEmail).orElseThrow().getLineUserId())
+        .isEqualTo(sub);
+  }
+
+  @Test
+  @DisplayName("連携済みアカウントの再連携は 409（付け替えを提供しない）")
+  void relinkingAlreadyLinkedAccountIsConflict() {
+    String email = uniqueEmail("line-relink");
+    String token = registerMemberAndLogin(email, "再連携花子");
+    String firstSub = uniqueSub("relink-first");
+    stubIdentity(firstSub, "LINE花子", uniqueEmail("line-relink-1"));
+    assertThat(linkLine(bearer(token)).getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+    stubIdentity(uniqueSub("relink-second"), "LINE花子", uniqueEmail("line-relink-2"));
+    ResponseEntity<JsonNode> res = linkLine(bearer(token));
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(platformUserRepository.findByEmail(email).orElseThrow().getLineUserId())
+        .isEqualTo(firstSub);
+  }
+
+  @Test
+  @DisplayName("登録チケットは 1 度きり（2 度目の登録確定は 4xx で拒否され、身分を作らない）")
+  void registrationTicketIsSingleUse() {
+    String sub = uniqueSub("single-use");
+    String firstEmail = uniqueEmail("line-ticket-1");
+    String ticket = ticketForUnknownSub(sub, "LINE花子", firstEmail);
+    assertThat(lineRegister(ticket, "会員花子", firstEmail).getStatusCode())
+        .isEqualTo(HttpStatus.CREATED);
+
+    String secondEmail = uniqueEmail("line-ticket-2");
+    ResponseEntity<JsonNode> res = lineRegister(ticket, "会員次郎", secondEmail);
+
+    assertThat(res.getStatusCode().is4xxClientError()).isTrue();
+    assertThat(platformUserRepository.findByEmail(secondEmail)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("登録がメール重複の 409 でもチケットは残り、入力を直して同じチケットで登録し直せる")
+  void registrationTicketSurvivesDuplicateEmailConflict() {
+    String takenEmail = uniqueEmail("taken");
+    registerMemberAndLogin(takenEmail, "既存会員");
+    String sub = uniqueSub("retry");
+    String ticket = ticketForUnknownSub(sub, "LINE次郎", uniqueEmail("line-retry"));
+
+    ResponseEntity<JsonNode> conflict = lineRegister(ticket, "会員次郎", takenEmail);
+    assertThat(conflict.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+
+    String freshEmail = uniqueEmail("line-retry-ok");
+    ResponseEntity<JsonNode> retried = lineRegister(ticket, "会員次郎", freshEmail);
+    assertThat(retried.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(platformUserRepository.findByEmail(freshEmail).orElseThrow().getLineUserId())
+        .isEqualTo(sub);
+  }
+
+  @Test
+  @DisplayName("未知の登録チケットは 4xx で拒否される")
+  void unknownRegistrationTicketIsRejected() {
+    String email = uniqueEmail("line-unknown-ticket");
+
+    ResponseEntity<JsonNode> res = lineRegister("no-such-ticket", "会員花子", email);
+
+    assertThat(res.getStatusCode().is4xxClientError()).isTrue();
+    assertThat(platformUserRepository.findByEmail(email)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("陳腐な Bearer を付けたままでも LINE の公開端点（設定・ログイン・登録）は匿名で通ること")
+  void publicLineEndpointsIgnoreBrokenBearer() {
+    HttpHeaders headers = jsonHeaders();
+    headers.setBearerAuth("stale-or-broken-token-value");
+
+    ResponseEntity<JsonNode> config =
+        rest.exchange(
+            "/platform/line/config", HttpMethod.GET, new HttpEntity<>(headers), JsonNode.class);
+    assertThat(config.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    String sub = uniqueSub("broken-bearer");
+    String email = uniqueEmail("line-broken-bearer");
+    stubIdentity(sub, "LINE花子", email);
+    ResponseEntity<JsonNode> login =
+        rest.exchange(
+            "/platform/line/login",
+            HttpMethod.POST,
+            new HttpEntity<>(authorizationBody(), headers),
+            JsonNode.class);
+    assertThat(login.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    String body =
+        String.format(
+            "{\"registration_ticket\": \"%s\", \"display_name\": \"陳腐Bearer花子\", \"email\": \"%s\"}",
+            login.getBody().path("registration_ticket").asString(), email);
+    ResponseEntity<JsonNode> registered =
+        rest.exchange(
+            "/platform/line/register",
+            HttpMethod.POST,
+            new HttpEntity<>(body, headers),
+            JsonNode.class);
+    assertThat(registered.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(platformUserRepository.findByEmail(email)).isPresent();
+  }
+}

--- a/backend/src/integrationTest/java/com/kizuna/settings/SmtpSettingsReadIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/settings/SmtpSettingsReadIT.java
@@ -1,0 +1,29 @@
+package com.kizuna.settings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.kizuna.settings.application.SystemConfigService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * SMTP 設定の読み取りが実インフラ（実 Redis）越しでも成立することを固定する IT。
+ *
+ * <p>キャッシュ値の既定シリアライザは JDK 直列化で、{@code Serializable} でない値をキャッシュに載せようとすると
+ * 読み取り自体が例外になる（呼び出し側が握り潰すと「メールが一切送信されない」静かな故障になる）。 単体テストはキャッシュプロキシを経由しないため、この断言は IT でしか固定できない。
+ */
+@SpringBootTest
+class SmtpSettingsReadIT {
+
+  @Autowired private SystemConfigService systemConfigService;
+
+  @Test
+  @DisplayName("smtpSettings は繰り返し呼んでも例外にならず、一貫した値を返すこと")
+  void smtpSettingsIsReadableThroughRealInfrastructure() {
+    assertThatCode(() -> systemConfigService.smtpSettings()).doesNotThrowAnyException();
+    assertThat(systemConfigService.smtpSettings()).isEqualTo(systemConfigService.smtpSettings());
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/api/dto/LineAuthorizationRequest.java
+++ b/backend/src/main/java/com/kizuna/auth/api/dto/LineAuthorizationRequest.java
@@ -1,0 +1,26 @@
+package com.kizuna.auth.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * LINE 認可コードの引き渡し（ログインと連携で共通）。JSON キーは Jackson 設定により snake_case（redirect_uri / code_verifier）。
+ *
+ * <p>{@code redirect_uri} は LINE の認可要求で使ったものと同一でなければならず、トークン交換時に LINE 自身が照合する。
+ */
+@Data
+public class LineAuthorizationRequest {
+
+  @NotBlank(message = "code is required")
+  @Size(max = 512)
+  private String code;
+
+  @NotBlank(message = "redirect_uri is required")
+  @Size(max = 512)
+  private String redirectUri;
+
+  @NotBlank(message = "code_verifier is required")
+  @Size(max = 128)
+  private String codeVerifier;
+}

--- a/backend/src/main/java/com/kizuna/auth/api/dto/LineConfigResponse.java
+++ b/backend/src/main/java/com/kizuna/auth/api/dto/LineConfigResponse.java
@@ -1,0 +1,9 @@
+package com.kizuna.auth.api.dto;
+
+/**
+ * GET /platform/line/config の応答。JSON キーは Jackson 設定により snake_case（channel_id）。
+ *
+ * @param enabled LINE ログインが利用可能か（チャネル ID とシークレットの双方が解決できたときだけ true）
+ * @param channelId 前端が認可要求を組み立てるためのチャネル ID。無効時は null（応答から省かれる）
+ */
+public record LineConfigResponse(boolean enabled, String channelId) {}

--- a/backend/src/main/java/com/kizuna/auth/api/dto/LineLoginResponse.java
+++ b/backend/src/main/java/com/kizuna/auth/api/dto/LineLoginResponse.java
@@ -1,0 +1,26 @@
+package com.kizuna.auth.api.dto;
+
+/**
+ * POST /platform/line/login の応答。JSON キーは Jackson 設定により snake_case（expires_at / registration_ticket
+ * / display_name）で、null 項目は応答から省かれる。
+ *
+ * <p>連携済み（{@code registered=true}）なら token と expires_at を、未登録なら登録チケットと LINE 表示名を返す 2 形態を取る。 未登録側で
+ * token を返さないことが、なりすまし（LINE 側のメール一致による既存アカウントへの自動ログイン）を構造的に排除している。
+ */
+public record LineLoginResponse(
+    boolean registered,
+    String token,
+    Long expiresAt,
+    String registrationTicket,
+    String displayName) {
+
+  /** 連携済み LINE アカウントのログイン成功。 */
+  public static LineLoginResponse registered(Token issued) {
+    return new LineLoginResponse(true, issued.token(), issued.expiresAt(), null, null);
+  }
+
+  /** 未登録 LINE アカウント。登録確定要求で使う 1 度きりのチケットと、初期表示名を返す。 */
+  public static LineLoginResponse unregistered(String registrationTicket, String displayName) {
+    return new LineLoginResponse(false, null, null, registrationTicket, displayName);
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/api/dto/LineRegistrationRequest.java
+++ b/backend/src/main/java/com/kizuna/auth/api/dto/LineRegistrationRequest.java
@@ -1,0 +1,30 @@
+package com.kizuna.auth.api.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * LINE 登録の確定要求。JSON キーは Jackson 設定により snake_case（registration_ticket / display_name）。
+ *
+ * <p>LINE ユーザー ID は要求に含めない（チケットの裏にある検証済みの値を使う）。メールアドレスはここで初めて収集する — 身分の一意キーは email のままで、LINE
+ * のみで登録した会員もパスワードログイン以外の全機構を共有する。
+ */
+@Data
+public class LineRegistrationRequest {
+
+  @NotBlank(message = "registration_ticket is required")
+  @Size(max = 128)
+  private String registrationTicket;
+
+  @NotBlank(message = "display_name is required")
+  @Size(max = 150)
+  private String displayName;
+
+  @NotBlank(message = "email is required")
+  @Email(message = "email format is invalid")
+  // 永続化前の小文字化で最大2倍に伸長する文字(U+0130 等)があっても t_users.email VARCHAR(255) に収まる上限。
+  @Size(max = 127)
+  private String email;
+}

--- a/backend/src/main/java/com/kizuna/auth/api/dto/PlatformMeResponse.java
+++ b/backend/src/main/java/com/kizuna/auth/api/dto/PlatformMeResponse.java
@@ -12,6 +12,8 @@ import java.util.List;
  * <p>{@code storeBridge} は店舗文脈（X-Store-ID）を確立できるか。JWT の {@code storeBridge} claim を設定するのと同一の私有
  * {@code PlatformAuthService.hasStoreConsole()} から導出する — {@code console}
  * と同一原則で、フロントエンドに権限→コンソールの対応表を複製させない。
+ *
+ * <p>{@code lineLinked} は LINE アカウントを連携済みか。LINE ユーザー ID 自体は本人にも返さない（連携の有無だけが 画面の分岐に必要な情報）。
  */
 public record PlatformMeResponse(
     String email,
@@ -21,4 +23,5 @@ public record PlatformMeResponse(
     String console,
     boolean storeBridge,
     String storeScopeType,
-    List<Long> storeIds) {}
+    List<Long> storeIds,
+    boolean lineLinked) {}

--- a/backend/src/main/java/com/kizuna/auth/api/platform/PlatformLineController.java
+++ b/backend/src/main/java/com/kizuna/auth/api/platform/PlatformLineController.java
@@ -1,0 +1,61 @@
+package com.kizuna.auth.api.platform;
+
+import com.kizuna.auth.api.dto.LineAuthorizationRequest;
+import com.kizuna.auth.api.dto.LineConfigResponse;
+import com.kizuna.auth.api.dto.LineLoginResponse;
+import com.kizuna.auth.api.dto.LineRegistrationRequest;
+import com.kizuna.auth.api.dto.Token;
+import com.kizuna.auth.application.LineAuthService;
+import jakarta.annotation.security.PermitAll;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * LINE を認証手段とする端点。認可コードの交換はバックエンドで行い、チャネルシークレットは前端へ出さない。
+ *
+ * <p>設定・ログイン・登録は匿名で叩かれる公開端点（SecurityConfig の CSRF 免除と PlatformBearerTokenResolver の Bearer 免除の対象）。
+ * 連携（POST /platform/me/line）だけは Bearer を要求し、現在の認証主体に結び付ける。
+ */
+@RestController
+@RequestMapping("/platform")
+@RequiredArgsConstructor
+public class PlatformLineController {
+
+  private final LineAuthService lineAuthService;
+
+  @GetMapping("/line/config")
+  @PermitAll
+  public ResponseEntity<LineConfigResponse> config() {
+    return ResponseEntity.ok(lineAuthService.config());
+  }
+
+  @PostMapping("/line/login")
+  @PermitAll
+  public ResponseEntity<LineLoginResponse> login(
+      @Valid @RequestBody LineAuthorizationRequest request) {
+    return ResponseEntity.ok(lineAuthService.login(request));
+  }
+
+  @PostMapping("/line/register")
+  @PermitAll
+  public ResponseEntity<Token> register(@Valid @RequestBody LineRegistrationRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(lineAuthService.register(request));
+  }
+
+  @PostMapping("/me/line")
+  @PreAuthorize("isAuthenticated()")
+  public ResponseEntity<Void> link(
+      Principal principal, @Valid @RequestBody LineAuthorizationRequest request) {
+    lineAuthService.link(principal.getName(), request);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/application/LineAuthService.java
+++ b/backend/src/main/java/com/kizuna/auth/application/LineAuthService.java
@@ -1,0 +1,132 @@
+package com.kizuna.auth.application;
+
+import com.kizuna.auth.api.dto.LineAuthorizationRequest;
+import com.kizuna.auth.api.dto.LineConfigResponse;
+import com.kizuna.auth.api.dto.LineLoginResponse;
+import com.kizuna.auth.api.dto.LineRegistrationRequest;
+import com.kizuna.auth.api.dto.Token;
+import com.kizuna.auth.infrastructure.LineApiClient;
+import com.kizuna.auth.infrastructure.LineChannel;
+import com.kizuna.auth.infrastructure.LineChannelResolver;
+import com.kizuna.auth.infrastructure.LineIdentity;
+import com.kizuna.auth.infrastructure.LineRegistrationTicketStore;
+import com.kizuna.member.application.MemberRegistrationService;
+import com.kizuna.shared.exception.ConflictException;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.ServiceUnavailableException;
+import com.kizuna.shared.exception.StaleSessionException;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * LINE を認証手段とするログイン・登録・連携のユースケース。前端が取得した認可コードをバックエンドが LINE と交換・検証し、 検証済みの LINE ユーザー ID
+ * だけを身分の同一性の根拠にする。
+ *
+ * <p>なりすまし防止の不変条件: ログイン経路は LINE ユーザー ID でしか身分を引かない。LINE 側の検証済みメールアドレスが 既存アカウントと一致しても自動連携はせず、未知の
+ * LINE ユーザー ID は必ず登録チケット経路へ落とす（メール一致は本人性の 証明にならず、自動連携を許すと LINE 側でメールを詐称できる限りアカウント乗っ取りになる）。
+ *
+ * <p>発行するトークンはパスワードログインと同一の {@link PlatformAuthService#issueTokenFor} を通す（認証手段による claim の齟齬を作らない）。
+ */
+@Service
+@RequiredArgsConstructor
+public class LineAuthService {
+
+  private static final String LINE_DISABLED_MESSAGE = "LINE ログインは利用できません";
+  private static final String INVALID_TICKET_MESSAGE = "登録チケットが無効または期限切れです。最初からやり直してください";
+  private static final String LINE_TAKEN_MESSAGE = "この LINE アカウントは既に別の身分と連携済みです";
+  private static final String LINE_USER_UNIQUE_CONSTRAINT = "uq_t_users_line_user_id";
+
+  private final LineChannelResolver channelResolver;
+  private final LineApiClient lineApiClient;
+  private final LineRegistrationTicketStore ticketStore;
+  private final PlatformUserRepository userRepository;
+  private final MemberRegistrationService memberRegistrationService;
+  private final PlatformAuthService authService;
+
+  /** 前端が認可要求を組み立てるための公開設定。無効なら channelId は返さない。 */
+  @Transactional(readOnly = true)
+  public LineConfigResponse config() {
+    return channelResolver
+        .resolve()
+        .map(channel -> new LineConfigResponse(true, channel.channelId()))
+        .orElseGet(() -> new LineConfigResponse(false, null));
+  }
+
+  /** LINE ログイン。連携済みならトークンを、未登録なら 1 度きりの登録チケットを返す。 */
+  @Transactional(readOnly = true)
+  public LineLoginResponse login(LineAuthorizationRequest request) {
+    LineIdentity identity = verify(request);
+    return userRepository
+        .findByLineUserId(identity.lineUserId())
+        .map(this::issueTokenForLinkedUser)
+        .orElseGet(
+            () ->
+                LineLoginResponse.unregistered(
+                    ticketStore.issue(identity.lineUserId()), identity.displayName()));
+  }
+
+  /** 登録チケットで会員身分を作成し、そのままログイン状態にする（自動ログイン）。 */
+  @Transactional
+  public Token register(LineRegistrationRequest request) {
+    String lineUserId =
+        ticketStore
+            .peek(request.getRegistrationTicket())
+            .orElseThrow(() -> new ServiceException(INVALID_TICKET_MESSAGE));
+    PlatformUser user =
+        memberRegistrationService.registerWithLine(
+            request.getEmail(), request.getDisplayName(), lineUserId);
+    // 消費は登録成功後 — 重複メールなどの失敗でチケットを失うと、入力を直すだけのやり直しに OAuth の再実行を強いるため。
+    ticketStore.consume(request.getRegistrationTicket());
+    return authService.issueTokenFor(user);
+  }
+
+  /** 認証済みの本人に LINE アカウントを連携する。連携の解除・付け替えは提供しない。 */
+  @Transactional
+  public void link(String email, LineAuthorizationRequest request) {
+    LineIdentity identity = verify(request);
+    PlatformUser user =
+        userRepository
+            .findByEmail(email)
+            .orElseThrow(() -> new StaleSessionException("認証セッションの主体が存在しません"));
+    // 連携先を取り合うのは未連携の身分だけ。連携済み本人の再連携は、相手が同じ LINE アカウントであっても
+    // linkLine が集約の不変条件として拒否する（付け替えを提供しないため、理由の表示も本人側の事実に揃える）。
+    if (user.getLineUserId() == null && userRepository.existsByLineUserId(identity.lineUserId())) {
+      throw new ConflictException(LINE_TAKEN_MESSAGE);
+    }
+    user.linkLine(identity.lineUserId());
+    try {
+      userRepository.saveAndFlush(user);
+    } catch (DataIntegrityViolationException ex) {
+      // 事前チェックを擦り抜けた並行連携。ここで違反し得る一意制約は LINE ユーザー ID だけであり、
+      // 「先に確定した別要求と衝突した」なので 409 に写像する。
+      String cause = ex.getMostSpecificCause().getMessage();
+      if (cause != null && cause.contains(LINE_USER_UNIQUE_CONSTRAINT)) {
+        throw new ConflictException(LINE_TAKEN_MESSAGE);
+      }
+      throw ex;
+    }
+  }
+
+  /** 認可コードを LINE と交換し、id_token を LINE に検証させて本人同一性を得る。 */
+  private LineIdentity verify(LineAuthorizationRequest request) {
+    LineChannel channel =
+        channelResolver
+            .resolve()
+            .orElseThrow(() -> new ServiceUnavailableException(LINE_DISABLED_MESSAGE));
+    return lineApiClient.exchangeAndVerify(
+        channel, request.getCode(), request.getRedirectUri(), request.getCodeVerifier());
+  }
+
+  /** 連携済み身分へのトークン発行。停止済みアカウントはパスワードログインと同じく 401 で拒否する。 */
+  private LineLoginResponse issueTokenForLinkedUser(PlatformUser user) {
+    if (!Boolean.TRUE.equals(user.getEnabled())) {
+      throw new DisabledException("アカウントが無効化されています");
+    }
+    return LineLoginResponse.registered(authService.issueTokenFor(user));
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/application/PlatformAuthService.java
+++ b/backend/src/main/java/com/kizuna/auth/application/PlatformAuthService.java
@@ -60,6 +60,17 @@ public class PlatformAuthService {
     // principal は認証成功時に自作 UserDetails が保持する PlatformUser（二次クエリを避ける）。
     PlatformUser user = ((PlatformUserDetails) authentication.getPrincipal()).getPlatformUser();
 
+    return issueTokenFor(user);
+  }
+
+  /**
+   * 認証済みの身分に対してトークンを発行する。パスワードログインと LINE ログインの双方から呼ばれ、 認証手段が変わっても claim の内容が一致することを構造的に保証する（認証手段ごとに
+   * claim を組み立てると、片方だけ 権限が欠ける・過剰になる齟齬が静かに生まれる）。
+   *
+   * <p>呼び出し側は本人性の確認（パスワード照合・LINE の id_token 検証）を済ませていること。
+   */
+  @Transactional(readOnly = true)
+  public Token issueTokenFor(PlatformUser user) {
     Set<PermissionCode> permissions = permissionsOf(user);
     Map<String, Object> claims = new HashMap<>();
     claims.put("authorities", buildAuthorities(user, permissions));
@@ -116,7 +127,8 @@ public class PlatformAuthService {
         consoleOf(user, permissions),
         hasStoreConsole(permissions),
         user.getStoreScopeType().name(),
-        user.getStoreIds().stream().sorted().toList());
+        user.getStoreIds().stream().sorted().toList(),
+        user.getLineUserId() != null);
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/LineApiClient.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/LineApiClient.java
@@ -1,8 +1,11 @@
 package com.kizuna.auth.infrastructure;
 
 import com.kizuna.shared.config.AppProperties;
+import java.net.http.HttpClient;
+import java.time.Duration;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -26,12 +29,26 @@ public class LineApiClient {
   private static final String TOKEN_PATH = "/oauth2/v2.1/token";
   private static final String VERIFY_PATH = "/oauth2/v2.1/verify";
 
+  // 公開端点（/platform/line/login）から呼ばれるため、LINE 側の停滞がサーブレットスレッドを
+  // 無期限に占有しないよう接続・読み取りとも有限にする。超過は RestClientException として
+  // 既存の写像（LineAuthenticationException → 401）に落ちる。
+  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+  private static final Duration READ_TIMEOUT = Duration.ofSeconds(10);
+
   private static final JsonMapper JSON = JsonMapper.builder().build();
 
   private final RestClient restClient;
 
   public LineApiClient(AppProperties appProperties) {
-    this.restClient = RestClient.builder().baseUrl(appProperties.getLine().getApiBaseUrl()).build();
+    JdkClientHttpRequestFactory requestFactory =
+        new JdkClientHttpRequestFactory(
+            HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build());
+    requestFactory.setReadTimeout(READ_TIMEOUT);
+    this.restClient =
+        RestClient.builder()
+            .baseUrl(appProperties.getLine().getApiBaseUrl())
+            .requestFactory(requestFactory)
+            .build();
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/LineApiClient.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/LineApiClient.java
@@ -1,0 +1,102 @@
+package com.kizuna.auth.infrastructure;
+
+import com.kizuna.shared.config.AppProperties;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * LINE プラットフォーム API の呼び出し。前端が取得した認可コードを id_token へ交換し、id_token を LINE 自身に検証させて 本人同一性を得る（チャネルシークレットは
+ * バックエンドの外へ出ない）。
+ *
+ * <p>応答は JSON をキー名で読む。LINE の項目名（id_token / sub / name）はワイヤ契約であり、Jackson の命名戦略に依存しないよう 専用の
+ * JsonMapper で木として読む。
+ */
+@Log4j2
+@Component
+public class LineApiClient {
+
+  private static final String TOKEN_PATH = "/oauth2/v2.1/token";
+  private static final String VERIFY_PATH = "/oauth2/v2.1/verify";
+
+  private static final JsonMapper JSON = JsonMapper.builder().build();
+
+  private final RestClient restClient;
+
+  public LineApiClient(AppProperties appProperties) {
+    this.restClient = RestClient.builder().baseUrl(appProperties.getLine().getApiBaseUrl()).build();
+  }
+
+  /**
+   * 認可コードを id_token へ交換し、LINE の検証端点で id_token を検証して本人同一性を返す。
+   *
+   * @throws LineAuthenticationException LINE がエラーを返した、または応答に sub が含まれない場合
+   */
+  public LineIdentity exchangeAndVerify(
+      LineChannel channel, String code, String redirectUri, String codeVerifier) {
+    String idToken = requestIdToken(channel, code, redirectUri, codeVerifier);
+    return verify(channel, idToken);
+  }
+
+  private String requestIdToken(
+      LineChannel channel, String code, String redirectUri, String codeVerifier) {
+    MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+    form.add("grant_type", "authorization_code");
+    form.add("code", code);
+    form.add("redirect_uri", redirectUri);
+    form.add("client_id", channel.channelId());
+    form.add("client_secret", channel.channelSecret());
+    if (codeVerifier != null && !codeVerifier.isBlank()) {
+      form.add("code_verifier", codeVerifier);
+    }
+    JsonNode body = post(TOKEN_PATH, form);
+    String idToken = body.path("id_token").asString(null);
+    if (idToken == null || idToken.isBlank()) {
+      throw new LineAuthenticationException("LINE のトークン応答に id_token が含まれていません");
+    }
+    return idToken;
+  }
+
+  private LineIdentity verify(LineChannel channel, String idToken) {
+    MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+    form.add("id_token", idToken);
+    form.add("client_id", channel.channelId());
+    JsonNode body = post(VERIFY_PATH, form);
+    String lineUserId = body.path("sub").asString(null);
+    if (lineUserId == null || lineUserId.isBlank()) {
+      throw new LineAuthenticationException("LINE の検証応答に sub が含まれていません");
+    }
+    return new LineIdentity(lineUserId, body.path("name").asString(""));
+  }
+
+  private JsonNode post(String path, MultiValueMap<String, String> form) {
+    String raw;
+    try {
+      raw =
+          restClient
+              .post()
+              .uri(path)
+              .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+              .body(form)
+              .retrieve()
+              .body(String.class);
+    } catch (RestClientException e) {
+      // LINE 側のエラー本文（invalid_grant 等）は攻撃者への手掛かりになるためログにのみ残す。
+      log.warn("LINE API 呼び出しに失敗しました path={}: {}", path, e.getMessage());
+      throw new LineAuthenticationException("LINE 認証に失敗しました", e);
+    }
+    try {
+      return JSON.readTree(raw == null ? "" : raw);
+    } catch (JacksonException e) {
+      log.warn("LINE API の応答を解釈できませんでした path={}", path);
+      throw new LineAuthenticationException("LINE 認証に失敗しました", e);
+    }
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/LineAuthenticationException.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/LineAuthenticationException.java
@@ -1,0 +1,20 @@
+package com.kizuna.auth.infrastructure;
+
+import org.springframework.security.core.AuthenticationException;
+
+/**
+ * LINE との認可コード交換・id_token 検証に失敗したことを表す例外。
+ *
+ * <p>{@code AuthenticationException} 系のため 401 で応答され、内部 message はワイヤへ出ない（LINE 側のエラー詳細は攻撃者への情報になるため、
+ * ログにだけ残す）。
+ */
+public class LineAuthenticationException extends AuthenticationException {
+
+  public LineAuthenticationException(String message) {
+    super(message);
+  }
+
+  public LineAuthenticationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/LineChannel.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/LineChannel.java
@@ -1,0 +1,9 @@
+package com.kizuna.auth.infrastructure;
+
+/**
+ * 解決済みの LINE ログインチャネル資格情報。
+ *
+ * @param channelId チャネル ID（前端にも公開される公開値）
+ * @param channelSecret チャネルシークレット（バックエンドから外へ出さない）
+ */
+public record LineChannel(String channelId, String channelSecret) {}

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/LineChannelResolver.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/LineChannelResolver.java
@@ -1,0 +1,37 @@
+package com.kizuna.auth.infrastructure;
+
+import com.kizuna.settings.application.LineChannelSettings;
+import com.kizuna.settings.application.SystemConfigService;
+import com.kizuna.shared.config.AppProperties;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * LINE チャネル資格情報の解決。システム設定（DB）を優先し、未設定のときだけ環境変数由来の設定（{@code app.line.*}）へフォールバックする — SMTP
+ * と同じ優先順位で、運用中の管理画面からの差し替えを再デプロイなしに効かせるため。
+ *
+ * <p>ID とシークレットの双方が揃わなければ「未設定」とみなす（片方だけでは LINE と通信できず、公開端点が enabled=true を返してしまうため）。
+ */
+@Component
+@RequiredArgsConstructor
+public class LineChannelResolver {
+
+  private final SystemConfigService systemConfigService;
+  private final AppProperties appProperties;
+
+  /** 解決済みチャネル。両方の資格情報が揃わなければ空（＝LINE ログイン無効）。 */
+  public Optional<LineChannel> resolve() {
+    LineChannelSettings stored = systemConfigService.lineChannelSettings();
+    if (stored.configured()) {
+      return Optional.of(new LineChannel(stored.channelId(), stored.channelSecret()));
+    }
+    String channelId = appProperties.getLine().getChannelId();
+    String channelSecret = appProperties.getLine().getChannelSecret();
+    if (StringUtils.hasText(channelId) && StringUtils.hasText(channelSecret)) {
+      return Optional.of(new LineChannel(channelId, channelSecret));
+    }
+    return Optional.empty();
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/LineIdentity.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/LineIdentity.java
@@ -1,0 +1,9 @@
+package com.kizuna.auth.infrastructure;
+
+/**
+ * LINE が検証した本人同一性。
+ *
+ * @param lineUserId id_token の sub（LINE ユーザー ID）。身分の同一性はこの値だけで判定する
+ * @param displayName id_token の name（LINE プロフィール表示名。登録画面の初期値に使う）
+ */
+public record LineIdentity(String lineUserId, String displayName) {}

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/LineRegistrationTicketStore.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/LineRegistrationTicketStore.java
@@ -1,0 +1,60 @@
+package com.kizuna.auth.infrastructure;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 未登録 LINE アカウントの登録チケット（Redis）。LINE で検証済みの LINE ユーザー ID を短命の不透明値の裏に保持し、 登録確定要求がその LINE ユーザー ID
+ * を自称せずに済むようにする（自称できると任意の LINE アカウントを騙れる）。
+ *
+ * <p>チケットの消費は登録の成功時のみ: 参照（{@link #peek}）と削除（{@link #consume}）を分け、重複メールなどで登録が
+ * 失敗した場合はチケットを残して入力の修正・再試行を許す（OAuth のやり直しを強いない）。成功後の再利用は削除が防ぎ、 削除前の並行二重登録は t_users の LINE ユーザー ID
+ * 一意制約が最終防衛線として 409 に写像する。表示名は保持しない — 登録確定要求が利用者の編集後の表示名を送るため、検証時点の表示名は応答で前端へ返すだけでよい。
+ */
+@Component
+@RequiredArgsConstructor
+public class LineRegistrationTicketStore {
+
+  private static final String KEY_PREFIX = "line:registration:";
+
+  /** チケットの有効期間。登録確定画面でメールアドレスを入力するのに十分で、放置されたチケットは自然に消える。 */
+  private static final Duration TTL = Duration.ofMinutes(10);
+
+  private static final int TICKET_BYTES = 32;
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  private final SecureRandom random = new SecureRandom();
+
+  /** LINE ユーザー ID に対する新しいチケットを発行する。 */
+  public String issue(String lineUserId) {
+    byte[] bytes = new byte[TICKET_BYTES];
+    random.nextBytes(bytes);
+    String ticket = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    redisTemplate.opsForValue().set(KEY_PREFIX + ticket, lineUserId, TTL);
+    return ticket;
+  }
+
+  /** チケット裏の LINE ユーザー ID を消費せずに返す。未知・期限切れ・使用済みなら空。 */
+  public Optional<String> peek(String ticket) {
+    if (ticket == null || ticket.isBlank()) {
+      return Optional.empty();
+    }
+    Object lineUserId = redisTemplate.opsForValue().get(KEY_PREFIX + ticket);
+    return Optional.ofNullable(lineUserId).map(Object::toString);
+  }
+
+  /** チケットを消費して LINE ユーザー ID を返す。未知・期限切れ・使用済みなら空。 */
+  public Optional<String> consume(String ticket) {
+    if (ticket == null || ticket.isBlank()) {
+      return Optional.empty();
+    }
+    Object lineUserId = redisTemplate.opsForValue().getAndDelete(KEY_PREFIX + ticket);
+    return Optional.ofNullable(lineUserId).map(Object::toString);
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/PlatformBearerTokenResolver.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/PlatformBearerTokenResolver.java
@@ -29,6 +29,11 @@ public class PlatformBearerTokenResolver implements BearerTokenResolver {
     PathPatternRequestMatcher.withDefaults().matcher("/platform/cast-invitations/*/acceptance"),
     // 会員の自助登録（POST）。統一ログイン画面からの遷移で陳腐な token cookie が付きうる。
     PathPatternRequestMatcher.withDefaults().matcher("/platform/members"),
+    // LINE ログインの公開端点（設定照会・ログイン・登録確定）。統一ログイン画面からの遷移で陳腐な token cookie が付きうる。
+    // 連携（/platform/me/line）は認証必須のため対象外 — 免除すると Bearer が解決されず、常に匿名として 401 になる。
+    PathPatternRequestMatcher.withDefaults().matcher("/platform/line/config"),
+    PathPatternRequestMatcher.withDefaults().matcher("/platform/line/login"),
+    PathPatternRequestMatcher.withDefaults().matcher("/platform/line/register"),
     PathPatternRequestMatcher.withDefaults().matcher("/platform/stores/lookup"),
     PathPatternRequestMatcher.withDefaults().matcher("/store/config/public"),
     PathPatternRequestMatcher.withDefaults().matcher("/store/casts/public"),

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/SecurityConfig.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/SecurityConfig.java
@@ -38,6 +38,9 @@ public class SecurityConfig {
     PathPatternRequestMatcher.withDefaults().matcher("/platform/cast-invitations/*/acceptance"),
     // 匿名 POST の会員自助登録（同上: Bearer なしのため Bearer 免除に該当しない）。
     PathPatternRequestMatcher.withDefaults().matcher("/platform/members"),
+    // 匿名 POST の LINE ログインと LINE 登録確定（同上）。連携(/platform/me/line)は Bearer 付きで既存免除に該当する。
+    PathPatternRequestMatcher.withDefaults().matcher("/platform/line/login"),
+    PathPatternRequestMatcher.withDefaults().matcher("/platform/line/register"),
     request -> {
       String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
       return StringUtils.hasText(authHeader) && authHeader.startsWith("Bearer ");

--- a/backend/src/main/java/com/kizuna/member/application/MemberRegistrationService.java
+++ b/backend/src/main/java/com/kizuna/member/application/MemberRegistrationService.java
@@ -5,12 +5,14 @@ import com.kizuna.member.api.dto.MemberRegistrationResponse;
 import com.kizuna.member.domain.Member;
 import com.kizuna.member.domain.MemberCodes;
 import com.kizuna.member.domain.MemberRepository;
+import com.kizuna.shared.exception.ConflictException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
 import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.Locale;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +32,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberRegistrationService {
 
   private static final String EMAIL_UNIQUE_CONSTRAINT = "uq_t_users_email";
+  private static final String LINE_USER_UNIQUE_CONSTRAINT = "uq_t_users_line_user_id";
   private static final String DUPLICATE_EMAIL_MESSAGE = "このメールアドレスは既に登録されています。ログインしてご利用ください";
+  private static final String DUPLICATE_LINE_USER_MESSAGE = "この LINE アカウントは既に別の身分と連携済みです";
 
   /** 会員コード発行の再試行上限。数字 12 桁空間では衝突は実質発生せず、上限到達は乱数源の異常を意味する。 */
   private static final int CODE_ISSUE_ATTEMPTS = 5;
@@ -65,6 +69,48 @@ public class MemberRegistrationService {
     return new MemberRegistrationResponse(member.getMemberCode());
   }
 
+  /**
+   * LINE 認証で確定した身分の会員登録。パスワードは推測不能な乱数を符号化して置く — LINE のみで登録した会員は
+   * パスワードログインの経路を持たない（本人が忘れて困る値ではなく、空を許さない 列を埋めるための値）。
+   *
+   * <p>重複は 409 で返す（{@link #register} の 400 と異なる）。LINE 登録は前端が既存アカウントとの衝突を検出して 案内へ分岐する必要があり、入力形式の誤り
+   * （400）と区別できなければならない。
+   *
+   * @param lineUserId LINE が検証した LINE ユーザー ID
+   * @return 作成された会員身分のプラットフォームユーザー
+   */
+  @Transactional
+  public PlatformUser registerWithLine(String email, String displayName, String lineUserId) {
+    if (platformUserRepository.findByEmail(email.toLowerCase(Locale.ROOT)).isPresent()) {
+      throw new ConflictException(DUPLICATE_EMAIL_MESSAGE);
+    }
+    if (platformUserRepository.existsByLineUserId(lineUserId)) {
+      throw new ConflictException(DUPLICATE_LINE_USER_MESSAGE);
+    }
+    PlatformUser user =
+        saveLineUser(
+            PlatformUser.builder()
+                .email(email)
+                .password(passwordEncoder.encode(randomPassword()))
+                .displayName(displayName)
+                .enabled(true)
+                .userType(UserType.MEMBER)
+                .storeScopeType(StoreScopeType.SPECIFIC_STORES)
+                .storeIds(Set.of())
+                .lineUserId(lineUserId)
+                .build());
+    memberRepository.save(
+        Member.builder().memberCode(issueCode()).platformUserId(user.getId()).build());
+    return user;
+  }
+
+  /** パスワードログインを成立させないための乱数パスワード（符号化前の平文はどこにも残さない）。 */
+  private String randomPassword() {
+    byte[] bytes = new byte[32];
+    random.nextBytes(bytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+
   /** 一意の会員コードを発行する。事前の存在チェックで衝突を避け、上限到達は例外（並行登録との厳密な競合は DB の一意制約が最終防衛線として 409 で顕在化する）。 */
   private String issueCode() {
     for (int attempt = 0; attempt < CODE_ISSUE_ATTEMPTS; attempt++) {
@@ -87,6 +133,25 @@ public class MemberRegistrationService {
       String cause = ex.getMostSpecificCause().getMessage();
       if (cause != null && cause.contains(EMAIL_UNIQUE_CONSTRAINT)) {
         throw new ServiceException(DUPLICATE_EMAIL_MESSAGE);
+      }
+      throw ex;
+    }
+  }
+
+  /**
+   * LINE 登録の保存。事前チェックを擦り抜けた並行登録を、email・LINE ユーザー ID いずれの一意制約違反も 409 へ写像する
+   * （どちらも「先に確定した別要求と衝突した」であり、要求自体の形式は正しい）。
+   */
+  private PlatformUser saveLineUser(PlatformUser user) {
+    try {
+      return platformUserRepository.saveAndFlush(user);
+    } catch (DataIntegrityViolationException ex) {
+      String cause = ex.getMostSpecificCause().getMessage();
+      if (cause != null && cause.contains(EMAIL_UNIQUE_CONSTRAINT)) {
+        throw new ConflictException(DUPLICATE_EMAIL_MESSAGE);
+      }
+      if (cause != null && cause.contains(LINE_USER_UNIQUE_CONSTRAINT)) {
+        throw new ConflictException(DUPLICATE_LINE_USER_MESSAGE);
       }
       throw ex;
     }

--- a/backend/src/main/java/com/kizuna/member/application/MemberRegistrationService.java
+++ b/backend/src/main/java/com/kizuna/member/application/MemberRegistrationService.java
@@ -99,7 +99,8 @@ public class MemberRegistrationService {
                 .storeIds(Set.of())
                 .lineUserId(lineUserId)
                 .build());
-    memberRepository.save(
+    // flush まで行い、会員行の制約違反も呼び出し元が登録チケットを消費する前に顕在化させる
+    memberRepository.saveAndFlush(
         Member.builder().memberCode(issueCode()).platformUserId(user.getId()).build());
     return user;
   }

--- a/backend/src/main/java/com/kizuna/member/application/package-info.java
+++ b/backend/src/main/java/com/kizuna/member/application/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * member モジュールのアプリケーション層。
+ *
+ * <p>named interface 公開は過渡措置: auth モジュールの LINE 登録が会員身分の作成（プラットフォームユーザー + 会員集約の 単一トランザクション）を
+ * MemberRegistrationService に委ねているため。登録経路の受け口が整理された段階で公開面を狭める。
+ */
+@org.springframework.modulith.NamedInterface("application")
+package com.kizuna.member.application;

--- a/backend/src/main/java/com/kizuna/notification/application/MailService.java
+++ b/backend/src/main/java/com/kizuna/notification/application/MailService.java
@@ -21,14 +21,23 @@ public class MailService {
   private final ObjectProvider<JavaMailSender> mailSenderProvider;
 
   public void send(String to, String subject, String body) {
+    // 送信は呼び出し元の業務を止めない（例外を外へ出さない）。ただし「設定が読めない」と「送信に失敗した」は
+    // 別の故障であり、握り潰すと SMTP を設定してもメールが出ない静かな故障になるため、ログで区別する。
+    SmtpSettings smtp;
+    JavaMailSender sender;
     try {
-      SmtpSettings smtp = systemConfigService.smtpSettings();
-      JavaMailSender sender = resolveSender(smtp);
-      if (sender == null) {
-        // フォールバック: メール設定がなくてもシステムが動作するようログ出力のみ行う
-        log.info("[MAIL-FALLBACK] to={} subject={} body={} ", to, subject, body);
-        return;
-      }
+      smtp = systemConfigService.smtpSettings();
+      sender = resolveSender(smtp);
+    } catch (Exception e) {
+      log.error("SMTP 設定の読み取りに失敗したためメールを送信できません to={}", to, e);
+      return;
+    }
+    if (sender == null) {
+      // フォールバック: メール設定がなくてもシステムが動作するようログ出力のみ行う
+      log.info("[MAIL-FALLBACK] to={} subject={} body={} ", to, subject, body);
+      return;
+    }
+    try {
       SimpleMailMessage msg = new SimpleMailMessage();
       if (smtp.hasFrom()) {
         msg.setFrom(smtp.from());
@@ -38,7 +47,7 @@ public class MailService {
       msg.setText(body);
       sender.send(msg);
     } catch (Exception e) {
-      log.error("メール送信に失敗しました to={}: {}", to, e.getMessage());
+      log.error("メール送信に失敗しました to={}", to, e);
     }
   }
 
@@ -47,7 +56,7 @@ public class MailService {
     if (!smtp.configured()) {
       return mailSenderProvider.getIfAvailable();
     }
-    // ponytail: 設定は smtpSettings() 側でキャッシュ済み。送信クライアントの器の生成は軽量なので送信毎で足りる
+    // 送信クライアントの器の生成は軽量なので送信毎の組み立てで足りる（送信は低頻度）
     JavaMailSenderImpl impl = new JavaMailSenderImpl();
     impl.setHost(smtp.host());
     impl.setPort(smtp.port());

--- a/backend/src/main/java/com/kizuna/settings/application/LineChannelSettings.java
+++ b/backend/src/main/java/com/kizuna/settings/application/LineChannelSettings.java
@@ -1,0 +1,19 @@
+package com.kizuna.settings.application;
+
+/**
+ * LINE ログインチャネル資格情報の型付きスナップショット。キー名（line_channel_id 等）の知識は settings モジュールだけが持ち、
+ * 消費側（auth）はこの型のみに依存する。
+ *
+ * @param channelId チャネル ID（未設定なら空文字）
+ * @param channelSecret チャネルシークレット（未設定なら空文字）
+ */
+public record LineChannelSettings(String channelId, String channelSecret) {
+
+  /** DB に両方が設定されているか（false なら環境変数フォールバックを使う）。 */
+  public boolean configured() {
+    return channelId != null
+        && !channelId.isBlank()
+        && channelSecret != null
+        && !channelSecret.isBlank();
+  }
+}

--- a/backend/src/main/java/com/kizuna/settings/application/SystemConfigService.java
+++ b/backend/src/main/java/com/kizuna/settings/application/SystemConfigService.java
@@ -17,4 +17,7 @@ public interface SystemConfigService {
 
   /** SMTP 設定の型付きスナップショット（キー名の知識は settings 側に閉じる）。 */
   SmtpSettings smtpSettings();
+
+  /** LINE ログインチャネル資格情報の型付きスナップショット（キー名の知識は settings 側に閉じる）。 */
+  LineChannelSettings lineChannelSettings();
 }

--- a/backend/src/main/java/com/kizuna/settings/application/SystemConfigServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/settings/application/SystemConfigServiceImpl.java
@@ -41,7 +41,7 @@ public class SystemConfigServiceImpl implements SystemConfigService {
 
   @Override
   @Transactional
-  // smtpSettings のような集約キャッシュも確実に無効化するため全消去（設定更新は低頻度の管理操作）
+  // どのキーが更新されても確実に無効化するため全消去（設定更新は低頻度の管理操作）
   @CacheEvict(value = "systemConfigValues", allEntries = true)
   public SystemConfigResponse updateConfig(SystemConfigUpdateRequest request) {
     SystemConfig config =
@@ -62,9 +62,13 @@ public class SystemConfigServiceImpl implements SystemConfigService {
     return systemConfigRepository.findByConfigKey(configKey).map(SystemConfig::getConfigValue);
   }
 
+  /**
+   * SMTP 設定は都度読む（キャッシュしない）。キャッシュ値の既定シリアライザは JDK 直列化で、{@code Serializable} でない record
+   * を載せようとすると読み取り自体が例外になる（{@code getConfigValue} が動くのは Spring が Optional を解いて String
+   * を保存するため）。送信は低頻度で、都度読みなら管理画面での差し替えも次の送信から効く。
+   */
   @Override
   @Transactional(readOnly = true)
-  @Cacheable(value = "systemConfigValues", key = "'smtp:settings'")
   public SmtpSettings smtpSettings() {
     int port = 25;
     String rawPort = rawValue("smtp_port");
@@ -90,7 +94,7 @@ public class SystemConfigServiceImpl implements SystemConfigService {
     return new LineChannelSettings(rawValue("line_channel_id"), rawValue("line_channel_secret"));
   }
 
-  /** キャッシュプロキシを経由しない内部読み取り（smtpSettings 自体がキャッシュされる）。 */
+  /** {@code getConfigValue} のキャッシュを経由しない内部読み取り（設定スナップショットは都度 DB から組み立てる）。 */
   private String rawValue(String configKey) {
     return systemConfigRepository
         .findByConfigKey(configKey)

--- a/backend/src/main/java/com/kizuna/settings/application/SystemConfigServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/settings/application/SystemConfigServiceImpl.java
@@ -83,6 +83,13 @@ public class SystemConfigServiceImpl implements SystemConfigService {
         rawValue("smtp_from"));
   }
 
+  /** LINE チャネル資格情報は都度読む（キャッシュしない）。参照するのは LINE 端点だけで頻度が低く、 管理画面での差し替えを次の要求から効かせられる。 */
+  @Override
+  @Transactional(readOnly = true)
+  public LineChannelSettings lineChannelSettings() {
+    return new LineChannelSettings(rawValue("line_channel_id"), rawValue("line_channel_secret"));
+  }
+
   /** キャッシュプロキシを経由しない内部読み取り（smtpSettings 自体がキャッシュされる）。 */
   private String rawValue(String configKey) {
     return systemConfigRepository

--- a/backend/src/main/java/com/kizuna/shared/config/AppProperties.java
+++ b/backend/src/main/java/com/kizuna/shared/config/AppProperties.java
@@ -25,6 +25,9 @@ public class AppProperties {
   /** app.upload.* */
   private Upload upload = new Upload();
 
+  /** app.line.* */
+  private Line line = new Line();
+
   @Getter
   @Setter
   public static class Jwt {
@@ -43,6 +46,19 @@ public class AppProperties {
     private long maxFileSize = 10485760;
     private List<String> allowedTypes =
         List.of("image/jpeg", "image/png", "image/gif", "image/webp");
+  }
+
+  /**
+   * LINE ログインの設定。チャネル資格情報はシステム設定（DB）が優先で、未設定のときだけここ（環境変数）へフォールバックする。
+   *
+   * <p>{@code apiBaseUrl} は LINE プラットフォーム API の基底 URL。統合テストがスタブサーバーへ差し替えるための可変点で、 運用では既定値のまま使う。
+   */
+  @Getter
+  @Setter
+  public static class Line {
+    private String apiBaseUrl = "https://api.line.me";
+    private String channelId;
+    private String channelSecret;
   }
 
   public enum Scheme {

--- a/backend/src/main/java/com/kizuna/user/domain/LineAlreadyLinkedException.java
+++ b/backend/src/main/java/com/kizuna/user/domain/LineAlreadyLinkedException.java
@@ -1,0 +1,11 @@
+package com.kizuna.user.domain;
+
+import com.kizuna.shared.exception.ConflictException;
+
+/** 連携済みの身分に対して重ねて LINE 連携を試みたことを表すドメイン例外。ConflictException 継承により HTTP 409 で応答される。 */
+public class LineAlreadyLinkedException extends ConflictException {
+
+  public LineAlreadyLinkedException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/com/kizuna/user/domain/PlatformUser.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PlatformUser.java
@@ -48,6 +48,13 @@ public class PlatformUser extends BaseEntity {
   @Column(name = "display_name", nullable = false, length = 150)
   private String displayName;
 
+  /**
+   * 連携済み LINE ユーザー ID（未連携は null）。LINE ログインはこの値だけを同一性の根拠にし、メール一致による自動連携は行わない （LINE
+   * 側の検証済みメールが既存アカウントと一致しても、それだけでは本人性の証明にならないため）。
+   */
+  @Column(name = "line_user_id", length = 64)
+  private String lineUserId;
+
   @Column(nullable = false)
   private Boolean enabled = true;
 
@@ -83,7 +90,8 @@ public class PlatformUser extends BaseEntity {
       UserType userType,
       Set<Long> roleIds,
       StoreScopeType storeScopeType,
-      Set<Long> storeIds) {
+      Set<Long> storeIds,
+      String lineUserId) {
     Set<Long> roles = roleIds == null ? Set.of() : roleIds;
     Set<Long> stores = storeIds == null ? Set.of() : storeIds;
     validateRoleGrant(userType, roles);
@@ -91,6 +99,7 @@ public class PlatformUser extends BaseEntity {
     this.email = email == null ? null : email.toLowerCase(Locale.ROOT);
     this.password = password;
     this.displayName = displayName;
+    this.lineUserId = lineUserId;
     this.enabled = enabled;
     this.userType = userType;
     this.roleIds = new HashSet<>(roles);
@@ -130,6 +139,18 @@ public class PlatformUser extends BaseEntity {
   /** 表示名を更新する（自己プロフィール更新用。不変条件なし）。 */
   public void updateDisplayName(String displayName) {
     this.displayName = displayName;
+  }
+
+  /**
+   * LINE アカウントを連携する。連携は 1 身分につき 1 度きりで、解除も付け替えも提供しない。
+   *
+   * @throws LineAlreadyLinkedException 既に別の LINE アカウントを連携済みの場合
+   */
+  public void linkLine(String lineUserId) {
+    if (this.lineUserId != null) {
+      throw new LineAlreadyLinkedException("このアカウントは既に LINE と連携済みです");
+    }
+    this.lineUserId = lineUserId;
   }
 
   /** エンコード済みパスワードで置き換える（呼び出し側で符号化済みであること）。 */

--- a/backend/src/main/java/com/kizuna/user/domain/PlatformUserRepository.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PlatformUserRepository.java
@@ -13,6 +13,12 @@ public interface PlatformUserRepository
     extends JpaRepository<PlatformUser, Long>, JpaSpecificationExecutor<PlatformUser> {
   Optional<PlatformUser> findByEmail(String email);
 
+  /** 連携済み LINE ユーザー ID で身分を引く。LINE ログインが同一性の根拠にする唯一の経路。 */
+  Optional<PlatformUser> findByLineUserId(String lineUserId);
+
+  /** 指定 LINE ユーザー ID が既に別の身分へ連携済みか（連携要求の事前検証）。 */
+  boolean existsByLineUserId(String lineUserId);
+
   /**
    * 指定した本人種別で、現店舗を授権する（ALL_STORES または個別授権店舗集合に含む）有効なユーザーを表示名昇順で取得する。店舗スコープの絞り込みを DB
    * 層で行うことで、無関係な他店舗ユーザーの ElementCollection（ロール・店舗集合）を読み込まずに済む。

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -117,6 +117,12 @@ app:
   jwt:
     expiration: ${APP_JWT_EXPIRATION_MS:3600000}
     secret: ${APP_JWT_SECRET}
+  line:
+    # LINE プラットフォーム API の基底 URL。統合テストのスタブ差し替え用の可変点で、運用では既定のまま。
+    api-base-url: ${LINE_API_BASE_URL:https://api.line.me}
+    # チャネル資格情報はシステム設定（t_system_configs）が優先。両方が空なら LINE ログインは無効。
+    channel-id: ${LINE_CHANNEL_ID:}
+    channel-secret: ${LINE_CHANNEL_SECRET:}
   upload:
     endpoint: ${MINIO_ENDPOINT:http://localhost:9000}
     bucket: ${MINIO_BUCKET:uploads}

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -17,6 +17,9 @@ databaseChangeLog:
   - include:
       file: releases/v0.6.0/master.yaml
       relativeToChangelogFile: true
+  - include:
+      file: releases/v0.7.0/master.yaml
+      relativeToChangelogFile: true
   # reconcile/ は版に属さない恒久的な写像取り直しで、必ず全 release の後に置く（毎回実行されるため、
   # ロールの改名など release 側の移行より先に走ると、移行前の状態を見て齟齬と判定してしまう）。
   # 新しい release の include は必ずこの include より前に足すこと。

--- a/backend/src/main/resources/db/changelog/releases/v0.7.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.7.0/master.yaml
@@ -1,0 +1,8 @@
+# v0.7.0 = LINE ログイン（プラットフォーム認証手段）の追加。platform 層と seed 層。
+databaseChangeLog:
+  - include:
+      file: platform/01-line-login.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: seed/01-line-configs.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.7.0/platform/01-line-login.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.7.0/platform/01-line-login.yaml
@@ -1,0 +1,29 @@
+databaseChangeLog:
+  - changeSet:
+      id: platform-v0700-001-user-line-user-id
+      author: kanghouchao
+      # LINE 連携済みプラットフォームユーザーの LINE ユーザー ID。身分表は t_users のまま拡張し、
+      # 別の同一性テーブルは設けない。NULL 許容（未連携）だが、値を持つ行は一意
+      # （1 つの LINE アカウントが複数の身分に結び付くと、なりすまし経路になるため）。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - addColumn:
+            tableName: t_users
+            columns:
+              - column:
+                  name: line_user_id
+                  type: VARCHAR(64)
+                  remarks: 連携済み LINE ユーザー ID（未連携は NULL。値を持つ行は一意）
+        - addUniqueConstraint:
+            constraintName: uq_t_users_line_user_id
+            tableName: t_users
+            columnNames: line_user_id
+      rollback:
+        - dropUniqueConstraint:
+            constraintName: uq_t_users_line_user_id
+            tableName: t_users
+        - dropColumn:
+            tableName: t_users
+            columnName: line_user_id

--- a/backend/src/main/resources/db/changelog/releases/v0.7.0/seed/01-line-configs.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.7.0/seed/01-line-configs.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - changeSet:
+      id: seed-v0700-001-line-configs
+      author: kanghouchao
+      # LINE ログインのチャネル資格情報。SMTP と同じく「未設定（空文字）＝環境変数フォールバック」が既定で、
+      # 値を入れると DB 側が優先される（環境変数は LINE_CHANNEL_ID / LINE_CHANNEL_SECRET）。
+      # 双方とも空なら LINE ログインは無効（GET /platform/line/config が enabled=false を返す）。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - insert:
+            tableName: t_system_configs
+            columns:
+              - column: { name: config_key, value: "line_channel_id" }
+              - column: { name: config_value, value: "" }
+              - column: { name: category, value: "LINE" }
+              - column: { name: description, value: "LINEログインチャネルID" }
+        - insert:
+            tableName: t_system_configs
+            columns:
+              - column: { name: config_key, value: "line_channel_secret" }
+              - column: { name: config_value, value: "" }
+              - column: { name: category, value: "LINE" }
+              - column: { name: description, value: "LINEログインチャネルシークレット" }
+              - column: { name: secret, valueBoolean: true }
+      rollback:
+        - delete:
+            tableName: t_system_configs
+            where: config_key in ('line_channel_id', 'line_channel_secret')

--- a/backend/src/test/java/com/kizuna/auth/application/LineAuthServiceTest.java
+++ b/backend/src/test/java/com/kizuna/auth/application/LineAuthServiceTest.java
@@ -1,0 +1,270 @@
+package com.kizuna.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.kizuna.auth.api.dto.LineAuthorizationRequest;
+import com.kizuna.auth.api.dto.LineLoginResponse;
+import com.kizuna.auth.api.dto.LineRegistrationRequest;
+import com.kizuna.auth.api.dto.Token;
+import com.kizuna.auth.infrastructure.LineApiClient;
+import com.kizuna.auth.infrastructure.LineChannel;
+import com.kizuna.auth.infrastructure.LineChannelResolver;
+import com.kizuna.auth.infrastructure.LineIdentity;
+import com.kizuna.auth.infrastructure.LineRegistrationTicketStore;
+import com.kizuna.member.application.MemberRegistrationService;
+import com.kizuna.shared.exception.ConflictException;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.ServiceUnavailableException;
+import com.kizuna.user.domain.LineAlreadyLinkedException;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import com.kizuna.user.domain.StoreScopeType;
+import com.kizuna.user.domain.UserType;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.authentication.DisabledException;
+
+/** {@link LineAuthService} の単体テスト。 */
+@ExtendWith(MockitoExtension.class)
+class LineAuthServiceTest {
+
+  private static final LineChannel CHANNEL = new LineChannel("channel-id", "channel-secret");
+  private static final LineIdentity IDENTITY = new LineIdentity("U-line-1", "LINE太郎");
+  private static final Token TOKEN = new Token("issued-token", 1_700_000_000_000L);
+
+  @Mock private LineChannelResolver channelResolver;
+  @Mock private LineApiClient lineApiClient;
+  @Mock private LineRegistrationTicketStore ticketStore;
+  @Mock private PlatformUserRepository userRepository;
+  @Mock private MemberRegistrationService memberRegistrationService;
+  @Mock private PlatformAuthService authService;
+
+  @InjectMocks private LineAuthService lineAuthService;
+
+  private static LineAuthorizationRequest authorizationRequest() {
+    LineAuthorizationRequest request = new LineAuthorizationRequest();
+    request.setCode("auth-code");
+    request.setRedirectUri("https://app.test/cb");
+    request.setCodeVerifier("verifier");
+    return request;
+  }
+
+  private static LineRegistrationRequest registrationRequest() {
+    LineRegistrationRequest request = new LineRegistrationRequest();
+    request.setRegistrationTicket("ticket-1");
+    request.setDisplayName("会員太郎");
+    request.setEmail("member@kizuna.test");
+    return request;
+  }
+
+  private static PlatformUser member(String email) {
+    return PlatformUser.builder()
+        .email(email)
+        .password("hash")
+        .displayName("会員太郎")
+        .enabled(true)
+        .userType(UserType.MEMBER)
+        .storeScopeType(StoreScopeType.SPECIFIC_STORES)
+        .storeIds(Set.of())
+        .build();
+  }
+
+  private void stubVerifiedIdentity() {
+    when(channelResolver.resolve()).thenReturn(Optional.of(CHANNEL));
+    when(lineApiClient.exchangeAndVerify(CHANNEL, "auth-code", "https://app.test/cb", "verifier"))
+        .thenReturn(IDENTITY);
+  }
+
+  @Test
+  @DisplayName("チャネル解決できれば config は enabled=true とチャネル ID を返す")
+  void configExposesChannelIdWhenEnabled() {
+    when(channelResolver.resolve()).thenReturn(Optional.of(CHANNEL));
+
+    assertThat(lineAuthService.config().enabled()).isTrue();
+    assertThat(lineAuthService.config().channelId()).isEqualTo("channel-id");
+  }
+
+  @Test
+  @DisplayName("チャネル未設定なら config は enabled=false でチャネル ID を返さない")
+  void configHidesChannelIdWhenDisabled() {
+    when(channelResolver.resolve()).thenReturn(Optional.empty());
+
+    assertThat(lineAuthService.config().enabled()).isFalse();
+    assertThat(lineAuthService.config().channelId()).isNull();
+  }
+
+  @Test
+  @DisplayName("連携済み LINE ユーザーはパスワードログインと同一の発行経路でトークンを得る")
+  void loginWithLinkedLineUserIssuesToken() {
+    stubVerifiedIdentity();
+    PlatformUser user = member("member@kizuna.test");
+    when(userRepository.findByLineUserId("U-line-1")).thenReturn(Optional.of(user));
+    when(authService.issueTokenFor(user)).thenReturn(TOKEN);
+
+    LineLoginResponse response = lineAuthService.login(authorizationRequest());
+
+    assertThat(response.registered()).isTrue();
+    assertThat(response.token()).isEqualTo("issued-token");
+    assertThat(response.expiresAt()).isEqualTo(1_700_000_000_000L);
+    assertThat(response.registrationTicket()).isNull();
+  }
+
+  @Test
+  @DisplayName("未知の LINE ユーザーには登録チケットを返し、トークンは一切発行しない")
+  void loginWithUnknownLineUserReturnsRegistrationTicket() {
+    stubVerifiedIdentity();
+    when(userRepository.findByLineUserId("U-line-1")).thenReturn(Optional.empty());
+    when(ticketStore.issue("U-line-1")).thenReturn("ticket-1");
+
+    LineLoginResponse response = lineAuthService.login(authorizationRequest());
+
+    assertThat(response.registered()).isFalse();
+    assertThat(response.registrationTicket()).isEqualTo("ticket-1");
+    assertThat(response.displayName()).isEqualTo("LINE太郎");
+    assertThat(response.token()).isNull();
+    verify(authService, never()).issueTokenFor(any());
+  }
+
+  @Test
+  @DisplayName("ログイン経路はメールアドレスで身分を引かない（LINE 側メール一致による既存アカウントのなりすましを構造的に排除する）")
+  void loginNeverResolvesIdentityByEmail() {
+    stubVerifiedIdentity();
+    when(userRepository.findByLineUserId("U-line-1")).thenReturn(Optional.empty());
+    when(ticketStore.issue("U-line-1")).thenReturn("ticket-1");
+
+    lineAuthService.login(authorizationRequest());
+
+    verify(userRepository, never()).findByEmail(anyString());
+    verify(userRepository, never()).findByEmailForUpdate(anyString());
+  }
+
+  @Test
+  @DisplayName("停止済みアカウントの LINE ログインはパスワードログインと同じく 401 相当で拒否する")
+  void loginWithDisabledLinkedUserIsRejected() {
+    stubVerifiedIdentity();
+    PlatformUser user = member("member@kizuna.test");
+    user.stop();
+    when(userRepository.findByLineUserId("U-line-1")).thenReturn(Optional.of(user));
+
+    assertThatThrownBy(() -> lineAuthService.login(authorizationRequest()))
+        .isInstanceOf(DisabledException.class);
+    verify(authService, never()).issueTokenFor(any());
+  }
+
+  @Test
+  @DisplayName("チャネル未設定なら LINE ログインは 503 相当で拒否する")
+  void loginWithoutChannelIsUnavailable() {
+    when(channelResolver.resolve()).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> lineAuthService.login(authorizationRequest()))
+        .isInstanceOf(ServiceUnavailableException.class);
+  }
+
+  @Test
+  @DisplayName("登録はチケット裏の LINE ユーザー ID で会員を作り、成功時のみチケットを消費してトークンを発行する")
+  void registerConsumesTicketAndIssuesToken() {
+    when(ticketStore.peek("ticket-1")).thenReturn(Optional.of("U-line-1"));
+    PlatformUser created = member("member@kizuna.test");
+    when(memberRegistrationService.registerWithLine("member@kizuna.test", "会員太郎", "U-line-1"))
+        .thenReturn(created);
+    when(authService.issueTokenFor(created)).thenReturn(TOKEN);
+
+    assertThat(lineAuthService.register(registrationRequest())).isEqualTo(TOKEN);
+    verify(ticketStore).consume("ticket-1");
+  }
+
+  @Test
+  @DisplayName("無効・使用済みチケットでの登録は 400 相当で拒否し、会員を作らない")
+  void registerWithInvalidTicketIsRejected() {
+    when(ticketStore.peek("ticket-1")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> lineAuthService.register(registrationRequest()))
+        .isInstanceOf(ServiceException.class);
+    verify(memberRegistrationService, never())
+        .registerWithLine(anyString(), anyString(), anyString());
+  }
+
+  @Test
+  @DisplayName("登録が重複などで失敗してもチケットは消費せず、入力を直しての再試行を許す")
+  void registerKeepsTicketWhenRegistrationFails() {
+    when(ticketStore.peek("ticket-1")).thenReturn(Optional.of("U-line-1"));
+    when(memberRegistrationService.registerWithLine("member@kizuna.test", "会員太郎", "U-line-1"))
+        .thenThrow(new ConflictException("このメールアドレスは既に登録されています。ログインしてご利用ください"));
+
+    assertThatThrownBy(() -> lineAuthService.register(registrationRequest()))
+        .isInstanceOf(ConflictException.class);
+    verify(ticketStore, never()).consume(anyString());
+  }
+
+  @Test
+  @DisplayName("連携は現在の認証主体に結び付ける")
+  void linkAttachesLineUserToAuthenticatedUser() {
+    stubVerifiedIdentity();
+    PlatformUser user = member("member@kizuna.test");
+    when(userRepository.findByEmail("member@kizuna.test")).thenReturn(Optional.of(user));
+    when(userRepository.existsByLineUserId("U-line-1")).thenReturn(false);
+
+    lineAuthService.link("member@kizuna.test", authorizationRequest());
+
+    assertThat(user.getLineUserId()).isEqualTo("U-line-1");
+    verify(userRepository).saveAndFlush(user);
+  }
+
+  @Test
+  @DisplayName("事前チェックを擦り抜けた並行連携は一意制約違反を 409 に写像する")
+  void linkMapsConcurrentUniqueViolationToConflict() {
+    stubVerifiedIdentity();
+    PlatformUser user = member("member@kizuna.test");
+    when(userRepository.findByEmail("member@kizuna.test")).thenReturn(Optional.of(user));
+    when(userRepository.existsByLineUserId("U-line-1")).thenReturn(false);
+    when(userRepository.saveAndFlush(user))
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "could not execute statement",
+                new RuntimeException(
+                    "ERROR: duplicate key value violates unique constraint"
+                        + " \"uq_t_users_line_user_id\"")));
+
+    assertThatThrownBy(() -> lineAuthService.link("member@kizuna.test", authorizationRequest()))
+        .isInstanceOf(ConflictException.class);
+  }
+
+  @Test
+  @DisplayName("連携済み本人の再連携は同じ LINE アカウントでも本人側の不変条件で拒否する（他人に取られた旨の誤った理由を返さない）")
+  void relinkingAlreadyLinkedAccountReportsOwnLinkage() {
+    stubVerifiedIdentity();
+    PlatformUser user = member("member@kizuna.test");
+    user.linkLine("U-line-1");
+    when(userRepository.findByEmail("member@kizuna.test")).thenReturn(Optional.of(user));
+
+    assertThatThrownBy(() -> lineAuthService.link("member@kizuna.test", authorizationRequest()))
+        .isInstanceOf(LineAlreadyLinkedException.class);
+    verify(userRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("他の身分が連携済みの LINE アカウントは 409 で拒否し、保存しない")
+  void linkRejectsLineUserAlreadyBoundToAnotherAccount() {
+    stubVerifiedIdentity();
+    when(userRepository.existsByLineUserId("U-line-1")).thenReturn(true);
+    when(userRepository.findByEmail("member@kizuna.test"))
+        .thenReturn(Optional.of(member("member@kizuna.test")));
+
+    assertThatThrownBy(() -> lineAuthService.link("member@kizuna.test", authorizationRequest()))
+        .isInstanceOf(ConflictException.class);
+    verify(userRepository, never()).save(any());
+  }
+}

--- a/backend/src/test/java/com/kizuna/auth/infrastructure/LineApiClientTest.java
+++ b/backend/src/test/java/com/kizuna/auth/infrastructure/LineApiClientTest.java
@@ -67,6 +67,16 @@ class LineApiClientTest {
   }
 
   @Test
+  @DisplayName("LINE が空の応答本文を返した場合も未処理例外にせず認証失敗として扱う")
+  void emptyResponseBodyIsAuthenticationFailure() {
+    tokenBody = "";
+
+    assertThatThrownBy(
+            () -> client.exchangeAndVerify(CHANNEL, "auth-code", "https://app.test/cb", "verifier"))
+        .isInstanceOf(LineAuthenticationException.class);
+  }
+
+  @Test
   @DisplayName("認可コードを交換し id_token を検証して LINE ユーザー ID と表示名を返す")
   void exchangeAndVerifyReturnsIdentity() {
     LineIdentity identity =

--- a/backend/src/test/java/com/kizuna/auth/infrastructure/LineApiClientTest.java
+++ b/backend/src/test/java/com/kizuna/auth/infrastructure/LineApiClientTest.java
@@ -1,0 +1,137 @@
+package com.kizuna.auth.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.kizuna.shared.config.AppProperties;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link LineApiClient} の単体テスト。LINE 実サービスの代わりに、要求本文を記録して定型応答を返す HTTP スタブを
+ * ループバックへ立てる（実チャネルが無くても、送信するフォーム項目と 応答解釈・失敗時の写像を固定できる）。
+ */
+class LineApiClientTest {
+
+  private static final LineChannel CHANNEL = new LineChannel("channel-id", "channel-secret");
+
+  private HttpServer server;
+  private LineApiClient client;
+
+  private final Map<String, String> requestBodies = new LinkedHashMap<>();
+
+  private int tokenStatus = 200;
+  private String tokenBody = "{\"id_token\": \"dummy-id-token\"}";
+  private int verifyStatus = 200;
+  private String verifyBody = "{\"sub\": \"U-line-1\", \"name\": \"LINE太郎\"}";
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext(
+        "/oauth2/v2.1/token", exchange -> respond(exchange, "token", tokenStatus, tokenBody));
+    server.createContext(
+        "/oauth2/v2.1/verify", exchange -> respond(exchange, "verify", verifyStatus, verifyBody));
+    server.start();
+
+    AppProperties appProperties = new AppProperties();
+    appProperties.getLine().setApiBaseUrl("http://127.0.0.1:" + server.getAddress().getPort());
+    client = new LineApiClient(appProperties);
+  }
+
+  @AfterEach
+  void tearDown() {
+    server.stop(0);
+  }
+
+  private void respond(HttpExchange exchange, String name, int status, String body)
+      throws IOException {
+    try (InputStream in = exchange.getRequestBody()) {
+      requestBodies.put(name, new String(in.readAllBytes(), StandardCharsets.UTF_8));
+    }
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().add("Content-Type", "application/json");
+    exchange.sendResponseHeaders(status, bytes.length);
+    exchange.getResponseBody().write(bytes);
+    exchange.close();
+  }
+
+  @Test
+  @DisplayName("認可コードを交換し id_token を検証して LINE ユーザー ID と表示名を返す")
+  void exchangeAndVerifyReturnsIdentity() {
+    LineIdentity identity =
+        client.exchangeAndVerify(CHANNEL, "auth-code", "https://app.test/cb", "verifier");
+
+    assertThat(identity).isEqualTo(new LineIdentity("U-line-1", "LINE太郎"));
+  }
+
+  @Test
+  @DisplayName("トークン交換にはチャネル資格情報・redirect_uri・code_verifier を送る")
+  void tokenRequestCarriesChannelCredentials() {
+    client.exchangeAndVerify(CHANNEL, "auth-code", "https://app.test/cb", "verifier");
+
+    assertThat(requestBodies.get("token"))
+        .contains("grant_type=authorization_code")
+        .contains("code=auth-code")
+        .contains("client_id=channel-id")
+        .contains("client_secret=channel-secret")
+        .contains("code_verifier=verifier")
+        .contains("redirect_uri=https%3A%2F%2Fapp.test%2Fcb");
+    // 検証はチャネル ID 付きで LINE 自身に行わせる（自前の署名検証を持たない）。
+    assertThat(requestBodies.get("verify"))
+        .contains("id_token=dummy-id-token")
+        .contains("client_id=channel-id");
+  }
+
+  @Test
+  @DisplayName("LINE がエラーを返したら 401 系の認証例外へ写像する（LINE 側の詳細はワイヤへ出さない）")
+  void lineErrorBecomesAuthenticationException() {
+    tokenStatus = 400;
+    tokenBody = "{\"error\": \"invalid_grant\"}";
+
+    assertThatThrownBy(
+            () -> client.exchangeAndVerify(CHANNEL, "used-code", "https://app.test/cb", "verifier"))
+        .isInstanceOf(LineAuthenticationException.class)
+        .hasMessageNotContaining("invalid_grant");
+  }
+
+  @Test
+  @DisplayName("id_token を含まないトークン応答は認証例外")
+  void missingIdTokenBecomesAuthenticationException() {
+    tokenBody = "{\"access_token\": \"only-access-token\"}";
+
+    assertThatThrownBy(
+            () -> client.exchangeAndVerify(CHANNEL, "auth-code", "https://app.test/cb", "verifier"))
+        .isInstanceOf(LineAuthenticationException.class);
+  }
+
+  @Test
+  @DisplayName("sub を含まない検証応答は認証例外（同一性の根拠が無いまま先へ進ませない）")
+  void missingSubBecomesAuthenticationException() {
+    verifyBody = "{\"name\": \"LINE太郎\"}";
+
+    assertThatThrownBy(
+            () -> client.exchangeAndVerify(CHANNEL, "auth-code", "https://app.test/cb", "verifier"))
+        .isInstanceOf(LineAuthenticationException.class);
+  }
+
+  @Test
+  @DisplayName("JSON として解釈できない応答は認証例外")
+  void malformedResponseBecomesAuthenticationException() {
+    verifyBody = "not-json";
+
+    assertThatThrownBy(
+            () -> client.exchangeAndVerify(CHANNEL, "auth-code", "https://app.test/cb", "verifier"))
+        .isInstanceOf(LineAuthenticationException.class);
+  }
+}

--- a/backend/src/test/java/com/kizuna/auth/infrastructure/LineChannelResolverTest.java
+++ b/backend/src/test/java/com/kizuna/auth/infrastructure/LineChannelResolverTest.java
@@ -1,0 +1,85 @@
+package com.kizuna.auth.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.kizuna.settings.application.LineChannelSettings;
+import com.kizuna.settings.application.SystemConfigService;
+import com.kizuna.shared.config.AppProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** {@link LineChannelResolver} の単体テスト。 */
+@ExtendWith(MockitoExtension.class)
+class LineChannelResolverTest {
+
+  @Mock private SystemConfigService systemConfigService;
+
+  private final AppProperties appProperties = new AppProperties();
+
+  private LineChannelResolver resolver;
+
+  @BeforeEach
+  void setUp() {
+    resolver = new LineChannelResolver(systemConfigService, appProperties);
+  }
+
+  private void stubStored(String channelId, String channelSecret) {
+    when(systemConfigService.lineChannelSettings())
+        .thenReturn(new LineChannelSettings(channelId, channelSecret));
+  }
+
+  private void envChannel(String channelId, String channelSecret) {
+    appProperties.getLine().setChannelId(channelId);
+    appProperties.getLine().setChannelSecret(channelSecret);
+  }
+
+  @Test
+  @DisplayName("システム設定に両方あればそれを使う（環境変数より優先）")
+  void storedSettingsWinOverEnvironment() {
+    stubStored("db-id", "db-secret");
+    envChannel("env-id", "env-secret");
+
+    assertThat(resolver.resolve()).contains(new LineChannel("db-id", "db-secret"));
+  }
+
+  @Test
+  @DisplayName("システム設定が空なら環境変数へフォールバックする")
+  void fallsBackToEnvironmentWhenStoredIsEmpty() {
+    stubStored("", "");
+    envChannel("env-id", "env-secret");
+
+    assertThat(resolver.resolve()).contains(new LineChannel("env-id", "env-secret"));
+  }
+
+  @Test
+  @DisplayName("システム設定が片方だけなら未設定とみなし環境変数へフォールバックする（片方では LINE と通信できない）")
+  void partialStoredSettingsFallBackToEnvironment() {
+    stubStored("db-id", "");
+    envChannel("env-id", "env-secret");
+
+    assertThat(resolver.resolve()).contains(new LineChannel("env-id", "env-secret"));
+  }
+
+  @Test
+  @DisplayName("双方とも未設定なら空を返す（LINE ログイン無効）")
+  void emptyWhenNothingConfigured() {
+    stubStored("", "");
+    envChannel(null, null);
+
+    assertThat(resolver.resolve()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("環境変数が片方だけなら空を返す（enabled=true を返してしまわない）")
+  void emptyWhenEnvironmentIsPartial() {
+    stubStored("", "");
+    envChannel("env-id", "  ");
+
+    assertThat(resolver.resolve()).isEmpty();
+  }
+}

--- a/backend/src/test/java/com/kizuna/auth/infrastructure/LineRegistrationTicketStoreTest.java
+++ b/backend/src/test/java/com/kizuna/auth/infrastructure/LineRegistrationTicketStoreTest.java
@@ -1,0 +1,83 @@
+package com.kizuna.auth.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+/** {@link LineRegistrationTicketStore} の単体テスト。 */
+class LineRegistrationTicketStoreTest {
+
+  private static final String KEY_PREFIX = "line:registration:";
+
+  private RedisTemplate<String, Object> redisTemplate;
+  private ValueOperations<String, Object> valueOperations;
+  private LineRegistrationTicketStore store;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() {
+    redisTemplate = mock(RedisTemplate.class);
+    valueOperations = mock(ValueOperations.class);
+    store = new LineRegistrationTicketStore(redisTemplate);
+  }
+
+  @Test
+  @DisplayName("発行したチケットは推測不能で、10 分の TTL 付きで LINE ユーザー ID を保持する")
+  void issueWritesLineUserIdWithTtl() {
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+    String ticket = store.issue("U-line-1");
+
+    ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+    verify(valueOperations).set(key.capture(), eq("U-line-1"), eq(Duration.ofMinutes(10)));
+    assertThat(key.getValue()).isEqualTo(KEY_PREFIX + ticket);
+    // 32 バイト乱数の base64url（パディングなし）＝43 文字。総当たり不能な長さであること。
+    assertThat(ticket).hasSize(43).matches("[A-Za-z0-9_-]+");
+  }
+
+  @Test
+  @DisplayName("発行のたびに異なるチケットになる")
+  void issueGeneratesDistinctTickets() {
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+    assertThat(store.issue("U-line-1")).isNotEqualTo(store.issue("U-line-1"));
+  }
+
+  @Test
+  @DisplayName("消費は取得と削除を単一操作で行う（並行する二重登録でも一方しか通らない）")
+  void consumeReadsAndDeletesAtomically() {
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    when(valueOperations.getAndDelete(KEY_PREFIX + "ticket-1")).thenReturn("U-line-1");
+
+    assertThat(store.consume("ticket-1")).contains("U-line-1");
+  }
+
+  @Test
+  @DisplayName("未知・期限切れ・使用済みのチケットは空を返す")
+  void consumeReturnsEmptyForUnknownTicket() {
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    when(valueOperations.getAndDelete(KEY_PREFIX + "gone")).thenReturn(null);
+
+    assertThat(store.consume("gone")).isEmpty();
+  }
+
+  @Test
+  @DisplayName("空のチケットは Redis へ問い合わせずに空を返す")
+  void consumeSkipsRedisForBlankTicket() {
+    assertThat(store.consume("  ")).isEmpty();
+    assertThat(store.consume(null)).isEmpty();
+
+    verifyNoInteractions(redisTemplate);
+  }
+}

--- a/backend/src/test/java/com/kizuna/auth/infrastructure/PlatformBearerTokenResolverTest.java
+++ b/backend/src/test/java/com/kizuna/auth/infrastructure/PlatformBearerTokenResolverTest.java
@@ -25,6 +25,10 @@ class PlatformBearerTokenResolverTest {
         "/platform/login",
         "/platform/cast-invitations/abc123",
         "/platform/cast-invitations/abc123/acceptance",
+        "/platform/members",
+        "/platform/line/config",
+        "/platform/line/login",
+        "/platform/line/register",
         "/platform/stores/lookup",
         "/store/config/public",
         "/store/casts/public",
@@ -50,6 +54,14 @@ class PlatformBearerTokenResolverTest {
   @DisplayName("保護端点では従来どおり Bearer を解決すること(免除が保護端点まで漏れていないこと)")
   void resolvesTokenForProtectedEndpoint() {
     MockHttpServletRequest request = requestWithBearer("GET", "/platform/me");
+
+    assertThat(resolver.resolve(request)).isEqualTo("broken-token-value");
+  }
+
+  @Test
+  @DisplayName("LINE 連携(/platform/me/line)は免除対象でなく Bearer を解決すること(免除すると常に匿名となり連携先を特定できない)")
+  void resolvesTokenForLineLink() {
+    MockHttpServletRequest request = requestWithBearer("POST", "/platform/me/line");
 
     assertThat(resolver.resolve(request)).isEqualTo("broken-token-value");
   }

--- a/backend/src/test/java/com/kizuna/member/application/MemberRegistrationServiceTest.java
+++ b/backend/src/test/java/com/kizuna/member/application/MemberRegistrationServiceTest.java
@@ -13,6 +13,7 @@ import com.kizuna.member.api.dto.MemberRegistrationRequest;
 import com.kizuna.member.api.dto.MemberRegistrationResponse;
 import com.kizuna.member.domain.Member;
 import com.kizuna.member.domain.MemberRepository;
+import com.kizuna.shared.exception.ConflictException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
@@ -113,6 +114,90 @@ class MemberRegistrationServiceTest {
     assertThatThrownBy(() -> service.register(request())).isInstanceOf(ServiceException.class);
 
     verify(memberRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("LINE 登録は MEMBER 身分に LINE ユーザー ID を持たせ、推測不能な乱数パスワードで作成する")
+  void registerWithLineCreatesMemberIdentityWithLineUserId() {
+    when(platformUserRepository.findByEmail("member@example.com")).thenReturn(Optional.empty());
+    when(platformUserRepository.existsByLineUserId("U-line-1")).thenReturn(false);
+    when(passwordEncoder.encode(anyString())).thenReturn("encoded-random");
+    ArgumentCaptor<PlatformUser> userCaptor = ArgumentCaptor.forClass(PlatformUser.class);
+    when(platformUserRepository.saveAndFlush(userCaptor.capture())).thenReturn(savedUser(10L));
+    when(memberRepository.existsByMemberCode(anyString())).thenReturn(false);
+    ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+    when(memberRepository.save(memberCaptor.capture()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.registerWithLine("member@example.com", "会員 花子", "U-line-1");
+
+    PlatformUser user = userCaptor.getValue();
+    assertThat(user.getUserType()).isEqualTo(UserType.MEMBER);
+    assertThat(user.getLineUserId()).isEqualTo("U-line-1");
+    assertThat(user.getStoreScopeType()).isEqualTo(StoreScopeType.SPECIFIC_STORES);
+    assertThat(user.getStoreIds()).isEmpty();
+    assertThat(memberCaptor.getValue().getMemberCode()).matches("\\d{12}");
+    // 平文パスワードは利用者が知り得ない乱数（パスワードログイン経路を持たせない）。
+    ArgumentCaptor<String> rawPassword = ArgumentCaptor.forClass(String.class);
+    verify(passwordEncoder).encode(rawPassword.capture());
+    assertThat(rawPassword.getValue()).hasSizeGreaterThanOrEqualTo(32);
+  }
+
+  @Test
+  @DisplayName("LINE 登録の重複 email は 409 系例外で拒否する（入力形式の誤りと区別する）")
+  void registerWithLineRejectsDuplicateEmailWithConflict() {
+    when(platformUserRepository.findByEmail("member@example.com"))
+        .thenReturn(Optional.of(savedUser(10L)));
+
+    assertThatThrownBy(() -> service.registerWithLine("member@example.com", "会員 花子", "U-line-1"))
+        .isInstanceOf(ConflictException.class);
+
+    verify(platformUserRepository, never()).saveAndFlush(any());
+    verify(memberRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("既に連携済みの LINE ユーザー ID での登録は 409 系例外で拒否する")
+  void registerWithLineRejectsAlreadyLinkedLineUser() {
+    when(platformUserRepository.findByEmail("member@example.com")).thenReturn(Optional.empty());
+    when(platformUserRepository.existsByLineUserId("U-line-1")).thenReturn(true);
+
+    assertThatThrownBy(() -> service.registerWithLine("member@example.com", "会員 花子", "U-line-1"))
+        .isInstanceOf(ConflictException.class);
+
+    verify(platformUserRepository, never()).saveAndFlush(any());
+  }
+
+  @Test
+  @DisplayName("並行 LINE 登録の LINE ユーザー ID 一意制約違反は 409 系例外へ写像する（生の 500 にしない）")
+  void registerWithLineMapsLineUserConstraintViolationToConflict() {
+    when(platformUserRepository.findByEmail("member@example.com")).thenReturn(Optional.empty());
+    when(platformUserRepository.existsByLineUserId("U-line-1")).thenReturn(false);
+    when(passwordEncoder.encode(anyString())).thenReturn("encoded-random");
+    when(platformUserRepository.saveAndFlush(any()))
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "duplicate key value violates unique constraint \"uq_t_users_line_user_id\""));
+
+    assertThatThrownBy(() -> service.registerWithLine("member@example.com", "会員 花子", "U-line-1"))
+        .isInstanceOf(ConflictException.class);
+
+    verify(memberRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("並行 LINE 登録の email 一意制約違反も 409 系例外へ写像する")
+  void registerWithLineMapsEmailConstraintViolationToConflict() {
+    when(platformUserRepository.findByEmail("member@example.com")).thenReturn(Optional.empty());
+    when(platformUserRepository.existsByLineUserId("U-line-1")).thenReturn(false);
+    when(passwordEncoder.encode(anyString())).thenReturn("encoded-random");
+    when(platformUserRepository.saveAndFlush(any()))
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "duplicate key value violates unique constraint \"uq_t_users_email\""));
+
+    assertThatThrownBy(() -> service.registerWithLine("member@example.com", "会員 花子", "U-line-1"))
+        .isInstanceOf(ConflictException.class);
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/member/application/MemberRegistrationServiceTest.java
+++ b/backend/src/test/java/com/kizuna/member/application/MemberRegistrationServiceTest.java
@@ -126,7 +126,7 @@ class MemberRegistrationServiceTest {
     when(platformUserRepository.saveAndFlush(userCaptor.capture())).thenReturn(savedUser(10L));
     when(memberRepository.existsByMemberCode(anyString())).thenReturn(false);
     ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
-    when(memberRepository.save(memberCaptor.capture()))
+    when(memberRepository.saveAndFlush(memberCaptor.capture()))
         .thenAnswer(invocation -> invocation.getArgument(0));
 
     service.registerWithLine("member@example.com", "会員 花子", "U-line-1");

--- a/backend/src/test/java/com/kizuna/notification/application/MailServiceTests.java
+++ b/backend/src/test/java/com/kizuna/notification/application/MailServiceTests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.kizuna.settings.application.SmtpSettings;
@@ -44,6 +45,17 @@ class MailServiceTests {
 
     service.send("to@example.com", "件名", "本文");
     // 例外が出なければ成功
+  }
+
+  @Test
+  @DisplayName("SMTP 設定の読み取りが例外でも send は例外を外へ出さず、送信クライアントにも触れないこと")
+  void send_settingsReadFailureIsLoggedNotThrown() {
+    when(systemConfigService.smtpSettings())
+        .thenThrow(new IllegalStateException("Cannot serialize value"));
+
+    service.send("to@example.com", "件名", "本文");
+
+    verifyNoInteractions(mailSenderProvider, mailSender);
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/settings/application/SystemConfigServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/settings/application/SystemConfigServiceImplTest.java
@@ -222,6 +222,28 @@ class SystemConfigServiceImplTest {
     assertThat(smtp.hasFrom()).isFalse();
   }
 
+  @Test
+  void lineChannelSettings_buildsTypedSnapshotFromKeys() {
+    when(systemConfigRepository.findByConfigKey("line_channel_id"))
+        .thenReturn(Optional.of(config("line_channel_id", "2000000000")));
+    when(systemConfigRepository.findByConfigKey("line_channel_secret"))
+        .thenReturn(Optional.of(config("line_channel_secret", "test-placeholder-secret")));
+
+    LineChannelSettings line = systemConfigService.lineChannelSettings();
+
+    assertThat(line.configured()).isTrue();
+    assertThat(line.channelId()).isEqualTo("2000000000");
+    assertThat(line.channelSecret()).isEqualTo("test-placeholder-secret");
+  }
+
+  @Test
+  void lineChannelSettings_notConfiguredWhenUnset() {
+    when(systemConfigRepository.findByConfigKey(org.mockito.ArgumentMatchers.anyString()))
+        .thenReturn(Optional.empty());
+
+    assertThat(systemConfigService.lineChannelSettings().configured()).isFalse();
+  }
+
   private SystemConfig config(String key, String value) {
     return SystemConfig.builder().configKey(key).configValue(value).build();
   }

--- a/backend/src/test/java/com/kizuna/user/domain/PlatformUserTest.java
+++ b/backend/src/test/java/com/kizuna/user/domain/PlatformUserTest.java
@@ -235,4 +235,26 @@ class PlatformUserTest {
 
     assertThat(user.getPassword()).isEqualTo("new-encoded-hash");
   }
+
+  @Test
+  @DisplayName("未連携の身分は linkLine で LINE ユーザー ID を持つ")
+  void linkLineSetsLineUserId() {
+    PlatformUser user = staffBuilder().build();
+    assertThat(user.getLineUserId()).isNull();
+
+    user.linkLine("U-line-1");
+
+    assertThat(user.getLineUserId()).isEqualTo("U-line-1");
+  }
+
+  @Test
+  @DisplayName("連携済みの身分への再連携は 409 相当のドメイン例外（付け替えを許すと連携先を無断で移せる）")
+  void linkLineOnAlreadyLinkedUserThrows() {
+    PlatformUser user = staffBuilder().build();
+    user.linkLine("U-line-1");
+
+    assertThatThrownBy(() -> user.linkLine("U-line-2"))
+        .isInstanceOf(LineAlreadyLinkedException.class);
+    assertThat(user.getLineUserId()).isEqualTo("U-line-1");
+  }
 }

--- a/frontend/setupTests.ts
+++ b/frontend/setupTests.ts
@@ -1,4 +1,20 @@
 import '@testing-library/jest-dom';
+import { webcrypto } from 'crypto';
+import { TextEncoder } from 'util';
+
+// jsdom の Crypto は getRandomValues のみで SubtleCrypto を持たず、TextEncoder も公開しない。
+// PKCE の code_challenge（SHA-256）を検証できるよう Node の実装を補う。
+if (!globalThis.crypto) {
+  Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
+} else if (!globalThis.crypto.subtle) {
+  Object.defineProperty(globalThis.crypto, 'subtle', {
+    value: webcrypto.subtle,
+    configurable: true,
+  });
+}
+if (!globalThis.TextEncoder) {
+  Object.defineProperty(globalThis, 'TextEncoder', { value: TextEncoder, configurable: true });
+}
 
 // Radix のプリミティブは要素の採寸に ResizeObserver を使う（フォーム内 Checkbox が
 // 描画する hidden な BubbleInput など）。jsdom には未実装のため、全テスト共通の

--- a/frontend/src/_pages/cast-portal/ui/CastAccountPage.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastAccountPage.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { platformAuthApi, useAuth } from '@/entities/user';
+import { LineLinkSection } from '@/features/line-auth';
 import { Button, Card, CardContent } from '@/shared/ui';
 
 /** アカウントタブ。表示名とログアウトのみの最小画面。 */
@@ -25,7 +26,7 @@ export function CastAccountPage() {
   }, []);
 
   return (
-    <div className="p-4">
+    <div className="space-y-4 p-4">
       <Card>
         <CardContent>
           <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
@@ -39,6 +40,7 @@ export function CastAccountPage() {
           </Button>
         </CardContent>
       </Card>
+      <LineLinkSection />
     </div>
   );
 }

--- a/frontend/src/_pages/cast-portal/ui/__tests__/CastAccountPage.test.tsx
+++ b/frontend/src/_pages/cast-portal/ui/__tests__/CastAccountPage.test.tsx
@@ -1,13 +1,15 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { CastAccountPage } from '../CastAccountPage';
-import { platformAuthApi, useAuth } from '@/entities/user';
+import { platformAuthApi, platformLineApi, useAuth } from '@/entities/user';
 
 jest.mock('@/entities/user', () => ({
   platformAuthApi: { me: jest.fn() },
+  platformLineApi: { config: jest.fn() },
   useAuth: jest.fn(),
 }));
 
 const mockedMe = platformAuthApi.me as jest.Mock;
+const mockedLineConfig = platformLineApi.config as jest.Mock;
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const mockLogout = jest.fn();
 
@@ -15,6 +17,7 @@ describe('CastAccountPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedUseAuth.mockReturnValue({ logout: mockLogout });
+    mockedLineConfig.mockResolvedValue({ enabled: false, channel_id: null });
   });
 
   it('表示名を取得して表示する', async () => {
@@ -33,5 +36,15 @@ describe('CastAccountPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'ログアウト' }));
 
     await waitFor(() => expect(mockLogout).toHaveBeenCalledTimes(1));
+  });
+
+  it('LINE 連携が有効なら連携ブロックを表示する', async () => {
+    mockedMe.mockResolvedValue({ display_name: '田中一郎', line_linked: false });
+    mockedLineConfig.mockResolvedValue({ enabled: true, channel_id: 'channel-1' });
+
+    render(<CastAccountPage />);
+
+    expect(await screen.findByRole('heading', { name: 'LINE連携' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'LINEを連携する' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/_pages/platform-line-callback/__tests__/LineCallbackPage.test.tsx
+++ b/frontend/src/_pages/platform-line-callback/__tests__/LineCallbackPage.test.tsx
@@ -1,11 +1,14 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import Cookies from 'js-cookie';
 import LineCallbackPage from '../ui/LineCallbackPage';
-import { platformLineApi } from '@/entities/user';
+import { platformAuthApi, platformLineApi } from '@/entities/user';
 import { completePlatformLogin } from '@/features/platform-login';
 
 const mockPush = jest.fn();
-jest.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }));
+const mockReplace = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+}));
 
 jest.mock('react-hot-toast', () => ({
   __esModule: true,
@@ -16,6 +19,7 @@ jest.mock('@/entities/user', () => {
   const actual = jest.requireActual('@/entities/user');
   return {
     ...actual,
+    platformAuthApi: { ...actual.platformAuthApi, me: jest.fn() },
     platformLineApi: {
       config: jest.fn(),
       login: jest.fn(),
@@ -30,12 +34,16 @@ jest.mock('@/features/platform-login', () => ({
 }));
 
 const mockedLineApi = platformLineApi as jest.Mocked<typeof platformLineApi>;
+const mockedMe = platformAuthApi.me as jest.Mock;
 const mockedComplete = completePlatformLogin as jest.MockedFunction<typeof completePlatformLogin>;
 
 const STORAGE_KEY = 'kizuna-line-oauth';
 const REDIRECT_URI = 'http://localhost/platform/line/callback';
 
-function arriveAt(query: string, stored?: { state: string; verifier: string; intent: string }) {
+function arriveAt(
+  query: string,
+  stored?: { state: string; verifier: string; intent: string; subject?: string }
+) {
   if (stored) {
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
   }
@@ -72,7 +80,8 @@ describe('LineCallbackPage', () => {
           code_verifier: 'v1',
         })
       );
-      await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/member/'));
+      // 消費済みのコールバック URL を履歴に残さないため replace で遷移する
+      await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/member/'));
       // 保存値は一度きりの消費
       expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
     });
@@ -119,7 +128,7 @@ describe('LineCallbackPage', () => {
           email: 'member@kizuna.test',
         })
       );
-      await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/member/'));
+      await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/member/'));
       expect(Cookies.get('token')).toBe('jwt-token');
       expect(Cookies.get('platform-role')).toBe('member');
     });
@@ -160,8 +169,14 @@ describe('LineCallbackPage', () => {
   });
 
   describe('連携意図', () => {
-    it('本人の LINE 連携を要求し、アカウント設定へ戻す', async () => {
-      arriveAt('?code=auth-code&state=s2', { state: 's2', verifier: 'v2', intent: 'link' });
+    it('発起主体と現在のログインが一致すれば連携を要求し、アカウント設定へ戻す', async () => {
+      arriveAt('?code=auth-code&state=s2', {
+        state: 's2',
+        verifier: 'v2',
+        intent: 'link',
+        subject: 'me@kizuna.test',
+      });
+      mockedMe.mockResolvedValue({ email: 'me@kizuna.test' });
       mockedLineApi.link.mockResolvedValue(undefined);
 
       render(<LineCallbackPage />);
@@ -173,24 +188,52 @@ describe('LineCallbackPage', () => {
           code_verifier: 'v2',
         })
       );
-      await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/platform/settings/account'));
+      await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/platform/settings/account'));
       expect(mockedLineApi.login).not.toHaveBeenCalled();
     });
 
-    it('409 は連携済みの案内を出し、アカウント設定への戻り導線を示す', async () => {
-      arriveAt('?code=auth-code&state=s2', { state: 's2', verifier: 'v2', intent: 'link' });
-      mockedLineApi.link.mockRejectedValue({ response: { status: 409 } });
+    it('外部認可の往復中に別アカウントへ切り替わっていたら連携を送らない', async () => {
+      arriveAt('?code=auth-code&state=s2', {
+        state: 's2',
+        verifier: 'v2',
+        intent: 'link',
+        subject: 'me@kizuna.test',
+      });
+      mockedMe.mockResolvedValue({ email: 'other@kizuna.test' });
 
       render(<LineCallbackPage />);
 
       expect(
-        await screen.findByText('このLINEアカウントは既に別のアカウントで利用されています')
+        await screen.findByText(
+          'LINE連携を開始したアカウントと現在のログインが一致しません。アカウント設定からやり直してください'
+        )
+      ).toBeInTheDocument();
+      expect(mockedLineApi.link).not.toHaveBeenCalled();
+    });
+
+    it('409 はサーバーの文言を表示し、アカウント設定への戻り導線を示す', async () => {
+      arriveAt('?code=auth-code&state=s2', {
+        state: 's2',
+        verifier: 'v2',
+        intent: 'link',
+        subject: 'me@kizuna.test',
+      });
+      mockedMe.mockResolvedValue({ email: 'me@kizuna.test' });
+      // 「本人が連携済み」と「他の身分が連携済み」はサーバーが文言で区別する
+      mockedLineApi.link.mockRejectedValue({
+        response: { status: 409, data: { error: 'このアカウントは既に LINE と連携済みです' } },
+      });
+
+      render(<LineCallbackPage />);
+
+      expect(
+        await screen.findByText('このアカウントは既に LINE と連携済みです')
       ).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'アカウント設定へ戻る' })).toHaveAttribute(
         'href',
         '/platform/settings/account'
       );
-      expect(mockPush).not.toHaveBeenCalled();
+      expect(mockReplace).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/_pages/platform-line-callback/__tests__/LineCallbackPage.test.tsx
+++ b/frontend/src/_pages/platform-line-callback/__tests__/LineCallbackPage.test.tsx
@@ -1,0 +1,256 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import Cookies from 'js-cookie';
+import LineCallbackPage from '../ui/LineCallbackPage';
+import { platformLineApi } from '@/entities/user';
+import { completePlatformLogin } from '@/features/platform-login';
+
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }));
+
+jest.mock('react-hot-toast', () => ({
+  __esModule: true,
+  toast: { error: jest.fn(), success: jest.fn() },
+}));
+
+jest.mock('@/entities/user', () => {
+  const actual = jest.requireActual('@/entities/user');
+  return {
+    ...actual,
+    platformLineApi: {
+      config: jest.fn(),
+      login: jest.fn(),
+      register: jest.fn(),
+      link: jest.fn(),
+    },
+  };
+});
+
+jest.mock('@/features/platform-login', () => ({
+  completePlatformLogin: jest.fn(),
+}));
+
+const mockedLineApi = platformLineApi as jest.Mocked<typeof platformLineApi>;
+const mockedComplete = completePlatformLogin as jest.MockedFunction<typeof completePlatformLogin>;
+
+const STORAGE_KEY = 'kizuna-line-oauth';
+const REDIRECT_URI = 'http://localhost/platform/line/callback';
+
+function arriveAt(query: string, stored?: { state: string; verifier: string; intent: string }) {
+  if (stored) {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+  }
+  window.history.replaceState({}, '', `/platform/line/callback${query}`);
+}
+
+describe('LineCallbackPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    Cookies.remove('token');
+    Cookies.remove('platform-role');
+  });
+
+  describe('ログイン意図', () => {
+    it('登録済みならセッションを確立して着地先へ遷移する', async () => {
+      arriveAt('?code=auth-code&state=s1', { state: 's1', verifier: 'v1', intent: 'login' });
+      mockedLineApi.login.mockResolvedValue({
+        registered: true,
+        token: 'jwt-token',
+        expires_at: Date.now() + 3_600_000,
+      });
+      mockedComplete.mockResolvedValue({ status: 'ok', path: '/member/' });
+
+      render(<LineCallbackPage />);
+
+      await waitFor(() =>
+        expect(mockedLineApi.login).toHaveBeenCalledWith({
+          code: 'auth-code',
+          redirect_uri: REDIRECT_URI,
+          code_verifier: 'v1',
+        })
+      );
+      await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/member/'));
+      // 保存値は一度きりの消費
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    it('未登録なら会員登録の確認段階を同じ画面に表示する', async () => {
+      arriveAt('?code=auth-code&state=s1', { state: 's1', verifier: 'v1', intent: 'login' });
+      mockedLineApi.login.mockResolvedValue({
+        registered: false,
+        registration_ticket: 'ticket-1',
+        display_name: 'LINE太郎',
+      });
+
+      render(<LineCallbackPage />);
+
+      expect(await screen.findByLabelText('表示名')).toHaveValue('LINE太郎');
+      expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument();
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it('登録は登録チケットと入力値を送り、会員セッションで会員ポータルへ遷移する', async () => {
+      arriveAt('?code=auth-code&state=s1', { state: 's1', verifier: 'v1', intent: 'login' });
+      mockedLineApi.login.mockResolvedValue({
+        registered: false,
+        registration_ticket: 'ticket-1',
+        display_name: 'LINE太郎',
+      });
+      mockedLineApi.register.mockResolvedValue({
+        token: 'jwt-token',
+        expires_at: Date.now() + 3_600_000,
+      });
+
+      render(<LineCallbackPage />);
+
+      fireEvent.change(await screen.findByLabelText('メールアドレス'), {
+        target: { value: 'member@kizuna.test' },
+      });
+      fireEvent.click(screen.getByLabelText('利用規約およびプライバシーポリシーに同意します'));
+      fireEvent.click(screen.getByRole('button', { name: '登録する' }));
+
+      await waitFor(() =>
+        expect(mockedLineApi.register).toHaveBeenCalledWith({
+          registration_ticket: 'ticket-1',
+          display_name: 'LINE太郎',
+          email: 'member@kizuna.test',
+        })
+      );
+      await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/member/'));
+      expect(Cookies.get('token')).toBe('jwt-token');
+      expect(Cookies.get('platform-role')).toBe('member');
+    });
+
+    it('同意チェックが無ければ登録を送らない', async () => {
+      arriveAt('?code=auth-code&state=s1', { state: 's1', verifier: 'v1', intent: 'login' });
+      mockedLineApi.login.mockResolvedValue({
+        registered: false,
+        registration_ticket: 'ticket-1',
+        display_name: 'LINE太郎',
+      });
+
+      render(<LineCallbackPage />);
+
+      fireEvent.change(await screen.findByLabelText('メールアドレス'), {
+        target: { value: 'member@kizuna.test' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: '登録する' }));
+
+      expect(await screen.findByText('同意いただける場合のみ登録できます')).toBeInTheDocument();
+      expect(mockedLineApi.register).not.toHaveBeenCalled();
+    });
+
+    it('着地先の無い利用者種別はエラー表示にする', async () => {
+      arriveAt('?code=auth-code&state=s1', { state: 's1', verifier: 'v1', intent: 'login' });
+      mockedLineApi.login.mockResolvedValue({
+        registered: true,
+        token: 'jwt-token',
+        expires_at: Date.now() + 3_600_000,
+      });
+      mockedComplete.mockResolvedValue({ status: 'unsupported' });
+
+      render(<LineCallbackPage />);
+
+      expect(await screen.findByText('この利用者種別のポータルは準備中です')).toBeInTheDocument();
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('連携意図', () => {
+    it('本人の LINE 連携を要求し、アカウント設定へ戻す', async () => {
+      arriveAt('?code=auth-code&state=s2', { state: 's2', verifier: 'v2', intent: 'link' });
+      mockedLineApi.link.mockResolvedValue(undefined);
+
+      render(<LineCallbackPage />);
+
+      await waitFor(() =>
+        expect(mockedLineApi.link).toHaveBeenCalledWith({
+          code: 'auth-code',
+          redirect_uri: REDIRECT_URI,
+          code_verifier: 'v2',
+        })
+      );
+      await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/platform/settings/account'));
+      expect(mockedLineApi.login).not.toHaveBeenCalled();
+    });
+
+    it('409 は連携済みの案内を出し、アカウント設定への戻り導線を示す', async () => {
+      arriveAt('?code=auth-code&state=s2', { state: 's2', verifier: 'v2', intent: 'link' });
+      mockedLineApi.link.mockRejectedValue({ response: { status: 409 } });
+
+      render(<LineCallbackPage />);
+
+      expect(
+        await screen.findByText('このLINEアカウントは既に別のアカウントで利用されています')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'アカウント設定へ戻る' })).toHaveAttribute(
+        'href',
+        '/platform/settings/account'
+      );
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('異常系', () => {
+    it('state が食い違う場合はエラー表示にし、引き換えを試みない', async () => {
+      arriveAt('?code=auth-code&state=別のstate', {
+        state: 's1',
+        verifier: 'v1',
+        intent: 'login',
+      });
+
+      render(<LineCallbackPage />);
+
+      expect(
+        await screen.findByText(
+          '認証を確認できませんでした。お手数ですが最初からやり直してください'
+        )
+      ).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'ログイン画面へ戻る' })).toHaveAttribute(
+        'href',
+        '/platform/login'
+      );
+      expect(mockedLineApi.login).not.toHaveBeenCalled();
+    });
+
+    it('保存が無い場合（別タブでの開始など）もエラー表示にする', async () => {
+      arriveAt('?code=auth-code&state=s1');
+
+      render(<LineCallbackPage />);
+
+      expect(
+        await screen.findByText(
+          '認証を確認できませんでした。お手数ですが最初からやり直してください'
+        )
+      ).toBeInTheDocument();
+      expect(mockedLineApi.login).not.toHaveBeenCalled();
+    });
+
+    it('LINE 側のエラー（利用者による中止）はエラー表示にする', async () => {
+      arriveAt('?error=access_denied&error_description=User+denied&state=s1', {
+        state: 's1',
+        verifier: 'v1',
+        intent: 'login',
+      });
+
+      render(<LineCallbackPage />);
+
+      expect(await screen.findByText('LINEでの認証が完了しませんでした')).toBeInTheDocument();
+      expect(mockedLineApi.login).not.toHaveBeenCalled();
+    });
+
+    it('引き換えの失敗はサーバーの文言を表示する', async () => {
+      arriveAt('?code=auth-code&state=s1', { state: 's1', verifier: 'v1', intent: 'login' });
+      mockedLineApi.login.mockRejectedValue({
+        response: { data: { error: '認可コードが無効です' } },
+      });
+
+      render(<LineCallbackPage />);
+
+      expect(await screen.findByText('認可コードが無効です')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/_pages/platform-line-callback/index.ts
+++ b/frontend/src/_pages/platform-line-callback/index.ts
@@ -1,0 +1,1 @@
+export { default as LineCallbackPage } from './ui/LineCallbackPage';

--- a/frontend/src/_pages/platform-line-callback/ui/LineCallbackPage.tsx
+++ b/frontend/src/_pages/platform-line-callback/ui/LineCallbackPage.tsx
@@ -5,12 +5,11 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import Cookies from 'js-cookie';
 import { toast } from 'react-hot-toast';
-import { LineAuthorizationRequest, platformLineApi } from '@/entities/user';
+import { LineAuthorizationRequest, platformAuthApi, platformLineApi } from '@/entities/user';
 import { completePlatformLogin } from '@/features/platform-login';
 import {
   consumeLineAuthorization,
   getApiErrorMessage,
-  isConflict,
   lineCallbackRedirectUri,
   startPlatformSession,
 } from '@/shared/lib';
@@ -64,22 +63,29 @@ export default function LineCallbackPage() {
         fail('この利用者種別のポータルは準備中です', 'login');
         return;
       }
-      router.push(completion.path);
+      // 消費済みのコールバック URL を履歴に残さない（戻るで再実行するとエラー画面になるだけのため）
+      router.replace(completion.path);
     };
 
-    const runLink = async (request: LineAuthorizationRequest) => {
-      try {
-        await platformLineApi.link(request);
-      } catch (error) {
+    const runLink = async (request: LineAuthorizationRequest, subject: string | undefined) => {
+      // 発起主体と現在のログインが一致するときだけ連携する。外部認可の往復中に別アカウントへ
+      // 切り替わっていた場合、そのまま送ると意図しないアカウントに LINE が恒久的に付く（解除は未提供）。
+      const me = await platformAuthApi.me();
+      if (!subject || me.email !== subject) {
         fail(
-          isConflict(error)
-            ? 'このLINEアカウントは既に別のアカウントで利用されています'
-            : getApiErrorMessage(error, 'LINE連携に失敗しました'),
+          'LINE連携を開始したアカウントと現在のログインが一致しません。アカウント設定からやり直してください',
           'settings'
         );
         return;
       }
-      router.push('/platform/settings/account');
+      try {
+        await platformLineApi.link(request);
+      } catch (error) {
+        // 409 には「本人が連携済み」「他の身分が連携済み」の二つの原因があり、区別はサーバーの文言が正
+        fail(getApiErrorMessage(error, 'LINE連携に失敗しました'), 'settings');
+        return;
+      }
+      router.replace('/platform/settings/account');
     };
 
     const run = async () => {
@@ -107,7 +113,7 @@ export default function LineCallbackPage() {
 
       try {
         if (authorization.intent === 'link') {
-          await runLink(request);
+          await runLink(request, authorization.subject);
           return;
         }
         await runLogin(request);
@@ -129,7 +135,8 @@ export default function LineCallbackPage() {
       // epoch millis を Date に変換する（expires_at をそのまま日数として解釈すると不正な有効期限になる）
       Cookies.set('token', token ?? '', { expires: new Date(expires_at) });
       startPlatformSession('member', expires_at);
-      router.push('/member/');
+      // 消費済みのコールバック URL と使用済みフォームを履歴に残さない
+      router.replace('/member/');
     } catch (error) {
       toast.error(getApiErrorMessage(error, '会員登録に失敗しました'));
     }

--- a/frontend/src/_pages/platform-line-callback/ui/LineCallbackPage.tsx
+++ b/frontend/src/_pages/platform-line-callback/ui/LineCallbackPage.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import Cookies from 'js-cookie';
+import { toast } from 'react-hot-toast';
+import { LineAuthorizationRequest, platformLineApi } from '@/entities/user';
+import { completePlatformLogin } from '@/features/platform-login';
+import {
+  consumeLineAuthorization,
+  getApiErrorMessage,
+  isConflict,
+  lineCallbackRedirectUri,
+  startPlatformSession,
+} from '@/shared/lib';
+import { AuthLayout } from '@/shared/ui';
+import LineRegisterStep, { LineRegisterValues } from './LineRegisterStep';
+
+type Stage = 'processing' | 'register' | 'error';
+
+/** エラー表示の戻り先。連携（ログイン済み）はアカウント設定、それ以外はログイン画面。 */
+type BackTo = 'login' | 'settings';
+
+const BACK_LINKS: Record<BackTo, { href: string; label: string }> = {
+  login: { href: '/platform/login', label: 'ログイン画面へ戻る' },
+  settings: { href: '/platform/settings/account', label: 'アカウント設定へ戻る' },
+};
+
+/**
+ * LINE 認可のコールバック（公開）。ログイン・会員登録・既存アカウントへの連携の
+ * 三つの入口が同じ URL に戻るため、開始時に保存した意図で分岐する。
+ */
+export default function LineCallbackPage() {
+  const router = useRouter();
+  const startedRef = useRef(false);
+  const [stage, setStage] = useState<Stage>('processing');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [backTo, setBackTo] = useState<BackTo>('login');
+  const [registrationTicket, setRegistrationTicket] = useState('');
+  const [lineDisplayName, setLineDisplayName] = useState('');
+
+  useEffect(() => {
+    // 保存した state/code_verifier は一度きりの消費のため、開発時の二重実行で空振りさせない
+    if (startedRef.current) return;
+    startedRef.current = true;
+
+    const fail = (message: string, destination: BackTo) => {
+      setErrorMessage(message);
+      setBackTo(destination);
+      setStage('error');
+    };
+
+    const runLogin = async (request: LineAuthorizationRequest) => {
+      const response = await platformLineApi.login(request);
+      if (!response.registered) {
+        setRegistrationTicket(response.registration_ticket ?? '');
+        setLineDisplayName(response.display_name ?? '');
+        setStage('register');
+        return;
+      }
+      const completion = await completePlatformLogin(response);
+      if (completion.status === 'unsupported') {
+        fail('この利用者種別のポータルは準備中です', 'login');
+        return;
+      }
+      router.push(completion.path);
+    };
+
+    const runLink = async (request: LineAuthorizationRequest) => {
+      try {
+        await platformLineApi.link(request);
+      } catch (error) {
+        fail(
+          isConflict(error)
+            ? 'このLINEアカウントは既に別のアカウントで利用されています'
+            : getApiErrorMessage(error, 'LINE連携に失敗しました'),
+          'settings'
+        );
+        return;
+      }
+      router.push('/platform/settings/account');
+    };
+
+    const run = async () => {
+      const params = new URLSearchParams(window.location.search);
+      const authorization = consumeLineAuthorization(params.get('state'));
+      const destination: BackTo = authorization?.intent === 'link' ? 'settings' : 'login';
+
+      // 利用者が LINE 側で拒否した場合など。error_description は英語のため表示しない
+      if (params.get('error')) {
+        fail('LINEでの認証が完了しませんでした', destination);
+        return;
+      }
+
+      const code = params.get('code');
+      if (!code || !authorization) {
+        fail('認証を確認できませんでした。お手数ですが最初からやり直してください', destination);
+        return;
+      }
+
+      const request: LineAuthorizationRequest = {
+        code,
+        redirect_uri: lineCallbackRedirectUri(),
+        code_verifier: authorization.verifier,
+      };
+
+      try {
+        if (authorization.intent === 'link') {
+          await runLink(request);
+          return;
+        }
+        await runLogin(request);
+      } catch (error) {
+        fail(getApiErrorMessage(error, 'LINEでの認証に失敗しました'), destination);
+      }
+    };
+
+    void run();
+  }, [router]);
+
+  const submitRegistration = async (values: LineRegisterValues) => {
+    try {
+      const { token, expires_at } = await platformLineApi.register({
+        registration_ticket: registrationTicket,
+        display_name: values.display_name,
+        email: values.email,
+      });
+      // epoch millis を Date に変換する（expires_at をそのまま日数として解釈すると不正な有効期限になる）
+      Cookies.set('token', token ?? '', { expires: new Date(expires_at) });
+      startPlatformSession('member', expires_at);
+      router.push('/member/');
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, '会員登録に失敗しました'));
+    }
+  };
+
+  if (stage === 'error') {
+    const back = BACK_LINKS[backTo];
+    return (
+      <AuthLayout title="LINE認証を完了できません" subtitle="以下の内容をご確認ください">
+        <div className="space-y-6">
+          <div className="auth-alert auth-alert--error">{errorMessage}</div>
+          <p className="text-center text-xs text-[#9a958e]">
+            <Link href={back.href} className="auth-link">
+              {back.label}
+            </Link>
+          </p>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  if (stage === 'register') {
+    return (
+      <AuthLayout title="会員登録" subtitle="LINEアカウントで登録します。内容をご確認ください">
+        <LineRegisterStep defaultDisplayName={lineDisplayName} onSubmit={submitRegistration} />
+      </AuthLayout>
+    );
+  }
+
+  return (
+    <AuthLayout title="LINE認証を確認しています" subtitle="しばらくお待ちください">
+      <p className="text-center text-sm text-[#9a958e]">読み込み中...</p>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/_pages/platform-line-callback/ui/LineRegisterStep.tsx
+++ b/frontend/src/_pages/platform-line-callback/ui/LineRegisterStep.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+
+export interface LineRegisterValues {
+  display_name: string;
+  email: string;
+  consent: boolean;
+}
+
+interface LineRegisterStepProps {
+  defaultDisplayName: string;
+  onSubmit: (values: LineRegisterValues) => Promise<void>;
+}
+
+/**
+ * 未登録の LINE アカウントに対する会員登録の確認段階。
+ * 同意チェックは画面側の関門で、サーバーへは送信しない。
+ */
+export default function LineRegisterStep({ defaultDisplayName, onSubmit }: LineRegisterStepProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<LineRegisterValues>({
+    defaultValues: { display_name: defaultDisplayName, email: '', consent: false },
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-7">
+      <div className="auth-field">
+        <label
+          htmlFor="line-register-display-name"
+          className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
+        >
+          表示名
+        </label>
+        <input
+          id="line-register-display-name"
+          type="text"
+          required
+          maxLength={150}
+          className="auth-field__input"
+          placeholder="表示名を入力"
+          {...register('display_name', { required: true, maxLength: 150 })}
+        />
+        <span className="auth-field__accent" />
+      </div>
+
+      <div className="auth-field">
+        <label
+          htmlFor="line-register-email"
+          className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
+        >
+          メールアドレス
+        </label>
+        <input
+          id="line-register-email"
+          type="email"
+          autoComplete="email"
+          required
+          maxLength={127}
+          className="auth-field__input"
+          placeholder="example@mail.com"
+          {...register('email', { required: true, maxLength: 127 })}
+        />
+        <span className="auth-field__accent" />
+      </div>
+
+      <div className="space-y-2">
+        <label
+          htmlFor="line-register-consent"
+          className="flex items-start gap-3 text-xs text-[#6b6660] leading-relaxed"
+        >
+          <input
+            id="line-register-consent"
+            type="checkbox"
+            className="auth-check mt-0.5"
+            {...register('consent', { required: true })}
+          />
+          <span>利用規約およびプライバシーポリシーに同意します</span>
+        </label>
+        {errors.consent && (
+          <p className="text-xs text-[#dc2626]">同意いただける場合のみ登録できます</p>
+        )}
+      </div>
+
+      <div className="pt-2">
+        <button type="submit" disabled={isSubmitting} className="auth-btn">
+          {isSubmitting ? (
+            <span className="flex items-center justify-center gap-2.5">
+              <span className="auth-spinner" />
+              登録中...
+            </span>
+          ) : (
+            '登録する'
+          )}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/_pages/platform-login/ui/PlatformLoginPage.tsx
+++ b/frontend/src/_pages/platform-login/ui/PlatformLoginPage.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { LineLoginButton } from '@/features/line-auth';
 import { PlatformLoginForm } from '@/features/platform-login';
 import { AuthLayout } from '@/shared/ui';
 
@@ -12,6 +13,8 @@ export default function PlatformLoginPage() {
   return (
     <AuthLayout title="統一ログイン" subtitle="メールアドレスとパスワードでログインしてください">
       <PlatformLoginForm />
+      {/* LINE ログインの入口（公開設定が無効なら何も描画されない） */}
+      <LineLoginButton />
       {/* 新規会員登録の入口（登録入口から生まれる身分は会員のみ） */}
       <p className="mt-6 text-center text-xs text-[#9a958e]">
         はじめての方は{' '}

--- a/frontend/src/_pages/platform-settings/ui/AccountPage.tsx
+++ b/frontend/src/_pages/platform-settings/ui/AccountPage.tsx
@@ -1,16 +1,20 @@
 'use client';
 
+import { LineLinkSection } from '@/features/line-auth';
 import { PasswordChangeForm } from '@/features/password-change';
 
-/** アカウント設定ページ（パスワード変更） */
+/** アカウント設定ページ（パスワード変更・LINE連携） */
 export default function AccountPage() {
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-foreground">アカウント設定</h1>
-        <p className="text-sm text-muted-foreground mt-1">自分のパスワードを管理します。</p>
+        <p className="text-sm text-muted-foreground mt-1">
+          自分のパスワードとLINE連携を管理します。
+        </p>
       </div>
       <PasswordChangeForm />
+      <LineLinkSection />
     </div>
   );
 }

--- a/frontend/src/app/(public)/platform/line/callback/page.tsx
+++ b/frontend/src/app/(public)/platform/line/callback/page.tsx
@@ -1,0 +1,1 @@
+export { LineCallbackPage as default } from '@/_pages/platform-line-callback';

--- a/frontend/src/entities/user/__tests__/line-api.test.ts
+++ b/frontend/src/entities/user/__tests__/line-api.test.ts
@@ -1,0 +1,53 @@
+import { platformLineApi } from '@/entities/user';
+import { apiClient } from '@/shared/api';
+
+jest.mock('@/shared/api/client', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(async (url: string) => ({ data: { url } })),
+    post: jest.fn(async (url: string) => ({ data: { url } })),
+  },
+}));
+
+const mockedClient = apiClient as unknown as { get: jest.Mock; post: jest.Mock };
+
+const authorization = {
+  code: 'auth-code',
+  redirect_uri: 'https://kizuna.test/platform/line/callback',
+  code_verifier: 'verifier',
+};
+
+describe('platform line api', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('config は /platform/line/config を GET する', async () => {
+    await platformLineApi.config();
+    expect(mockedClient.get).toHaveBeenCalledWith('/platform/line/config');
+  });
+
+  it('login は /platform/line/login へ引き換え要求を送り、401 の共通処理を回避する', async () => {
+    await platformLineApi.login(authorization);
+    expect(mockedClient.post).toHaveBeenCalledWith('/platform/line/login', authorization, {
+      skipAuthRedirect: true,
+    });
+  });
+
+  it('register は /platform/line/register へ登録チケットを送る', async () => {
+    const request = {
+      registration_ticket: 'ticket',
+      display_name: '会員太郎',
+      email: 'member@kizuna.test',
+    };
+    await platformLineApi.register(request);
+    expect(mockedClient.post).toHaveBeenCalledWith('/platform/line/register', request, {
+      skipAuthRedirect: true,
+    });
+  });
+
+  it('link は /platform/me/line へ引き換え要求を送る（Bearer は共通配線が付与する）', async () => {
+    await platformLineApi.link(authorization);
+    expect(mockedClient.post).toHaveBeenCalledWith('/platform/me/line', authorization);
+  });
+});

--- a/frontend/src/entities/user/api/line.ts
+++ b/frontend/src/entities/user/api/line.ts
@@ -1,0 +1,37 @@
+import { apiClient } from '@/shared/api';
+import {
+  LineAuthorizationRequest,
+  LineConfigResponse,
+  LineLoginResponse,
+  LineRegisterRequest,
+  LoginResponse,
+} from '../model/types';
+
+export const platformLineApi = {
+  /** LINE ログインの公開設定（匿名）。enabled=false なら入口を描画しない。 */
+  config: async (): Promise<LineConfigResponse> => {
+    const response = await apiClient.get('/platform/line/config');
+    return response.data;
+  },
+  /**
+   * 認可コードを引き換えてログインする（公開・匿名）。
+   * 呼び出し元がセッションと失敗表示を自前で扱うため、グローバルな 401 ハンドリングから除外する。
+   */
+  login: async (data: LineAuthorizationRequest): Promise<LineLoginResponse> => {
+    const response = await apiClient.post('/platform/line/login', data, {
+      skipAuthRedirect: true,
+    } as any);
+    return response.data;
+  },
+  /** 登録チケットで会員を作成し、そのままログインする（公開・匿名）。 */
+  register: async (data: LineRegisterRequest): Promise<LoginResponse> => {
+    const response = await apiClient.post('/platform/line/register', data, {
+      skipAuthRedirect: true,
+    } as any);
+    return response.data;
+  },
+  /** 既存アカウントへ LINE を連携する。409 は連携済み ないし 当該 LINE が他アカウントに使用済み。 */
+  link: async (data: LineAuthorizationRequest): Promise<void> => {
+    await apiClient.post('/platform/me/line', data);
+  },
+};

--- a/frontend/src/entities/user/index.ts
+++ b/frontend/src/entities/user/index.ts
@@ -1,5 +1,6 @@
 export * from './model/types';
 export { platformAuthApi } from './api/platform';
+export { platformLineApi } from './api/line';
 export { platformStaffApi, platformRoleApi } from './api/platform-staff';
 export { resolvePlatformDestination } from './model/platformRouting';
 export type { PlatformDestination } from './model/platformRouting';

--- a/frontend/src/entities/user/model/types.ts
+++ b/frontend/src/entities/user/model/types.ts
@@ -59,6 +59,8 @@ export interface PlatformMeResponse {
   store_bridge: boolean;
   store_scope_type?: PlatformStoreScopeType;
   store_ids?: number[];
+  // LINE アカウントと連携済みか。Java 側が primitive の boolean のため、キーは必ず応答に含まれる。
+  line_linked: boolean;
 }
 
 // 平台自己プロフィール更新リクエスト
@@ -160,4 +162,31 @@ export interface PlatformStaffUpdateRequest {
   enabled?: boolean;
   // 楽観ロック用バージョン（応答の version をそのまま返送。不一致は 409）
   version: number;
+}
+
+// LINE ログインの公開設定。enabled=false のとき入口自体を描画しない。
+export interface LineConfigResponse {
+  // Java 側が primitive の boolean のため、キーは必ず応答に含まれる。
+  enabled: boolean;
+  channel_id?: string;
+}
+
+// LINE 認可コードの引き換え要求（ログインと連携で同形）。
+// redirect_uri は認可要求時と同一値でなければならない。
+export interface LineAuthorizationRequest {
+  code: string;
+  redirect_uri: string;
+  code_verifier: string;
+}
+
+// LINE ログインの応答。未登録の LINE ユーザーには token ではなく登録チケットが返る。
+export type LineLoginResponse =
+  | ({ registered: true } & LoginResponse)
+  | { registered: false; registration_ticket?: string; display_name?: string };
+
+// LINE 経由の会員登録要求（登録チケットと入力 2 項目。同意チェックは画面側の関門で送信しない）
+export interface LineRegisterRequest {
+  registration_ticket: string;
+  display_name: string;
+  email: string;
 }

--- a/frontend/src/features/line-auth/index.ts
+++ b/frontend/src/features/line-auth/index.ts
@@ -1,0 +1,2 @@
+export { LineLoginButton } from './ui/LineLoginButton';
+export { LineLinkSection } from './ui/LineLinkSection';

--- a/frontend/src/features/line-auth/ui/LineLinkSection.tsx
+++ b/frontend/src/features/line-auth/ui/LineLinkSection.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { platformAuthApi, platformLineApi } from '@/entities/user';
+import { startLineAuthorization } from '@/shared/lib';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui';
+
+/**
+ * アカウント設定の LINE 連携ブロック。連携済みなら状態表示のみで、解除は提供しない。
+ * 公開設定が無効・取得失敗のときはブロックごと描画しない。
+ */
+export function LineLinkSection() {
+  const [channelId, setChannelId] = useState('');
+  const [linked, setLinked] = useState(false);
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [config, me] = await Promise.all([platformLineApi.config(), platformAuthApi.me()]);
+        setLinked(me.line_linked);
+        if (config.enabled && config.channel_id) {
+          setChannelId(config.channel_id);
+        }
+      } catch {
+        // 設定ないし本人情報を取得できない場合はブロックを出さない
+      }
+    };
+    void load();
+  }, []);
+
+  if (!channelId) return null;
+
+  const start = async () => {
+    setIsRedirecting(true);
+    try {
+      await startLineAuthorization(channelId, 'link');
+    } catch {
+      // PKCE の生成には SubtleCrypto が要り、安全な接続でないと利用できない
+      setIsRedirecting(false);
+      toast.error('LINE連携を開始できませんでした。安全な接続でお試しください');
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle role="heading" aria-level={2}>
+          LINE連携
+        </CardTitle>
+        <CardDescription>連携すると、次回からLINEアカウントでログインできます。</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {linked ? (
+          <Badge variant="secondary">連携済み</Badge>
+        ) : (
+          <Button type="button" onClick={start} disabled={isRedirecting}>
+            {isRedirecting ? 'LINEへ移動中...' : 'LINEを連携する'}
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/line-auth/ui/LineLinkSection.tsx
+++ b/frontend/src/features/line-auth/ui/LineLinkSection.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { platformAuthApi, platformLineApi } from '@/entities/user';
-import { startLineAuthorization } from '@/shared/lib';
+import { isLinePlatformHost, startLineAuthorization } from '@/shared/lib';
 import {
   Badge,
   Button,
@@ -21,13 +21,17 @@ import {
 export function LineLinkSection() {
   const [channelId, setChannelId] = useState('');
   const [linked, setLinked] = useState(false);
+  const [subject, setSubject] = useState('');
   const [isRedirecting, setIsRedirecting] = useState(false);
 
   useEffect(() => {
+    // 店舗ドメイン上ではコールバック URL がチャネル登録の平台 origin と食い違い認可が成立しないため、入口を出さない
+    if (!isLinePlatformHost()) return;
     const load = async () => {
       try {
         const [config, me] = await Promise.all([platformLineApi.config(), platformAuthApi.me()]);
         setLinked(me.line_linked);
+        setSubject(me.email ?? '');
         if (config.enabled && config.channel_id) {
           setChannelId(config.channel_id);
         }
@@ -43,7 +47,8 @@ export function LineLinkSection() {
   const start = async () => {
     setIsRedirecting(true);
     try {
-      await startLineAuthorization(channelId, 'link');
+      // 発起主体を認可記録に束縛し、外部認可の往復中に別アカウントへ切り替わった場合の誤連携を防ぐ
+      await startLineAuthorization(channelId, 'link', subject);
     } catch {
       // PKCE の生成には SubtleCrypto が要り、安全な接続でないと利用できない
       setIsRedirecting(false);

--- a/frontend/src/features/line-auth/ui/LineLoginButton.tsx
+++ b/frontend/src/features/line-auth/ui/LineLoginButton.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { platformLineApi } from '@/entities/user';
+import { startLineAuthorization } from '@/shared/lib';
+
+/**
+ * 統一ログイン画面の LINE ログイン入口。
+ * 公開設定が無効・チャネル未設定・設定の取得失敗のいずれでも何も描画しない
+ * （押しても始まらないボタンを見せない。パスワードログインは影響を受けない）。
+ */
+export function LineLoginButton() {
+  const [channelId, setChannelId] = useState('');
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const config = await platformLineApi.config();
+        if (config.enabled && config.channel_id) {
+          setChannelId(config.channel_id);
+        }
+      } catch {
+        // 設定を取得できない場合は入口ごと出さない
+      }
+    };
+    void load();
+  }, []);
+
+  if (!channelId) return null;
+
+  const start = async () => {
+    setIsRedirecting(true);
+    try {
+      await startLineAuthorization(channelId, 'login');
+    } catch {
+      // PKCE の生成には SubtleCrypto が要り、安全な接続でないと利用できない
+      setIsRedirecting(false);
+      toast.error('LINEログインを開始できませんでした。安全な接続でお試しください');
+    }
+  };
+
+  return (
+    <div className="mt-8 space-y-6">
+      <div className="auth-divider">または</div>
+      <button
+        type="button"
+        onClick={start}
+        disabled={isRedirecting}
+        className="auth-btn auth-btn--line"
+      >
+        {isRedirecting ? (
+          <span className="flex items-center justify-center gap-2.5">
+            <span className="auth-spinner" />
+            LINEへ移動中...
+          </span>
+        ) : (
+          'LINEでログイン'
+        )}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/features/line-auth/ui/LineLoginButton.tsx
+++ b/frontend/src/features/line-auth/ui/LineLoginButton.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import { platformLineApi } from '@/entities/user';
-import { startLineAuthorization } from '@/shared/lib';
+import { isLinePlatformHost, startLineAuthorization } from '@/shared/lib';
 
 /**
  * 統一ログイン画面の LINE ログイン入口。
@@ -15,6 +15,8 @@ export function LineLoginButton() {
   const [isRedirecting, setIsRedirecting] = useState(false);
 
   useEffect(() => {
+    // 店舗ドメイン上ではコールバック URL がチャネル登録の平台 origin と食い違い認可が成立しないため、入口を出さない
+    if (!isLinePlatformHost()) return;
     const load = async () => {
       try {
         const config = await platformLineApi.config();

--- a/frontend/src/features/line-auth/ui/__tests__/LineLinkSection.test.tsx
+++ b/frontend/src/features/line-auth/ui/__tests__/LineLinkSection.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { LineLinkSection } from '../LineLinkSection';
+import { platformAuthApi, platformLineApi } from '@/entities/user';
+import { startLineAuthorization } from '@/shared/lib';
+import type { PlatformMeResponse } from '@/entities/user';
+
+jest.mock('react-hot-toast', () => ({
+  __esModule: true,
+  toast: { error: jest.fn() },
+}));
+
+jest.mock('@/entities/user', () => {
+  const actual = jest.requireActual('@/entities/user');
+  return {
+    ...actual,
+    platformLineApi: { ...actual.platformLineApi, config: jest.fn() },
+    platformAuthApi: { ...actual.platformAuthApi, me: jest.fn() },
+  };
+});
+
+jest.mock('@/shared/lib', () => {
+  const actual = jest.requireActual('@/shared/lib');
+  return { ...actual, startLineAuthorization: jest.fn() };
+});
+
+const mockedConfig = platformLineApi.config as jest.Mock;
+const mockedMe = platformAuthApi.me as jest.Mock;
+const mockedStart = startLineAuthorization as jest.Mock;
+
+function meResponse(lineLinked: boolean): PlatformMeResponse {
+  return {
+    email: 'user@kizuna.test',
+    display_name: '本人',
+    user_type: 'MEMBER',
+    permissions: [],
+    console: 'none',
+    store_bridge: false,
+    line_linked: lineLinked,
+  };
+}
+
+describe('LineLinkSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedConfig.mockResolvedValue({ enabled: true, channel_id: 'channel-1' });
+  });
+
+  it('未連携なら連携ボタンを表示する', async () => {
+    mockedMe.mockResolvedValue(meResponse(false));
+
+    render(<LineLinkSection />);
+
+    expect(await screen.findByRole('button', { name: 'LINEを連携する' })).toBeInTheDocument();
+    expect(screen.queryByText('連携済み')).not.toBeInTheDocument();
+  });
+
+  it('連携済みなら状態のみ表示し、解除の導線は出さない', async () => {
+    mockedMe.mockResolvedValue(meResponse(true));
+
+    render(<LineLinkSection />);
+
+    expect(await screen.findByText('連携済み')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'LINEを連携する' })).not.toBeInTheDocument();
+  });
+
+  it('押下で連携意図の認可を開始する', async () => {
+    mockedMe.mockResolvedValue(meResponse(false));
+    mockedStart.mockResolvedValue(undefined);
+
+    render(<LineLinkSection />);
+    fireEvent.click(await screen.findByRole('button', { name: 'LINEを連携する' }));
+
+    await waitFor(() => expect(mockedStart).toHaveBeenCalledWith('channel-1', 'link'));
+  });
+
+  it('公開設定が無効ならブロックごと描画しない', async () => {
+    mockedConfig.mockResolvedValue({ enabled: false });
+    mockedMe.mockResolvedValue(meResponse(false));
+
+    render(<LineLinkSection />);
+
+    await waitFor(() => expect(mockedConfig).toHaveBeenCalled());
+    expect(screen.queryByText('LINE連携')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/line-auth/ui/__tests__/LineLinkSection.test.tsx
+++ b/frontend/src/features/line-auth/ui/__tests__/LineLinkSection.test.tsx
@@ -63,14 +63,28 @@ describe('LineLinkSection', () => {
     expect(screen.queryByRole('button', { name: 'LINEを連携する' })).not.toBeInTheDocument();
   });
 
-  it('押下で連携意図の認可を開始する', async () => {
+  it('押下で発起主体つきの連携意図の認可を開始する', async () => {
     mockedMe.mockResolvedValue(meResponse(false));
     mockedStart.mockResolvedValue(undefined);
 
     render(<LineLinkSection />);
     fireEvent.click(await screen.findByRole('button', { name: 'LINEを連携する' }));
 
-    await waitFor(() => expect(mockedStart).toHaveBeenCalledWith('channel-1', 'link'));
+    await waitFor(() =>
+      expect(mockedStart).toHaveBeenCalledWith('channel-1', 'link', 'user@kizuna.test')
+    );
+  });
+
+  it('店舗ドメイン上（role=store cookie）ではブロックごと描画しない', async () => {
+    document.cookie = 'x-mw-role=store';
+    try {
+      render(<LineLinkSection />);
+
+      await waitFor(() => expect(mockedConfig).not.toHaveBeenCalled());
+      expect(screen.queryByText('LINE連携')).not.toBeInTheDocument();
+    } finally {
+      document.cookie = 'x-mw-role=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+    }
   });
 
   it('公開設定が無効ならブロックごと描画しない', async () => {

--- a/frontend/src/features/line-auth/ui/__tests__/LineLoginButton.test.tsx
+++ b/frontend/src/features/line-auth/ui/__tests__/LineLoginButton.test.tsx
@@ -37,6 +37,18 @@ describe('LineLoginButton', () => {
     expect(await screen.findByRole('button', { name: 'LINEでログイン' })).toBeInTheDocument();
   });
 
+  it('店舗ドメイン上（role=store cookie）では設定を照会せず何も描画しない', async () => {
+    document.cookie = 'x-mw-role=store';
+    try {
+      render(<LineLoginButton />);
+
+      await waitFor(() => expect(mockedConfig).not.toHaveBeenCalled());
+      expect(screen.queryByRole('button', { name: 'LINEでログイン' })).not.toBeInTheDocument();
+    } finally {
+      document.cookie = 'x-mw-role=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+    }
+  });
+
   it('公開設定が無効なら何も描画しない', async () => {
     mockedConfig.mockResolvedValue({ enabled: false });
 

--- a/frontend/src/features/line-auth/ui/__tests__/LineLoginButton.test.tsx
+++ b/frontend/src/features/line-auth/ui/__tests__/LineLoginButton.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { LineLoginButton } from '../LineLoginButton';
+import { platformLineApi } from '@/entities/user';
+import { startLineAuthorization } from '@/shared/lib';
+
+jest.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: { error: jest.fn() },
+}));
+
+jest.mock('@/entities/user', () => {
+  const actual = jest.requireActual('@/entities/user');
+  return {
+    ...actual,
+    platformLineApi: { ...actual.platformLineApi, config: jest.fn() },
+  };
+});
+
+jest.mock('@/shared/lib', () => {
+  const actual = jest.requireActual('@/shared/lib');
+  return { ...actual, startLineAuthorization: jest.fn() };
+});
+
+const mockedConfig = platformLineApi.config as jest.Mock;
+const mockedStart = startLineAuthorization as jest.Mock;
+
+describe('LineLoginButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('公開設定が有効なときだけ入口を描画する', async () => {
+    mockedConfig.mockResolvedValue({ enabled: true, channel_id: 'channel-1' });
+
+    render(<LineLoginButton />);
+
+    expect(await screen.findByRole('button', { name: 'LINEでログイン' })).toBeInTheDocument();
+  });
+
+  it('公開設定が無効なら何も描画しない', async () => {
+    mockedConfig.mockResolvedValue({ enabled: false });
+
+    render(<LineLoginButton />);
+
+    await waitFor(() => expect(mockedConfig).toHaveBeenCalled());
+    expect(screen.queryByRole('button', { name: 'LINEでログイン' })).not.toBeInTheDocument();
+  });
+
+  it('チャネル未設定なら何も描画しない', async () => {
+    mockedConfig.mockResolvedValue({ enabled: true });
+
+    render(<LineLoginButton />);
+
+    await waitFor(() => expect(mockedConfig).toHaveBeenCalled());
+    expect(screen.queryByRole('button', { name: 'LINEでログイン' })).not.toBeInTheDocument();
+  });
+
+  it('設定の取得に失敗しても何も描画しない（パスワードログインは無傷）', async () => {
+    mockedConfig.mockRejectedValue(new Error('network'));
+
+    render(<LineLoginButton />);
+
+    await waitFor(() => expect(mockedConfig).toHaveBeenCalled());
+    expect(screen.queryByRole('button', { name: 'LINEでログイン' })).not.toBeInTheDocument();
+  });
+
+  it('押下でログイン意図の認可を開始する', async () => {
+    mockedConfig.mockResolvedValue({ enabled: true, channel_id: 'channel-1' });
+    mockedStart.mockResolvedValue(undefined);
+
+    render(<LineLoginButton />);
+    fireEvent.click(await screen.findByRole('button', { name: 'LINEでログイン' }));
+
+    await waitFor(() => expect(mockedStart).toHaveBeenCalledWith('channel-1', 'login'));
+  });
+});

--- a/frontend/src/features/platform-login/index.ts
+++ b/frontend/src/features/platform-login/index.ts
@@ -1,1 +1,3 @@
 export { default as PlatformLoginForm } from './ui/PlatformLoginForm';
+export { completePlatformLogin } from './model/completePlatformLogin';
+export type { PlatformLoginCompletion } from './model/completePlatformLogin';

--- a/frontend/src/features/platform-login/model/completePlatformLogin.ts
+++ b/frontend/src/features/platform-login/model/completePlatformLogin.ts
@@ -1,0 +1,51 @@
+import Cookies from 'js-cookie';
+import { LoginResponse, platformAuthApi, resolvePlatformDestination } from '@/entities/user';
+import { clearPlatformSession, startPlatformSession, storeEntryPath } from '@/shared/lib';
+
+/** ログイン完了の結果。unsupported は着地先の無い利用者種別で、セッションは破棄済み。 */
+export type PlatformLoginCompletion = { status: 'ok'; path: string } | { status: 'unsupported' };
+
+/**
+ * ログイン応答から平台セッションを確立し、着地先パスを返す。
+ * パスワードログインと LINE ログインが共有する唯一の後処理で、遷移自体は呼び出し元が行う。
+ */
+export async function completePlatformLogin({
+  token,
+  expires_at,
+}: LoginResponse): Promise<PlatformLoginCompletion> {
+  // epoch millis を Date に変換する（expires_at をそのまま日数として解釈すると不正な有効期限になる）
+  Cookies.set('token', token ?? '', { expires: new Date(expires_at) });
+
+  const me = await platformAuthApi.me();
+  const activeConsole = me.console ?? 'none';
+  const destination = resolvePlatformDestination(activeConsole);
+
+  if (destination === 'platform') {
+    startPlatformSession(activeConsole, expires_at);
+    return { status: 'ok', path: '/platform/dashboard/' };
+  }
+
+  if (destination === 'store') {
+    // 着地方針（授権店舗の選択とメニュー由来の着地先解決）は StoreEntryPage 一箇所に集約する。
+    // ここでは無条件に入口へ渡し、店舗の解決には関与しない。
+    startPlatformSession(activeConsole, expires_at);
+    return { status: 'ok', path: storeEntryPath() };
+  }
+
+  // destination='unsupported'（console='none' — CAST または MEMBER）。両者は console だけでは
+  // 区別できないため、既に取得済みの user_type で分岐する。
+  if (me.user_type === 'CAST') {
+    startPlatformSession('cast', expires_at);
+    return { status: 'ok', path: '/cast/schedule/' };
+  }
+
+  if (me.user_type === 'MEMBER') {
+    startPlatformSession('member', expires_at);
+    return { status: 'ok', path: '/member/' };
+  }
+
+  // 想定外の user_type: 着地先が無いためセッションを破棄する
+  Cookies.remove('token');
+  clearPlatformSession();
+  return { status: 'unsupported' };
+}

--- a/frontend/src/features/platform-login/ui/PlatformLoginForm.tsx
+++ b/frontend/src/features/platform-login/ui/PlatformLoginForm.tsx
@@ -4,13 +4,9 @@ import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import Cookies from 'js-cookie';
 import toast from 'react-hot-toast';
-import { platformAuthApi, PlatformLoginRequest, resolvePlatformDestination } from '@/entities/user';
-import {
-  clearPlatformSession,
-  getApiErrorMessage,
-  startPlatformSession,
-  storeEntryPath,
-} from '@/shared/lib';
+import { platformAuthApi, PlatformLoginRequest } from '@/entities/user';
+import { getApiErrorMessage } from '@/shared/lib';
+import { completePlatformLogin } from '../model/completePlatformLogin';
 
 /** 統一ログイン動作。ログイン成功後はロールに応じて自動的に適切なコンソールへ遷移する。 */
 export default function PlatformLoginForm() {
@@ -24,46 +20,12 @@ export default function PlatformLoginForm() {
   const onSubmit = async (data: PlatformLoginRequest) => {
     Cookies.remove('token');
     try {
-      const { token, expires_at } = await platformAuthApi.login(data);
-      // epoch millis を Date に変換する（expires_at をそのまま日数として解釈すると不正な有効期限になる）
-      Cookies.set('token', token ?? '', { expires: new Date(expires_at) });
-
-      const me = await platformAuthApi.me();
-      const activeConsole = me.console ?? 'none';
-      const destination = resolvePlatformDestination(activeConsole);
-
-      if (destination === 'platform') {
-        startPlatformSession(activeConsole, expires_at);
-        router.push('/platform/dashboard/');
+      const completion = await completePlatformLogin(await platformAuthApi.login(data));
+      if (completion.status === 'unsupported') {
+        toast.error('この利用者種別のポータルは準備中です');
         return;
       }
-
-      if (destination === 'store') {
-        // 着地方針（授権店舗の選択とメニュー由来の着地先解決）は StoreEntryPage 一箇所に集約する。
-        // ログインフォームは無条件に入口へ渡し、店舗の解決には関与しない。
-        startPlatformSession(activeConsole, expires_at);
-        router.push(storeEntryPath());
-        return;
-      }
-
-      // destination='unsupported'（console='none' — CAST または MEMBER）。両者は console だけでは
-      // 区別できないため、既に取得済みの user_type で分岐する。
-      if (me.user_type === 'CAST') {
-        startPlatformSession('cast', expires_at);
-        router.push('/cast/schedule/');
-        return;
-      }
-
-      if (me.user_type === 'MEMBER') {
-        startPlatformSession('member', expires_at);
-        router.push('/member/');
-        return;
-      }
-
-      // 想定外の user_type: 着地先が無いためセッションを破棄する
-      Cookies.remove('token');
-      clearPlatformSession();
-      toast.error('この利用者種別のポータルは準備中です');
+      router.push(completion.path);
     } catch (error) {
       console.error('Platform login failed:', error);
       toast.error(

--- a/frontend/src/features/platform-login/ui/__tests__/PlatformLoginForm.test.tsx
+++ b/frontend/src/features/platform-login/ui/__tests__/PlatformLoginForm.test.tsx
@@ -38,6 +38,7 @@ function meResponse(overrides: Partial<PlatformMeResponse>): PlatformMeResponse 
     store_bridge: false,
     store_scope_type: 'ALL_STORES',
     store_ids: [],
+    line_linked: false,
     ...overrides,
   };
 }

--- a/frontend/src/shared/lib/__tests__/line-oauth.test.ts
+++ b/frontend/src/shared/lib/__tests__/line-oauth.test.ts
@@ -1,0 +1,136 @@
+import {
+  LINE_AUTHORIZE_ENDPOINT,
+  consumeLineAuthorization,
+  lineCallbackRedirectUri,
+  prepareLineAuthorization,
+  startLineAuthorization,
+} from '../line-oauth';
+
+const STORAGE_KEY = 'kizuna-line-oauth';
+
+describe('line-oauth', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  describe('prepareLineAuthorization', () => {
+    it('認可URLに PKCE(S256) と state を載せ、code_verifier を保存する', async () => {
+      const url = new URL(await prepareLineAuthorization('channel-1', 'login'));
+
+      expect(`${url.origin}${url.pathname}`).toBe(LINE_AUTHORIZE_ENDPOINT);
+      expect(url.searchParams.get('response_type')).toBe('code');
+      expect(url.searchParams.get('client_id')).toBe('channel-1');
+      expect(url.searchParams.get('redirect_uri')).toBe(lineCallbackRedirectUri());
+      expect(url.searchParams.get('scope')).toBe('profile openid');
+      expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+
+      const stored = JSON.parse(sessionStorage.getItem(STORAGE_KEY) as string);
+      expect(stored.intent).toBe('login');
+      expect(stored.state).toBe(url.searchParams.get('state'));
+      // code_verifier は PKCE が要求する 43〜128 文字の URL 安全文字列
+      expect(stored.verifier).toMatch(/^[A-Za-z0-9\-_]{43}$/);
+    });
+
+    it('code_challenge は code_verifier の SHA-256 を base64url にしたもの', async () => {
+      const url = new URL(await prepareLineAuthorization('channel-1', 'login'));
+      const { verifier } = JSON.parse(sessionStorage.getItem(STORAGE_KEY) as string);
+
+      const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+      const expected = btoa(String.fromCharCode(...new Uint8Array(digest)))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+
+      expect(url.searchParams.get('code_challenge')).toBe(expected);
+    });
+
+    it('呼び出しごとに state と code_verifier が変わる', async () => {
+      await prepareLineAuthorization('channel-1', 'login');
+      const first = JSON.parse(sessionStorage.getItem(STORAGE_KEY) as string);
+      await prepareLineAuthorization('channel-1', 'login');
+      const second = JSON.parse(sessionStorage.getItem(STORAGE_KEY) as string);
+
+      expect(second.state).not.toBe(first.state);
+      expect(second.verifier).not.toBe(first.verifier);
+    });
+
+    it('SubtleCrypto が使えない環境（平文HTTP等）では失敗し、保存もしない', async () => {
+      const original = globalThis.crypto.subtle;
+      Object.defineProperty(globalThis.crypto, 'subtle', {
+        value: undefined,
+        configurable: true,
+      });
+
+      await expect(prepareLineAuthorization('channel-1', 'login')).rejects.toThrow();
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+
+      Object.defineProperty(globalThis.crypto, 'subtle', { value: original, configurable: true });
+    });
+  });
+
+  describe('startLineAuthorization', () => {
+    // jsdom の location は差し替え不能（unforgeable）で遷移も未実装のため、
+    // 遷移そのものは観測できない。ここでは意図の保存までを検証し、
+    // 遷移の引数は各画面のテストが startLineAuthorization を差し替えて確認する。
+    it('遷移前に意図つきで認可情報を保存する', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await startLineAuthorization('channel-1', 'link');
+
+      expect(JSON.parse(sessionStorage.getItem(STORAGE_KEY) as string).intent).toBe('link');
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe('consumeLineAuthorization', () => {
+    it('state が一致すれば code_verifier と意図を返し、保存値を破棄する', async () => {
+      await prepareLineAuthorization('channel-1', 'link');
+      const stored = JSON.parse(sessionStorage.getItem(STORAGE_KEY) as string);
+
+      expect(consumeLineAuthorization(stored.state)).toEqual({
+        state: stored.state,
+        verifier: stored.verifier,
+        intent: 'link',
+      });
+      // 認可要求 1 回に対して引き換えは 1 回きり
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+      expect(consumeLineAuthorization(stored.state)).toBeNull();
+    });
+
+    it('state が食い違う場合は null（保存値も破棄する）', async () => {
+      await prepareLineAuthorization('channel-1', 'login');
+
+      expect(consumeLineAuthorization('別のstate')).toBeNull();
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    it('保存が無い場合は null', () => {
+      expect(consumeLineAuthorization('state')).toBeNull();
+    });
+
+    it('state を伴わないコールバックは null', async () => {
+      await prepareLineAuthorization('channel-1', 'login');
+
+      expect(consumeLineAuthorization(null)).toBeNull();
+    });
+
+    it('保存値が壊れている場合は null', () => {
+      sessionStorage.setItem(STORAGE_KEY, '{壊れたJSON');
+      expect(consumeLineAuthorization('state')).toBeNull();
+
+      sessionStorage.setItem(STORAGE_KEY, '"文字列"');
+      expect(consumeLineAuthorization('state')).toBeNull();
+
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ state: 'state', verifier: 1 }));
+      expect(consumeLineAuthorization('state')).toBeNull();
+
+      // 未知の意図は受け付けない（分岐先が無い）
+      sessionStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ state: 'state', verifier: 'v', intent: 'unknown' })
+      );
+      expect(consumeLineAuthorization('state')).toBeNull();
+    });
+  });
+});

--- a/frontend/src/shared/lib/__tests__/line-oauth.test.ts
+++ b/frontend/src/shared/lib/__tests__/line-oauth.test.ts
@@ -1,6 +1,7 @@
 import {
   LINE_AUTHORIZE_ENDPOINT,
   consumeLineAuthorization,
+  isLinePlatformHost,
   lineCallbackRedirectUri,
   prepareLineAuthorization,
   startLineAuthorization,
@@ -83,6 +84,19 @@ describe('line-oauth', () => {
     });
   });
 
+  describe('isLinePlatformHost', () => {
+    it('店舗ドメイン（proxy が立てる role=store cookie）でのみ false', () => {
+      expect(isLinePlatformHost()).toBe(true);
+      document.cookie = 'x-mw-role=store';
+      try {
+        expect(isLinePlatformHost()).toBe(false);
+      } finally {
+        document.cookie = 'x-mw-role=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+      }
+      expect(isLinePlatformHost()).toBe(true);
+    });
+  });
+
   describe('consumeLineAuthorization', () => {
     it('state が一致すれば code_verifier と意図を返し、保存値を破棄する', async () => {
       await prepareLineAuthorization('channel-1', 'link');
@@ -96,6 +110,13 @@ describe('line-oauth', () => {
       // 認可要求 1 回に対して引き換えは 1 回きり
       expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
       expect(consumeLineAuthorization(stored.state)).toBeNull();
+    });
+
+    it('発起主体つきで保存した場合は消費時に返す（連携意図の本人束縛）', async () => {
+      await prepareLineAuthorization('channel-1', 'link', 'me@kizuna.test');
+      const stored = JSON.parse(sessionStorage.getItem(STORAGE_KEY) as string);
+
+      expect(consumeLineAuthorization(stored.state)?.subject).toBe('me@kizuna.test');
     });
 
     it('state が食い違う場合は null（保存値も破棄する）', async () => {

--- a/frontend/src/shared/lib/app-area.ts
+++ b/frontend/src/shared/lib/app-area.ts
@@ -1,9 +1,15 @@
-/** セッション不要の platform ルート（ログインフォーム・招待受諾・会員登録）。ルート守衛が参照する。 */
+/**
+ * セッション不要の platform ルート（ログインフォーム・招待受諾・会員登録・LINE コールバック）。
+ * ルート守衛が参照する。LINE コールバックは未ログインのログイン/登録経路が通るため公開扱いが必須で、
+ * 連携経路（ログイン済み）でも会員・キャストのコンソールから /platform/* へ到達するため
+ * コンソール整合ガードの対象外である必要がある。
+ */
 export function isPublicPlatformPath(path: string): boolean {
   return (
     path.startsWith('/platform/login') ||
     path.startsWith('/platform/invite') ||
-    path.startsWith('/platform/register')
+    path.startsWith('/platform/register') ||
+    path.startsWith('/platform/line/callback')
   );
 }
 

--- a/frontend/src/shared/lib/index.ts
+++ b/frontend/src/shared/lib/index.ts
@@ -25,5 +25,13 @@ export {
 } from './store-route';
 export { cn } from './utils';
 export { isPublicPlatformPath } from './app-area';
+export {
+  LINE_AUTHORIZE_ENDPOINT,
+  consumeLineAuthorization,
+  lineCallbackRedirectUri,
+  prepareLineAuthorization,
+  startLineAuthorization,
+} from './line-oauth';
+export type { LineOauthIntent } from './line-oauth';
 export { hasPermission, readTokenClaims } from './token-claims';
 export type { TokenClaims } from './token-claims';

--- a/frontend/src/shared/lib/index.ts
+++ b/frontend/src/shared/lib/index.ts
@@ -28,6 +28,7 @@ export { isPublicPlatformPath } from './app-area';
 export {
   LINE_AUTHORIZE_ENDPOINT,
   consumeLineAuthorization,
+  isLinePlatformHost,
   lineCallbackRedirectUri,
   prepareLineAuthorization,
   startLineAuthorization,

--- a/frontend/src/shared/lib/line-oauth.ts
+++ b/frontend/src/shared/lib/line-oauth.ts
@@ -1,0 +1,106 @@
+/** LINE の認可エンドポイント（認可コードフロー + PKCE）。 */
+export const LINE_AUTHORIZE_ENDPOINT = 'https://access.line.me/oauth2/v2.1/authorize';
+
+/** LINE から要求する権限。表示名の取得に profile、id_token に openid が必要。 */
+const LINE_SCOPE = 'profile openid';
+
+/** state / code_verifier / 開始時の意図の保管先。単一のコールバック画面が三つの入口を捌くため意図も持たせる。 */
+const STORAGE_KEY = 'kizuna-line-oauth';
+
+/** LINE 認可を開始した入口。ログイン（未登録なら会員登録へ分岐）と既存アカウントへの連携。 */
+export type LineOauthIntent = 'login' | 'link';
+
+interface LineAuthorizationRecord {
+  state: string;
+  verifier: string;
+  intent: LineOauthIntent;
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** 32 バイト乱数の base64url 表現（43 文字）。PKCE の code_verifier が要求する 43〜128 文字を満たす。 */
+function randomToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return toBase64Url(bytes);
+}
+
+/** LINE 側に登録するコールバック URL。認可要求と引き換え要求で同一値でなければならない。 */
+export function lineCallbackRedirectUri(): string {
+  return `${window.location.origin}/platform/line/callback`;
+}
+
+/**
+ * state と code_verifier を生成して sessionStorage に保存し、認可 URL を組み立てる。
+ * SubtleCrypto は安全なコンテキスト（HTTPS ないし localhost）でしか公開されないため、
+ * 平文 HTTP で開いた場合はここで失敗する（呼び出し元が利用者向けの案内を出す）。
+ */
+export async function prepareLineAuthorization(
+  channelId: string,
+  intent: LineOauthIntent
+): Promise<string> {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) {
+    throw new Error('SubtleCrypto is unavailable');
+  }
+
+  const state = randomToken();
+  const verifier = randomToken();
+  const digest = await subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  const challenge = toBase64Url(new Uint8Array(digest));
+
+  const record: LineAuthorizationRecord = { state, verifier, intent };
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(record));
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: channelId,
+    redirect_uri: lineCallbackRedirectUri(),
+    state,
+    scope: LINE_SCOPE,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+  });
+  return `${LINE_AUTHORIZE_ENDPOINT}?${params.toString()}`;
+}
+
+/** 認可 URL を組み立てて LINE へ遷移する。 */
+export async function startLineAuthorization(
+  channelId: string,
+  intent: LineOauthIntent
+): Promise<void> {
+  const url = await prepareLineAuthorization(channelId, intent);
+  window.location.assign(url);
+}
+
+/**
+ * コールバックで受け取った state を保存値と照合し、code_verifier と意図を取り出す。
+ * 保存値は照合の成否に依らず破棄する（認可要求 1 回に対して引き換えは 1 回）。
+ * 保存が無い・state が食い違う場合は null（改竄ないし別タブでの開始）。
+ */
+export function consumeLineAuthorization(state: string | null): LineAuthorizationRecord | null {
+  const raw = sessionStorage.getItem(STORAGE_KEY);
+  sessionStorage.removeItem(STORAGE_KEY);
+  if (!raw || !state) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  const record = parsed as Partial<LineAuthorizationRecord>;
+  if (typeof record.state !== 'string' || typeof record.verifier !== 'string') return null;
+  if (record.intent !== 'login' && record.intent !== 'link') return null;
+  if (record.state !== state) return null;
+
+  return { state: record.state, verifier: record.verifier, intent: record.intent };
+}

--- a/frontend/src/shared/lib/line-oauth.ts
+++ b/frontend/src/shared/lib/line-oauth.ts
@@ -1,3 +1,5 @@
+import Cookies from 'js-cookie';
+
 /** LINE の認可エンドポイント（認可コードフロー + PKCE）。 */
 export const LINE_AUTHORIZE_ENDPOINT = 'https://access.line.me/oauth2/v2.1/authorize';
 
@@ -14,6 +16,16 @@ interface LineAuthorizationRecord {
   state: string;
   verifier: string;
   intent: LineOauthIntent;
+  /** 連携意図の発起主体（メールアドレス）。外部認可の往復中に別アカウントへ切り替わった場合の誤連携を拒むための束縛。 */
+  subject?: string;
+}
+
+/**
+ * この host で LINE 入口を出してよいか。コールバック URL はチャネルに登録した平台 origin だけが有効なため、
+ * 店舗ドメイン（公開専用、proxy が role=store の cookie を立てる）では入口ごと出さない。
+ */
+export function isLinePlatformHost(): boolean {
+  return Cookies.get('x-mw-role') !== 'store';
 }
 
 function toBase64Url(bytes: Uint8Array): string {
@@ -43,7 +55,8 @@ export function lineCallbackRedirectUri(): string {
  */
 export async function prepareLineAuthorization(
   channelId: string,
-  intent: LineOauthIntent
+  intent: LineOauthIntent,
+  subject?: string
 ): Promise<string> {
   const subtle = globalThis.crypto?.subtle;
   if (!subtle) {
@@ -55,7 +68,7 @@ export async function prepareLineAuthorization(
   const digest = await subtle.digest('SHA-256', new TextEncoder().encode(verifier));
   const challenge = toBase64Url(new Uint8Array(digest));
 
-  const record: LineAuthorizationRecord = { state, verifier, intent };
+  const record: LineAuthorizationRecord = { state, verifier, intent, subject };
   sessionStorage.setItem(STORAGE_KEY, JSON.stringify(record));
 
   const params = new URLSearchParams({
@@ -73,9 +86,10 @@ export async function prepareLineAuthorization(
 /** 認可 URL を組み立てて LINE へ遷移する。 */
 export async function startLineAuthorization(
   channelId: string,
-  intent: LineOauthIntent
+  intent: LineOauthIntent,
+  subject?: string
 ): Promise<void> {
-  const url = await prepareLineAuthorization(channelId, intent);
+  const url = await prepareLineAuthorization(channelId, intent, subject);
   window.location.assign(url);
 }
 
@@ -102,5 +116,10 @@ export function consumeLineAuthorization(state: string | null): LineAuthorizatio
   if (record.intent !== 'login' && record.intent !== 'link') return null;
   if (record.state !== state) return null;
 
-  return { state: record.state, verifier: record.verifier, intent: record.intent };
+  return {
+    state: record.state,
+    verifier: record.verifier,
+    intent: record.intent,
+    subject: typeof record.subject === 'string' ? record.subject : undefined,
+  };
 }

--- a/frontend/src/shared/lib/proxy/__tests__/routeGuard.test.ts
+++ b/frontend/src/shared/lib/proxy/__tests__/routeGuard.test.ts
@@ -65,6 +65,22 @@ describe('routeGuard', () => {
     expect(res).toBeNull();
   });
 
+  it('allows access to /platform/line/callback without token (public route)', () => {
+    const req = createRequest('/platform/line/callback', false);
+    const res = handleRouteProtection(req, 'platform');
+
+    expect(NextResponse.redirect).not.toHaveBeenCalled();
+    expect(res).toBeNull();
+  });
+
+  it('allows a member-console session on /platform/line/callback (link flow)', () => {
+    const req = createRequest('/platform/line/callback', true, { 'platform-role': 'member' });
+    const res = handleRouteProtection(req, 'platform');
+
+    expect(NextResponse.redirect).not.toHaveBeenCalled();
+    expect(res).toBeNull();
+  });
+
   it('redirects to / when accessing /store without token', () => {
     const req = createRequest('/store/orders', false);
     const res = handleRouteProtection(req, 'store');

--- a/frontend/src/styles/auth.css
+++ b/frontend/src/styles/auth.css
@@ -312,6 +312,36 @@
   cursor: not-allowed;
 }
 
+/* LINE ログイン。ブランドガイドラインの指定色を用いる */
+.auth-btn--line {
+  background: #06c755;
+}
+
+.auth-btn--line:hover:not(:disabled) {
+  box-shadow:
+    0 8px 30px rgba(6, 199, 85, 0.28),
+    0 2px 8px rgba(6, 199, 85, 0.2);
+}
+
+/* ========== 区切り線（文言を中央に挟む） ========== */
+
+.auth-divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: #9a958e;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+}
+
+.auth-divider::before,
+.auth-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: #e5e1dc;
+}
+
 /* ========== スタガードアニメーション ========== */
 
 .auth-stagger > * {


### PR DESCRIPTION
## 概要

LINE OAuth(認可コードフロー・PKCE S256)をプラットフォーム認証手段として追加する。未登録の LINE 認証は確認ステップ(表示名・メール・同意)を経て会員(MEMBER)を作成しそのままログイン、既存アカウント(全ロール)は認証済み経路でのみ LINE を紐づけられる。

Closes #332

## 変更内容

- **DB**: `t_users.line_user_id`(nullable+unique、Liquibase v0.7.0)。チャネル資格情報は `t_system_configs`(空値=環境変数 `LINE_CHANNEL_ID`/`LINE_CHANNEL_SECRET` フォールバック、シークレットは `secret=true`)
- **バックエンド**: `GET /platform/line/config`・`POST /platform/line/login`・`POST /platform/line/register`(公開、@PermitAll+CSRF 免除+Bearer 免除で配線)、`POST /platform/me/line`(Bearer 必須)。認可コード交換と id_token 検証(LINE verify API)はバックエンド側で実施し、シークレットは前端へ出さない
- **トークン発行**: `PlatformAuthService#issueTokenFor` に集約し、パスワードログインと claim を構造的に同一化。`/platform/me` に `line_linked` を追加
- **登録チケット**: Redis の一度きり不透明値(TTL 10 分)。登録成功時のみ消費し、メール重複 409 後は同じチケットで再試行できる(OAuth のやり直しを強いない)
- **フロントエンド**: ログイン画面の「LINEでログイン」(チャネル未設定時は非表示)、`/platform/line/callback`(ログイン/登録確認/連携の三入口分岐)、アカウント設定とキャストアカウント画面の LINE 連携ブロック。PKCE/state は Web Crypto で生成し sessionStorage 保持(新規依存なし)
- **テスト**: 統合テスト 12 ケース(なりすまし負向・broken bearer・チケット再試行含む)、単体テスト 28 ケース、フロント Jest 一式

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0(`./gradlew check` + `task test service=frontend` + `task test-integration` 各 exit 0、統合 192 件)
- [x] `task build` exit 0
- [ ] `task e2e` — 実施せず。実 LINE チャネルが無く OAuth 往復を e2e 化できないため。会員フロー e2e は #321 の方針どおり登録→紐づけ→予約の全鎖成立時に具体化
- [x] ローカルで code-review 実施済み(Standards/Spec 二軸、指摘は下記決定ログ・備考に反映)

### 視覚確認(UI 変更時)

ユーザーが手動で目視確認済み(ダミーチャネル設定+HTTPS で LINE ログイン/登録/連携の各画面遷移を確認)。

## 決定ログ

grilling で確定した 6 裁定(いずれもユーザー承認済み):

1. **前端主導の認可コードフロー**: redirect_uri は前端ページ、code を POST でバックエンドへ。Spring oauth2Login(サーバー側フロー)は STATELESS 構成でセッション依存の授権要求リポジトリや連携時の本人特定に追加機構が要るため見送り
2. **email は確認ステップで収集**(NOT NULL 維持、JWT sub=email の意味論不変)。LINE のみの会員はパスワード列に乱数 bcrypt を置きパスワードログイン経路を持たない。email 可空化+sub 改造は全モジュール波及のため見送り
3. **`t_users.line_user_id` 単一列**。provider が一つの現状で同一性テーブルは早すぎる抽象のため見送り
4. **資格情報は SystemConfig**(SMTP 先例と同じ DB 優先・環境変数フォールバック)
5. **統合テストは LINE API をスタブ**(`app.line.api-base-url` を差し替え可能に)。実チャネルなしで認証境界を固定
6. **連携のみ・解除なし**(LINE のみアカウントが唯一のログイン手段を失う守衛が要るため別票)

なりすまし防止はログイン経路が LINE ユーザー ID でしか身分を引かない構造で保証(メール一致でも自動連携しない — 負向 IT `matchingEmailNeverAutoLinksExistingAccount` で固定)。

## 備考 / レビュー観点

- **重点**: `LineAuthService`(認証境界の中核)と `PlatformBearerTokenResolver`/`SecurityConfig` の公開端点配線
- 重複メールの応答が `/platform/line/register`=409、既存 `/platform/members`=400 と不一致(前端が衝突分岐に 409 を要するため。既存端点のワイヤ形状は不変更)
- 連携ブロックはチャネル未設定時に「連携済み」表示ごと消える/連携後の戻り先は常に共有設定ページ(cast 起点でも) — いずれも軽微と判断し現状維持
- 会員ポータルには口座画面が無いため member の連携入口は未設置(#336 のタブ拡張時に追加)
- チャネル資格情報の差し替えは同一 provider 内のローテーションを想定（LINE の sub は provider 単位で安定）。provider をまたぐ移行は既存の line_user_id が別命名空間になるため、連携解除・移行を扱う後続票の範疇（レビュー指摘 3699279234、コード変更なし）
- 実 LINE チャネルの設定・手動実測は未実施(チャネル未取得)。コールバック URL は `{origin}/platform/line/callback`、LINE 側登録には HTTPS が必要
- 別件として発見した `smtpSettings()` の `@Cacheable` Redis シリアライズ不能(常時例外を `MailService` が握り潰し SMTP 設定が無効化される既存不具合)は、本 PR の 2 つ目のコミット `fix(settings)` で修正済み(赤→緑の再現 IT 付き。キャッシュ値の既定シリアライザは JDK 直列化で、Serializable でない record は載らない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


