### PR TITLE
fix(user): 整合性違反の無条件変換を制約名照合で絞り、想定外の違反は伝播させる

### DIFF
--- a/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
+++ b/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
@@ -47,6 +47,9 @@ public class PlatformStaffService {
   /** 担当店舗集合が実在店舗を指すことを保証する t_user_stores の FK。FK 違反は全域ハンドラで 4xx にならないため、ここで照合して変換する。 */
   private static final String STORE_FK_CONSTRAINT = "fk_t_user_stores_store";
 
+  /** 授与ロールが実在することを保証する t_user_roles の FK。requireRoles 通過後の並行ロール削除で当たる。 */
+  private static final String ROLE_FK_CONSTRAINT = "fk_t_user_roles_role";
+
   /** LIKE パターンのエスケープ規則。派生クエリが内部で使うものと同一で、手書きの cb.like にも同じ規則を適用する。 */
   private static final EscapeCharacter LIKE_ESCAPE = EscapeCharacter.DEFAULT;
 
@@ -187,8 +190,8 @@ public class PlatformStaffService {
   }
 
   /**
-   * 保存時の整合性違反を制約名で分類する。email 一意制約違反（同一メール二重送信レース）は重複エラー、店舗 FK 違反（存在しない店舗 id）は店舗エラーへ変換する（いずれも
-   * 400）。それ以外の整合性違反は実装欠陥であり、握りつぶさず全域ハンドラの分類に委ねる。
+   * 保存時の整合性違反を制約名で分類する。email 一意制約違反（同一メール二重送信レース）は重複エラー、店舗 FK 違反（存在しない店舗 id）は店舗エラー、ロール FK
+   * 違反（requireRoles 通過後の並行ロール削除）はロール不存在エラーへ変換する（いずれも 400）。それ以外の整合性違反は実装欠陥であり、握りつぶさず全域ハンドラの分類に委ねる。
    *
    * <p>店舗集合等の @ElementCollection 行はトランザクション commit 時に flush されるため、{@code save} だけでは FK 違反が この try
    * を突き抜けて 500 になる。{@code saveAndFlush} で違反をここで顕在化させ 400 へ変換する。
@@ -203,6 +206,9 @@ public class PlatformStaffService {
       }
       if (cause != null && cause.contains(STORE_FK_CONSTRAINT)) {
         throw new InvalidStoreScopeException("指定された店舗が存在しません");
+      }
+      if (cause != null && cause.contains(ROLE_FK_CONSTRAINT)) {
+        throw new ServiceException("指定されたロールが存在しません");
       }
       throw ex;
     }

--- a/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
+++ b/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
@@ -44,6 +44,9 @@ public class PlatformStaffService {
 
   private static final String EMAIL_UNIQUE_CONSTRAINT = "uq_t_users_email";
 
+  /** 担当店舗集合が実在店舗を指すことを保証する t_user_stores の FK。FK 違反は全域ハンドラで 4xx にならないため、ここで照合して変換する。 */
+  private static final String STORE_FK_CONSTRAINT = "fk_t_user_stores_store";
+
   /** LIKE パターンのエスケープ規則。派生クエリが内部で使うものと同一で、手書きの cb.like にも同じ規則を適用する。 */
   private static final EscapeCharacter LIKE_ESCAPE = EscapeCharacter.DEFAULT;
 
@@ -184,8 +187,8 @@ public class PlatformStaffService {
   }
 
   /**
-   * 保存時の整合性違反を原因別に分類する。email 一意制約違反（同一メール二重送信レース）は重複エラー、それ以外（存在しない店舗 id の FK 違反）は店舗エラーへ変換する（いずれも
-   * 400。ロールは事前検証済みのため、残る FK 違反経路は店舗系のみ）。
+   * 保存時の整合性違反を制約名で分類する。email 一意制約違反（同一メール二重送信レース）は重複エラー、店舗 FK 違反（存在しない店舗 id）は店舗エラーへ変換する（いずれも
+   * 400）。それ以外の整合性違反は実装欠陥であり、握りつぶさず全域ハンドラの分類に委ねる。
    *
    * <p>店舗集合等の @ElementCollection 行はトランザクション commit 時に flush されるため、{@code save} だけでは FK 違反が この try
    * を突き抜けて 500 になる。{@code saveAndFlush} で違反をここで顕在化させ 400 へ変換する。
@@ -198,7 +201,10 @@ public class PlatformStaffService {
       if (cause != null && cause.contains(EMAIL_UNIQUE_CONSTRAINT)) {
         throw new DuplicateStaffEmailException("このメールアドレスは既に登録されています");
       }
-      throw new InvalidStoreScopeException("指定された店舗が存在しません");
+      if (cause != null && cause.contains(STORE_FK_CONSTRAINT)) {
+        throw new InvalidStoreScopeException("指定された店舗が存在しません");
+      }
+      throw ex;
     }
   }
 

--- a/backend/src/main/java/com/kizuna/user/application/RoleService.java
+++ b/backend/src/main/java/com/kizuna/user/application/RoleService.java
@@ -35,6 +35,9 @@ public class RoleService {
 
   private static final String NAME_UNIQUE_CONSTRAINT = "uq_t_roles_name";
 
+  /** 授与中ロールの削除を拒否する t_user_roles の RESTRICT 制約。FK 違反は全域ハンドラで 409 にならないため、ここで照合して変換する。 */
+  private static final String ROLE_IN_USE_FK_CONSTRAINT = "fk_t_user_roles_role";
+
   private final RoleRepository roleRepository;
   private final PermissionRepository permissionRepository;
   private final PlatformUserRepository platformUserRepository;
@@ -100,7 +103,12 @@ public class RoleService {
       roleRepository.delete(role);
       roleRepository.flush();
     } catch (DataIntegrityViolationException ex) {
-      throw new RoleInUseException("授与中のロールは削除できません");
+      String cause = ex.getMostSpecificCause().getMessage();
+      if (cause != null && cause.contains(ROLE_IN_USE_FK_CONSTRAINT)) {
+        throw new RoleInUseException("授与中のロールは削除できません");
+      }
+      // 授与 FK 以外の整合性違反は実装欠陥であり、握りつぶさず全域ハンドラの分類に委ねる。
+      throw ex;
     }
   }
 
@@ -118,7 +126,7 @@ public class RoleService {
   }
 
   /**
-   * 保存時の整合性違反を 400 へ変換する（現状の経路は名称の一意制約違反のみ — 権限は事前検証済み）。
+   * 保存時の名称一意制約違反（並行作成レース）を事前チェックと同じ 400 へ変換する。それ以外の整合性違反は実装欠陥であり（権限は事前検証済み）、 握りつぶさず全域ハンドラの分類に委ねる。
    *
    * <p>権限集合の @ElementCollection 行はトランザクション commit 時に flush されるため、{@code save} だけでは違反がこの try を突き抜けて
    * 500 になる。{@code saveAndFlush} で違反をここで顕在化させる。
@@ -131,7 +139,7 @@ public class RoleService {
       if (cause != null && cause.contains(NAME_UNIQUE_CONSTRAINT)) {
         throw new ServiceException("このロール名は既に使われています");
       }
-      throw new ServiceException("指定された権限が存在しません");
+      throw ex;
     }
   }
 

--- a/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
@@ -282,6 +282,35 @@ class PlatformStaffServiceTest {
   }
 
   @Test
+  void create_roleFkViolation_convertsToMissingRole() {
+    // requireRoles 通過後にロールが並行削除され、t_user_roles への授与行挿入が FK に当たるレース
+    // （RoleService.delete の事前検証は未授与ロールの削除を許すため実在する経路）。
+    // 事前検証と同じ 400（ロール不存在）へ分類する。
+    PlatformStaffCreateRequest req =
+        createRequest(
+            "role-race@kizuna.test",
+            "rawpass",
+            Set.of(MANAGER_ROLE),
+            StoreScopeType.SPECIFIC_STORES,
+            Set.of(1L));
+    when(roleRepository.findAllById(Set.of(MANAGER_ROLE)))
+        .thenReturn(List.of(role(MANAGER_ROLE, "店長")));
+    when(repository.findByEmail("role-race@kizuna.test")).thenReturn(Optional.empty());
+    when(encoder.encode("rawpass")).thenReturn("ENCODED");
+    when(repository.saveAndFlush(any()))
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "save failed",
+                new RuntimeException(
+                    "ERROR: insert or update on table \"t_user_roles\" violates foreign key"
+                        + " constraint \"fk_t_user_roles_role\"")));
+
+    assertThatThrownBy(() -> service.create(req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("ロールが存在しません");
+  }
+
+  @Test
   void create_duplicateEmailUniqueViolation_convertsToDuplicateEmail() {
     // 事前 findByEmail を通過した後に DB 一意制約で敗者が弾かれるレース。店舗エラーではなく重複エラーへ分類する。
     PlatformStaffCreateRequest req =

--- a/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
@@ -248,9 +248,37 @@ class PlatformStaffServiceTest {
     when(repository.findByEmail("fk@kizuna.test")).thenReturn(Optional.empty());
     when(encoder.encode("rawpass")).thenReturn("ENCODED");
     when(repository.saveAndFlush(any()))
-        .thenThrow(new DataIntegrityViolationException("fk violation"));
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "save failed",
+                new RuntimeException(
+                    "ERROR: insert or update on table \"t_user_stores\" violates foreign key"
+                        + " constraint \"fk_t_user_stores_store\"")));
 
     assertThatThrownBy(() -> service.create(req)).isInstanceOf(InvalidStoreScopeException.class);
+  }
+
+  @Test
+  void create_propagatesUnrelatedDataIntegrityViolation() {
+    // email 一意・店舗 FK 以外の整合性違反はサービスで握りつぶさず、そのまま伝播すること。
+    // 一意違反→409 / それ以外→500 の分類は CommonExceptionHandler が SQLSTATE で行うため、
+    // サービス層で 400 に変換すると想定外の実装欠陥まで「店舗が存在しません」に化けてしまう。
+    PlatformStaffCreateRequest req =
+        createRequest(
+            "fk@kizuna.test",
+            "rawpass",
+            Set.of(MANAGER_ROLE),
+            StoreScopeType.SPECIFIC_STORES,
+            Set.of(1L));
+    when(roleRepository.findAllById(Set.of(MANAGER_ROLE)))
+        .thenReturn(List.of(role(MANAGER_ROLE, "店長")));
+    when(repository.findByEmail("fk@kizuna.test")).thenReturn(Optional.empty());
+    when(encoder.encode("rawpass")).thenReturn("ENCODED");
+    DataIntegrityViolationException violation =
+        new DataIntegrityViolationException("save failed", new RuntimeException("NOT NULL 違反"));
+    when(repository.saveAndFlush(any())).thenThrow(violation);
+
+    assertThatThrownBy(() -> service.create(req)).isSameAs(violation);
   }
 
   @Test
@@ -382,7 +410,12 @@ class PlatformStaffServiceTest {
         .thenReturn(List.of(role(MANAGER_ROLE, "店長")));
     when(repository.findById(7L)).thenReturn(Optional.of(existing));
     when(repository.saveAndFlush(existing))
-        .thenThrow(new DataIntegrityViolationException("fk violation"));
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "save failed",
+                new RuntimeException(
+                    "ERROR: insert or update on table \"t_user_stores\" violates foreign key"
+                        + " constraint \"fk_t_user_stores_store\"")));
 
     assertThatThrownBy(
             () ->

--- a/backend/src/test/java/com/kizuna/user/application/RoleServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/RoleServiceTest.java
@@ -298,4 +298,33 @@ class RoleServiceTest {
 
     assertThatThrownBy(() -> service.delete(7L)).isInstanceOf(RoleInUseException.class);
   }
+
+  @Test
+  void delete_propagatesUnrelatedDataIntegrityViolation() {
+    // 授与 FK（RESTRICT）以外の整合性違反はサービスで握りつぶさず、そのまま伝播すること。
+    // 無条件に 409 へ変換すると想定外の実装欠陥まで「使用中」に化けてしまう。
+    Role existing = role(7L, "受付", false, Set.of(ORDER_MANAGE_ID));
+    when(roleRepository.findById(7L)).thenReturn(Optional.of(existing));
+    when(platformUserRepository.existsByRoleId(7L)).thenReturn(false);
+    DataIntegrityViolationException violation =
+        new DataIntegrityViolationException("delete failed", new RuntimeException("CHECK 制約違反"));
+    doThrow(violation).when(roleRepository).flush();
+
+    assertThatThrownBy(() -> service.delete(7L)).isSameAs(violation);
+  }
+
+  @Test
+  void create_propagatesUnrelatedDataIntegrityViolation() {
+    // ロール名一意制約以外の整合性違反はサービスで握りつぶさず、そのまま伝播すること。
+    // 一意違反→409 / それ以外→500 の分類は CommonExceptionHandler が SQLSTATE で行うため、
+    // サービス層で 400 に変換すると想定外の実装欠陥まで「権限が存在しません」に化けてしまう。
+    when(permissionRepository.findByCodeIn(Set.of("ORDER_MANAGE")))
+        .thenReturn(List.of(permission(ORDER_MANAGE_ID, PermissionCode.ORDER_MANAGE)));
+    DataIntegrityViolationException violation =
+        new DataIntegrityViolationException("save failed", new RuntimeException("NOT NULL 違反"));
+    when(roleRepository.saveAndFlush(any())).thenThrow(violation);
+
+    assertThatThrownBy(() -> service.create(createRequest("店長", Set.of("ORDER_MANAGE"))))
+        .isSameAs(violation);
+  }
 }


### PR DESCRIPTION
## 概要

`RoleService.delete` / `RoleService.save` / `PlatformStaffService.save` が `DataIntegrityViolationException` を無条件（または fallback で無分類）に業務エラーへ変換しており、NOT NULL・CHECK 等の実装欠陥が「使用中」「権限が存在しません」「店舗が存在しません」に化けて運用に埋もれる状態だった。cast 側（#556）と同じ欠陥類だが、これらは正当な 4xx 経路を持つため catch の撤去はできず、制約名照合で絞る。

## 変更内容

- `RoleService.delete`: `fk_t_user_roles_role`（授与 FK の RESTRICT 競合）のみ `RoleInUseException`（409）へ変換し、他は伝播
- `RoleService.save`: `uq_t_roles_name` のみ 400 へ変換し、fallback の「指定された権限が存在しません」400 変換を廃止して伝播
- `PlatformStaffService.save`: `uq_t_users_email`（重複 email）に加え `fk_t_user_stores_store`（存在しない店舗 id）・`fk_t_user_roles_role`（requireRoles 通過後の並行ロール削除）を明示照合して 400 へ変換し、他は伝播
- 単体テスト: 伝播断言（`isSameAs`）3 件を追加。店舗 FK 変換の既存テスト 2 件は mock 例外文言を実際の制約名を含む形へ更新（従来の `"fk violation"` は照合導入後に経路を証明できないため）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task test service=backend`: 単体+カバレッジ+統合、rebase 後に再実行）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全シナリオ）
- [x] ローカルで code-review 実施済み

## 決定ログ

- cast 側（#556）と異なり catch 撤去ではなく制約名照合を採用。`RoleService.delete` の正当経路は FK 違反（SQLSTATE 23503）で、全域ハンドラは 23505 のみ 409 へ写像するため、撤去すると正当な競合が 500 化する。`PlatformStaffService` の店舗 FK も同じく実ユーザー入力で到達する正当 400 経路
- 照合は既存の窄 catch（`LineAuthService.link` / `MemberRegistrationService`）と同じ `getMostSpecificCause().getMessage().contains(制約名)` 方式に揃えた

## 備考 / レビュー観点

**ワイヤ契約影響**: 3 経路とも、想定外の整合性違反が起きた場合の応答が 409/400 から 500（想定外の一意違反なら全域ハンドラの 409）へ変わる。制約名で照合される正当経路（授与競合 409・ロール名重複 400・email 重複 400・店舗不存在 400・ロール不存在 400）の応答は不変のため、フロントエンドへの追随変更はない。

これで `catch (DataIntegrityViolationException` 全 9 箇所の掃討が完了: 窄 catch 4 箇所（既存のまま健全）+ cast 撤去 2 箇所（#556）+ 本 PR の照合化 3 箇所。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
