### PR TITLE
feat(order): 予約受付 inbox のページングと受注ステータス表示ラベルの文脈分け

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/order/MemberOrderIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/MemberOrderIT.java
@@ -151,7 +151,7 @@ class MemberOrderIT extends CrossStoreTestSupport {
             JsonNode.class);
     assertThat(inbox.getStatusCode()).isEqualTo(HttpStatus.OK);
     List<String> ids = new ArrayList<>();
-    inbox.getBody().forEach(node -> ids.add(node.path("id").asString()));
+    inbox.getBody().path("content").forEach(node -> ids.add(node.path("id").asString()));
     assertThat(ids).as("会員の未確定申請は現れること").contains(requestId);
     assertThat(ids).as("店舗が起こした受注は受付経路が WEB でも現れないこと").doesNotContain(staffOrderId);
 
@@ -168,8 +168,42 @@ class MemberOrderIT extends CrossStoreTestSupport {
             new HttpEntity<>(storeHeaders(STORE_A)),
             JsonNode.class);
     List<String> remaining = new ArrayList<>();
-    afterConfirm.getBody().forEach(node -> remaining.add(node.path("id").asString()));
+    afterConfirm
+        .getBody()
+        .path("content")
+        .forEach(node -> remaining.add(node.path("id").asString()));
     assertThat(remaining).doesNotContain(requestId);
+  }
+
+  @Test
+  @DisplayName("取得件数の上限を超えた未処理の申請にも、ページを辿れば到達できること")
+  void inboxPagesThroughEveryPendingRequest() {
+    List<String> requested =
+        List.of(
+            requestReservation(memberAToken, STORE_A, "ページング 1"),
+            requestReservation(memberAToken, STORE_A, "ページング 2"),
+            requestReservation(memberAToken, STORE_A, "ページング 3"));
+
+    // 1 件ずつしか返さない窓でも、総ページ数を辿ればすべての未処理の申請に届く。
+    List<String> collected = new ArrayList<>();
+    int page = 0;
+    int totalPages;
+    do {
+      ResponseEntity<JsonNode> inbox =
+          rest.exchange(
+              "/store/orders/reservation-requests?page=" + page + "&size=1",
+              HttpMethod.GET,
+              new HttpEntity<>(storeHeaders(STORE_A)),
+              JsonNode.class);
+      assertThat(inbox.getStatusCode()).isEqualTo(HttpStatus.OK);
+      JsonNode body = inbox.getBody();
+      assertThat(body.path("content").size()).as("1 回の取得件数が上限で抑えられること").isLessThanOrEqualTo(1);
+      body.path("content").forEach(node -> collected.add(node.path("id").asString()));
+      totalPages = body.path("total_pages").asInt();
+      page++;
+    } while (page < totalPages);
+
+    assertThat(collected).as("未処理の申請がすべて取得窓に現れること").containsAll(requested);
   }
 
   private String createCastAs(long storeId, String name) {
@@ -221,7 +255,7 @@ class MemberOrderIT extends CrossStoreTestSupport {
             JsonNode.class);
     assertThat(inbox.getStatusCode()).isEqualTo(HttpStatus.OK);
     List<String> ids = new ArrayList<>();
-    inbox.getBody().forEach(node -> ids.add(node.path("id").asString()));
+    inbox.getBody().path("content").forEach(node -> ids.add(node.path("id").asString()));
     assertThat(ids).as("会員 ID が欠落しても未確定の申請は処理対象として残ること").contains(orderId);
 
     ResponseEntity<JsonNode> confirmed =

--- a/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
+++ b/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
@@ -58,11 +58,12 @@ public class OrderController {
         .body(orderService.create(request));
   }
 
-  /** 予約受付 inbox の未確定申請一覧。 */
+  /** 予約受付 inbox の未確定申請一覧。並び（古い順）は読み口が固定するため、既定の sort は置かない。 */
   @GetMapping("/reservation-requests")
   @PreAuthorize("hasAuthority('PERM_ORDER_MANAGE')")
-  public ResponseEntity<List<OrderResponse>> listReservationRequests() {
-    return ResponseEntity.ok(orderService.listPendingReservationRequests());
+  public ResponseEntity<Page<OrderResponse>> listReservationRequests(
+      @PageableDefault(size = 20) Pageable pageable) {
+    return ResponseEntity.ok(orderService.listPendingReservationRequests(pageable));
   }
 
   /** 予約申請を確定する（受注として受け付ける）。 */

--- a/backend/src/main/java/com/kizuna/order/application/OrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderService.java
@@ -69,13 +69,16 @@ public class OrderService {
    * 予約受付 inbox の未確定申請一覧。
    *
    * <p>絞り込みは DB 側で行う — 受注一覧の先頭ページを取って手元で選り分けると、確定済みの受注が積み上がった店舗で 未処理の申請が窓から落ちて見えなくなる。
+   *
+   * <p>絞り込んだうえでページングもする。未処理の申請は店舗が処理し終えるまで残り続けるため、無界で返すと 積み上がるほど 1
+   * 回の取得・応答・描画が重くなる。総件数を伴うので、上限を超えた分にも呼出側が到達できる。
    */
   @StoreScoped
   @Transactional(readOnly = true)
-  public List<OrderResponse> listPendingReservationRequests() {
-    return orderRepository.findPendingReservationRequestViews().stream()
-        .map(orderMapper::toResponse)
-        .toList();
+  public Page<OrderResponse> listPendingReservationRequests(Pageable pageable) {
+    return orderRepository
+        .findPendingReservationRequestViews(pageable)
+        .map(orderMapper::toResponse);
   }
 
   @StoreScoped

--- a/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
@@ -1,6 +1,5 @@
 package com.kizuna.order.domain;
 
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -51,6 +50,15 @@ public interface OrderRepository
   @Query(VIEW_SELECT + " where o.id = :id")
   Optional<OrderView> findViewById(@Param("id") String id);
 
+  // 未確定の申請の抽出条件。本体と件数の問い合わせが同じ条件を共有する（片方だけ直すと
+  // 総件数と中身が食い違い、ページングが到達できない申請を生む）。
+  String PENDING_REQUEST_WHERE =
+      """
+      where o.status = com.kizuna.order.domain.OrderStatus.CREATED
+        and o.receptionRoute = com.kizuna.order.domain.ReceptionRoute.WEB
+        and o.requesterMemberCode is not null
+      """;
+
   /**
    * 予約受付 inbox が扱う未確定の申請（会員ポータルからの Web 申請のうち、まだ確定も謝絶もしていないもの）。
    *
@@ -59,17 +67,13 @@ public interface OrderRepository
    * <p>申請者の判定に使うのは会員 ID ではなく会員コードのスナップショットである。会員行が消えると FK は SET NULL で 会員 ID
    * が欠落するが、未確定の申請はそれでも店舗が処理し終える必要がある。ID を要求すると、その申請が CREATED のまま inbox から消えて処理不能になる。
    *
-   * <p>処理済みの閲覧は受注一覧の責務なので、ここでは未確定のものだけを古い順に返す。
+   * <p>処理済みの閲覧は受注一覧の責務なので、ここでは未確定のものだけを古い順に返す。並びは問い合わせ側で 一意な副キー id
+   * まで固定する（未処理の申請は処理するまで残り続けるため、offset ページングで行の重複・欠落を 起こさない全順序が要る）。
    */
   @Query(
-      VIEW_SELECT
-          + """
-          where o.status = com.kizuna.order.domain.OrderStatus.CREATED
-            and o.receptionRoute = com.kizuna.order.domain.ReceptionRoute.WEB
-            and o.requesterMemberCode is not null
-          order by o.createdAt asc, o.id asc
-          """)
-  List<OrderView> findPendingReservationRequestViews();
+      value = VIEW_SELECT + PENDING_REQUEST_WHERE + " order by o.createdAt asc, o.id asc",
+      countQuery = "select count(o) from com.kizuna.order.domain.Order o " + PENDING_REQUEST_WHERE)
+  Page<OrderView> findPendingReservationRequestViews(Pageable pageable);
 
   // 平台横断一覧（集合作用域）。where 句を書かず、濾過は storeSetFilter が session 層で行う。
   // 店舗（store）表示名の join は張らない。

--- a/backend/src/test/java/com/kizuna/order/api/store/OrderControllerTest.java
+++ b/backend/src/test/java/com/kizuna/order/api/store/OrderControllerTest.java
@@ -70,6 +70,26 @@ class OrderControllerTest {
   }
 
   @Test
+  @DisplayName("予約受付 inbox が要求されたページを読み口へ渡すこと")
+  @WithMockUser(authorities = "PERM_ORDER_MANAGE")
+  void reservationRequestsForwardTheRequestedPage() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+    ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+    when(orderService.listPendingReservationRequests(pageableCaptor.capture()))
+        .thenReturn(new PageImpl<>(List.of()));
+
+    mockMvc
+        .perform(
+            get("/store/orders/reservation-requests?page=1&size=5")
+                .header("X-Role", "store")
+                .header("X-Store-ID", "1"))
+        .andExpect(status().isOk());
+
+    assertThat(pageableCaptor.getValue().getPageNumber()).isEqualTo(1);
+    assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(5);
+  }
+
+  @Test
   @DisplayName("受注管理権限が無ければ予約受付 inbox を読めないこと")
   @WithMockUser(authorities = "PERM_CUSTOMER_MANAGE")
   void reservationRequestsAreRejectedWithoutOrderManage() throws Exception {

--- a/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
@@ -540,12 +540,26 @@ class OrderServiceTest {
   void listPendingReservationRequestsDelegatesFilteringToTheQuery() {
     OrderView view = mock(OrderView.class);
     OrderResponse res = OrderResponse.builder().id("o1").build();
-    when(orderRepository.findPendingReservationRequestViews()).thenReturn(List.of(view));
+    Pageable pageable = PageRequest.of(0, 20);
+    when(orderRepository.findPendingReservationRequestViews(pageable))
+        .thenReturn(new PageImpl<>(List.of(view), pageable, 1));
     when(orderMapper.toResponse(view)).thenReturn(res);
 
-    assertThat(service.listPendingReservationRequests()).containsExactly(res);
+    assertThat(service.listPendingReservationRequests(pageable).getContent()).containsExactly(res);
     // 受注一覧の先頭ページを取って手元で選り分ける実装だと、確定済みが積み上がった店舗で申請が窓から落ちる
     verify(orderRepository, never()).findAllViews(any(), any(Pageable.class));
+  }
+
+  @Test
+  void listPendingReservationRequestsReportsTheTotalSoCallersCanReachEveryRequest() {
+    OrderView view = mock(OrderView.class);
+    Pageable pageable = PageRequest.of(0, 1);
+    when(orderRepository.findPendingReservationRequestViews(pageable))
+        .thenReturn(new PageImpl<>(List.of(view), pageable, 3));
+    when(orderMapper.toResponse(view)).thenReturn(OrderResponse.builder().id("o1").build());
+
+    // 取得件数の上限を超えた未処理の申請が「無い」ことにならないよう、総件数を伝える
+    assertThat(service.listPendingReservationRequests(pageable).getTotalElements()).isEqualTo(3);
   }
 
   /** 確定・謝絶の対象となる会員申請の形（Web 受付 + 申請時点の会員コード）。 */

--- a/frontend/src/_pages/member-portal/ui/MemberReservationNewPage.tsx
+++ b/frontend/src/_pages/member-portal/ui/MemberReservationNewPage.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation';
 import { memberOrderApi } from '@/entities/order';
 import { ConfirmedShiftCast, shiftApi } from '@/entities/shift';
 import { Store, platformStoreApi } from '@/entities/store';
+import { isNotFound } from '@/shared/lib';
 import {
   Button,
   Card,
@@ -41,7 +42,12 @@ export function MemberReservationNewPage() {
 
   const [store, setStore] = useState<Store | null>(null);
   const [storeResolved, setStoreResolved] = useState(false);
+  // 照会そのものの失敗。「その店舗が無い」と同じ表示にすると、瞬断のときに再試行する手段が無くなる。
+  const [storeLookupFailed, setStoreLookupFailed] = useState(false);
+  // 取得失敗時の再試行用。ドメインが同じままでも effect を引き直せるようにする。
+  const [storeReloadNonce, setStoreReloadNonce] = useState(0);
   const [casts, setCasts] = useState<ConfirmedShiftCast[]>([]);
+  const [castsLoading, setCastsLoading] = useState(false);
   const [castsFailed, setCastsFailed] = useState(false);
   // 取得失敗時の再試行用。日付・店舗が同じままでも effect を引き直せるようにする。
   const [castsReloadNonce, setCastsReloadNonce] = useState(0);
@@ -66,18 +72,24 @@ export function MemberReservationNewPage() {
   const businessDate = watch('business_date');
 
   useEffect(() => {
+    // ドメインが変わった時点で前の店舗を捨てる。照会の完了を待つと、その間だけ前の店舗宛の
+    // フォームが送信可能なまま残る。
+    setStore(null);
+    setStoreLookupFailed(false);
     if (!domain) {
       setStoreResolved(true);
       return;
     }
+    setStoreResolved(false);
     let cancelled = false;
     platformStoreApi
       .lookupByDomain(domain)
       .then(resolved => {
         if (!cancelled) setStore(resolved);
       })
-      .catch(() => {
-        if (!cancelled) setStore(null);
+      .catch(error => {
+        // 「そのドメインの店舗が無い」（404）と照会自体の失敗を区別する。後者は再試行で復帰しうる。
+        if (!cancelled && !isNotFound(error)) setStoreLookupFailed(true);
       })
       .finally(() => {
         if (!cancelled) setStoreResolved(true);
@@ -85,7 +97,7 @@ export function MemberReservationNewPage() {
     return () => {
       cancelled = true;
     };
-  }, [domain]);
+  }, [domain, storeReloadNonce]);
 
   const storeId = store?.id ? Number(store.id) : null;
 
@@ -96,8 +108,11 @@ export function MemberReservationNewPage() {
     setCastsFailed(false);
     setValue('cast_id', '');
     if (storeId === null || !businessDate) {
+      // 取得するものが無い＝待っているものも無い。読み込み中として送信を止めない。
+      setCastsLoading(false);
       return;
     }
+    setCastsLoading(true);
     let cancelled = false;
     shiftApi
       .confirmedCasts({ store_id: storeId, date: businessDate })
@@ -108,6 +123,9 @@ export function MemberReservationNewPage() {
         // 取得失敗を空候補と区別する — 「出勤なし」に見せると、指名するつもりの会員が
         // 誤った空き情報のまま指名なしで申請してしまう
         if (!cancelled) setCastsFailed(true);
+      })
+      .finally(() => {
+        if (!cancelled) setCastsLoading(false);
       });
     return () => {
       cancelled = true;
@@ -147,6 +165,18 @@ export function MemberReservationNewPage() {
         <CardContent>
           {!storeResolved ? (
             <p className="text-sm text-muted-foreground">読み込み中...</p>
+          ) : storeLookupFailed ? (
+            <div className="space-y-2">
+              <p className="text-sm text-destructive-strong">店舗情報を取得できませんでした。</p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setStoreReloadNonce(nonce => nonce + 1)}
+              >
+                再読み込み
+              </Button>
+            </div>
           ) : !store ? (
             <p className="text-sm text-muted-foreground">
               店舗が特定できませんでした。店舗公式サイトの予約ボタンからお進みください。
@@ -205,7 +235,10 @@ export function MemberReservationNewPage() {
                     </option>
                   ))}
                 </select>
-                {businessDate && castsFailed && (
+                {businessDate && castsLoading && (
+                  <p className="mt-1 text-xs text-muted-foreground">出勤情報を確認しています...</p>
+                )}
+                {businessDate && !castsLoading && castsFailed && (
                   <div className="mt-1 flex items-center gap-2">
                     <p className="text-xs text-destructive-strong">
                       出勤情報を取得できませんでした。
@@ -220,7 +253,9 @@ export function MemberReservationNewPage() {
                     </Button>
                   </div>
                 )}
-                {businessDate && !castsFailed && casts.length === 0 && (
+                {/* 取得が終わるまで「出勤なし」と言い切らない — 未解決の間に空表示を出すと、
+                    指名するつもりの会員が誤った空き情報のまま指名なしで申請してしまう。 */}
+                {businessDate && !castsLoading && !castsFailed && casts.length === 0 && (
                   <p className="mt-1 text-xs text-muted-foreground">
                     この日に出勤予定のキャストはいません。
                   </p>
@@ -239,7 +274,8 @@ export function MemberReservationNewPage() {
                   <p className="mt-1 text-xs text-destructive-strong">{errors.remarks.message}</p>
                 )}
               </div>
-              <Button type="submit" className="w-full" disabled={submitting}>
+              {/* 候補が確定するまで送信させない。指名を選ぶ機会が無いまま「指名なし」で申請が通る。 */}
+              <Button type="submit" className="w-full" disabled={submitting || castsLoading}>
                 この内容で申請する
               </Button>
             </form>

--- a/frontend/src/_pages/member-portal/ui/MemberReservationNewPage.tsx
+++ b/frontend/src/_pages/member-portal/ui/MemberReservationNewPage.tsx
@@ -274,8 +274,14 @@ export function MemberReservationNewPage() {
                   <p className="mt-1 text-xs text-destructive-strong">{errors.remarks.message}</p>
                 )}
               </div>
-              {/* 候補が確定するまで送信させない。指名を選ぶ機会が無いまま「指名なし」で申請が通る。 */}
-              <Button type="submit" className="w-full" disabled={submitting || castsLoading}>
+              {/* 候補が確定するまで送信させない。取得中も失敗中も「その日に誰が出勤するか」は
+                  未確定であり、指名を選ぶ機会が無いまま「指名なし」で申請が通ってしまう。
+                  失敗のときは再読み込みが復帰の手段になる。 */}
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={submitting || castsLoading || castsFailed}
+              >
                 この内容で申請する
               </Button>
             </form>

--- a/frontend/src/_pages/member-portal/ui/MemberReservationsPage.tsx
+++ b/frontend/src/_pages/member-portal/ui/MemberReservationsPage.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import Link from 'next/link';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'react-hot-toast';
-import { MemberOrder, ORDER_STATUS_LABELS, memberOrderApi } from '@/entities/order';
+import { MEMBER_ORDER_STATUS_LABELS, MemberOrder, memberOrderApi } from '@/entities/order';
 import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from '@/shared/ui';
 
 /** 予約の状態バッジ。確定前だけが取り下げ可能なので、申請中を強調する。 */
@@ -18,7 +18,7 @@ function StatusBadge({ status }: { status: MemberOrder['status'] }) {
           : 'border-transparent bg-muted text-foreground'
       }
     >
-      {ORDER_STATUS_LABELS[status]}
+      {MEMBER_ORDER_STATUS_LABELS[status]}
     </Badge>
   );
 }
@@ -30,24 +30,43 @@ const PAGE_SIZE = 20;
 export function MemberReservationsPage() {
   const [reservations, setReservations] = useState<MemberOrder[]>([]);
   const [loading, setLoading] = useState(true);
+  // 表示できるものが何も無い状態での取得失敗。空表示（＝予約なし）と区別する。
   const [failed, setFailed] = useState(false);
+  // 表示中の予約を保ったまま失敗した取得の対象ページ数（再試行にそのまま使う）。
+  const [failedPages, setFailedPages] = useState<number | null>(null);
   const [processingId, setProcessingId] = useState<string | null>(null);
   // 読み込み済みのページ数。追加読み込み後の再取得でも同じ範囲を取り直せるように保持する。
   const [loadedPages, setLoadedPages] = useState(1);
   const [hasMore, setHasMore] = useState(false);
+  // 失敗時の分岐に使う「今表示している件数」。load を再生成しない（mount 用 effect を引き直さない）ため
+  // state を読まずに済ませる。
+  const shownCount = useRef(0);
 
   const load = useCallback((pages: number) => {
     setLoading(true);
+    setFailedPages(null);
+    setFailed(false);
     // 取り下げ後も表示中の範囲を保つため、読み込み済みページ分をまとめて取り直す。
+    const size = pages * PAGE_SIZE;
     memberOrderApi
-      .list({ page: 0, size: pages * PAGE_SIZE })
+      .list({ page: 0, size })
       .then(page => {
+        shownCount.current = page.rows.length;
         setReservations(page.rows);
-        setHasMore(page.rows.length < page.total);
+        // 要求した件数より少なく返ってきたのに残りがある＝サーバ側の上限に当たっている。
+        // ここで「もっと見る」を出し続けると、押しても増えないボタンになる。
+        setHasMore(page.rows.length < page.total && page.rows.length >= size);
         setLoadedPages(pages);
-        setFailed(false);
       })
-      .catch(() => setFailed(true))
+      .catch(() => {
+        // 表示中の予約があるなら消さない — 追加読み込みの失敗で既読み込み分まで失うと、
+        // 取り下げられる予約すら見えなくなる。読み込み済みページ数も進めない。
+        if (shownCount.current === 0) {
+          setFailed(true);
+        } else {
+          setFailedPages(pages);
+        }
+      })
       .finally(() => setLoading(false));
   }, []);
 
@@ -82,7 +101,7 @@ export function MemberReservationsPage() {
             <p className="text-sm text-destructive-strong">
               予約を取得できませんでした。再読み込みしてください。
             </p>
-          ) : loading ? (
+          ) : loading && reservations.length === 0 ? (
             <p className="text-sm text-muted-foreground">読み込み中...</p>
           ) : reservations.length === 0 ? (
             <p className="text-sm text-muted-foreground">予約はまだありません。</p>
@@ -120,7 +139,25 @@ export function MemberReservationsPage() {
               ))}
             </ul>
           )}
-          {hasMore && (
+          {/* 追加読み込みの失敗は、失敗した拡張だけを再試行できる形で出す。全体を失敗表示に
+              置き換えると、すでに読み込めていた予約（取り下げられるもの）まで消えてしまう。 */}
+          {failedPages !== null && (
+            <div className="mt-4 space-y-2">
+              <p className="text-sm text-destructive-strong">
+                予約を追加で取得できませんでした。表示は前回の取得内容です。
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                onClick={() => load(failedPages)}
+                disabled={loading}
+              >
+                再試行
+              </Button>
+            </div>
+          )}
+          {hasMore && failedPages === null && (
             <Button
               type="button"
               variant="outline"

--- a/frontend/src/_pages/member-portal/ui/MemberReservationsPage.tsx
+++ b/frontend/src/_pages/member-portal/ui/MemberReservationsPage.tsx
@@ -46,16 +46,20 @@ export function MemberReservationsPage() {
     setLoading(true);
     setFailedPages(null);
     setFailed(false);
-    // 取り下げ後も表示中の範囲を保つため、読み込み済みページ分をまとめて取り直す。
-    const size = pages * PAGE_SIZE;
-    memberOrderApi
-      .list({ page: 0, size })
-      .then(page => {
-        shownCount.current = page.rows.length;
-        setReservations(page.rows);
-        // 要求した件数より少なく返ってきたのに残りがある＝サーバ側の上限に当たっている。
-        // ここで「もっと見る」を出し続けると、押しても増えないボタンになる。
-        setHasMore(page.rows.length < page.total && page.rows.length >= size);
+    // 1 回の取得は常に PAGE_SIZE 件に抑え、表示中の範囲は固定長ページを並べて組み立てる。
+    // 要求サイズ自体を膨らませると、サーバ側のページ上限に当たった時点でそれ以降の予約へ
+    // 到達できなくなる。取り下げ後に読み込み済みの範囲を丸ごと読み直すのは従来どおり。
+    Promise.all(
+      Array.from({ length: pages }, (_, index) =>
+        memberOrderApi.list({ page: index, size: PAGE_SIZE })
+      )
+    )
+      .then(fetched => {
+        const rows = fetched.flatMap(one => one.rows);
+        const total = fetched[fetched.length - 1].total;
+        shownCount.current = rows.length;
+        setReservations(rows);
+        setHasMore(rows.length < total);
         setLoadedPages(pages);
       })
       .catch(() => {

--- a/frontend/src/_pages/member-portal/ui/MemberReservationsPage.tsx
+++ b/frontend/src/_pages/member-portal/ui/MemberReservationsPage.tsx
@@ -124,13 +124,15 @@ export function MemberReservationsPage() {
                     指名: {reservation.cast_name ?? 'なし'}
                   </p>
                   {reservation.status === 'CREATED' && (
+                    // 取り直しの最中は行が古いままなので、取り下げを受け付けない。取り下げ直後の
+                    // 再取得が届くまで同じ行を押せると、済んだ取り下げをもう一度投げてしまう。
                     <Button
                       type="button"
                       variant="outline"
                       size="sm"
                       className="mt-3"
                       onClick={() => cancel(reservation.id ?? '')}
-                      disabled={processingId === reservation.id}
+                      disabled={loading || processingId === reservation.id}
                     >
                       取り下げる
                     </Button>

--- a/frontend/src/_pages/member-portal/ui/__tests__/MemberReservationNewPage.test.tsx
+++ b/frontend/src/_pages/member-portal/ui/__tests__/MemberReservationNewPage.test.tsx
@@ -26,6 +26,8 @@ const mockedLookup = platformStoreApi.lookupByDomain as jest.Mock;
 const mockedCasts = shiftApi.confirmedCasts as jest.Mock;
 const mockedCreate = memberOrderApi.create as jest.Mock;
 
+const submitButton = () => screen.getByRole('button', { name: 'この内容で申請する' });
+
 describe('MemberReservationNewPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -43,7 +45,7 @@ describe('MemberReservationNewPage', () => {
   });
 
   it('店舗を特定できないときはフォームを出さず案内だけ表示する', async () => {
-    mockedLookup.mockRejectedValue(new Error('not found'));
+    mockedLookup.mockRejectedValue({ response: { status: 404 } });
 
     render(<MemberReservationNewPage />);
 
@@ -53,6 +55,42 @@ describe('MemberReservationNewPage', () => {
       )
     ).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'この内容で申請する' })).not.toBeInTheDocument();
+  });
+
+  it('照会自体の失敗は「店舗が無い」と区別し、再読み込みで復帰できる', async () => {
+    // 瞬断を 404 と同じ案内に見せると、正しい導線から来た会員が再試行できないまま行き止まる
+    mockedLookup.mockRejectedValueOnce(new Error('network'));
+    mockedLookup.mockResolvedValueOnce({ id: '1', name: 'サンプル店舗' });
+
+    render(<MemberReservationNewPage />);
+
+    expect(await screen.findByText('店舗情報を取得できませんでした。')).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        '店舗が特定できませんでした。店舗公式サイトの予約ボタンからお進みください。'
+      )
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '再読み込み' }));
+
+    expect(await screen.findByRole('button', { name: 'この内容で申請する' })).toBeInTheDocument();
+  });
+
+  it('店舗パラメータが変わったら、照会が終わるまで前の店舗のフォームを残さない', async () => {
+    mockedLookup.mockResolvedValueOnce({ id: '1', name: 'サンプル店舗' });
+
+    const { rerender } = render(<MemberReservationNewPage />);
+    expect(await screen.findByRole('button', { name: 'この内容で申請する' })).toBeInTheDocument();
+
+    // 次の照会は解決させない（照会中の相を保ったまま観測する）
+    mockedLookup.mockReturnValueOnce(new Promise(() => {}));
+    searchParams = new URLSearchParams('store=store2.kizuna.test');
+    rerender(<MemberReservationNewPage />);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'この内容で申請する' })).not.toBeInTheDocument()
+    );
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
   });
 
   it('店舗パラメータが無いときも案内だけ表示する', async () => {
@@ -89,6 +127,7 @@ describe('MemberReservationNewPage', () => {
     render(<MemberReservationNewPage />);
 
     fireEvent.change(await screen.findByLabelText('利用日'), { target: { value: '2026-08-10' } });
+    await waitFor(() => expect(submitButton()).toBeEnabled());
     const pax = screen.getByLabelText('人数');
     fireEvent.change(pax, { target: { value: '' } });
     fireEvent.change(pax, { target: { value: '3' } });
@@ -108,8 +147,9 @@ describe('MemberReservationNewPage', () => {
     render(<MemberReservationNewPage />);
 
     fireEvent.change(await screen.findByLabelText('利用日'), { target: { value: '2026-08-10' } });
+    await waitFor(() => expect(submitButton()).toBeEnabled());
     fireEvent.change(screen.getByLabelText('人数'), { target: { value: '' } });
-    fireEvent.click(screen.getByRole('button', { name: 'この内容で申請する' }));
+    fireEvent.click(submitButton());
 
     expect(await screen.findByText('人数を入力してください')).toBeInTheDocument();
     expect(mockedCreate).not.toHaveBeenCalled();
@@ -136,6 +176,28 @@ describe('MemberReservationNewPage', () => {
     expect(screen.queryByText('出勤情報を取得できませんでした。')).not.toBeInTheDocument();
   });
 
+  it('指名候補の取得中は「出勤なし」を出さず、送信も抑止する', async () => {
+    // 未解決のまま空表示にすると、指名するつもりの会員が候補を見ないまま指名なしで申請できてしまう
+    mockedLookup.mockResolvedValue({ id: '1', name: 'サンプル店舗' });
+    mockedCasts.mockReturnValue(new Promise(() => {}));
+
+    render(<MemberReservationNewPage />);
+
+    fireEvent.change(await screen.findByLabelText('利用日'), { target: { value: '2026-08-10' } });
+
+    expect(await screen.findByText('出勤情報を確認しています...')).toBeInTheDocument();
+    expect(screen.queryByText('この日に出勤予定のキャストはいません。')).not.toBeInTheDocument();
+    expect(submitButton()).toBeDisabled();
+  });
+
+  it('利用日を選ぶ前は送信を抑止しない（待っているものが無い）', async () => {
+    mockedLookup.mockResolvedValue({ id: '1', name: 'サンプル店舗' });
+
+    render(<MemberReservationNewPage />);
+
+    expect(await screen.findByRole('button', { name: 'この内容で申請する' })).toBeEnabled();
+  });
+
   it('ご要望が 500 文字を超えると申請せずに検証エラーを出す', async () => {
     // エラーを描画しないと、送信ボタンが何も起こさないように見える（API 呼び出しも失敗トーストも無い）
     mockedLookup.mockResolvedValue({ id: '1', name: 'サンプル店舗' });
@@ -143,10 +205,11 @@ describe('MemberReservationNewPage', () => {
     render(<MemberReservationNewPage />);
 
     fireEvent.change(await screen.findByLabelText('利用日'), { target: { value: '2026-08-10' } });
+    await waitFor(() => expect(submitButton()).toBeEnabled());
     fireEvent.change(screen.getByLabelText('ご要望（任意）'), {
       target: { value: 'あ'.repeat(501) },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'この内容で申請する' }));
+    fireEvent.click(submitButton());
 
     expect(await screen.findByText('ご要望は 500 文字以内で入力してください')).toBeInTheDocument();
     expect(mockedCreate).not.toHaveBeenCalled();

--- a/frontend/src/_pages/member-portal/ui/__tests__/MemberReservationNewPage.test.tsx
+++ b/frontend/src/_pages/member-portal/ui/__tests__/MemberReservationNewPage.test.tsx
@@ -170,10 +170,15 @@ describe('MemberReservationNewPage', () => {
     expect(await screen.findByText('出勤情報を取得できませんでした。')).toBeInTheDocument();
     expect(screen.queryByText('この日に出勤予定のキャストはいません。')).not.toBeInTheDocument();
 
+    // 誰が出勤するか不明のまま送信できると、指名するつもりの会員が「指名なし」で申請してしまう
+    expect(submitButton()).toBeDisabled();
+
     fireEvent.click(screen.getByRole('button', { name: '再読み込み' }));
 
     expect(await screen.findByRole('option', { name: 'さくら（18:00〜）' })).toBeInTheDocument();
     expect(screen.queryByText('出勤情報を取得できませんでした。')).not.toBeInTheDocument();
+    // 再読み込みが通れば送信できる（失敗が行き止まりにならない）
+    expect(submitButton()).toBeEnabled();
   });
 
   it('指名候補の取得中は「出勤なし」を出さず、送信も抑止する', async () => {

--- a/frontend/src/_pages/member-portal/ui/__tests__/MemberReservationsPage.test.tsx
+++ b/frontend/src/_pages/member-portal/ui/__tests__/MemberReservationsPage.test.tsx
@@ -76,4 +76,40 @@ describe('MemberReservationsPage', () => {
       await screen.findByText('予約を取得できませんでした。再読み込みしてください。')
     ).toBeInTheDocument();
   });
+
+  it('追加読み込みに失敗しても既に読み込んだ予約は消さず、その拡張だけ再試行できる', async () => {
+    // 窓が満ちているかどうかを見る画面なので、件数は実際の応答と同じ形にする
+    const reservations = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        id: `o${i}`,
+        store_name: i === 0 ? '店舗A' : `店舗${i}`,
+        business_date: '2026-08-10',
+        status: 'CREATED',
+      }));
+    mockedList.mockResolvedValueOnce({ rows: reservations(20), page: 0, pageCount: 2, total: 25 });
+    mockedList.mockRejectedValueOnce(new Error('failed'));
+    mockedList.mockResolvedValueOnce({ rows: reservations(25), page: 0, pageCount: 2, total: 25 });
+
+    render(<MemberReservationsPage />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'もっと見る' }));
+
+    expect(
+      await screen.findByText('予約を追加で取得できませんでした。表示は前回の取得内容です。')
+    ).toBeInTheDocument();
+    // 全体を失敗表示に置き換えない — 既に読み込めていた予約は取り下げられるままにする
+    expect(screen.getByText('店舗A')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: '取り下げる' })).toHaveLength(20);
+    expect(
+      screen.queryByText('予約を取得できませんでした。再読み込みしてください。')
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '再試行' }));
+
+    // 失敗した拡張と同じ範囲を取り直す（読み込み済みページ数を進めていない）
+    await waitFor(() => expect(mockedList).toHaveBeenLastCalledWith({ page: 0, size: 40 }));
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: '取り下げる' })).toHaveLength(25)
+    );
+  });
 });

--- a/frontend/src/_pages/member-portal/ui/__tests__/MemberReservationsPage.test.tsx
+++ b/frontend/src/_pages/member-portal/ui/__tests__/MemberReservationsPage.test.tsx
@@ -67,6 +67,25 @@ describe('MemberReservationsPage', () => {
     expect(mockedList).toHaveBeenCalledTimes(2);
   });
 
+  it('取り下げ後の取り直しが届くまで、表示中の行の取り下げを受け付けない', async () => {
+    // 行は残したままだが、古い行を押せると済んだ取り下げをもう一度投げてしまう
+    mockedList.mockResolvedValueOnce(
+      page([{ id: 'o1', store_name: '店舗A', business_date: '2026-08-10', status: 'CREATED' }])
+    );
+    mockedCancel.mockResolvedValue({});
+    mockedList.mockReturnValueOnce(new Promise(() => {}));
+
+    render(<MemberReservationsPage />);
+
+    fireEvent.click(await screen.findByRole('button', { name: '取り下げる' }));
+
+    // 取り直しが始まった＝processingId は既にクリアされている。ここから先が観測したい窓。
+    await waitFor(() => expect(mockedList).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole('button', { name: '取り下げる' })).toBeDisabled();
+    // 行そのものは消さない
+    expect(screen.getByText('店舗A')).toBeInTheDocument();
+  });
+
   it('取得に失敗したらエラーメッセージを表示する', async () => {
     mockedList.mockRejectedValue(new Error('failed'));
 

--- a/frontend/src/_pages/member-portal/ui/__tests__/MemberReservationsPage.test.tsx
+++ b/frontend/src/_pages/member-portal/ui/__tests__/MemberReservationsPage.test.tsx
@@ -10,7 +10,22 @@ jest.mock('@/entities/order', () => ({
 const mockedList = memberOrderApi.list as jest.Mock;
 const mockedCancel = memberOrderApi.cancel as jest.Mock;
 
-const page = (rows: unknown[]) => ({ rows, page: 0, pageCount: 1, total: rows.length });
+const page = (rows: unknown[], total = rows.length) => ({ rows, page: 0, pageCount: 1, total });
+
+/** 固定長ページを返すサーバの代役。1 回の取得は常に 20 件までという前提を持つ。 */
+const pagedServer = (total: number) => (params: { page: number; size: number }) => {
+  const start = params.page * params.size;
+  const rows = Array.from(
+    { length: Math.max(0, Math.min(params.size, total - start)) },
+    (_, i) => ({
+      id: `o${start + i}`,
+      store_name: `店舗${start + i}`,
+      business_date: '2026-08-10',
+      status: 'CREATED',
+    })
+  );
+  return Promise.resolve(page(rows, total));
+};
 
 describe('MemberReservationsPage', () => {
   beforeEach(() => {
@@ -97,38 +112,50 @@ describe('MemberReservationsPage', () => {
   });
 
   it('追加読み込みに失敗しても既に読み込んだ予約は消さず、その拡張だけ再試行できる', async () => {
-    // 窓が満ちているかどうかを見る画面なので、件数は実際の応答と同じ形にする
-    const reservations = (n: number) =>
-      Array.from({ length: n }, (_, i) => ({
-        id: `o${i}`,
-        store_name: i === 0 ? '店舗A' : `店舗${i}`,
-        business_date: '2026-08-10',
-        status: 'CREATED',
-      }));
-    mockedList.mockResolvedValueOnce({ rows: reservations(20), page: 0, pageCount: 2, total: 25 });
-    mockedList.mockRejectedValueOnce(new Error('failed'));
-    mockedList.mockResolvedValueOnce({ rows: reservations(25), page: 0, pageCount: 2, total: 25 });
+    const server = pagedServer(25);
+    mockedList.mockImplementation(server);
 
     render(<MemberReservationsPage />);
+    await screen.findByRole('button', { name: 'もっと見る' });
 
-    fireEvent.click(await screen.findByRole('button', { name: 'もっと見る' }));
+    // 拡張の取得だけを落とす
+    mockedList.mockImplementation(params =>
+      params.page === 1 ? Promise.reject(new Error('failed')) : server(params)
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'もっと見る' }));
 
     expect(
       await screen.findByText('予約を追加で取得できませんでした。表示は前回の取得内容です。')
     ).toBeInTheDocument();
     // 全体を失敗表示に置き換えない — 既に読み込めていた予約は取り下げられるままにする
-    expect(screen.getByText('店舗A')).toBeInTheDocument();
+    expect(screen.getByText('店舗0')).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: '取り下げる' })).toHaveLength(20);
     expect(
       screen.queryByText('予約を取得できませんでした。再読み込みしてください。')
     ).not.toBeInTheDocument();
 
+    mockedList.mockImplementation(server);
     fireEvent.click(screen.getByRole('button', { name: '再試行' }));
 
     // 失敗した拡張と同じ範囲を取り直す（読み込み済みページ数を進めていない）
-    await waitFor(() => expect(mockedList).toHaveBeenLastCalledWith({ page: 0, size: 40 }));
+    await waitFor(() => expect(mockedList).toHaveBeenCalledWith({ page: 1, size: 20 }));
     await waitFor(() =>
       expect(screen.getAllByRole('button', { name: '取り下げる' })).toHaveLength(25)
+    );
+  });
+
+  it('どこまで広げても 1 回の取得件数は上限のまま', async () => {
+    // 要求サイズ自体を膨らませると、サーバ側のページ上限に当たった時点で以降の予約へ到達できなくなる
+    mockedList.mockImplementation(pagedServer(2500));
+
+    render(<MemberReservationsPage />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'もっと見る' }));
+    await waitFor(() => expect(mockedList).toHaveBeenCalledWith({ page: 1, size: 20 }));
+
+    expect(mockedList.mock.calls.every(([params]) => params.size === 20)).toBe(true);
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: '取り下げる' })).toHaveLength(40)
     );
   });
 });

--- a/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
@@ -37,7 +37,12 @@ describe('店側オーダー画面の描画', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // 一覧ページは予約受付 inbox を同居させるため、その読み口も満たしておく
-    mockedOrderApi.listReservationRequests.mockResolvedValue([]);
+    mockedOrderApi.listReservationRequests.mockResolvedValue({
+      rows: [],
+      page: 0,
+      pageCount: 0,
+      total: 0,
+    });
   });
 
   // fixture は手書きであり、バックエンドの実応答を見ているわけではない。
@@ -103,6 +108,23 @@ describe('店側オーダー画面の描画', () => {
     );
     const links = screen.getAllByRole('link');
     expect(links.map(link => link.getAttribute('href'))).toContain('/store/1/orders/7/edit');
+  });
+
+  it('店舗が手入力した未確定の受注を「申請中」と表示しないこと', async () => {
+    // CREATED は申請でも店舗起点の受注でも起きる。申請中と呼ぶと、店舗が起こした受注まで
+    // 会員の申請に見えて予約受付 inbox の対象と誤認される。
+    mockedOrderApi.list.mockResolvedValue({
+      rows: [{ id: '9', business_date: '2026-07-05', status: 'CREATED' }],
+      page: 0,
+      pageCount: 1,
+      total: 1,
+    });
+
+    render(<OrderListPage />);
+
+    expect(await screen.findByText('未確定')).toBeInTheDocument();
+    expect(screen.queryByText('申請中')).not.toBeInTheDocument();
+    expect(screen.queryByText('WEB申請')).not.toBeInTheDocument();
   });
 
   it('キャスト未指名はフリー表記になること', async () => {
@@ -188,7 +210,12 @@ describe('オーダー一覧ページ固有の要素', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // 一覧ページは予約受付 inbox を同居させるため、その読み口も満たしておく
-    mockedOrderApi.listReservationRequests.mockResolvedValue([]);
+    mockedOrderApi.listReservationRequests.mockResolvedValue({
+      rows: [],
+      page: 0,
+      pageCount: 0,
+      total: 0,
+    });
     mockedOrderApi.list.mockResolvedValue({
       rows: [],
       page: 0,
@@ -215,7 +242,12 @@ describe('オーダー一覧のページ送り', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // 一覧ページは予約受付 inbox を同居させるため、その読み口も満たしておく
-    mockedOrderApi.listReservationRequests.mockResolvedValue([]);
+    mockedOrderApi.listReservationRequests.mockResolvedValue({
+      rows: [],
+      page: 0,
+      pageCount: 0,
+      total: 0,
+    });
   });
 
   // 1 ページ 20 件で、101 件目以降にもページ送りで到達できることを固定する

--- a/frontend/src/_pages/store-orders/__tests__/ReservationRequestInbox.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/ReservationRequestInbox.test.tsx
@@ -33,6 +33,14 @@ const page = (rows: unknown[], total = rows.length) => ({
   total,
 });
 
+/** 固定長ページを返すサーバの代役。1 回の取得は常に 20 件までという前提を持つ。 */
+const pagedServer = (total: number) => (params: { page: number; size: number }) => {
+  const start = params.page * params.size;
+  return Promise.resolve(
+    page(requests(Math.max(0, Math.min(params.size, total - start)), start), total)
+  );
+};
+
 describe('ReservationRequestInbox', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -164,45 +172,48 @@ describe('ReservationRequestInbox', () => {
     expect(screen.queryByText('予約申請を取得できませんでした。')).not.toBeInTheDocument();
   });
 
-  it('サーバ側の上限に当たったら「もっと見る」を出さない', async () => {
-    // 要求より少ない件数しか返らないのに残りがある状態で出し続けると、押しても増えないボタンになる
-    mockedList.mockResolvedValueOnce(page(requests(20), 2500));
-    // 40 件要求したのに 20 件しか返らない＝サーバ側の上限に当たっている
-    mockedList.mockResolvedValueOnce(page(requests(20), 2500));
+  it('どこまで広げても 1 回の取得件数は上限のまま', async () => {
+    // 要求サイズ自体を膨らませると、サーバ側のページ上限に当たった時点で以降の申請へ到達できなくなる
+    mockedList.mockImplementation(pagedServer(2500));
 
     render(<ReservationRequestInbox onProcessed={jest.fn()} />);
 
     fireEvent.click(await screen.findByRole('button', { name: 'もっと見る' }));
+    await waitFor(() => expect(mockedList).toHaveBeenCalledWith({ page: 1, size: 20 }));
+    fireEvent.click(await screen.findByRole('button', { name: 'もっと見る' }));
+    await waitFor(() => expect(mockedList).toHaveBeenCalledWith({ page: 2, size: 20 }));
 
-    await waitFor(() => expect(mockedList).toHaveBeenLastCalledWith({ page: 0, size: 40 }));
-    await waitFor(() =>
-      expect(screen.queryByRole('button', { name: 'もっと見る' })).not.toBeInTheDocument()
-    );
+    expect(mockedList.mock.calls.every(([params]) => params.size === 20)).toBe(true);
+    await waitFor(() => expect(screen.getAllByRole('button', { name: '確定' })).toHaveLength(60));
   });
 
   it('取得件数の上限を超える申請は追加読み込みで辿れる', async () => {
-    mockedList.mockResolvedValueOnce(page(requests(20), 25));
-    mockedList.mockResolvedValueOnce(page(requests(25), 25));
+    mockedList.mockImplementation(pagedServer(25));
 
     render(<ReservationRequestInbox onProcessed={jest.fn()} />);
 
     fireEvent.click(await screen.findByRole('button', { name: 'もっと見る' }));
 
-    // 継ぎ足しではなく読み込み済みの範囲ごと取り直す（処理で 1 件消えた分の繰り上がりで申請を飛ばさない）
-    await waitFor(() => expect(mockedList).toHaveBeenLastCalledWith({ page: 0, size: 40 }));
+    // 読み込み済みの範囲は毎回まとめて読み直す（処理で 1 件消えた分の繰り上がりで申請を飛ばさない）
+    await waitFor(() => expect(mockedList).toHaveBeenCalledWith({ page: 0, size: 20 }));
+    expect(mockedList).toHaveBeenCalledWith({ page: 1, size: 20 });
     await waitFor(() => expect(screen.getAllByRole('button', { name: '確定' })).toHaveLength(25));
     // 全件に届いたので追加読み込みは消える
     expect(screen.queryByRole('button', { name: 'もっと見る' })).not.toBeInTheDocument();
   });
 
   it('追加読み込みに失敗しても既に読み込んだ申請は消さず、その拡張だけ再試行できる', async () => {
-    mockedList.mockResolvedValueOnce(page(requests(20), 25));
-    mockedList.mockRejectedValueOnce(new Error('network'));
-    mockedList.mockResolvedValueOnce(page(requests(25), 25));
+    const server = pagedServer(25);
+    mockedList.mockImplementation(server);
 
     render(<ReservationRequestInbox onProcessed={jest.fn()} />);
+    await screen.findByRole('button', { name: 'もっと見る' });
 
-    fireEvent.click(await screen.findByRole('button', { name: 'もっと見る' }));
+    // 拡張の取得だけを落とす
+    mockedList.mockImplementation(params =>
+      params.page === 1 ? Promise.reject(new Error('network')) : server(params)
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'もっと見る' }));
 
     expect(
       await screen.findByText('予約申請を取得できませんでした。表示は前回の取得内容です。')
@@ -210,10 +221,11 @@ describe('ReservationRequestInbox', () => {
     // 見えていた未処理の申請が消えない
     expect(screen.getAllByRole('button', { name: '確定' })).toHaveLength(20);
 
+    mockedList.mockImplementation(server);
     fireEvent.click(screen.getByRole('button', { name: '再試行' }));
 
     // 失敗した拡張と同じ範囲を取り直す（読み込み済みページ数を進めていない）
-    await waitFor(() => expect(mockedList).toHaveBeenLastCalledWith({ page: 0, size: 40 }));
+    await waitFor(() => expect(mockedList).toHaveBeenCalledWith({ page: 1, size: 20 }));
     await waitFor(() => expect(screen.getAllByRole('button', { name: '確定' })).toHaveLength(25));
   });
 });

--- a/frontend/src/_pages/store-orders/__tests__/ReservationRequestInbox.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/ReservationRequestInbox.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
 import { ReservationRequestInbox } from '../ui/ReservationRequestInbox';
 import { orderApi } from '@/entities/order';
 
@@ -6,9 +7,31 @@ jest.mock('@/entities/order', () => ({
   orderApi: { listReservationRequests: jest.fn(), confirm: jest.fn(), decline: jest.fn() },
 }));
 
+jest.mock('react-hot-toast', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
 const mockedList = orderApi.listReservationRequests as jest.Mock;
 const mockedConfirm = orderApi.confirm as jest.Mock;
 const mockedDecline = orderApi.decline as jest.Mock;
+
+const request = (id: string) => ({
+  id,
+  status: 'CREATED',
+  reception_route: 'WEB',
+  business_date: '2026-08-10',
+});
+
+/** n 件の申請。窓が満ちているかどうかを見る画面なので、件数は実際の応答と同じ形にする。 */
+const requests = (n: number, offset = 0) =>
+  Array.from({ length: n }, (_, i) => request(`o${offset + i}`));
+
+const page = (rows: unknown[], total = rows.length) => ({
+  rows,
+  page: 0,
+  pageCount: 1,
+  total,
+});
 
 describe('ReservationRequestInbox', () => {
   beforeEach(() => {
@@ -16,29 +39,21 @@ describe('ReservationRequestInbox', () => {
   });
 
   it('サーバ側で絞り込まれた申請を表示し、一覧の取得では代替しないこと', async () => {
-    mockedList.mockResolvedValue([
-      {
-        id: 'web-pending',
-        status: 'CREATED',
-        reception_route: 'WEB',
-        business_date: '2026-08-10',
-        requester_member_code: '123456789012',
-      },
-    ]);
+    mockedList.mockResolvedValue(
+      page([{ ...request('web-pending'), requester_member_code: '123456789012' }])
+    );
 
     render(<ReservationRequestInbox onProcessed={jest.fn()} />);
 
     expect(await screen.findByText('2026-08-10')).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: '確定' })).toHaveLength(1);
     expect(screen.getByText('会員コード: 123456789012')).toBeInTheDocument();
-    // 絞り込みはサーバ側の責務。ページ指定を渡していないことで、取得窓に依存していないことを示す。
-    expect(mockedList).toHaveBeenCalledWith();
+    // 絞り込みは専用読み口の責務。取得するのはページの窓だけで、手元では選り分けない。
+    expect(mockedList).toHaveBeenCalledWith({ page: 0, size: 20 });
   });
 
   it('確定すると確定 API を呼び、一覧の再取得を促す', async () => {
-    mockedList.mockResolvedValue([
-      { id: 'o1', status: 'CREATED', reception_route: 'WEB', business_date: '2026-08-10' },
-    ]);
+    mockedList.mockResolvedValue(page([request('o1')]));
     mockedConfirm.mockResolvedValue({});
     const onProcessed = jest.fn();
 
@@ -51,9 +66,7 @@ describe('ReservationRequestInbox', () => {
   });
 
   it('謝絶すると謝絶 API を呼ぶ', async () => {
-    mockedList.mockResolvedValue([
-      { id: 'o1', status: 'CREATED', reception_route: 'WEB', business_date: '2026-08-10' },
-    ]);
+    mockedList.mockResolvedValue(page([request('o1')]));
     mockedDecline.mockResolvedValue({});
 
     render(<ReservationRequestInbox onProcessed={jest.fn()} />);
@@ -63,8 +76,42 @@ describe('ReservationRequestInbox', () => {
     await waitFor(() => expect(mockedDecline).toHaveBeenCalledWith('o1'));
   });
 
+  it('確定に失敗したら、対処方法を含むサーバの文言をそのまま出す', async () => {
+    mockedList.mockResolvedValue(page([request('o1')]));
+    // 指名の再検証は「修正するか謝絶するか」を伝える 400 を返す。汎用文言に潰すと行動できない。
+    mockedConfirm.mockRejectedValue({
+      response: {
+        status: 400,
+        data: {
+          error: '指名キャストが在籍中でないため確定できません。内容を修正するか謝絶してください',
+        },
+      },
+    });
+
+    render(<ReservationRequestInbox onProcessed={jest.fn()} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: '確定' }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        '指名キャストが在籍中でないため確定できません。内容を修正するか謝絶してください'
+      )
+    );
+  });
+
+  it('サーバの文言が無ければ汎用の失敗文言へ落とす', async () => {
+    mockedList.mockResolvedValue(page([request('o1')]));
+    mockedConfirm.mockRejectedValue(new Error('network'));
+
+    render(<ReservationRequestInbox onProcessed={jest.fn()} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: '確定' }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('確定に失敗しました'));
+  });
+
   it('未確定の申請が無ければその旨を表示する', async () => {
-    mockedList.mockResolvedValue([]);
+    mockedList.mockResolvedValue(page([]));
 
     render(<ReservationRequestInbox onProcessed={jest.fn()} />);
 
@@ -74,9 +121,7 @@ describe('ReservationRequestInbox', () => {
   it('取得に失敗したら空表示ではなくエラーを出し、再読み込みで復帰できる', async () => {
     // 瞬断を「申請なし」に見せると、店舗が未処理の申請を見落とす
     mockedList.mockRejectedValueOnce(new Error('network'));
-    mockedList.mockResolvedValueOnce([
-      { id: 'o1', status: 'CREATED', reception_route: 'WEB', business_date: '2026-08-10' },
-    ]);
+    mockedList.mockResolvedValueOnce(page([request('o1')]));
 
     render(<ReservationRequestInbox onProcessed={jest.fn()} />);
 
@@ -86,5 +131,71 @@ describe('ReservationRequestInbox', () => {
     fireEvent.click(screen.getByRole('button', { name: '再読み込み' }));
 
     expect(await screen.findByText('2026-08-10')).toBeInTheDocument();
+  });
+
+  it('再読み込み中は失敗表示を畳んで読み込み中を出す', async () => {
+    // 失敗表示のまま黙って待たせると、押した再読み込みが効いているのか分からない
+    mockedList.mockRejectedValueOnce(new Error('network'));
+    mockedList.mockReturnValueOnce(new Promise(() => {}));
+
+    render(<ReservationRequestInbox onProcessed={jest.fn()} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: '再読み込み' }));
+
+    expect(await screen.findByText('読み込み中...')).toBeInTheDocument();
+    expect(screen.queryByText('予約申請を取得できませんでした。')).not.toBeInTheDocument();
+  });
+
+  it('サーバ側の上限に当たったら「もっと見る」を出さない', async () => {
+    // 要求より少ない件数しか返らないのに残りがある状態で出し続けると、押しても増えないボタンになる
+    mockedList.mockResolvedValueOnce(page(requests(20), 2500));
+    // 40 件要求したのに 20 件しか返らない＝サーバ側の上限に当たっている
+    mockedList.mockResolvedValueOnce(page(requests(20), 2500));
+
+    render(<ReservationRequestInbox onProcessed={jest.fn()} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'もっと見る' }));
+
+    await waitFor(() => expect(mockedList).toHaveBeenLastCalledWith({ page: 0, size: 40 }));
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'もっと見る' })).not.toBeInTheDocument()
+    );
+  });
+
+  it('取得件数の上限を超える申請は追加読み込みで辿れる', async () => {
+    mockedList.mockResolvedValueOnce(page(requests(20), 25));
+    mockedList.mockResolvedValueOnce(page(requests(25), 25));
+
+    render(<ReservationRequestInbox onProcessed={jest.fn()} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'もっと見る' }));
+
+    // 継ぎ足しではなく読み込み済みの範囲ごと取り直す（処理で 1 件消えた分の繰り上がりで申請を飛ばさない）
+    await waitFor(() => expect(mockedList).toHaveBeenLastCalledWith({ page: 0, size: 40 }));
+    await waitFor(() => expect(screen.getAllByRole('button', { name: '確定' })).toHaveLength(25));
+    // 全件に届いたので追加読み込みは消える
+    expect(screen.queryByRole('button', { name: 'もっと見る' })).not.toBeInTheDocument();
+  });
+
+  it('追加読み込みに失敗しても既に読み込んだ申請は消さず、その拡張だけ再試行できる', async () => {
+    mockedList.mockResolvedValueOnce(page(requests(20), 25));
+    mockedList.mockRejectedValueOnce(new Error('network'));
+    mockedList.mockResolvedValueOnce(page(requests(25), 25));
+
+    render(<ReservationRequestInbox onProcessed={jest.fn()} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'もっと見る' }));
+
+    expect(
+      await screen.findByText('予約申請を取得できませんでした。表示は前回の取得内容です。')
+    ).toBeInTheDocument();
+    // 見えていた未処理の申請が消えない
+    expect(screen.getAllByRole('button', { name: '確定' })).toHaveLength(20);
+
+    fireEvent.click(screen.getByRole('button', { name: '再試行' }));
+
+    // 失敗した拡張と同じ範囲を取り直す（読み込み済みページ数を進めていない）
+    await waitFor(() => expect(mockedList).toHaveBeenLastCalledWith({ page: 0, size: 40 }));
+    await waitFor(() => expect(screen.getAllByRole('button', { name: '確定' })).toHaveLength(25));
   });
 });

--- a/frontend/src/_pages/store-orders/__tests__/ReservationRequestInbox.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/ReservationRequestInbox.test.tsx
@@ -65,6 +65,24 @@ describe('ReservationRequestInbox', () => {
     expect(onProcessed).toHaveBeenCalled();
   });
 
+  it('処理後の取り直しが届くまで、表示中の行の確定・謝絶を受け付けない', async () => {
+    // 行は残したまま（見失わせないため）だが、古い行を押せると済んだ遷移をもう一度投げてしまう
+    mockedList.mockResolvedValueOnce(page([request('o1')]));
+    mockedConfirm.mockResolvedValue({});
+    mockedList.mockReturnValueOnce(new Promise(() => {}));
+
+    render(<ReservationRequestInbox onProcessed={jest.fn()} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: '確定' }));
+
+    // 取り直しが始まった＝processingId は既にクリアされている。ここから先が観測したい窓。
+    await waitFor(() => expect(mockedList).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole('button', { name: '確定' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '謝絶' })).toBeDisabled();
+    // 行そのものは消さない
+    expect(screen.getByText('2026-08-10')).toBeInTheDocument();
+  });
+
   it('謝絶すると謝絶 API を呼ぶ', async () => {
     mockedList.mockResolvedValue(page([request('o1')]));
     mockedDecline.mockResolvedValue({});

--- a/frontend/src/_pages/store-orders/ui/ReservationRequestInbox.tsx
+++ b/frontend/src/_pages/store-orders/ui/ReservationRequestInbox.tsx
@@ -143,13 +143,15 @@ export function ReservationRequestInbox({ onProcessed }: ReservationRequestInbox
                 <p className="mt-1 text-xs text-muted-foreground">{request.remarks}</p>
               )}
             </div>
+            {/* 取り直しの最中は行が古いままなので、確定・謝絶を受け付けない。処理直後の再取得が
+                届くまで同じ行を押せると、済んだ遷移をもう一度投げてしまう。 */}
             <div className="flex gap-2">
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
                 onClick={() => process(request.id ?? '', 'decline')}
-                disabled={processingId === request.id}
+                disabled={loading || processingId === request.id}
               >
                 謝絶
               </Button>
@@ -157,7 +159,7 @@ export function ReservationRequestInbox({ onProcessed }: ReservationRequestInbox
                 type="button"
                 size="sm"
                 onClick={() => process(request.id ?? '', 'confirm')}
-                disabled={processingId === request.id}
+                disabled={loading || processingId === request.id}
               >
                 確定
               </Button>

--- a/frontend/src/_pages/store-orders/ui/ReservationRequestInbox.tsx
+++ b/frontend/src/_pages/store-orders/ui/ReservationRequestInbox.tsx
@@ -1,14 +1,18 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { Order, orderApi } from '@/entities/order';
+import { getApiErrorMessage } from '@/shared/lib';
 import { Badge, Button } from '@/shared/ui';
 
 interface ReservationRequestInboxProps {
   /** 確定・謝絶の成功後に呼ばれる（同じ受注の状態が変わるため、一覧の再取得に使う）。 */
   onProcessed: () => void;
 }
+
+/** 1 回に読み込む件数。未処理の申請は処理し終えるまで残り続けるため、取得は上限で抑えて追加読み込みで辿る。 */
+const PAGE_SIZE = 20;
 
 /**
  * 予約受付 inbox。会員ポータルからの未確定申請だけを表示する。
@@ -20,24 +24,51 @@ interface ReservationRequestInboxProps {
 export function ReservationRequestInbox({ onProcessed }: ReservationRequestInboxProps) {
   const [requests, setRequests] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
+  // 表示できるものが何も無い状態での取得失敗。空表示（＝申請なし）と区別する。
   const [failed, setFailed] = useState(false);
+  // 表示中の申請を保ったまま失敗した取得の対象ページ数（再試行にそのまま使う）。
+  const [failedPages, setFailedPages] = useState<number | null>(null);
   const [processingId, setProcessingId] = useState<string | null>(null);
+  // 読み込み済みのページ数。確定・謝絶後の取り直しでも同じ範囲を保つために持つ。
+  const [loadedPages, setLoadedPages] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  // 失敗時の分岐に使う「今表示している件数」。load は再生成しない（mount 用 effect を引き直さない）ため
+  // state を読まずに済ませる。
+  const shownCount = useRef(0);
 
-  const load = () => {
+  const load = useCallback((pages: number) => {
     setLoading(true);
+    setFailedPages(null);
+    // 再読み込み中は失敗表示を畳む。残したままだと、押した再読み込みが効いているのか分からない。
+    setFailed(false);
+    // 処理後も表示中の範囲を保つため、読み込み済みページ分をまとめて取り直す。
+    // ページ単位で継ぎ足すと、処理で 1 件消えた分だけ後続が繰り上がり、境界の申請を飛ばす。
+    const size = pages * PAGE_SIZE;
     orderApi
-      .listReservationRequests()
-      .then(list => {
-        setRequests(list);
-        setFailed(false);
+      .listReservationRequests({ page: 0, size })
+      .then(page => {
+        shownCount.current = page.rows.length;
+        setRequests(page.rows);
+        // 要求した件数より少なく返ってきたのに残りがある＝サーバ側の上限に当たっている。
+        // ここで「もっと見る」を出し続けると、押しても増えないボタンになる。
+        setHasMore(page.rows.length < page.total && page.rows.length >= size);
+        setLoadedPages(pages);
       })
-      .catch(() => setFailed(true))
+      .catch(() => {
+        // 表示中の申請があるなら消さない — 追加読み込みの失敗で既読み込み分まで消すと、
+        // 見えていた未処理の申請を見失う。読み込み済みページ数も進めない。
+        if (shownCount.current === 0) {
+          setFailed(true);
+        } else {
+          setFailedPages(pages);
+        }
+      })
       .finally(() => setLoading(false));
-  };
+  }, []);
 
   useEffect(() => {
-    load();
-  }, []);
+    load(1);
+  }, [load]);
 
   const process = async (id: string, action: 'confirm' | 'decline') => {
     setProcessingId(id);
@@ -49,16 +80,22 @@ export function ReservationRequestInbox({ onProcessed }: ReservationRequestInbox
         await orderApi.decline(id);
         toast.success('予約を謝絶しました');
       }
-      load();
+      load(loadedPages);
       onProcessed();
-    } catch {
-      toast.error(action === 'confirm' ? '確定に失敗しました' : '謝絶に失敗しました');
+    } catch (error) {
+      // 指名の再検証など、サーバは対処方法（修正か謝絶か）を含む文言を返す。汎用文言に潰さない。
+      toast.error(
+        getApiErrorMessage(
+          error,
+          action === 'confirm' ? '確定に失敗しました' : '謝絶に失敗しました'
+        )
+      );
     } finally {
       setProcessingId(null);
     }
   };
 
-  if (loading) {
+  if (loading && requests.length === 0) {
     return <p className="text-sm text-muted-foreground">読み込み中...</p>;
   }
   // 取得失敗を空表示と区別する — 「申請なし」に見せると未処理の申請を見落とす
@@ -66,7 +103,7 @@ export function ReservationRequestInbox({ onProcessed }: ReservationRequestInbox
     return (
       <div className="flex items-center gap-3">
         <p className="text-sm text-destructive-strong">予約申請を取得できませんでした。</p>
-        <Button type="button" variant="outline" size="sm" onClick={load}>
+        <Button type="button" variant="outline" size="sm" onClick={() => load(loadedPages)}>
           再読み込み
         </Button>
       </div>
@@ -77,55 +114,84 @@ export function ReservationRequestInbox({ onProcessed }: ReservationRequestInbox
   }
 
   return (
-    <ul className="space-y-3">
-      {requests.map(request => (
-        <li
-          key={request.id}
-          className="flex items-center justify-between rounded-[10px] border bg-card p-4 shadow-sm"
-        >
-          <div>
-            <p className="flex items-center gap-2 text-sm font-medium text-foreground">
-              {request.business_date}
-              <Badge
+    <>
+      <ul className="space-y-3">
+        {requests.map(request => (
+          <li
+            key={request.id}
+            className="flex items-center justify-between rounded-[10px] border bg-card p-4 shadow-sm"
+          >
+            <div>
+              <p className="flex items-center gap-2 text-sm font-medium text-foreground">
+                {request.business_date}
+                <Badge
+                  variant="outline"
+                  className="border-transparent bg-primary/10 text-primary-strong"
+                >
+                  WEB申請
+                </Badge>
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {request.arrival_scheduled_start_time?.slice(0, 5) ?? '時刻未定'}
+                {request.pax != null ? ` / ${request.pax} 名` : ''} / 指名:{' '}
+                {request.cast_name ?? 'なし'}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                会員コード: {request.requester_member_code ?? '-'}
+              </p>
+              {request.remarks && (
+                <p className="mt-1 text-xs text-muted-foreground">{request.remarks}</p>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button
+                type="button"
                 variant="outline"
-                className="border-transparent bg-primary/10 text-primary-strong"
+                size="sm"
+                onClick={() => process(request.id ?? '', 'decline')}
+                disabled={processingId === request.id}
               >
-                WEB申請
-              </Badge>
-            </p>
-            <p className="text-sm text-muted-foreground">
-              {request.arrival_scheduled_start_time?.slice(0, 5) ?? '時刻未定'}
-              {request.pax != null ? ` / ${request.pax} 名` : ''} / 指名:{' '}
-              {request.cast_name ?? 'なし'}
-            </p>
-            <p className="text-xs text-muted-foreground">
-              会員コード: {request.requester_member_code ?? '-'}
-            </p>
-            {request.remarks && (
-              <p className="mt-1 text-xs text-muted-foreground">{request.remarks}</p>
-            )}
-          </div>
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => process(request.id ?? '', 'decline')}
-              disabled={processingId === request.id}
-            >
-              謝絶
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              onClick={() => process(request.id ?? '', 'confirm')}
-              disabled={processingId === request.id}
-            >
-              確定
-            </Button>
-          </div>
-        </li>
-      ))}
-    </ul>
+                謝絶
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => process(request.id ?? '', 'confirm')}
+                disabled={processingId === request.id}
+              >
+                確定
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {failedPages !== null && (
+        <div className="mt-3 flex items-center gap-3">
+          <p className="text-sm text-destructive-strong">
+            予約申請を取得できませんでした。表示は前回の取得内容です。
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={loading}
+            onClick={() => load(failedPages)}
+          >
+            再試行
+          </Button>
+        </div>
+      )}
+      {hasMore && failedPages === null && (
+        <Button
+          type="button"
+          variant="outline"
+          className="mt-3 w-full"
+          disabled={loading}
+          onClick={() => load(loadedPages + 1)}
+        >
+          もっと見る
+        </Button>
+      )}
+    </>
   );
 }

--- a/frontend/src/_pages/store-orders/ui/ReservationRequestInbox.tsx
+++ b/frontend/src/_pages/store-orders/ui/ReservationRequestInbox.tsx
@@ -41,17 +41,24 @@ export function ReservationRequestInbox({ onProcessed }: ReservationRequestInbox
     setFailedPages(null);
     // 再読み込み中は失敗表示を畳む。残したままだと、押した再読み込みが効いているのか分からない。
     setFailed(false);
-    // 処理後も表示中の範囲を保つため、読み込み済みページ分をまとめて取り直す。
-    // ページ単位で継ぎ足すと、処理で 1 件消えた分だけ後続が繰り上がり、境界の申請を飛ばす。
-    const size = pages * PAGE_SIZE;
-    orderApi
-      .listReservationRequests({ page: 0, size })
-      .then(page => {
-        shownCount.current = page.rows.length;
-        setRequests(page.rows);
-        // 要求した件数より少なく返ってきたのに残りがある＝サーバ側の上限に当たっている。
-        // ここで「もっと見る」を出し続けると、押しても増えないボタンになる。
-        setHasMore(page.rows.length < page.total && page.rows.length >= size);
+    // 1 回の取得は常に PAGE_SIZE 件に抑え、表示中の範囲は固定長ページを並べて組み立てる。
+    // 要求サイズ自体を膨らませる形にすると、サーバ側のページ上限に当たった時点で
+    // それ以降の申請へ到達する手段が無くなる。
+    //
+    // 処理後も読み込み済みの範囲を丸ごと読み直すのは、ページ単位で継ぎ足すと処理で 1 件消えた分だけ
+    // 後続が繰り上がり、境界の申請を飛ばすため。
+    Promise.all(
+      Array.from({ length: pages }, (_, index) =>
+        orderApi.listReservationRequests({ page: index, size: PAGE_SIZE })
+      )
+    )
+      .then(fetched => {
+        const rows = fetched.flatMap(one => one.rows);
+        // 総件数は最後に読んだページのものを採る（取得中に処理が入っても、次の取り直しで揃う）。
+        const total = fetched[fetched.length - 1].total;
+        shownCount.current = rows.length;
+        setRequests(rows);
+        setHasMore(rows.length < total);
         setLoadedPages(pages);
       })
       .catch(() => {

--- a/frontend/src/entities/order/__tests__/order-api.test.ts
+++ b/frontend/src/entities/order/__tests__/order-api.test.ts
@@ -42,10 +42,26 @@ describe('orderApi', () => {
       url: '/store/orders/receptionists',
     });
   });
-  it('listReservationRequests は予約受付の専用読み口を GET する', async () => {
-    expect(await orderApi.listReservationRequests()).toEqual({
-      ok: true,
-      url: '/store/orders/reservation-requests',
+  it('listReservationRequests は予約受付の専用読み口を GET し、Spring Page を正規化する', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        content: [{ id: 'o1' }],
+        total_pages: 2,
+        total_elements: 21,
+        size: 20,
+        number: 0,
+      },
+    });
+
+    // 絞り込みは専用読み口の責務。受注一覧を取って手元で選り分ける形へは戻さない。
+    await expect(orderApi.listReservationRequests({ page: 0, size: 20 })).resolves.toEqual({
+      rows: [{ id: 'o1' }],
+      page: 0,
+      pageCount: 2,
+      total: 21,
+    });
+    expect(mockedGet).toHaveBeenCalledWith('/store/orders/reservation-requests', {
+      params: { page: 0, size: 20 },
     });
   });
   it('confirm は確定の子リソースを POST する', async () => {

--- a/frontend/src/entities/order/api/order.ts
+++ b/frontend/src/entities/order/api/order.ts
@@ -22,10 +22,10 @@ export const orderApi = {
     const response = await apiClient.get('/store/orders/receptionists');
     return response.data;
   },
-  /** 予約受付 inbox の未確定申請一覧（絞り込みはサーバ側）。 */
-  listReservationRequests: async (): Promise<Order[]> => {
-    const response = await apiClient.get('/store/orders/reservation-requests');
-    return response.data;
+  /** 予約受付 inbox の未確定申請一覧（絞り込みと並びはサーバ側、取得件数はページで抑える）。 */
+  listReservationRequests: async (params?: PaginationParams): Promise<PageResult<Order>> => {
+    const response = await apiClient.get('/store/orders/reservation-requests', { params });
+    return fromSpringPage(response.data);
   },
   /** 予約申請を確定する（受注として受け付ける）。 */
   confirm: async (id: string): Promise<Order> => {

--- a/frontend/src/entities/order/model/types.ts
+++ b/frontend/src/entities/order/model/types.ts
@@ -2,18 +2,29 @@
 // 応答の任意性は Java 側の可空性が正本。wrapper 型のフィールドは
 // default-property-inclusion: non_null によりキーごと応答から消えるため optional にする。
 
-// 受注ステータス。CREATED=申請中/CONFIRMED=確定/COMPLETED=完了/CANCELLED=キャンセル。
+// 受注ステータス。CREATED=未確定/CONFIRMED=確定/COMPLETED=完了/CANCELLED=キャンセル。
 export type OrderStatus = 'CREATED' | 'CONFIRMED' | 'COMPLETED' | 'CANCELLED';
 
 // 受付経路。WEB=会員ポータルからの申請/PHONE=電話受付。
 export type ReceptionRoute = 'WEB' | 'PHONE';
 
-/** 受注ステータスの日本語表示。 */
+/**
+ * 受注ステータスの日本語表示（既定）。
+ *
+ * CREATED は会員の申請でも店舗が手入力した受注でも起きるため、中立に「未確定」と呼ぶ。
+ * 申請かどうかは別途 WEB申請 バッジが担う。
+ */
 export const ORDER_STATUS_LABELS: Record<OrderStatus, string> = {
-  CREATED: '申請中',
+  CREATED: '未確定',
   CONFIRMED: '確定',
   COMPLETED: '完了',
   CANCELLED: 'キャンセル',
+};
+
+/** 会員ポータルでの表示。会員本人の予約は必ず申請として起きるので、CREATED を「申請中」と呼べる。 */
+export const MEMBER_ORDER_STATUS_LABELS: Record<OrderStatus, string> = {
+  ...ORDER_STATUS_LABELS,
+  CREATED: '申請中',
 };
 
 export interface Order {

--- a/frontend/src/shared/api/__tests__/client-401.test.ts
+++ b/frontend/src/shared/api/__tests__/client-401.test.ts
@@ -3,10 +3,12 @@ import Cookies from 'js-cookie';
 // mock navigation helper before importing client so that interceptor uses the mock
 const redirectMock = jest.fn();
 const clearPlatformSessionMock = jest.fn();
+const rememberMemberReturnPathMock = jest.fn();
 let platformConsoleValue: string | undefined;
 jest.mock('@/shared/lib', () => ({
   redirectToLogin: () => redirectMock(),
   clearPlatformSession: () => clearPlatformSessionMock(),
+  rememberMemberReturnPath: (value: string) => rememberMemberReturnPathMock(value),
   getPlatformConsole: () => platformConsoleValue,
   getPlatformStoreId: () => undefined,
   isStoreConsole: (v: string | undefined) => v === 'store',
@@ -58,6 +60,19 @@ describe('apiClient 401/403 interceptor', () => {
 
     expect(removeSpy).toHaveBeenCalledWith('token');
     // assert that our navigation helper was called (no real navigation in jsdom)
+    expect(redirectMock).toHaveBeenCalled();
+  });
+
+  it('401 でログインへ差し戻す前に、会員ポータルの現在地を戻り先として覚える', async () => {
+    // 失効した MEMBER token は画面の入口を通ってしまうため、差し戻しがここで初めて起きる。
+    // 覚えないとログイン後に店舗つきの申請画面へ戻れない。
+    window.history.pushState({}, '', '/member/reservations/new?store=store1.kizuna.test');
+
+    await withRejectingAdapter(401, () => apiClient.get('/platform/me/orders'));
+
+    expect(rememberMemberReturnPathMock).toHaveBeenCalledWith(
+      '/member/reservations/new?store=store1.kizuna.test'
+    );
     expect(redirectMock).toHaveBeenCalled();
   });
 

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -5,6 +5,7 @@ import {
   getPlatformConsole,
   getStoreIdFromPath,
   redirectToLogin,
+  rememberMemberReturnPath,
   setPlatformStore,
 } from '@/shared/lib';
 
@@ -82,6 +83,10 @@ apiClient.interceptors.response.use(
       }
       Cookies.remove('token');
       if (typeof window !== 'undefined' && !window.location.pathname.includes('/login')) {
+        // 失効した MEMBER token でも画面の入口は通るため、差し戻しはここが初めてになりうる。
+        // 会員ポータルの現在地（店舗つき）を覚えないと、ログイン後の戻り先を失う。
+        // 白名単の外（店舗コンソール等）は rememberMemberReturnPath が黙って捨てる。
+        rememberMemberReturnPath(`${window.location.pathname}${window.location.search}`);
         redirectToLogin();
       }
     }

--- a/frontend/src/shared/lib/__tests__/apiError.test.ts
+++ b/frontend/src/shared/lib/__tests__/apiError.test.ts
@@ -1,4 +1,4 @@
-import { getApiErrorMessage } from '@/shared/lib';
+import { getApiErrorMessage, isConflict, isNotFound } from '@/shared/lib';
 
 describe('getApiErrorMessage', () => {
   it('error フィールドを優先して返す', () => {
@@ -20,5 +20,21 @@ describe('getApiErrorMessage', () => {
   it('error / message が文字列でなければ無視して fallback を返す', () => {
     expect(getApiErrorMessage({ response: { data: { error: { code: 1 } } } }, '代替')).toBe('代替');
     expect(getApiErrorMessage({ response: { data: { message: 42 } } }, '代替')).toBe('代替');
+  });
+});
+
+describe('isConflict / isNotFound', () => {
+  it('該当する状態コードだけを真とする', () => {
+    expect(isConflict({ response: { status: 409 } })).toBe(true);
+    expect(isNotFound({ response: { status: 404 } })).toBe(true);
+    expect(isConflict({ response: { status: 404 } })).toBe(false);
+    expect(isNotFound({ response: { status: 409 } })).toBe(false);
+  });
+
+  it('応答を伴わない失敗（瞬断など）は「見つからない」ではない', () => {
+    // 通信失敗を 404 と同じ扱いにすると、再試行できる失敗まで行き止まりの案内になる
+    expect(isNotFound(new Error('network'))).toBe(false);
+    expect(isNotFound(null)).toBe(false);
+    expect(isNotFound({ response: {} })).toBe(false);
   });
 });

--- a/frontend/src/shared/lib/apiError.ts
+++ b/frontend/src/shared/lib/apiError.ts
@@ -16,6 +16,18 @@ export function getApiErrorMessage(error: unknown, fallback: string): string {
  * 再試行も閉じ直しも同じ 409 を繰り返す。
  */
 export function isConflict(error: unknown): boolean {
-  if (!error || typeof error !== 'object' || !('response' in error)) return false;
-  return (error as { response?: { status?: number } }).response?.status === 409;
+  return statusOf(error) === 409;
+}
+
+/**
+ * 対象が存在しない（404）か。「見つからない」と「取得そのものの失敗」を同じ表示に潰さないために使う。
+ * 潰すと、瞬断で消えたように見える画面から利用者が再試行できなくなる。
+ */
+export function isNotFound(error: unknown): boolean {
+  return statusOf(error) === 404;
+}
+
+function statusOf(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object' || !('response' in error)) return undefined;
+  return (error as { response?: { status?: number } }).response?.status;
 }

--- a/frontend/src/shared/lib/index.ts
+++ b/frontend/src/shared/lib/index.ts
@@ -1,6 +1,6 @@
 export * from './config';
 export { default as redirectToLogin } from './navigation';
-export { getApiErrorMessage, isConflict } from './apiError';
+export { getApiErrorMessage, isConflict, isNotFound } from './apiError';
 export { useManagedList } from './useManagedList';
 export { useListPage } from './useListPage';
 export { useDeleteAction } from './useDeleteAction';


### PR DESCRIPTION
## 概要

受注ステータス `CREATED` の表示を文脈で分け（店舗側は中立な「未確定」、会員ポータルは「申請中」）、予約受付 inbox の無界取得をサーバ側の絞り込みを保ったままページングへ寄せる。あわせて #559 の評審で挙がった「取得中・取得失敗を空/正常表示と区別する」同族の 6 件を同じ画面群でまとめて直す。

Closes #560

## 変更内容

### 1. 受注ステータスの表示ラベルを文脈で分ける

- `ORDER_STATUS_LABELS.CREATED` を中立な `未確定` にし、会員ポータル用に `MEMBER_ORDER_STATUS_LABELS`（`CREATED: 申請中`）を追加
- `CREATED` は店舗が手入力した受注でも起きるため、既定を「申請中」にすると店舗一覧で申請でないものまで申請に見える。申請かどうかは既存の `WEB申請` バッジが引き続き担う

### 2. 予約受付 inbox のページング

- `OrderRepository.findPendingReservationRequestViews` をサーバ側の絞り込み・並び（古い順 + 一意な副キー id）を保ったまま `Page` 化（`countQuery` 付き）
- `GET /store/orders/reservation-requests` に `@PageableDefault(size = 20)`
- inbox UI に「もっと見る」を追加（会員の予約一覧と同型）

### 3〜8. 取得中・取得失敗を空/正常表示と区別する（#560 のコメント 6 件）

- **失効トークンでの戻り先喪失**: 401 でログインへ差し戻す前に `/member/**` の現在地を保存する。失効した MEMBER token はシェルを通ってしまうため、この経路が最初の差し戻しになりうる
- **店舗 lookup の失敗と不明店舗の混同**: 404（その店舗が無い）と照会自体の失敗を分け、後者に再読み込みを出す。判定は `shared/lib/apiError` に `isNotFound` を追加（既存の `isConflict` と同居）
- **もっと見る失敗で既読み込み分まで消える**: 表示中の行を保ち、失敗した拡張だけを再試行できるようにする（inbox・会員の予約一覧の両方に同じ規則）
- **`?store=` 変更時の旧店舗残留**: ドメイン変化の時点で店舗を捨てて読み込み状態へ戻す
- **指名候補の取得中に「出勤なし」を出さない**: 読み込み状態を持たせ、確定するまで空表示と送信を抑止する
- **確定失敗時に API のエラーメッセージを表示する**: 指名再検証の 400 は対処方法（修正か謝絶か）を含むので、汎用文言に潰さない

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task test-unit` / `task test-integration` を個別に実行、いずれも exit 0。統合テストは他の docker 作業と同時に走らせない）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全 24 シナリオ、24 passed）
- [x] ローカルで code-review 実施済み（Standards / Spec の 2 軸）

主要な振る舞いは赤緑の両方向を確認している（実装を一時的に壊して該当テストが落ちることを見てから戻した）: 追加読み込み失敗時に既存行を保つ／確定失敗でサーバ文言を出す／401 で戻り先を保存する。

### 視覚確認（UI 変更時）

未実施。既存コンポーネント（`Button` / テキスト）の追加のみでレイアウト・デザイントークンには触れていないため、実スタックでの目視は行っていない。必要であれば `task up` して inbox に未処理の申請を用意したうえで確認する。

## 決定ログ

**採った形: 表示は累積、取得は固定長ページ**（会員の予約一覧と同型）。1 回の取得は常に 20 件で、読み込み済みの範囲は `page=0..N` を並べて組み立てる。

- ページ単位で「継ぎ足す」形は見送った — 確定・謝絶・取り下げで 1 件消えると後続が繰り上がり、ページ境界の行を飛ばす。処理後は読み込み済みの範囲を丸ごと読み直す。
- 逆に「要求サイズ自体を膨らませる」形（`size: pages * 20`）も見送った。初版はこれだったが、サーバ側のページ上限（既定 2000）に当たった時点でそれ以降の申請へ到達する手段が無くなる。無界で返していた従来には無かった不到達域を、ページング化と引き換えに作ってしまう。Codex のレビューで指摘され、固定長ページへ改めた（`10cead25`）。
- 引き換えに、範囲が 2 ページ以上に広がっている間の読み直しは単一クエリのスナップショットではなくなる。並行して処理が入ると境界で 1 件ずれうるが、処理のたびに全範囲を読み直すため次の取り直しで揃う。

**`未確定` の語**: 店舗側の shift ステータス `TENTATIVE` の表示ラベルも `未確定`（`ShiftFormModal.tsx` / `ShiftCalendar.tsx`）。画面が別なので機能上の問題は無く、issue 自身が例として `未確定` を挙げているためこの語を採ったが、CONTEXT.md が用語の正本である以上ここに記しておく。別語にするなら 1 語の変更で済む。

**見送り**: 失敗状態機（`failedPages` / `shownCount`）が inbox と会員の予約一覧で 2 箇所に重複しているが、`shared/lib` への `useCumulativeList` 抽出は見送った。CLAUDE.md の "Duplicate twice before abstracting" は 2 つ目までを許す閾値なので、3 つ目の消費者が出た時点で抽出する。

**見送り**: 8 件を複数コミットへ分割することも検討したが、issue 自身が「同じ画面群に触るためまとめて行うのが安い」としてまとめており、ページングと確定失敗文言は `ReservationRequestInbox.tsx` の同じ hunk 群を共有するため、hunk 単位の staging に見合う可読性の利得が無いと判断した。

## 備考 / レビュー観点

- **e2e の初回実行は落ちたが、本 diff の回帰ではない**。`member-reservation.feature` の inbox ステップが `.first()` で確定対象を選ぶ一方、inbox は `createdAt` 昇順のため、前回の run が残した未処理の申請が常に自分のものより前に来る。しかも After フックの `deleteOrder` は未確定の申請に対してサーバ側が拒否する（#559 で入った「未確定の予約申請は削除できません」）ため残骸が消えず、一度落ちると以後永久に落ちる。残骸を手で確定してから再実行して 24/24。根治は別 issue へ切り出す（このステップが自分の作った order id を特定するようにする）。
- **取得戦略の扇出は据え置き、#563 へ切り出した（このスレッドは未 resolve）。** `load(pages)` は読み込み済みページ数と同数のリクエストを撒く（[thread](https://github.com/kanghouchao/Kizuna/pull/562#discussion_r3708853357)）。offset ページングのままだと「(1) 変更後に境界の行を飛ばさない = 範囲を丸ごと読み直す」「(2) サーバ側のページ上限に当たらない = `size` を膨らませない」「(3) N 並列を撒かない = 範囲を N ページに割らない」の 3 つが同時に満たせず、レビュー 3 巡はこの三すくみを往復した。破綻する規模（未処理 400 件超）は前巡で直した clamp 到達性と同一区間のため、#560 の受け入れ基準を満たしたところで止め、3 つを同時に満たす keyset ページングは #563 で扱う。
- Codex のレビュー 3 巡で挙がった 5 件のうち 4 件を反映済み（`81722715` / `10cead25`）。うち 2 件は本 PR が持ち込んだ回帰で、いずれも赤緑両方向を確認したテストを追加している: 取り直しの最中に行が再度押せた件（取得中も行を残すようにした副作用）と、要求サイズ膨張による不到達域。
- 重点的に見てほしい箇所: `OrderRepository` の `PENDING_REQUEST_WHERE`（本体と件数の問い合わせが同じ条件を共有していること）と、`ReservationRequestInbox` / `MemberReservationsPage` の失敗時分岐（表示中の行があるかどうかで全体失敗と部分失敗を分ける規則）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
