### PR TITLE
feat(order): 確定後の指名なし受注を汎用更新で編集できるようにする

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/order/MemberOrderIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/MemberOrderIT.java
@@ -143,15 +143,7 @@ class MemberOrderIT extends CrossStoreTestSupport {
     String castId = createCastAs(STORE_A, "inbox 判定用キャスト");
     String staffOrderId = createStoreOrderTaggedWeb(castId);
 
-    ResponseEntity<JsonNode> inbox =
-        rest.exchange(
-            "/store/orders/reservation-requests",
-            HttpMethod.GET,
-            new HttpEntity<>(storeHeaders(STORE_A)),
-            JsonNode.class);
-    assertThat(inbox.getStatusCode()).isEqualTo(HttpStatus.OK);
-    List<String> ids = new ArrayList<>();
-    inbox.getBody().path("content").forEach(node -> ids.add(node.path("id").asString()));
+    List<String> ids = allPendingIds();
     assertThat(ids).as("会員の未確定申請は現れること").contains(requestId);
     assertThat(ids).as("店舗が起こした受注は受付経路が WEB でも現れないこと").doesNotContain(staffOrderId);
 
@@ -161,18 +153,7 @@ class MemberOrderIT extends CrossStoreTestSupport {
         HttpMethod.POST,
         new HttpEntity<>(storeHeaders(STORE_A)),
         JsonNode.class);
-    ResponseEntity<JsonNode> afterConfirm =
-        rest.exchange(
-            "/store/orders/reservation-requests",
-            HttpMethod.GET,
-            new HttpEntity<>(storeHeaders(STORE_A)),
-            JsonNode.class);
-    List<String> remaining = new ArrayList<>();
-    afterConfirm
-        .getBody()
-        .path("content")
-        .forEach(node -> remaining.add(node.path("id").asString()));
-    assertThat(remaining).doesNotContain(requestId);
+    assertThat(allPendingIds()).doesNotContain(requestId);
   }
 
   @Test
@@ -268,6 +249,22 @@ class MemberOrderIT extends CrossStoreTestSupport {
     return inbox.getBody();
   }
 
+  /**
+   * 未処理の申請を続きの位置を辿って全件集める。
+   *
+   * <p>先頭ページだけを見て在不在を断言すると、未処理の申請が取得窓の件数まで積み上がった時点で 自分の申請が窓から落ち、判定が他のテストの残す件数に左右される。
+   */
+  private List<String> allPendingIds() {
+    List<String> collected = new ArrayList<>();
+    String cursor = null;
+    do {
+      JsonNode body = fetchInbox(cursor, 20);
+      collected.addAll(idsOf(body));
+      cursor = nextCursor(body);
+    } while (cursor != null && collected.size() <= PAGING_GUARD);
+    return collected;
+  }
+
   private static List<String> idsOf(JsonNode body) {
     List<String> ids = new ArrayList<>();
     body.path("content").forEach(node -> ids.add(node.path("id").asString()));
@@ -335,16 +332,7 @@ class MemberOrderIT extends CrossStoreTestSupport {
               orderRepository.save(order);
             });
 
-    ResponseEntity<JsonNode> inbox =
-        rest.exchange(
-            "/store/orders/reservation-requests",
-            HttpMethod.GET,
-            new HttpEntity<>(storeHeaders(STORE_A)),
-            JsonNode.class);
-    assertThat(inbox.getStatusCode()).isEqualTo(HttpStatus.OK);
-    List<String> ids = new ArrayList<>();
-    inbox.getBody().path("content").forEach(node -> ids.add(node.path("id").asString()));
-    assertThat(ids).as("会員 ID が欠落しても未確定の申請は処理対象として残ること").contains(orderId);
+    assertThat(allPendingIds()).as("会員 ID が欠落しても未確定の申請は処理対象として残ること").contains(orderId);
 
     ResponseEntity<JsonNode> confirmed =
         rest.exchange(
@@ -647,6 +635,92 @@ class MemberOrderIT extends CrossStoreTestSupport {
     assertThat(updateReservationRequest(STORE_A, orderId, "{\"pax\": 2}").getStatusCode())
         .as("確定後は通常の受注として汎用更新が受け持つこと")
         .isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
+  private ResponseEntity<JsonNode> updateOrder(String id, String body) {
+    return rest.exchange(
+        "/store/orders/" + id,
+        HttpMethod.PUT,
+        new HttpEntity<>(body, storeHeaders(STORE_A)),
+        JsonNode.class);
+  }
+
+  @Test
+  @DisplayName("指名なしで確定した受注を、キャストを設定せずに汎用更新で編集できること")
+  void confirmedNominationFreeOrderCanBeEditedByTheGenericUpdate() {
+    String orderId = requestReservation(memberAToken, STORE_A, "確定後に人数を直す");
+    ResponseEntity<JsonNode> confirmed =
+        rest.exchange(
+            "/store/orders/" + orderId + "/confirmation",
+            HttpMethod.POST,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(confirmed.getStatusCode()).as("前提: 指名なしのまま確定できること").isEqualTo(HttpStatus.OK);
+    assertThat(confirmed.getBody().path("cast_id").isMissingNode()).as("前提: 指名なしであること").isTrue();
+    long receptionistId = confirmed.getBody().path("receptionist_id").asLong();
+
+    ResponseEntity<JsonNode> edited =
+        updateOrder(
+            orderId,
+            "{\"receptionist_id\": "
+                + receptionistId
+                + ", \"pax\": 6, \"remarks\": \"確定後に人数を直した\"}");
+    assertThat(edited.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(edited.getBody().path("pax").asInt()).isEqualTo(6);
+    assertThat(edited.getBody().path("remarks").asString()).isEqualTo("確定後に人数を直した");
+    assertThat(edited.getBody().path("cast_id").isMissingNode()).as("編集のために指名を作り出さずに済むこと").isTrue();
+
+    // 受付担当が未設定のまま確定した受注（確定した実行者が受付候補の条件を満たさない場合）も同じく編集できる。
+    // その状態は実行者の適格性に依るため、ここでは確定後の行から受付担当を外して同じ形を作る。
+    orderRepository
+        .findById(orderId)
+        .ifPresent(
+            order -> {
+              order.assignReceptionist(null);
+              orderRepository.save(order);
+            });
+
+    ResponseEntity<JsonNode> withoutReceptionist = updateOrder(orderId, "{\"pax\": 7}");
+    assertThat(withoutReceptionist.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(withoutReceptionist.getBody().path("pax").asInt()).isEqualTo(7);
+    assertThat(withoutReceptionist.getBody().path("receptionist_id").isMissingNode())
+        .as("受付担当を作り出さずに済むこと")
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("汎用更新では既にある指名・受付担当を省略で外せないこと")
+  void genericUpdateCannotRemoveAnExistingNominationOrReceptionist() {
+    String castId = createCastAs(STORE_A, "汎用更新の必須性ガード用キャスト");
+    String storeOrderId = createStoreOrderTaggedWeb(castId);
+
+    ResponseEntity<JsonNode> withoutReceptionist = updateOrder(storeOrderId, "{\"pax\": 3}");
+    assertThat(withoutReceptionist.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(withoutReceptionist.getBody().path("error").asString())
+        .as("拒否が経路の都合ではなく必須性の判定から来ていること")
+        .contains("受付担当を外すことはできません");
+
+    ResponseEntity<JsonNode> withoutCast =
+        updateOrder(storeOrderId, "{\"receptionist_id\": 3, \"pax\": 3}");
+    assertThat(withoutCast.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(withoutCast.getBody().path("error").asString()).contains("指名を外すことはできません");
+
+    // 撥ねられた要求は受注を書き換えない
+    ResponseEntity<JsonNode> untouched =
+        rest.exchange(
+            "/store/orders/" + storeOrderId,
+            HttpMethod.GET,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(untouched.getBody().path("cast_id").asString()).isEqualTo(castId);
+    assertThat(untouched.getBody().path("pax").isMissingNode()).isTrue();
+
+    // 正向対照: 両方を送れば同じ受注を編集できる（拒否が PUT そのものの不達ではない証明）
+    ResponseEntity<JsonNode> edited =
+        updateOrder(
+            storeOrderId, "{\"receptionist_id\": 3, \"cast_id\": \"" + castId + "\", \"pax\": 3}");
+    assertThat(edited.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(edited.getBody().path("pax").asInt()).isEqualTo(3);
   }
 
   @Test

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderUpdateRequest.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderUpdateRequest.java
@@ -1,21 +1,27 @@
 package com.kizuna.order.api.dto;
 
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.Data;
 
+/**
+ * 受注の部分更新の内容（null は「変更しない」）。確定後の受注のライフサイクルはこの契約が受け持つ。
+ *
+ * <p>指名・受付担当に必須の宣言を置かないのは、どちらも未設定のまま正規の導線で確定しうるため — 会員は指名なしで申請でき、店舗は無効になった指名を確定前に外せる。受付担当も、確定した実行者が
+ * 受付候補の条件を満たさなければ未設定のまま残る。契約の側で必須にすると、そうして生まれた受注は 人数を直すだけでも指名や受付担当を作り出さないと編集できない。
+ *
+ * <p>ただしこの 2 項目は、省略しても元の値が残る他の項目と違い、既に設定済みの受注では要求そのものが撥ねられる（{@link
+ * com.kizuna.order.application.OrderService#update} が受注の状態を見て判定する）。省略が「変更しない」なのか「外す」なのかを
+ * 契約の側で区別できないため、 指名・受付担当が外れた結果を黙って作らない。
+ */
 @Data
 public class OrderUpdateRequest {
-  @NotNull(message = "受付は必須です")
   private Long receptionistId;
 
   private LocalTime arrivalScheduledStartTime;
   private LocalTime arrivalScheduledEndTime;
 
-  @NotBlank(message = "キャストIDは必須です")
   private String castId;
 
   @Min(value = 1, message = "人数は 1 以上です")

--- a/backend/src/main/java/com/kizuna/order/application/OrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderService.java
@@ -145,16 +145,41 @@ public class OrderService {
       throw new ServiceException("予約申請の状態は確定・謝絶の操作でのみ変更できます");
     }
 
+    // 空文字は「送っていない」と同じに扱う。編集画面の未選択がそのまま乗ってくる形なので、存在しない
+    // キャストとして扱って 404 を返すより、指名なしの要求として同じ判定に載せる方が呼び手に意味が通る。
+    String castId =
+        (request.getCastId() == null || request.getCastId().isBlank()) ? null : request.getCastId();
+    Long receptionistId = request.getReceptionistId();
+
+    // 指名・受付担当の検証は書き換えより先に済ませる。撥ねる要求が集約を触った後だと、拒否の健全さが
+    // トランザクションの巻き戻しだけに掛かる（同一トランザクション内の後続の読みには変わった値が見えてしまう）。
+    //
+    // 必須性は契約ではなく受注の状態が決める。未設定のまま確定した受注（指名を外した
+    // 会員申請、受付候補でない実行者が確定したもの）は未設定のまま他項目を直せなければならない一方、
+    // 既に付いているものを省略で外せると、この汎用更新が指名解除・受付担当解除の裏口になる。
+    if (receptionistId != null) {
+      validateReceptionist(receptionistId);
+    } else if (order.getReceptionistId() != null) {
+      throw new ServiceException("受付担当を外すことはできません。受付担当を指定してください");
+    }
+    if (castId != null) {
+      if (!castRepository.existsById(castId)) {
+        throw new NotFoundException("キャストが見つかりません: " + castId);
+      }
+    } else if (order.getCastId() != null) {
+      throw new ServiceException("指名を外すことはできません。キャストを指定してください");
+    }
+
     // 非nullフィールドのみをドメインの部分更新コマンドとして適用
     order.apply(orderMapper.toPatch(request));
 
-    // 関連 ID の更新（存在確認のうえ）
-    validateReceptionist(request.getReceptionistId());
-    order.assignReceptionist(request.getReceptionistId());
-    if (!castRepository.existsById(request.getCastId())) {
-      throw new NotFoundException("キャストが見つかりません: " + request.getCastId());
+    // 関連 ID の更新（存在確認は上で済ませている）
+    if (castId != null) {
+      order.assignCast(castId);
     }
-    order.assignCast(request.getCastId());
+    if (receptionistId != null) {
+      order.assignReceptionist(receptionistId);
+    }
 
     // ステータスはドメインの遷移メソッド経由で変更（不正な遷移はドメイン例外 → 400）
     if (request.getStatus() != null) {

--- a/backend/src/test/java/com/kizuna/order/api/store/OrderControllerTest.java
+++ b/backend/src/test/java/com/kizuna/order/api/store/OrderControllerTest.java
@@ -174,20 +174,29 @@ class OrderControllerTest {
   }
 
   @Test
-  @DisplayName("店舗起点の受注を更新する汎用契約ではキャスト・受付担当が必須のままであること")
+  @DisplayName("汎用更新の契約はキャスト・受付担当の省略を受け付けること（可否は受注の状態が決める）")
   @WithMockUser(authorities = "PERM_ORDER_MANAGE")
-  void orderUpdateStillRequiresCastAndReceptionist() throws Exception {
+  void orderUpdateContractAcceptsAnOmittedCastAndReceptionist() throws Exception {
     when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+    when(orderService.update(any(), any())).thenReturn(OrderResponse.builder().build());
 
-    // 申請専用の可空な契約を足しても、既存の受注更新は必須項目を緩めない
-    mockMvc
-        .perform(storePut("/store/orders/o1", "{\"pax\": 3}"))
-        .andExpect(status().isBadRequest());
+    // 省略を契約で撥ねると、指名・受付担当が未設定のまま確定した受注が編集できなくなる。
+    // 「既にある指名・受付担当は外せない」判定は受注の状態を見るサービス層が持つ（OrderServiceTest）。
+    // 店舗起点の受注に対する 400 が経路として維持されることは MemberOrderIT が通しで固定する。
+    mockMvc.perform(storePut("/store/orders/o1", "{\"pax\": 3}")).andExpect(status().isOk());
     mockMvc
         .perform(storePut("/store/orders/o1", "{\"cast_id\": \"cast-1\", \"pax\": 3}"))
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("汎用更新の契約でも人数の下限は撥ねられること")
+  @WithMockUser(authorities = "PERM_ORDER_MANAGE")
+  void orderUpdateStillRejectsAnInvalidPax() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+
     mockMvc
-        .perform(storePut("/store/orders/o1", "{\"receptionist_id\": 2, \"pax\": 3}"))
+        .perform(storePut("/store/orders/o1", "{\"pax\": 0}"))
         .andExpect(status().isBadRequest());
   }
 

--- a/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
@@ -492,7 +492,6 @@ class OrderServiceTest {
     Order existing = Order.builder().status(OrderStatus.CREATED).build();
     when(storeContext.getStoreId()).thenReturn(STORE_ID);
     when(orderRepository.findById("o1")).thenReturn(Optional.of(existing));
-    when(orderMapper.toPatch(any(OrderUpdateRequest.class))).thenReturn(emptyPatch());
     when(castRepository.existsById("none")).thenReturn(false);
     when(platformUserRepository.findById(2L)).thenReturn(Optional.of(authorizedReceptionist()));
 
@@ -508,7 +507,6 @@ class OrderServiceTest {
     Order existing = Order.builder().status(OrderStatus.CREATED).build();
     when(storeContext.getStoreId()).thenReturn(STORE_ID);
     when(orderRepository.findById("o1")).thenReturn(Optional.of(existing));
-    when(orderMapper.toPatch(any(OrderUpdateRequest.class))).thenReturn(emptyPatch());
     // 別店舗(store_id=2)専用スコープ: 現店舗(=1)を授権しない
     when(platformUserRepository.findById(2L))
         .thenReturn(
@@ -529,7 +527,6 @@ class OrderServiceTest {
     Order existing = Order.builder().status(OrderStatus.CREATED).build();
     when(storeContext.getStoreId()).thenReturn(STORE_ID);
     when(orderRepository.findById("o1")).thenReturn(Optional.of(existing));
-    when(orderMapper.toPatch(any(OrderUpdateRequest.class))).thenReturn(emptyPatch());
     // 全店舗授権でも CAST 本人種別は受付担当者になれない
     when(platformUserRepository.findById(2L))
         .thenReturn(Optional.of(receptionist(UserType.CAST, StoreScopeType.ALL_STORES, Set.of())));
@@ -542,6 +539,107 @@ class OrderServiceTest {
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("受付担当者が見つかりません");
     verify(orderRepository, never()).save(any());
+  }
+
+  /** 人数と備考だけを差し替える部分更新コマンド（汎用更新の典型的な編集）。 */
+  private static OrderPatch paxAndRemarksPatch(Integer pax, String remarks) {
+    return new OrderPatch(null, null, pax, null, null, null, null, null, null, null, remarks, null);
+  }
+
+  @Test
+  void updateEditsConfirmedNominationFreeOrderWithoutSettingCast() {
+    // 指名を外したまま確定した受注は、キャストを作り出さずに人数・備考を直せなければならない
+    Order confirmed =
+        reservationRequest().status(OrderStatus.CONFIRMED).receptionistId(3L).pax(2).build();
+    when(storeContext.getStoreId()).thenReturn(STORE_ID);
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(confirmed));
+    when(orderMapper.toPatch(any(OrderUpdateRequest.class)))
+        .thenReturn(paxAndRemarksPatch(5, "人数を直した"));
+    when(platformUserRepository.findById(3L)).thenReturn(Optional.of(authorizedReceptionist()));
+    stubReservationRequestUpdateResponse();
+
+    OrderUpdateRequest req = new OrderUpdateRequest();
+    req.setReceptionistId(3L);
+    req.setPax(5);
+    req.setRemarks("人数を直した");
+
+    service.update("o1", req);
+
+    assertThat(confirmed.getPax()).isEqualTo(5);
+    assertThat(confirmed.getRemarks()).isEqualTo("人数を直した");
+    assertThat(confirmed.getCastId()).as("指名なしのままであること").isNull();
+    verify(castRepository, never()).existsById(anyString());
+  }
+
+  @Test
+  void updateEditsOrderWhoseReceptionistWasNeverAssigned() {
+    // 確定した実行者が受付候補の条件を満たさなければ受付担当は未設定のまま残る。その行も編集できなければならない
+    Order confirmed = reservationRequest().status(OrderStatus.CONFIRMED).pax(2).build();
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(confirmed));
+    when(orderMapper.toPatch(any(OrderUpdateRequest.class)))
+        .thenReturn(paxAndRemarksPatch(4, null));
+    stubReservationRequestUpdateResponse();
+
+    OrderUpdateRequest req = new OrderUpdateRequest();
+    req.setPax(4);
+
+    service.update("o1", req);
+
+    assertThat(confirmed.getPax()).isEqualTo(4);
+    assertThat(confirmed.getReceptionistId()).as("未設定のままであること").isNull();
+    verify(platformUserRepository, never()).findById(any());
+  }
+
+  @Test
+  void updateRejectsRemovingAnExistingNomination() {
+    // 店舗が起こした受注は必ず指名を持つ。省略で外せると、汎用更新が指名解除の裏口になる
+    Order storeOrder = Order.builder().status(OrderStatus.CONFIRMED).castId("g1").pax(2).build();
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(storeOrder));
+
+    OrderUpdateRequest req = new OrderUpdateRequest();
+    req.setPax(9);
+
+    assertThatThrownBy(() -> service.update("o1", req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("指名を外すことはできません");
+    // 撥ねる要求は集約を触る前に止める（拒否の健全さをトランザクションの巻き戻しだけに委ねない）
+    assertThat(storeOrder.getPax()).isEqualTo(2);
+    assertThat(storeOrder.getCastId()).isEqualTo("g1");
+    verify(orderRepository, never()).save(any(Order.class));
+  }
+
+  @Test
+  void updateRejectsRemovingAnExistingReceptionist() {
+    Order storeOrder =
+        Order.builder().status(OrderStatus.CONFIRMED).castId("g1").receptionistId(3L).build();
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(storeOrder));
+
+    OrderUpdateRequest req = new OrderUpdateRequest();
+    req.setCastId("g1");
+    req.setPax(9);
+
+    assertThatThrownBy(() -> service.update("o1", req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("受付担当を外すことはできません");
+    assertThat(storeOrder.getReceptionistId()).isEqualTo(3L);
+    verify(orderRepository, never()).save(any(Order.class));
+  }
+
+  @Test
+  void updateTreatsABlankCastIdAsAnOmittedNomination() {
+    // 編集画面の未選択がそのまま空文字で乗ってくる。存在しないキャストとして 404 を返すより、
+    // 指名なしの要求として同じ判定（外せない）に載せる方が呼び手にとって意味が通る
+    Order storeOrder = Order.builder().status(OrderStatus.CONFIRMED).castId("g1").build();
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(storeOrder));
+
+    OrderUpdateRequest req = new OrderUpdateRequest();
+    req.setCastId("");
+    req.setPax(9);
+
+    assertThatThrownBy(() -> service.update("o1", req))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("指名を外すことはできません");
+    verify(castRepository, never()).existsById(anyString());
   }
 
   /** 予約受付 inbox の読み口が返す 1 行分の projection。 */


### PR DESCRIPTION
## 概要

確定後の受注を受け持つ汎用更新 `PUT /store/orders/{id}` が、指名・受付担当を契約の側で必須にしていたため、未設定のまま確定した受注は人数を直すだけでも指名を作り出さないと編集できなかった。必須性の判定を契約からサービス層へ移し、「既にある指名・受付担当は汎用更新では外せない」という受注の状態に対する不変量に置き換える。

Closes #565

## 変更内容

- `OrderUpdateRequest` から `@NotBlank castId` / `@NotNull receptionistId` を撤去（必須性は受注の状態に依るため、呼び出しだけを見て判定できない）
- `OrderService.update()` に状態を見る守衛を追加 — 送られなかった指名・受付担当は、受注が元から未設定のときだけ通る。既に設定済みなら 400 で撥ねる
- 守衛は `order.apply()` **より前**に置く（撥ねる要求が集約を触った後だと、拒否の健全さがトランザクションの巻き戻しだけに掛かる。#564 と同じ理由）
- 空文字のキャスト ID は省略と同じに扱う（`existsById("")` の 404 ではなく、理由の分かる 400 になる）
- `OrderControllerTest` の固定内容を、契約が省略を受け付けることの固定へ置き換え。店舗起点受注の 400 は `MemberOrderIT` が通しで固定する
- 予約受付 inbox の在不在断言を先頭ページ依存から続き辿りへ（下記「備考」参照）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（backend `test-unit`（coverage gate 込み）+ 統合テスト全量 231 件。独自 compose プロジェクト名で隔離実行）
- [x] `task build` exit 0
- [ ] `task e2e`（未実行 — この端点はフロントに消費者が無く（`orderApi` に `update` は無い）、シナリオで到達できないため）
- [x] ローカルで code-review 実施済み（Standards / Spec 二軸。指摘のうち「コメントが実際より広い不変量を主張している」「契約の javadoc と実装で null の意味が食い違う」の 2 件を修正）

### 赤を確認した手順

- サービス層の新規 5 テスト: 修正前に実行して赤（`NotFoundException` / 断言失敗）→ 修正後に緑
- `MemberOrderIT` の新規 2 テスト: 撤去した注解を一時的に戻して実行し、**2 件とも赤**になることを実測 → 戻して緑

## 決定ログ

**採用: 受注の状態に対する不変量（「既にあるものは外せない」）**

店舗が起こした受注は `create()` が指名・受付担当を必須にしているため必ず両方を持つ。したがって省略は引き続き 400 になり、受け入れ基準 3（既存の店舗起点受注の更新契約が退行しない）は行そのものの形から自動的に満たされる。`PlatformOrderService` 経由で起きた受注も同じ判定に載る。指名を黙って落とす事故も起きない（キャスト選び直しは別 issue の範囲）。

**見送り 1: 受付経路（`isReservationRequest()`）による来源判定**

「会員起点だけ可空」にすると、店舗起点受注の必須性が行の形ではなく来源の判定に依存する。判定が壊れたときに必須性が静かに消える。

**見送り 2: 指名・受付担当も純粋な「null＝変更しない」にする**

裸の `{"pax": 6}` がどこでも通る代わりに、省略が撥ねられなくなるので受け入れ基準 3 の 400 が**丸ごと消える**。基準 3 を明示的に要求している以上、採らなかった。

## 備考 / レビュー観点

**1. issue の再現手順 4 は、正常に確定した受注では今も 400 になる**

`confirm()` は実行者が受付候補の条件を満たせば受付担当として補うため、通常の確定を経た会員受注は受付担当を持つ。その行に裸の `{"pax": 6}` を投げると、メッセージが「キャストIDは必須です」から「受付担当を外すことはできません」に変わるだけで 400 のままになる。呼び出し側は行が既に持っている `receptionist_id` を回送する必要がある（全項目を載せる編集フォームでは自然な形）。

受け入れ基準 1 の文面（「キャストを設定せずに編集できる」）と基準 2（受付担当が未設定の行）はいずれも満たしているが、**裸の `{"pax": …}` をどこでも通したい**なら上記「見送り 2」を採ることになり、その場合は基準 3 の 400 が消える。裁定が要るならこの点。

**2. 省略時の 400 の応答形が変わる**

bean validation のエラー列から `{"error": "..."}` へ。現時点でこの端点を叩くフロントの消費者は無いため何も壊れないが、wire に見える変化なので記録しておく。

**3. inbox テストの断言を先頭ページ依存から外した理由**

`MemberOrderIT` に本件のテストを足すと JUnit の実行順が変わり、未処理の申請が取得窓（20 件）まで積み上がった時点で自分の申請が窓から落ちて 2 件が赤になった（master では緑、本改動で赤になることを stash 対照で実測）。先頭ページだけを見る断言が他のテストの残す件数に左右されるのが原因なので、続きの位置を辿って全件から判定するよう直した。この一覧はカーソルで辿る作業キューなので、その読み方の方が一覧の性質にも合う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
