### PR TITLE
feat(order): 予約申請の店舗側編集経路（指名の維持・解除ができる可空キャスト対応）

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/order/MemberOrderIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/MemberOrderIT.java
@@ -435,6 +435,119 @@ class MemberOrderIT extends CrossStoreTestSupport {
     assertThat(confirmed.getBody().path("status").asString()).isEqualTo("CONFIRMED");
   }
 
+  private ResponseEntity<JsonNode> updateReservationRequest(long storeId, String id, String body) {
+    return rest.exchange(
+        "/store/orders/reservation-requests/" + id,
+        HttpMethod.PUT,
+        new HttpEntity<>(body, storeHeaders(storeId)),
+        JsonNode.class);
+  }
+
+  @Test
+  @DisplayName("指名なしの申請を、キャストを設定せずに編集して確定できること")
+  void nominationFreeRequestCanBeEditedWithoutSettingACast() {
+    String orderId = requestReservation(memberAToken, STORE_A, "編集前の備考");
+    String businessDate =
+        rest.exchange(
+                "/store/orders/" + orderId,
+                HttpMethod.GET,
+                new HttpEntity<>(storeHeaders(STORE_A)),
+                JsonNode.class)
+            .getBody()
+            .path("business_date")
+            .asString();
+
+    ResponseEntity<JsonNode> edited =
+        updateReservationRequest(
+            STORE_A, orderId, "{\"receptionist_id\": 3, \"pax\": 5, \"remarks\": \"店舗が人数を直した\"}");
+    assertThat(edited.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(edited.getBody().path("pax").asInt()).isEqualTo(5);
+    assertThat(edited.getBody().path("remarks").asString()).isEqualTo("店舗が人数を直した");
+    assertThat(edited.getBody().path("receptionist_id").asLong()).isEqualTo(3L);
+    assertThat(edited.getBody().path("cast_id").isMissingNode())
+        .as("キャストを埋めずに編集できること（指名付きの受注へ変換されない）")
+        .isTrue();
+    assertThat(edited.getBody().path("business_date").asString())
+        .as("編集の契約が持たない項目は書き換わらないこと")
+        .isEqualTo(businessDate);
+
+    ResponseEntity<JsonNode> confirmed =
+        rest.exchange(
+            "/store/orders/" + orderId + "/confirmation",
+            HttpMethod.POST,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(confirmed.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(confirmed.getBody().path("status").asString()).isEqualTo("CONFIRMED");
+  }
+
+  @Test
+  @DisplayName("指名を明示的に外しても申請者の記録が壊れず、そのまま確定できること")
+  void nominationCanBeClearedBeforeConfirmation() {
+    String orderId = requestReservation(memberAToken, STORE_A, "指名解除の対象");
+    // 指名先は在籍中のキャストに限るため、状態を明示して作る（作成 API は既定値を持たない）
+    ResponseEntity<JsonNode> cast =
+        rest.postForEntity(
+            "/store/casts",
+            new HttpEntity<>(
+                "{\"name\": \"指名解除テスト用キャスト\", \"status\": \"ACTIVE\"}", storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(cast.getStatusCode().is2xxSuccessful()).as("前提: キャスト作成が成功すること").isTrue();
+    String castId = cast.getBody().path("id").asString();
+
+    ResponseEntity<JsonNode> nominated =
+        updateReservationRequest(STORE_A, orderId, "{\"cast_id\": \"" + castId + "\", \"pax\": 3}");
+    assertThat(nominated.getStatusCode()).as("前提: 店舗が指名を設定できること").isEqualTo(HttpStatus.OK);
+    assertThat(nominated.getBody().path("cast_id").asString()).isEqualTo(castId);
+
+    ResponseEntity<JsonNode> cleared = updateReservationRequest(STORE_A, orderId, "{\"pax\": 3}");
+    assertThat(cleared.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(cleared.getBody().path("cast_id").isMissingNode()).isTrue();
+    assertThat(cleared.getBody().path("cast_name").isMissingNode()).isTrue();
+    assertThat(cleared.getBody().path("requester_member_code").asString())
+        .as("申請者のスナップショットが指名解除で欠けないこと")
+        .isNotBlank();
+    assertThat(cleared.getBody().path("reception_route").asString()).isEqualTo("WEB");
+
+    // 会員側から見た予約も残り続ける（同じ行であることの現れ）
+    JsonNode own = firstReservation(memberAToken);
+    assertThat(own.path("id").asString()).isEqualTo(orderId);
+    assertThat(own.path("status").asString()).isEqualTo("CREATED");
+
+    ResponseEntity<JsonNode> confirmed =
+        rest.exchange(
+            "/store/orders/" + orderId + "/confirmation",
+            HttpMethod.POST,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(confirmed.getStatusCode()).as("無効になった指名を外してから確定できること").isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  @DisplayName("申請編集の収口が、他店舗・店舗起点の受注・確定済みの申請に届かないこと")
+  void reservationRequestUpdateReachesOnlyPendingRequestsOfTheOwningStore() {
+    String orderId = requestReservation(memberAToken, STORE_A, "編集収口のガード対象");
+
+    assertThat(updateReservationRequest(STORE_B, orderId, "{\"pax\": 2}").getStatusCode())
+        .as("他店舗からは到達できないこと")
+        .isEqualTo(HttpStatus.FORBIDDEN);
+
+    String castId = createCastAs(STORE_A, "編集収口ガード用キャスト");
+    String storeOrderId = createStoreOrderTaggedWeb(castId);
+    assertThat(updateReservationRequest(STORE_A, storeOrderId, "{\"pax\": 2}").getStatusCode())
+        .as("店舗が起こした受注は申請専用の可空な契約では変更できないこと")
+        .isEqualTo(HttpStatus.NOT_FOUND);
+
+    rest.exchange(
+        "/store/orders/" + orderId + "/confirmation",
+        HttpMethod.POST,
+        new HttpEntity<>(storeHeaders(STORE_A)),
+        JsonNode.class);
+    assertThat(updateReservationRequest(STORE_A, orderId, "{\"pax\": 2}").getStatusCode())
+        .as("確定後は通常の受注として汎用更新が受け持つこと")
+        .isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
   @Test
   @DisplayName("他店舗は会員の申請を確定も謝絶もできず、申請はその後も処理できること")
   void otherStoreCannotConfirmOrDeclineForeignApplication() {

--- a/backend/src/integrationTest/java/com/kizuna/order/MemberOrderIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/MemberOrderIT.java
@@ -500,6 +500,19 @@ class MemberOrderIT extends CrossStoreTestSupport {
     assertThat(nominated.getStatusCode()).as("前提: 店舗が指名を設定できること").isEqualTo(HttpStatus.OK);
     assertThat(nominated.getBody().path("cast_id").asString()).isEqualTo(castId);
 
+    // 撥ねられた編集は元の指名を残す（拒否の健全さをトランザクションの巻き戻しだけに委ねない）
+    ResponseEntity<JsonNode> rejected =
+        updateReservationRequest(STORE_A, orderId, "{\"cast_id\": \"does-not-exist\", \"pax\": 9}");
+    assertThat(rejected.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    ResponseEntity<JsonNode> afterRejection =
+        rest.exchange(
+            "/store/orders/" + orderId,
+            HttpMethod.GET,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(afterRejection.getBody().path("cast_id").asString()).isEqualTo(castId);
+    assertThat(afterRejection.getBody().path("pax").asInt()).isEqualTo(3);
+
     ResponseEntity<JsonNode> cleared = updateReservationRequest(STORE_A, orderId, "{\"pax\": 3}");
     assertThat(cleared.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(cleared.getBody().path("cast_id").isMissingNode()).isTrue();

--- a/backend/src/main/java/com/kizuna/order/api/dto/ReservationRequestUpdateRequest.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/ReservationRequestUpdateRequest.java
@@ -1,0 +1,31 @@
+package com.kizuna.order.api.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * 未確定の予約申請に対する店舗側の編集内容。
+ *
+ * <p>受け取った値がそのまま新しい内容になる（省略・null は「未設定にする」）。部分更新の {@link OrderUpdateRequest}
+ * と違い、指名や受付担当を明示的に外せることがこの契約の目的であり、「省略＝変更しない」では外す手段が無くなる。
+ *
+ * <p>そのため項目は編集画面が扱う 4 つだけに絞る。ここに増やした項目は、送られてこなければ消える。
+ */
+@Data
+public class ReservationRequestUpdateRequest {
+
+  /** 受付担当。null は未設定（確定時に実行者から補われる余地を残す）。 */
+  private Long receptionistId;
+
+  /** 指名するキャスト。null は指名なし。 */
+  private String castId;
+
+  @NotNull(message = "人数は必須です")
+  @Min(value = 1, message = "人数は 1 以上です")
+  private Integer pax;
+
+  @Size(max = 500, message = "備考は 500 文字以内です")
+  private String remarks;
+}

--- a/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
+++ b/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
@@ -4,6 +4,7 @@ import com.kizuna.order.api.dto.OrderCreateRequest;
 import com.kizuna.order.api.dto.OrderReceptionistResponse;
 import com.kizuna.order.api.dto.OrderResponse;
 import com.kizuna.order.api.dto.OrderUpdateRequest;
+import com.kizuna.order.api.dto.ReservationRequestUpdateRequest;
 import com.kizuna.order.application.OrderService;
 import jakarta.validation.Valid;
 import java.security.Principal;
@@ -64,6 +65,17 @@ public class OrderController {
   public ResponseEntity<Page<OrderResponse>> listReservationRequests(
       @PageableDefault(size = 20) Pageable pageable) {
     return ResponseEntity.ok(orderService.listPendingReservationRequests(pageable));
+  }
+
+  /**
+   * 未確定の予約申請を編集する。指名・受付担当を可空で扱う専用の契約で、汎用更新（{@link #update}）の必須項目に縛られずに
+   * 人数・備考を直したり指名を外したりできる。受け取った内容がそのまま新しい申請内容になる。
+   */
+  @PutMapping("/reservation-requests/{id}")
+  @PreAuthorize("hasAuthority('PERM_ORDER_MANAGE')")
+  public ResponseEntity<OrderResponse> updateReservationRequest(
+      @PathVariable String id, @Valid @RequestBody ReservationRequestUpdateRequest request) {
+    return ResponseEntity.ok(orderService.updateReservationRequest(id, request));
   }
 
   /** 予約申請を確定する（受注として受け付ける）。 */

--- a/backend/src/main/java/com/kizuna/order/application/OrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderService.java
@@ -183,18 +183,19 @@ public class OrderService {
       throw new ServiceException("確定・謝絶済みの予約は編集できません");
     }
 
+    // 検証は書き換えより先にすべて済ませる。撥ねる要求が集約を触った後だと、拒否の健全さが
+    // トランザクションの巻き戻しだけに掛かる（同一トランザクション内の後続の読みには変わった値が見えてしまう）。
     if (request.getReceptionistId() != null) {
       validateReceptionist(request.getReceptionistId());
     }
-    order.assignReceptionist(request.getReceptionistId());
-
-    order.assignCast(request.getCastId());
-    if (order.getCastId() != null) {
-      nominatableCast(order)
-          .orElseThrow(() -> new NotFoundException("キャストが見つかりません: " + order.getCastId()));
+    if (request.getCastId() != null) {
+      // 対象は店舗スタッフなので、確定時の再検証と同じく列挙を防ぐ 404 ではなく理由と対処の分かる 400 で返す
+      nominatableCast(order.getStoreId(), request.getCastId())
+          .orElseThrow(() -> new ServiceException("指名できるキャストではありません。在籍中のキャストを選ぶか、指名を外してください"));
     }
 
-    order.reviseRequest(request.getPax(), request.getRemarks());
+    order.revise(
+        request.getReceptionistId(), request.getCastId(), request.getPax(), request.getRemarks());
 
     Order saved = orderRepository.save(order);
     return toResponse(saved.getId());
@@ -231,7 +232,7 @@ public class OrderService {
     if (order.getCastId() == null) {
       return;
     }
-    nominatableCast(order)
+    nominatableCast(order.getStoreId(), order.getCastId())
         .orElseThrow(() -> new ServiceException("指名キャストが在籍中でないため確定できません。内容を修正するか謝絶してください"));
     if (!confirmedShiftLookupService.hasConfirmedShift(
         order.getStoreId(), order.getCastId(), order.getBusinessDate())) {
@@ -240,15 +241,15 @@ public class OrderService {
   }
 
   /**
-   * 指名先として成立するキャスト（受注と同じ店舗に在籍する在籍中のキャスト）を引く。
+   * 指名先として成立するキャスト（対象店舗に在籍する在籍中のキャスト）を引く。
    *
    * <p>店舗の一致を述語に置くのは、キャストの読み取りに掛かる絞り込みへ暗黙に頼らないため。編集時の指名先と確定時の再検証が 同じ条件を共有する。当日の確定シフトの有無は確定時だけが見る —
    * 先の日付の申請は編集時点でシフトが確定していないのが通常で、 編集で要求すると指名を差し替える手段が事実上無くなる。
    */
-  private Optional<Cast> nominatableCast(Order order) {
+  private Optional<Cast> nominatableCast(Long storeId, String castId) {
     return castRepository
-        .findById(order.getCastId())
-        .filter(cast -> order.getStoreId().equals(cast.getStoreId()))
+        .findById(castId)
+        .filter(cast -> storeId.equals(cast.getStoreId()))
         .filter(cast -> ACTIVE_CAST_STATUS.equals(cast.getStatus()));
   }
 

--- a/backend/src/main/java/com/kizuna/order/application/OrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderService.java
@@ -1,5 +1,6 @@
 package com.kizuna.order.application;
 
+import com.kizuna.cast.domain.Cast;
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.customer.domain.Customer;
 import com.kizuna.customer.domain.CustomerMemberLink;
@@ -11,6 +12,7 @@ import com.kizuna.order.api.dto.OrderMapper;
 import com.kizuna.order.api.dto.OrderReceptionistResponse;
 import com.kizuna.order.api.dto.OrderResponse;
 import com.kizuna.order.api.dto.OrderUpdateRequest;
+import com.kizuna.order.api.dto.ReservationRequestUpdateRequest;
 import com.kizuna.order.domain.Order;
 import com.kizuna.order.domain.OrderRepository;
 import com.kizuna.order.domain.OrderStatus;
@@ -166,6 +168,38 @@ public class OrderService {
     return toResponse(id);
   }
 
+  /**
+   * 未確定の予約申請を店舗が編集する。汎用更新（{@link #update}）と別の収口なのは、指名と受付担当を可空として扱うため —
+   * 会員は指名なしで申請できるので、必須の契約しか無いと人数や備考を直すだけで指名付きの受注に変えざるを得ず、 無効になった指名を確定前に外すこともできない。
+   *
+   * <p>受け取った内容がそのまま新しい申請内容になる（省略＝未設定にする）。確定・謝絶と同じく対象は未確定の申請だけで、 確定後は通常の受注として汎用更新が引き続き受け持つ。
+   */
+  @StoreScoped
+  @Transactional
+  public OrderResponse updateReservationRequest(
+      String id, ReservationRequestUpdateRequest request) {
+    Order order = findReservationRequest(id);
+    if (order.getStatus() != OrderStatus.CREATED) {
+      throw new ServiceException("確定・謝絶済みの予約は編集できません");
+    }
+
+    if (request.getReceptionistId() != null) {
+      validateReceptionist(request.getReceptionistId());
+    }
+    order.assignReceptionist(request.getReceptionistId());
+
+    order.assignCast(request.getCastId());
+    if (order.getCastId() != null) {
+      nominatableCast(order)
+          .orElseThrow(() -> new NotFoundException("キャストが見つかりません: " + order.getCastId()));
+    }
+
+    order.reviseRequest(request.getPax(), request.getRemarks());
+
+    Order saved = orderRepository.save(order);
+    return toResponse(saved.getId());
+  }
+
   /** 予約申請を謝絶する。確定前の申請のみが対象で、確定後の取り消しは通常のキャンセル経路に委ねる。 */
   @StoreScoped
   @Transactional
@@ -197,15 +231,25 @@ public class OrderService {
     if (order.getCastId() == null) {
       return;
     }
-    castRepository
-        .findById(order.getCastId())
-        .filter(cast -> order.getStoreId().equals(cast.getStoreId()))
-        .filter(cast -> ACTIVE_CAST_STATUS.equals(cast.getStatus()))
+    nominatableCast(order)
         .orElseThrow(() -> new ServiceException("指名キャストが在籍中でないため確定できません。内容を修正するか謝絶してください"));
     if (!confirmedShiftLookupService.hasConfirmedShift(
         order.getStoreId(), order.getCastId(), order.getBusinessDate())) {
       throw new ServiceException("指名キャストにこの日の確定シフトが無いため確定できません。内容を修正するか謝絶してください");
     }
+  }
+
+  /**
+   * 指名先として成立するキャスト（受注と同じ店舗に在籍する在籍中のキャスト）を引く。
+   *
+   * <p>店舗の一致を述語に置くのは、キャストの読み取りに掛かる絞り込みへ暗黙に頼らないため。編集時の指名先と確定時の再検証が 同じ条件を共有する。当日の確定シフトの有無は確定時だけが見る —
+   * 先の日付の申請は編集時点でシフトが確定していないのが通常で、 編集で要求すると指名を差し替える手段が事実上無くなる。
+   */
+  private Optional<Cast> nominatableCast(Order order) {
+    return castRepository
+        .findById(order.getCastId())
+        .filter(cast -> order.getStoreId().equals(cast.getStoreId()))
+        .filter(cast -> ACTIVE_CAST_STATUS.equals(cast.getStatus()));
   }
 
   private Optional<Long> eligibleReceptionistId(String actorEmail) {

--- a/backend/src/main/java/com/kizuna/order/domain/Order.java
+++ b/backend/src/main/java/com/kizuna/order/domain/Order.java
@@ -147,6 +147,17 @@ public class Order extends StoreScopedEntity {
     return receptionRoute == ReceptionRoute.WEB && requesterMemberCode != null;
   }
 
+  /**
+   * 申請の内容を店舗が書き換える。渡された値がそのまま新しい内容になり、null は「未設定にする」を意味する。
+   *
+   * <p>「null は変更しない」の {@link #apply(OrderPatch)} と意味が逆なのは、備考を空に戻せる必要があるため —
+   * 部分更新では消せる項目と消せない項目が生まれ、申請を確定できる形に直しきれない。
+   */
+  public void reviseRequest(Integer pax, String remarks) {
+    this.pax = pax;
+    this.remarks = remarks;
+  }
+
   /** 部分更新コマンドを適用する。null のフィールドは変更しない。 */
   public void apply(OrderPatch patch) {
     if (patch.arrivalScheduledStartTime() != null) {

--- a/backend/src/main/java/com/kizuna/order/domain/Order.java
+++ b/backend/src/main/java/com/kizuna/order/domain/Order.java
@@ -148,12 +148,16 @@ public class Order extends StoreScopedEntity {
   }
 
   /**
-   * 申請の内容を店舗が書き換える。渡された値がそのまま新しい内容になり、null は「未設定にする」を意味する。
+   * 未確定の申請の内容を店舗が書き換える。渡された値がそのまま新しい内容になり、null は「未設定にする」を意味する。
    *
-   * <p>「null は変更しない」の {@link #apply(OrderPatch)} と意味が逆なのは、備考を空に戻せる必要があるため —
+   * <p>「null は変更しない」の {@link #apply(OrderPatch)} と意味が逆なのは、指名・受付担当・備考を空に戻せる必要があるため —
    * 部分更新では消せる項目と消せない項目が生まれ、申請を確定できる形に直しきれない。
+   *
+   * <p>編集できる項目を一度に置き換えるのは、書き換えの途中で撥ねられた集約が中途半端な状態で残らないようにするため（存在確認は application 層が呼び出しより前に済ませる）。
    */
-  public void reviseRequest(Integer pax, String remarks) {
+  public void revise(Long receptionistId, String castId, Integer pax, String remarks) {
+    this.receptionistId = receptionistId;
+    this.castId = castId;
     this.pax = pax;
     this.remarks = remarks;
   }

--- a/backend/src/test/java/com/kizuna/order/api/store/OrderControllerTest.java
+++ b/backend/src/test/java/com/kizuna/order/api/store/OrderControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.kizuna.order.api.dto.OrderResponse;
@@ -25,6 +26,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -125,12 +127,64 @@ class OrderControllerTest {
     mockMvc.perform(storePost("/store/orders/o1/decline")).andExpect(status().isForbidden());
   }
 
+  @Test
+  @DisplayName("予約申請の編集はキャスト・受付担当を省いても受け付けられること")
+  @WithMockUser(authorities = "PERM_ORDER_MANAGE")
+  void reservationRequestUpdateAcceptsAnOmittedCastAndReceptionist() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+    when(orderService.updateReservationRequest(any(), any()))
+        .thenReturn(OrderResponse.builder().build());
+
+    mockMvc
+        .perform(storePut("/store/orders/reservation-requests/o1", "{\"pax\": 3}"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("受注管理権限が無ければ予約申請を編集できないこと")
+  @WithMockUser(authorities = "PERM_CUSTOMER_MANAGE")
+  void reservationRequestUpdateIsRejectedWithoutOrderManage() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+
+    mockMvc
+        .perform(storePut("/store/orders/reservation-requests/o1", "{\"pax\": 3}"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("店舗起点の受注を更新する汎用契約ではキャスト・受付担当が必須のままであること")
+  @WithMockUser(authorities = "PERM_ORDER_MANAGE")
+  void orderUpdateStillRequiresCastAndReceptionist() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+
+    // 申請専用の可空な契約を足しても、既存の受注更新は必須項目を緩めない
+    mockMvc
+        .perform(storePut("/store/orders/o1", "{\"pax\": 3}"))
+        .andExpect(status().isBadRequest());
+    mockMvc
+        .perform(storePut("/store/orders/o1", "{\"cast_id\": \"cast-1\", \"pax\": 3}"))
+        .andExpect(status().isBadRequest());
+    mockMvc
+        .perform(storePut("/store/orders/o1", "{\"receptionist_id\": 2, \"pax\": 3}"))
+        .andExpect(status().isBadRequest());
+  }
+
   // 本番では認証済み主体をサーブレットコンテナが載せるが、@WebMvcTest の最小チェーンでは載らないため明示する。
   private MockHttpServletRequestBuilder storePost(String path) {
     return post(path)
         .header("X-Role", "store")
         .header("X-Store-ID", "1")
         .principal(() -> "staff@kizuna.test")
+        .with(csrf());
+  }
+
+  private MockHttpServletRequestBuilder storePut(String path, String body) {
+    return put(path)
+        .header("X-Role", "store")
+        .header("X-Store-ID", "1")
+        .principal(() -> "staff@kizuna.test")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(body)
         .with(csrf());
   }
 }

--- a/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
@@ -24,6 +24,7 @@ import com.kizuna.order.api.dto.OrderMapper;
 import com.kizuna.order.api.dto.OrderReceptionistResponse;
 import com.kizuna.order.api.dto.OrderResponse;
 import com.kizuna.order.api.dto.OrderUpdateRequest;
+import com.kizuna.order.api.dto.ReservationRequestUpdateRequest;
 import com.kizuna.order.domain.IllegalOrderStateTransitionException;
 import com.kizuna.order.domain.Order;
 import com.kizuna.order.domain.OrderPatch;
@@ -774,6 +775,157 @@ class OrderServiceTest {
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("予約申請が見つかりません");
     assertThat(storeOrder.getStatus()).isEqualTo(OrderStatus.CREATED);
+    verify(orderRepository, never()).save(any(Order.class));
+  }
+
+  /** 編集後の応答組み立て（読み口 → DTO）だけを満たす stub。編集そのものの検証は集約の状態で行う。 */
+  private void stubReservationRequestUpdateResponse() {
+    when(orderRepository.save(any(Order.class))).thenAnswer(i -> i.getArgument(0));
+    when(orderRepository.findViewById(nullable(String.class)))
+        .thenReturn(Optional.of(mock(OrderView.class)));
+    when(orderMapper.toResponse(any(OrderView.class))).thenReturn(OrderResponse.builder().build());
+  }
+
+  private ReservationRequestUpdateRequest reservationRequestUpdate(
+      Long receptionistId, String castId, Integer pax, String remarks) {
+    ReservationRequestUpdateRequest req = new ReservationRequestUpdateRequest();
+    req.setReceptionistId(receptionistId);
+    req.setCastId(castId);
+    req.setPax(pax);
+    req.setRemarks(remarks);
+    return req;
+  }
+
+  @Test
+  void updateReservationRequestEditsNominationFreeRequestWithoutSettingCast() {
+    // 指名なしの申請は、キャストを埋めずに人数・備考・受付担当を直せなければならない
+    Order request = reservationRequest().pax(2).build();
+    request.setStoreId(STORE_ID);
+    when(storeContext.getStoreId()).thenReturn(STORE_ID);
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(request));
+    when(platformUserRepository.findById(2L)).thenReturn(Optional.of(authorizedReceptionist()));
+    stubReservationRequestUpdateResponse();
+
+    service.updateReservationRequest("o1", reservationRequestUpdate(2L, null, 4, "人数変更"));
+
+    assertThat(request.getPax()).isEqualTo(4);
+    assertThat(request.getRemarks()).isEqualTo("人数変更");
+    assertThat(request.getReceptionistId()).isEqualTo(2L);
+    assertThat(request.getCastId()).as("指名なしのままであること").isNull();
+    verify(castRepository, never()).findById(anyString());
+  }
+
+  @Test
+  void updateReservationRequestKeepsNominationWhenTheCastIsSentBack() {
+    Order request = nominatedRequest();
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(request));
+    when(castRepository.findById("cast-1")).thenReturn(Optional.of(castWithStatus("ACTIVE")));
+    stubReservationRequestUpdateResponse();
+
+    service.updateReservationRequest("o1", reservationRequestUpdate(null, "cast-1", 3, null));
+
+    assertThat(request.getCastId()).isEqualTo("cast-1");
+    assertThat(request.getPax()).isEqualTo(3);
+    // 当日の確定シフトは確定時だけが見る。先の日付の申請は編集時点で未確定なのが通常のため
+    verify(confirmedShiftLookupService, never()).hasConfirmedShift(any(), any(), any());
+  }
+
+  @Test
+  void updateReservationRequestClearsNominationWhenTheCastIsOmitted() {
+    // 無効になった指名を確定前に外す導線。省略が「変更しない」だと外す手段が無くなる
+    Order request = nominatedRequest();
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(request));
+    stubReservationRequestUpdateResponse();
+
+    service.updateReservationRequest("o1", reservationRequestUpdate(null, null, 2, null));
+
+    assertThat(request.getCastId()).isNull();
+    assertThat(request.getReceptionistId()).as("受付担当も同じく外せること").isNull();
+    assertThat(request.getRequesterMemberCode())
+        .as("申請者のスナップショットは指名解除で壊れないこと")
+        .isEqualTo("123456789012");
+    assertThat(request.getReceptionRoute()).isEqualTo(ReceptionRoute.WEB);
+    verify(castRepository, never()).findById(anyString());
+  }
+
+  @Test
+  void updateReservationRequestRejectsCastOfAnotherStore() {
+    Order request = nominatedRequest();
+    Cast otherStoreCast = Cast.builder().name("他店のキャスト").status("ACTIVE").build();
+    otherStoreCast.setId("cast-1");
+    otherStoreCast.setStoreId(2L);
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(request));
+    when(castRepository.findById("cast-1")).thenReturn(Optional.of(otherStoreCast));
+
+    assertThatThrownBy(
+            () ->
+                service.updateReservationRequest(
+                    "o1", reservationRequestUpdate(null, "cast-1", 2, null)))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("キャストが見つかりません");
+    verify(orderRepository, never()).save(any(Order.class));
+  }
+
+  @Test
+  void updateReservationRequestRejectsSuspendedCast() {
+    Order request = nominatedRequest();
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(request));
+    when(castRepository.findById("cast-1")).thenReturn(Optional.of(castWithStatus("INACTIVE")));
+
+    assertThatThrownBy(
+            () ->
+                service.updateReservationRequest(
+                    "o1", reservationRequestUpdate(null, "cast-1", 2, null)))
+        .isInstanceOf(NotFoundException.class);
+    verify(orderRepository, never()).save(any(Order.class));
+  }
+
+  @Test
+  void updateReservationRequestRejectsAlreadyProcessedRequests() {
+    // 確定後は通常の受注として汎用更新が受け持つ。ここを通せば確定済みの受注から指名を外せてしまう
+    Order confirmed = reservationRequest().status(OrderStatus.CONFIRMED).castId("cast-1").build();
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(confirmed));
+
+    assertThatThrownBy(
+            () ->
+                service.updateReservationRequest(
+                    "o1", reservationRequestUpdate(null, null, 2, null)))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("編集できません");
+    assertThat(confirmed.getCastId()).isEqualTo("cast-1");
+    verify(orderRepository, never()).save(any(Order.class));
+  }
+
+  @Test
+  void updateReservationRequestRejectsStoreOriginatedOrders() {
+    // 申請専用の収口。店舗が起こした受注は ID を知っていても可空の契約では変更させない
+    Order storeOrder = Order.builder().status(OrderStatus.CREATED).castId("cast-1").build();
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(storeOrder));
+
+    assertThatThrownBy(
+            () ->
+                service.updateReservationRequest(
+                    "o1", reservationRequestUpdate(null, null, 2, null)))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("予約申請が見つかりません");
+    assertThat(storeOrder.getCastId()).isEqualTo("cast-1");
+    verify(orderRepository, never()).save(any(Order.class));
+  }
+
+  @Test
+  void updateReservationRequestRejectsReceptionistOfAnotherStore() {
+    Order request = reservationRequest().build();
+    when(storeContext.getStoreId()).thenReturn(STORE_ID);
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(request));
+    when(platformUserRepository.findById(2L))
+        .thenReturn(
+            Optional.of(receptionist(UserType.STAFF, StoreScopeType.SPECIFIC_STORES, Set.of(2L))));
+
+    assertThatThrownBy(
+            () ->
+                service.updateReservationRequest("o1", reservationRequestUpdate(2L, null, 2, null)))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("受付担当者が見つかりません");
     verify(orderRepository, never()).save(any(Order.class));
   }
 

--- a/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
@@ -852,31 +852,36 @@ class OrderServiceTest {
   void updateReservationRequestRejectsCastOfAnotherStore() {
     Order request = nominatedRequest();
     Cast otherStoreCast = Cast.builder().name("他店のキャスト").status("ACTIVE").build();
-    otherStoreCast.setId("cast-1");
+    otherStoreCast.setId("cast-2");
     otherStoreCast.setStoreId(2L);
     when(orderRepository.findById("o1")).thenReturn(Optional.of(request));
-    when(castRepository.findById("cast-1")).thenReturn(Optional.of(otherStoreCast));
+    when(castRepository.findById("cast-2")).thenReturn(Optional.of(otherStoreCast));
 
     assertThatThrownBy(
             () ->
                 service.updateReservationRequest(
-                    "o1", reservationRequestUpdate(null, "cast-1", 2, null)))
-        .isInstanceOf(NotFoundException.class)
-        .hasMessageContaining("キャストが見つかりません");
+                    "o1", reservationRequestUpdate(null, "cast-2", 2, null)))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("指名を外してください");
+    // 撥ねる要求は集約を触らない — 拒否の健全さをトランザクションの巻き戻しだけに委ねない
+    assertThat(request.getCastId()).as("元の指名が残ること").isEqualTo("cast-1");
     verify(orderRepository, never()).save(any(Order.class));
   }
 
   @Test
   void updateReservationRequestRejectsSuspendedCast() {
+    // 対象は店舗スタッフなので、確定時の再検証と同じく列挙を防ぐ 404 ではなく対処の分かる 400 で返す
     Order request = nominatedRequest();
     when(orderRepository.findById("o1")).thenReturn(Optional.of(request));
-    when(castRepository.findById("cast-1")).thenReturn(Optional.of(castWithStatus("INACTIVE")));
+    when(castRepository.findById("cast-2")).thenReturn(Optional.of(castWithStatus("INACTIVE")));
 
     assertThatThrownBy(
             () ->
                 service.updateReservationRequest(
-                    "o1", reservationRequestUpdate(null, "cast-1", 2, null)))
-        .isInstanceOf(NotFoundException.class);
+                    "o1", reservationRequestUpdate(null, "cast-2", 2, null)))
+        .isInstanceOf(ServiceException.class)
+        .isNotInstanceOf(NotFoundException.class);
+    assertThat(request.getCastId()).as("元の指名が残ること").isEqualTo("cast-1");
     verify(orderRepository, never()).save(any(Order.class));
   }
 

--- a/backend/src/test/java/com/kizuna/order/domain/OrderTest.java
+++ b/backend/src/test/java/com/kizuna/order/domain/OrderTest.java
@@ -131,6 +131,19 @@ class OrderTest {
   }
 
   @Test
+  @DisplayName("申請の書き換えは渡した値で置き換え、null は未設定にすること")
+  void reviseRequest_replacesInsteadOfPatching() {
+    Order order = Order.builder().status(OrderStatus.CREATED).pax(2).remarks("元の備考").build();
+
+    order.reviseRequest(5, "書き換えた備考");
+    assertThat(order.getPax()).isEqualTo(5);
+    assertThat(order.getRemarks()).isEqualTo("書き換えた備考");
+
+    order.reviseRequest(5, null);
+    assertThat(order.getRemarks()).as("備考を空に戻せること（部分更新では消せない）").isNull();
+  }
+
+  @Test
   @DisplayName("同じステータスへの遷移は何もしない（冪等）こと")
   void transitionTo_sameStatus_isNoOp() {
     Order order = orderWithStatus(OrderStatus.CONFIRMED);

--- a/backend/src/test/java/com/kizuna/order/domain/OrderTest.java
+++ b/backend/src/test/java/com/kizuna/order/domain/OrderTest.java
@@ -132,15 +132,27 @@ class OrderTest {
 
   @Test
   @DisplayName("申請の書き換えは渡した値で置き換え、null は未設定にすること")
-  void reviseRequest_replacesInsteadOfPatching() {
-    Order order = Order.builder().status(OrderStatus.CREATED).pax(2).remarks("元の備考").build();
+  void revise_replacesInsteadOfPatching() {
+    Order order =
+        Order.builder()
+            .status(OrderStatus.CREATED)
+            .receptionistId(3L)
+            .castId("cast-1")
+            .pax(2)
+            .remarks("元の備考")
+            .build();
 
-    order.reviseRequest(5, "書き換えた備考");
+    order.revise(4L, "cast-2", 5, "書き換えた備考");
+    assertThat(order.getReceptionistId()).isEqualTo(4L);
+    assertThat(order.getCastId()).isEqualTo("cast-2");
     assertThat(order.getPax()).isEqualTo(5);
     assertThat(order.getRemarks()).isEqualTo("書き換えた備考");
 
-    order.reviseRequest(5, null);
-    assertThat(order.getRemarks()).as("備考を空に戻せること（部分更新では消せない）").isNull();
+    // 部分更新（apply）では消せない項目を、この経路では空に戻せる
+    order.revise(null, null, 5, null);
+    assertThat(order.getReceptionistId()).isNull();
+    assertThat(order.getCastId()).isNull();
+    assertThat(order.getRemarks()).isNull();
   }
 
   @Test

--- a/frontend/src/_pages/store-orders/__tests__/ReservationRequestEditModal.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/ReservationRequestEditModal.test.tsx
@@ -94,9 +94,38 @@ describe('ReservationRequestEditModal', () => {
     expect(screen.queryByRole('checkbox', { name: '指名を外す' })).not.toBeInTheDocument();
   });
 
+  it('人数が空欄なら送信せず、無反応にもせず理由を出す', async () => {
+    // 検証の結果を出さないと、押した保存が効いているのか分からないまま止まる
+    renderModal(nominationFreeRequest);
+
+    fireEvent.change(await screen.findByLabelText('人数'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    expect(await screen.findByText('人数を入力してください')).toBeInTheDocument();
+    expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+
+  it('備考がサーバ側の上限を超えたら送信せず理由を出す', async () => {
+    renderModal(nominationFreeRequest);
+
+    fireEvent.change(await screen.findByLabelText('備考'), {
+      target: { value: 'あ'.repeat(501) },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    expect(await screen.findByText('備考は 500 文字以内で入力してください')).toBeInTheDocument();
+    expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+
   it('保存に失敗したら、対処方法を含むサーバの文言をそのまま出す', async () => {
+    // 指名の検証は「在籍中を選ぶか外すか」を伝える 400 を返す。汎用文言に潰すと行動できない
     mockedUpdate.mockRejectedValue({
-      response: { status: 404, data: { error: 'キャストが見つかりません: cast-1' } },
+      response: {
+        status: 400,
+        data: {
+          error: '指名できるキャストではありません。在籍中のキャストを選ぶか、指名を外してください',
+        },
+      },
     });
     const onSaved = jest.fn();
     renderModal(nominatedRequest, onSaved);
@@ -104,7 +133,9 @@ describe('ReservationRequestEditModal', () => {
     fireEvent.click(await screen.findByRole('button', { name: '保存する' }));
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith('キャストが見つかりません: cast-1')
+      expect(toast.error).toHaveBeenCalledWith(
+        '指名できるキャストではありません。在籍中のキャストを選ぶか、指名を外してください'
+      )
     );
     expect(onSaved).not.toHaveBeenCalled();
   });

--- a/frontend/src/_pages/store-orders/__tests__/ReservationRequestEditModal.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/ReservationRequestEditModal.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
+import { ReservationRequestEditModal } from '../ui/ReservationRequestEditModal';
+import { Order, orderApi } from '@/entities/order';
+
+jest.mock('@/entities/order', () => ({
+  orderApi: { listReceptionists: jest.fn(), updateReservationRequest: jest.fn() },
+}));
+
+jest.mock('react-hot-toast', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockedUpdate = orderApi.updateReservationRequest as jest.Mock;
+const mockedReceptionists = orderApi.listReceptionists as jest.Mock;
+
+const nominationFreeRequest: Order = {
+  id: 'o1',
+  status: 'CREATED',
+  reception_route: 'WEB',
+  business_date: '2026-08-10',
+  pax: 3,
+  remarks: '元の備考',
+};
+
+const nominatedRequest: Order = {
+  ...nominationFreeRequest,
+  cast_id: 'cast-1',
+  cast_name: 'あや',
+};
+
+const renderModal = (request: Order, onSaved = jest.fn(), onClose = jest.fn()) =>
+  render(<ReservationRequestEditModal request={request} onClose={onClose} onSaved={onSaved} />);
+
+describe('ReservationRequestEditModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedReceptionists.mockResolvedValue([]);
+    mockedUpdate.mockResolvedValue({});
+  });
+
+  it('指名なしの申請を、キャストを埋めずに保存できる', async () => {
+    renderModal(nominationFreeRequest);
+
+    fireEvent.change(await screen.findByLabelText('人数'), { target: { value: '5' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() =>
+      expect(mockedUpdate).toHaveBeenCalledWith('o1', {
+        receptionist_id: undefined,
+        cast_id: undefined,
+        pax: 5,
+        remarks: '元の備考',
+      })
+    );
+  });
+
+  it('指名を外さなければ、そのまま送り返して指名を維持する', async () => {
+    // 契約は部分更新ではないため、送らなかった指名は消える。維持は「送り返す」ことで成立する
+    renderModal(nominatedRequest);
+
+    fireEvent.click(await screen.findByRole('button', { name: '保存する' }));
+
+    await waitFor(() =>
+      expect(mockedUpdate).toHaveBeenCalledWith(
+        'o1',
+        expect.objectContaining({ cast_id: 'cast-1' })
+      )
+    );
+  });
+
+  it('指名を外すと、キャストを送らずに保存して一覧の取り直しを促す', async () => {
+    const onSaved = jest.fn();
+    const onClose = jest.fn();
+    renderModal(nominatedRequest, onSaved, onClose);
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: '指名を外す' }));
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() =>
+      expect(mockedUpdate).toHaveBeenCalledWith(
+        'o1',
+        expect.objectContaining({ cast_id: undefined })
+      )
+    );
+    expect(onSaved).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('指名が無い申請には指名解除の操作を出さない', async () => {
+    renderModal(nominationFreeRequest);
+
+    expect(await screen.findByText('なし')).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { name: '指名を外す' })).not.toBeInTheDocument();
+  });
+
+  it('保存に失敗したら、対処方法を含むサーバの文言をそのまま出す', async () => {
+    mockedUpdate.mockRejectedValue({
+      response: { status: 404, data: { error: 'キャストが見つかりません: cast-1' } },
+    });
+    const onSaved = jest.fn();
+    renderModal(nominatedRequest, onSaved);
+
+    fireEvent.click(await screen.findByRole('button', { name: '保存する' }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('キャストが見つかりません: cast-1')
+    );
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/_pages/store-orders/__tests__/ReservationRequestInbox.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/ReservationRequestInbox.test.tsx
@@ -4,7 +4,13 @@ import { ReservationRequestInbox } from '../ui/ReservationRequestInbox';
 import { orderApi } from '@/entities/order';
 
 jest.mock('@/entities/order', () => ({
-  orderApi: { listReservationRequests: jest.fn(), confirm: jest.fn(), decline: jest.fn() },
+  orderApi: {
+    listReservationRequests: jest.fn(),
+    confirm: jest.fn(),
+    decline: jest.fn(),
+    listReceptionists: jest.fn(),
+    updateReservationRequest: jest.fn(),
+  },
 }));
 
 jest.mock('react-hot-toast', () => ({
@@ -89,6 +95,25 @@ describe('ReservationRequestInbox', () => {
     expect(screen.getByRole('button', { name: '謝絶' })).toBeDisabled();
     // 行そのものは消さない
     expect(screen.getByText('2026-08-10')).toBeInTheDocument();
+  });
+
+  it('編集を押すとその申請の編集モーダルが開き、保存後に一覧を取り直す', async () => {
+    mockedList.mockResolvedValue(page([{ ...request('o1'), pax: 3 }]));
+    (orderApi.listReceptionists as jest.Mock).mockResolvedValue([]);
+    (orderApi.updateReservationRequest as jest.Mock).mockResolvedValue({});
+    const onProcessed = jest.fn();
+
+    render(<ReservationRequestInbox onProcessed={onProcessed} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: '編集' }));
+    fireEvent.click(await screen.findByRole('button', { name: '保存する' }));
+
+    await waitFor(() =>
+      expect(orderApi.updateReservationRequest).toHaveBeenCalledWith('o1', expect.anything())
+    );
+    // 編集した行は古いままなので、確定・謝絶と同じく読み直す
+    await waitFor(() => expect(mockedList).toHaveBeenCalledTimes(2));
+    expect(onProcessed).toHaveBeenCalled();
   });
 
   it('謝絶すると謝絶 API を呼ぶ', async () => {

--- a/frontend/src/_pages/store-orders/ui/ReservationRequestEditModal.tsx
+++ b/frontend/src/_pages/store-orders/ui/ReservationRequestEditModal.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
+import { Order, OrderReceptionist, orderApi } from '@/entities/order';
+import { getApiErrorMessage } from '@/shared/lib';
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from '@/shared/ui';
+
+// Radix Select は value="" を許容しないため、受付担当なしを表す番兵値。
+const SELECT_NONE = '__none__';
+
+interface ReservationRequestEditFormValues {
+  /** '' は受付担当なし。 */
+  receptionist_id: string;
+  pax: number;
+  remarks: string;
+  /** 指名を外して保存するか。申請が指名を持つときだけ意味を持つ。 */
+  clear_cast: boolean;
+}
+
+interface ReservationRequestEditModalProps {
+  /** 編集対象の申請。null なら閉じている。 */
+  request: Order | null;
+  onClose: () => void;
+  /** 保存の成功後に呼ばれる（一覧の取り直し用）。 */
+  onSaved: () => void;
+}
+
+/**
+ * 未確定の予約申請の編集モーダル。
+ *
+ * 会員は指名なしでも申請できるため、キャストを埋めずに人数・備考・受付担当を直せることと、
+ * 無効になった指名を確定前に外せることがこの画面の目的。編集の収口は受注の汎用更新とは別で、
+ * 送った内容がそのまま新しい申請内容になる（画面が持たない項目は契約にも無いので書き換わらない）。
+ */
+export function ReservationRequestEditModal({
+  request,
+  onClose,
+  onSaved,
+}: ReservationRequestEditModalProps) {
+  const form = useForm<ReservationRequestEditFormValues>({
+    defaultValues: { receptionist_id: '', pax: 1, remarks: '', clear_cast: false },
+  });
+  const {
+    register,
+    handleSubmit,
+    reset,
+    control,
+    watch,
+    formState: { isSubmitting },
+  } = form;
+  const [receptionistOptions, setReceptionistOptions] = useState<OrderReceptionist[]>([]);
+
+  useEffect(() => {
+    if (!request) return;
+    reset({
+      receptionist_id: request.receptionist_id != null ? String(request.receptionist_id) : '',
+      pax: request.pax ?? 1,
+      remarks: request.remarks ?? '',
+      clear_cast: false,
+    });
+  }, [request, reset]);
+
+  useEffect(() => {
+    if (!request) return;
+    orderApi
+      .listReceptionists()
+      .then(setReceptionistOptions)
+      .catch(() => toast.error('受付担当者の取得に失敗しました'));
+  }, [request]);
+
+  const submit = async (values: ReservationRequestEditFormValues) => {
+    if (!request?.id) return;
+    try {
+      await orderApi.updateReservationRequest(request.id, {
+        receptionist_id: values.receptionist_id ? Number(values.receptionist_id) : undefined,
+        // 指名は「そのまま送り返す」ことで維持される。外すときは送らない
+        cast_id: values.clear_cast ? undefined : (request.cast_id ?? undefined),
+        pax: Number(values.pax),
+        remarks: values.remarks ? values.remarks : undefined,
+      });
+      toast.success('予約申請を更新しました');
+      onSaved();
+      onClose();
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, '予約申請の更新に失敗しました'));
+    }
+  };
+
+  const clearCast = watch('clear_cast');
+
+  return (
+    <Dialog
+      open={request !== null}
+      onOpenChange={next => {
+        // 保存中に閉じると、結果が分からないまま古い一覧が残る
+        if (!next && !isSubmitting) onClose();
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        aria-describedby={undefined}
+        className="gap-0 rounded-[10px] p-0 sm:max-w-md"
+      >
+        <DialogTitle className="border-b px-6 py-4">予約申請を編集</DialogTitle>
+        <Form {...form}>
+          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
+            <FormField
+              control={control}
+              name="receptionist_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>受付担当</FormLabel>
+                  <Select
+                    value={field.value ? field.value : SELECT_NONE}
+                    onValueChange={v => field.onChange(v === SELECT_NONE ? '' : v)}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value={SELECT_NONE}>未設定</SelectItem>
+                      {receptionistOptions.map(option => {
+                        const id = option.id;
+                        if (id === undefined) return null;
+                        return (
+                          <SelectItem key={id} value={String(id)}>
+                            {option.display_name}
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
+                </FormItem>
+              )}
+            />
+            <div className="grid gap-2">
+              <Label htmlFor="pax">人数</Label>
+              <Input
+                id="pax"
+                type="number"
+                min={1}
+                {...register('pax', { required: true, min: 1 })}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label>指名</Label>
+              {request?.cast_id ? (
+                <>
+                  <p
+                    className={clearCast ? 'text-sm text-muted-foreground line-through' : 'text-sm'}
+                  >
+                    {request.cast_name ?? request.cast_id}
+                  </p>
+                  <FormField
+                    control={control}
+                    name="clear_cast"
+                    render={({ field }) => (
+                      <FormItem className="flex flex-row items-center gap-2">
+                        <FormControl>
+                          <Checkbox
+                            id="clear_cast"
+                            checked={field.value}
+                            onCheckedChange={value => field.onChange(value === true)}
+                          />
+                        </FormControl>
+                        <FormLabel htmlFor="clear_cast" className="font-medium">
+                          指名を外す
+                        </FormLabel>
+                      </FormItem>
+                    )}
+                  />
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">なし</p>
+              )}
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="remarks">備考</Label>
+              <Textarea id="remarks" rows={3} {...register('remarks')} />
+            </div>
+            <div className="flex justify-end gap-3 border-t pt-4">
+              <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
+                キャンセル
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? '保存中...' : '保存する'}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/_pages/store-orders/ui/ReservationRequestEditModal.tsx
+++ b/frontend/src/_pages/store-orders/ui/ReservationRequestEditModal.tsx
@@ -16,6 +16,7 @@ import {
   FormField,
   FormItem,
   FormLabel,
+  FormMessage,
   Input,
   Label,
   Select,
@@ -67,7 +68,7 @@ export function ReservationRequestEditModal({
     reset,
     control,
     watch,
-    formState: { isSubmitting },
+    formState: { errors, isSubmitting },
   } = form;
   const [receptionistOptions, setReceptionistOptions] = useState<OrderReceptionist[]>([]);
 
@@ -156,15 +157,25 @@ export function ReservationRequestEditModal({
                 </FormItem>
               )}
             />
-            <div className="grid gap-2">
-              <Label htmlFor="pax">人数</Label>
-              <Input
-                id="pax"
-                type="number"
-                min={1}
-                {...register('pax', { required: true, min: 1 })}
-              />
-            </div>
+            {/* 人数はサーバ側が @NotNull @Min(1)。検証の結果を出さないと、空欄のまま押した保存が
+                無反応に見える */}
+            <FormField
+              control={control}
+              name="pax"
+              rules={{
+                required: '人数を入力してください',
+                min: { value: 1, message: '人数は 1 以上です' },
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>人数</FormLabel>
+                  <FormControl>
+                    <Input type="number" min={1} {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
             <div className="grid gap-2">
               <Label>指名</Label>
               {request?.cast_id ? (
@@ -199,7 +210,17 @@ export function ReservationRequestEditModal({
             </div>
             <div className="grid gap-2">
               <Label htmlFor="remarks">備考</Label>
-              <Textarea id="remarks" rows={3} {...register('remarks')} />
+              {/* 上限はサーバ側の @Size(max = 500) に合わせる（会員の申請画面と同じ） */}
+              <Textarea
+                id="remarks"
+                rows={3}
+                {...register('remarks', {
+                  maxLength: { value: 500, message: '備考は 500 文字以内で入力してください' },
+                })}
+              />
+              {errors.remarks && (
+                <p className="text-xs text-destructive-strong">{errors.remarks.message}</p>
+              )}
             </div>
             <div className="flex justify-end gap-3 border-t pt-4">
               <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>

--- a/frontend/src/_pages/store-orders/ui/ReservationRequestInbox.tsx
+++ b/frontend/src/_pages/store-orders/ui/ReservationRequestInbox.tsx
@@ -5,6 +5,7 @@ import { toast } from 'react-hot-toast';
 import { Order, orderApi } from '@/entities/order';
 import { getApiErrorMessage } from '@/shared/lib';
 import { Badge, Button } from '@/shared/ui';
+import { ReservationRequestEditModal } from './ReservationRequestEditModal';
 
 interface ReservationRequestInboxProps {
   /** 確定・謝絶の成功後に呼ばれる（同じ受注の状態が変わるため、一覧の再取得に使う）。 */
@@ -29,6 +30,7 @@ export function ReservationRequestInbox({ onProcessed }: ReservationRequestInbox
   // 表示中の申請を保ったまま失敗した取得の対象ページ数（再試行にそのまま使う）。
   const [failedPages, setFailedPages] = useState<number | null>(null);
   const [processingId, setProcessingId] = useState<string | null>(null);
+  const [editing, setEditing] = useState<Order | null>(null);
   // 読み込み済みのページ数。確定・謝絶後の取り直しでも同じ範囲を保つために持つ。
   const [loadedPages, setLoadedPages] = useState(1);
   const [hasMore, setHasMore] = useState(false);
@@ -155,6 +157,15 @@ export function ReservationRequestInbox({ onProcessed }: ReservationRequestInbox
             <div className="flex gap-2">
               <Button
                 type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setEditing(request)}
+                disabled={loading || processingId === request.id}
+              >
+                編集
+              </Button>
+              <Button
+                type="button"
                 variant="outline"
                 size="sm"
                 onClick={() => process(request.id ?? '', 'decline')}
@@ -201,6 +212,15 @@ export function ReservationRequestInbox({ onProcessed }: ReservationRequestInbox
           もっと見る
         </Button>
       )}
+      <ReservationRequestEditModal
+        request={editing}
+        onClose={() => setEditing(null)}
+        // 編集後の行は古いままなので、確定・謝絶と同じ範囲で読み直す
+        onSaved={() => {
+          load(loadedPages);
+          onProcessed();
+        }}
+      />
     </>
   );
 }

--- a/frontend/src/entities/order/api/order.ts
+++ b/frontend/src/entities/order/api/order.ts
@@ -5,6 +5,7 @@ import {
   Order,
   OrderCreateRequest,
   OrderReceptionist,
+  ReservationRequestUpdateRequest,
 } from '../model/types';
 
 export const orderApi = {
@@ -26,6 +27,14 @@ export const orderApi = {
   listReservationRequests: async (params?: PaginationParams): Promise<PageResult<Order>> => {
     const response = await apiClient.get('/store/orders/reservation-requests', { params });
     return fromSpringPage(response.data);
+  },
+  /** 未確定の予約申請を編集する。送った内容がそのまま新しい申請内容になる（省略＝未設定）。 */
+  updateReservationRequest: async (
+    id: string,
+    data: ReservationRequestUpdateRequest
+  ): Promise<Order> => {
+    const response = await apiClient.put(`/store/orders/reservation-requests/${id}`, data);
+    return response.data;
   },
   /** 予約申請を確定する（受注として受け付ける）。 */
   confirm: async (id: string): Promise<Order> => {

--- a/frontend/src/entities/order/model/types.ts
+++ b/frontend/src/entities/order/model/types.ts
@@ -97,6 +97,17 @@ export interface OrderCreateRequest {
   ng_content?: string;
 }
 
+// 未確定の予約申請に対する店舗側の編集（PUT /store/orders/reservation-requests/{id}）。
+// 送った内容がそのまま新しい申請内容になる部分更新ではない契約で、省略した項目は未設定になる。
+// 指名・受付担当を外せることがこの契約の目的なので、両者は可空。
+export interface ReservationRequestUpdateRequest {
+  receptionist_id?: number;
+  cast_id?: string;
+  // Java 側が @NotNull @Min(1)
+  pax: number;
+  remarks?: string;
+}
+
 // 会員本人の予約1件（GET /platform/me/orders）。店舗の顧客台帳の項目は含まない。
 export interface MemberOrder {
   id?: string;


### PR DESCRIPTION
## 概要

未確定の予約申請を店舗が編集できる専用の収口を追加する。会員は指名なしで申請できるのに、店舗側の唯一の更新契約 `PUT /store/orders/{id}` はキャスト・受付担当が必須のため、人数や備考を直すだけで指名付きの受注へ変換せざるを得ず、無効になった指名を確定前に外す手段も無かった。

Closes #561

## 変更内容

- **`PUT /store/orders/reservation-requests/{id}` を追加**（`ReservationRequestUpdateRequest`）。指名・受付担当を可空で受け取り、**送った内容がそのまま新しい申請内容になる**（省略＝未設定にする）。部分更新にしないのは、「省略＝変更しない」では指名を外す手段がそもそも表現できないため。項目は編集画面が扱う 4 つ（受付担当・キャスト・人数・備考）に絞り、契約が持たない営業日・到着予定時刻は編集で書き換わらない。
- **対象は未確定（CREATED）の会員申請のみ**。確定・謝絶と同じ収口の考え方で、確定後は通常の受注として汎用更新が引き続き受け持つ。**既存の汎用更新の必須項目は緩めていない**（受け入れ基準 3）。その退行を `OrderControllerTest.orderUpdateStillRequiresCastAndReceptionist` が固定する。
- **指名先の検証は確定時の再検証と条件を共有**（`nominatableCast` を抽出、当店に在籍する ACTIVE のキャスト）。当日の確定シフトの有無は確定時だけが見る — 先の日付の申請は編集時点でシフトが未確定なのが通常で、編集でも要求すると指名を差し替える手段が事実上無くなるため。
- **検証はすべて集約の書き換えより前**に済ませ、編集項目は `Order.revise()` が一度に置き換える。撥ねる要求が集約を触った後だと、拒否の健全さがトランザクションの巻き戻しだけに掛かる。
- 指名が成立しないときは、確定時の再検証と揃えて**対処（在籍中を選ぶか外すか）を含む 400** で返す（列挙を防ぐ 404 は会員向け経路の作法で、相手が店舗スタッフのここでは当てはまらない）。
- **予約受付 inbox に編集モーダル**を追加（受付担当・人数・備考と「指名を外す」）。指名の維持は現在のキャストを送り返すことで成立する。人数・備考にはサーバ側の制約（`@NotNull @Min(1)` / `@Size(max = 500)`）に対応する検証表示を置く。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task test-unit` + `task test-integration` を個別に実行。frontend Jest 691 件 / backend 単体 + 統合）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全 24 件。**新規シナリオは追加していない** — 編集経路は統合テストと Jest で覆っている）
- [x] ローカルで code-review 実施済み（Standards / Spec の 2 軸）。指摘は本 PR 内で修正済み、下記「決定ログ」参照
- 新規テストはすべて**変異で赤になることを確認済み**（`Order.revise` への集約リファクタ後にも取り直し）

### 視覚確認（UI 変更時）

実機ブラウザ（`task up` 後の店舗コンソール `/store/1/orders`）で以下を確認済み:

- 指名なしの申請 → 編集モーダルが「指名: なし」で開き、人数・備考を直して保存すると inbox とオーダー一覧の両方が更新される
- 指名付きの申請 → 「指名を外す」チェックボックスが現れ、保存後に API 応答から `cast_id` / `cast_name` が消え、`requester_member_code` / `reception_route` / `business_date` は残る
- 人数を空欄にして保存 → 「人数を入力してください」が赤字で表示される（無反応にならない）

## 決定ログ

**採った設計**: 申請専用の編集端点を足し、既存の `PUT /store/orders/{id}` には触らない。受け入れ基準 3 が「既存の店舗起点受注の更新契約（castId 必須）の挙動が退行しない」を明示しているため、汎用契約を緩める案は取れない。確定・謝絶が既に申請専用の収口になっており、そこへ揃えるのが一貫する。

**見送った代替案 1**: `OrderUpdateRequest` の `castId` / `receptionistId` を可空にする案。受け入れ基準 3 に反する。申請かどうかで検証を出し分ける条件付き検証も、契約が状態に依存して読めなくなるため取らない。

**見送った代替案 2**: 編集も部分更新（null＝変更しない）にする案。指名を外す操作が表現できず、issue の主目的（無効になった指名を確定前に外す）を満たせない。置換にした代わり、契約の項目を編集画面が扱う 4 つだけに絞り、送り忘れで消える面を最小にしている。

**見送った代替案 3**: 編集時にも当日の確定シフトを要求する案。申請は最大 90 日先まで起こせるため、遠い日付では確定シフトがまだ存在しないのが通常で、指名を差し替える手段が事実上無くなる。指名の最終的な関門は確定時の再検証（PR #559）が引き続き担う。

**code-review 指摘への対応（3 件・本 PR 内で修正）**:
1. 指名不成立の応答が 404 だった。同じ述語を同じ相手（店舗スタッフ）に適用する確定時の再検証が一行隣で「列挙を防ぐ 404 ではなく理由の分かる 400」と決めており、逆の扱いになっていた → 400 + 対処を含む文言へ統一。
2. `assignCast` が検証より先に走っていた → 検証を全部前置し、`Order.revise()` で 4 項目を一度に置換。撥ねられた編集が元の指名を残すことを単体・統合の両方で固定（この順序を戻すと 2 件が赤になることを確認済み）。
3. 人数の検証結果を表示していなかった（`FormField` の外にあり `FormMessage` が無い）。空欄のまま押した保存が無反応に見える — PR #559 で会員側のご要望欄に入れたのと同じ危害 → `FormField` + `FormMessage` へ移し、備考にもサーバ側 `@Size(max = 500)` に対応する上限を入れた。

## 備考 / レビュー観点

**既知の妥協点 1（確定後の指名なし受注は編集できない）**: 指名を外してから確定すると、キャストが未設定の CONFIRMED 受注が残る — **本 PR が通す導線そのものが作る形**。この行を汎用更新で直そうとすると `castId` が必須のため、人数を直すだけでも指名を作り出さざるを得ない。PR #559 から続く穴で、本 PR は塞がないが到達しやすくしている。#561 の対象は未確定の申請、受け入れ基準 3 は汎用更新の契約を緩めないことを求めているため、塞ぐなら別票（確定後の受注にも可空の編集契約を用意する形）になる。**切り出すかどうかの判断をお願いしたい。**

**既知の妥協点 2（API と画面の非対称）**: 編集の契約は任意の新しいキャストの設定と受付担当の解除まで受け付けるが、画面は指名の維持・解除しか出さない。#561 の「少なくとも」の範囲内。キャスト検索は現状 `OrderForm`（新規受注フォーム）に内包されており、モーダルで使うには切り出しが要るため見送った。

**e2e の既存の脆さ（本 PR 起因ではない）**: `member-reservation.feature` の確定ステップが予約受付 inbox の `.first()` を掴むため、**inbox に先行する未処理の申請が 1 件でもあると別の申請を確定してしまい落ちる**。inbox は作成日時の昇順で、未確定の申請は削除 API が拒否する（#559）ためテストの後片付けでも消えず、一度失敗した run の残留が次の run を落とす連鎖になる。今回それを踏んだので、残留を謝絶してから取り直して 24 件緑を確認した。修正するならステップ側で自分が作った申請を特定して掴む形になる。

**重点的に見てほしい点**: 置換セマンティクス（省略＝未設定）が、契約の項目を 4 つに絞ることでしか安全になっていない点。ここに項目を足すと、送られてこない項目が黙って消える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
