### PR TITLE
fix(cast): 整合性違反の一括変換を廃止し CommonExceptionHandler の SQLSTATE 分類へ委ねる

### DIFF
--- a/backend/src/main/java/com/kizuna/cast/application/CastFieldDefinitionService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastFieldDefinitionService.java
@@ -11,14 +11,13 @@ import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreScoped;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
  * カスタムフィールド定義の CRUD ユースケース。
  *
- * <p>重複 key・件数上限はいずれも {@link ServiceException}（400）で統一する。DB 一意制約 {@code (store_id, key)}
+ * <p>事前チェックで検出した重複 key・件数上限は {@link ServiceException}（400）。DB 一意制約 {@code (store_id, key)}
  * を最終防波堤とし、悲観ロックは導入しない（{@code CastInvitationAcceptanceService} のメール重複チェックと同じ許容パターン）。
  */
 @Service
@@ -56,13 +55,10 @@ public class CastFieldDefinitionService {
             .displayOrder(nextOrder)
             .isPublic(Boolean.TRUE.equals(request.getIsPublic()))
             .build();
-    try {
-      return mapper.toResponse(repository.saveAndFlush(definition));
-    } catch (DataIntegrityViolationException ex) {
-      // 事前チェックをすり抜けた並行 create が (store_id, key) 一意制約に当たったレース。
-      // 事前チェックと同一の 400（ServiceException）へ変換する（saveAndFlush で違反をこの try 内に顕在化させる）。
-      throw new ServiceException("このキーは既に登録されています: " + request.getKey());
-    }
+    // 事前チェックをすり抜けた並行 create が (store_id, key) 一意制約に当たるレースはここで catch しない —
+    // CommonExceptionHandler が SQLSTATE で一意違反だけを 409 へ写像し、FK 等の他の整合性違反は
+    // 実装欠陥として 500 のまま大きく失敗させる分類を持っているため、そこへ委ねる。
+    return mapper.toResponse(repository.saveAndFlush(definition));
   }
 
   @StoreScoped

--- a/backend/src/main/java/com/kizuna/cast/application/CastInvitationService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastInvitationService.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -78,14 +77,12 @@ public class CastInvitationService {
             .expiresAt(OffsetDateTime.now().plus(CastInvitation.VALIDITY))
             .build();
     invitation.setStoreId(cast.getStoreId());
-    try {
-      CastInvitation saved = castInvitationRepository.saveAndFlush(invitation);
-      return new CastInvitationResponse(saved.getToken(), saved.getExpiresAt());
-    } catch (DataIntegrityViolationException ex) {
-      // 真の並行発行で他トランザクションが同一档案の PENDING を先に確定していた場合、部分ユニーク
-      // インデックス違反となる。意味のある 400（CastInvitationStateException）へ変換する。
-      throw new CastInvitationStateException("招待の発行が他の操作と競合しました。時間をおいて再度お試しください");
-    }
+    // 真の並行発行で他トランザクションが同一档案の PENDING を先に確定していた場合、部分ユニーク
+    // インデックス違反となるが、ここで catch しない — CommonExceptionHandler が SQLSTATE で一意違反
+    // だけを 409 へ写像し、FK 等の他の整合性違反は実装欠陥として 500 のまま大きく失敗させる分類を
+    // 持っているため、そこへ委ねる。
+    CastInvitation saved = castInvitationRepository.saveAndFlush(invitation);
+    return new CastInvitationResponse(saved.getToken(), saved.getExpiresAt());
   }
 
   /** ページ内の档案について招待状態（四態）を一括導出する。呼び出し元の storeFilter 有効なトランザクション内で使う。 */

--- a/backend/src/test/java/com/kizuna/cast/application/CastFieldDefinitionServiceTest.java
+++ b/backend/src/test/java/com/kizuna/cast/application/CastFieldDefinitionServiceTest.java
@@ -109,18 +109,19 @@ class CastFieldDefinitionServiceTest {
   }
 
   @Test
-  void create_convertsDbDuplicateKeyRaceTo400() {
-    // 事前チェックをすり抜けた並行 create が DB の (store_id, key) 一意制約に当たるレース。
-    // save 時の DataIntegrityViolationException を、事前チェックと同一の 400 へ変換する。
+  void create_propagatesDataIntegrityViolation() {
+    // 事前チェックをすり抜けた整合性違反はサービスで握りつぶさず、そのまま伝播すること。
+    // 一意違反→409 / それ以外→500 の分類は CommonExceptionHandler が SQLSTATE で行うため、
+    // サービス層で 400 に変換すると FK 等の実装欠陥まで「重複」に化けてしまう。
     when(repository.existsByKey("blood_type")).thenReturn(false);
     when(repository.count()).thenReturn(0L);
     when(repository.findMaxDisplayOrder()).thenReturn(null);
-    when(repository.saveAndFlush(any()))
-        .thenThrow(new DataIntegrityViolationException("uq_t_cast_field_definitions_store_key"));
+    DataIntegrityViolationException violation =
+        new DataIntegrityViolationException("uq_t_cast_field_definitions_store_key");
+    when(repository.saveAndFlush(any())).thenThrow(violation);
 
     assertThatThrownBy(() -> service.create(createRequest("blood_type", "血液型")))
-        .isInstanceOf(ServiceException.class)
-        .hasMessageContaining("既に登録されています");
+        .isSameAs(violation);
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/cast/application/CastInvitationServiceTest.java
+++ b/backend/src/test/java/com/kizuna/cast/application/CastInvitationServiceTest.java
@@ -105,15 +105,16 @@ class CastInvitationServiceTest {
   }
 
   @Test
-  void issue_convertsPendingUniqueViolationToStateException() {
-    // 真の並行発行で他トランザクションが同一档案の PENDING を先に確定した場合、部分ユニーク
-    // インデックス違反（DataIntegrityViolationException）となる。これを意味のある 400 に変換する。
+  void issue_propagatesDataIntegrityViolation() {
+    // 事前チェックをすり抜けた整合性違反はサービスで握りつぶさず、そのまま伝播すること。
+    // 一意違反→409 / それ以外→500 の分類は CommonExceptionHandler が SQLSTATE で行うため、
+    // サービス層で 400 に変換すると FK 等の実装欠陥まで「競合」に化けてしまう。
     when(castRepository.findById("c1")).thenReturn(Optional.of(cast("c1", null)));
-    when(castInvitationRepository.saveAndFlush(any()))
-        .thenThrow(new DataIntegrityViolationException("uq_t_cast_invitations_pending_cast"));
+    DataIntegrityViolationException violation =
+        new DataIntegrityViolationException("uq_t_cast_invitations_pending_cast");
+    when(castInvitationRepository.saveAndFlush(any())).thenThrow(violation);
 
-    assertThatThrownBy(() -> castInvitationService.issue("c1"))
-        .isInstanceOf(CastInvitationStateException.class);
+    assertThatThrownBy(() -> castInvitationService.issue("c1")).isSameAs(violation);
   }
 
   @Test


### PR DESCRIPTION
## 概要

`CastFieldDefinitionService.create` と `CastInvitationService.issue` が `DataIntegrityViolationException` を無分類で業務エラー（400）へ変換しており、一意違反以外（FK・NOT NULL・CHECK）の実装欠陥まで「重複」「競合」に化けて運用に埋もれる状態だった。catch を撤去し、SQLSTATE 23505（一意違反）のみ 409 へ写像し他は 500 のまま失敗させる `CommonExceptionHandler` の既存分類へ委ねる（customer 側 `CustomerMemberLinkService` の同種修正と同じ扱い）。

## 変更内容

- `CastFieldDefinitionService.create`: `DataIntegrityViolationException` の catch を撤去し全域ハンドラへ委ねる（`saveAndFlush` は維持）
- `CastInvitationService.issue`: 同上
- 単体テスト 2 件を「サービスで握りつぶさず、そのまま伝播すること」の断言（`isSameAs`）へ更新
- 全類掃討 `grep -rn "catch (DataIntegrityViolationException" backend/src/main/java` 済み — 同型（無分類の全吞 catch）は上記 cast 2 箇所のみ。残る user モジュール 3 箇所は形状が異なり（制約名照合済みの窄 catch、または撤去すると正当なレースが 500 化する経路）、別タスクとして切り出し済み

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task test service=backend`: 単体+カバレッジ+統合）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全シナリオ）
- [x] ローカルで code-review 実施済み（mattpocock-skills:code-review 両軸クリーン）

## 決定ログ

- catch 撤去（ハンドラ委譲）を採用。制約名を照合して一意違反だけ変換する窄 catch も検討したが、ハンドラが SQLSTATE で同じ分類を既に持ち、サービス層に制約名の字面を重複して持つ理由がないため見送り
- `CastInvitationService.issue` も同一 PR に含めた。同モジュール・同型欠陥で、片方だけ直すと同根因の逐次対応になるため

## 備考 / レビュー観点

**ワイヤ契約影響**: 両エンドポイントのレース時応答が 400 → 409 に変わり、本文はハンドラ共通の「既に登録されている値と重複しています」になる。

- フィールド定義 create: フロントエンドに呼び出し元なし（影響なし）
- 招待発行: フロントエンドはステータスコードで分岐せず、エラー本文メッセージを toast 表示するのみ。レース時の文言が「招待の発行が他の操作と競合しました。…」から共通文言へ変わるが、発生条件は真の並行発行のみ
- user モジュールの残 3 箇所（`RoleService.delete` / `RoleService.save` / `PlatformStaffService.save`）は正当な 4xx 経路を持つため単純撤去不可。制約名照合で絞る別タスクとして切り出し済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
