### PR TITLE
fix(cast): 招待発行時の档案 FK 違反を档案不在と同じ 404 へ分類する

### DIFF
--- a/backend/src/main/java/com/kizuna/cast/application/CastInvitationService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastInvitationService.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +29,9 @@ public class CastInvitationService {
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
   private static final int TOKEN_BYTES = 32;
   private static final String ALREADY_LINKED_MESSAGE = "この档案は既に平台身分と連携済みのため招待を発行できません";
+
+  /** 招待の宛先档案が実在することを保証する t_cast_invitations の FK。冒頭の findById 通過後の並行档案削除で当たる。 */
+  private static final String CAST_FK_CONSTRAINT = "fk_t_cast_invitations_cast";
 
   private final CastRepository castRepository;
   private final CastInvitationRepository castInvitationRepository;
@@ -80,9 +84,19 @@ public class CastInvitationService {
     // 真の並行発行で他トランザクションが同一档案の PENDING を先に確定していた場合、部分ユニーク
     // インデックス違反となるが、ここで catch しない — CommonExceptionHandler が SQLSTATE で一意違反
     // だけを 409 へ写像し、FK 等の他の整合性違反は実装欠陥として 500 のまま大きく失敗させる分類を
-    // 持っているため、そこへ委ねる。
-    CastInvitation saved = castInvitationRepository.saveAndFlush(invitation);
-    return new CastInvitationResponse(saved.getToken(), saved.getExpiresAt());
+    // 持っているため、そこへ委ねる。唯一の例外は cast FK 違反 — 冒頭の findById 通過後に並行の
+    // 档案削除（日常操作）が先にコミットすると当たるレースであり、実装欠陥ではないため、
+    // 冒頭の档案不在と同じ分類（NotFoundException → 404）へ変換する。
+    try {
+      CastInvitation saved = castInvitationRepository.saveAndFlush(invitation);
+      return new CastInvitationResponse(saved.getToken(), saved.getExpiresAt());
+    } catch (DataIntegrityViolationException ex) {
+      String cause = ex.getMostSpecificCause().getMessage();
+      if (cause != null && cause.contains(CAST_FK_CONSTRAINT)) {
+        throw new NotFoundException("キャストが見つかりません: " + castId);
+      }
+      throw ex;
+    }
   }
 
   /** ページ内の档案について招待状態（四態）を一括導出する。呼び出し元の storeFilter 有効なトランザクション内で使う。 */

--- a/backend/src/test/java/com/kizuna/cast/application/CastInvitationServiceTest.java
+++ b/backend/src/test/java/com/kizuna/cast/application/CastInvitationServiceTest.java
@@ -118,6 +118,25 @@ class CastInvitationServiceTest {
   }
 
   @Test
+  void issue_castFkViolation_convertsToNotFound() {
+    // 冒頭の findById 通過後に並行の CastService.delete（日常操作）が先にコミットすると、
+    // 招待行の INSERT が t_cast_invitations の cast FK に当たるレース。
+    // 冒頭の档案不在と同じ分類（NotFoundException → 404）へ変換する。
+    when(castRepository.findById("c1")).thenReturn(Optional.of(cast("c1", null)));
+    when(castInvitationRepository.saveAndFlush(any()))
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "save failed",
+                new RuntimeException(
+                    "ERROR: insert or update on table \"t_cast_invitations\" violates foreign key"
+                        + " constraint \"fk_t_cast_invitations_cast\"")));
+
+    assertThatThrownBy(() -> castInvitationService.issue("c1"))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("キャストが見つかりません");
+  }
+
+  @Test
   void issue_abortsWhenCastGetsLinkedConcurrentlyBeforeReissuing() {
     // 初回の連携チェック通過後、旧 PENDING 失効までの間に並行受諾が档案を紐づけた状況を模す。
     // 失効後に档案の紐づけを DB 再読込で再確認し、紐づき済みなら新規発行を中止する。


### PR DESCRIPTION
## 概要

`CastInvitationService.issue()` 冒頭の findById 通過後に並行の `CastService.delete`（日常操作）が先にコミットすると、招待行の INSERT が `fk_t_cast_invitations_cast`（SQLSTATE 23503）に当たる。#556 の全吞 catch 撤去でこのレースが 500 に化けていたので、PR #557 と同じ制約名照合で冒頭の档案不在と同一分類（`NotFoundException` → 404）へ変換する。

## 変更内容

- `CastInvitationService.issue()`: `saveAndFlush` の `DataIntegrityViolationException` を `getMostSpecificCause().getMessage().contains("fk_t_cast_invitations_cast")` で照合し、一致時のみ `NotFoundException`（メッセージは冒頭の findById 不在時と同文）へ変換。他の整合性違反（部分ユニークインデックス `uq_t_cast_invitations_pending_cast` 含む）は従来どおり伝播し、CommonExceptionHandler の SQLSTATE 分類（一意違反→409 / 他→500）に委ねる
- 単体テスト: 「DIVE cause に FK 制約名を含む → NotFoundException」を追加（修正前に赤を確認済み）。既存の伝播テスト `issue_propagatesDataIntegrityViolation` は保持 — その mock 文言は uq 制約名で FK 名を含まないため、rethrow 経路（uq 違反が catch に吞まれないこと）を引き続き証明する

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（単体+カバレッジ+統合、origin/master rebase 後に実行）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全シナリオ）
- [x] ローカルで code-review 実施済み（Standards / Spec 二軸、指摘なし）

## 決定ログ

- 分類先は 400 ではなく 404。冒頭の findById が档案不在に返す分類と同一に揃えた（呼び出し側から見て「削除済み档案への発行」はタイミングによらず同じ結果になる）
- 境界判断: StoreScopedEntity の INSERT は理論上すべて「store 並行削除 → FK 500」のレースを持つが、store 削除は稀な管理操作のため逐点 catch は追加しない。日常操作（档案削除）が引き金になる本経路のみ対処し、`fk_t_cast_invitations_store` は照合対象に含めていない
- 照合方式は PR #557（23ac6bdc）の先例に統一: javadoc 付き定数 + `getMostSpecificCause()` + `contains` + 不一致は rethrow

## 備考 / レビュー観点

**ワイヤ契約影響**: 档案並行削除レース時の応答が 500 → 404（`キャストが見つかりません`）へ変わる。正常系・他の整合性違反（並行発行の 409 含む）の応答は不変のため、フロントエンドへの追随変更はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
