### PR TITLE
fix(e2e): 予約確定ステップが inbox の先頭ではなく会員コードで自分の申請を掴むようにする

### DIFF
--- a/e2e/steps/member-reservation.steps.ts
+++ b/e2e/steps/member-reservation.steps.ts
@@ -1,10 +1,11 @@
-import { expect } from '@playwright/test';
+import { expect, type APIRequestContext } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 import { BASE_URL, PLATFORM_URL } from '../base-url';
 import {
   createCast,
   createCustomer,
   createShift,
+  declineOrder,
   deleteCast,
   deleteCustomer,
   deleteOrder,
@@ -13,6 +14,7 @@ import {
   loginAsStoreAdmin,
   loginViaUiAndEnterStore,
   registerMember,
+  STORE_HEADERS,
 } from './store-api';
 
 const { Given, When, Then, After } = createBdd();
@@ -26,20 +28,47 @@ const MEMBER_PASSWORD = 'pass12345';
 // 播種した実体の id / 認証情報。MEMBER PlatformUser には削除 API が無いためタイムスタンプ付き
 // メールアドレスで隔離し残留を許容する（顧客・キャスト・シフト・受注は明示削除する）。
 let memberEmail = '';
+// 会員コードはこの run のシナリオを一意に指す鍵。inbox は店舗共有で他の未処理申請が先に並ぶため、
+// 確定する行の特定にも、後片付けで自分の申請を引き直すのにも使う。
+let memberCode = '';
 let createdCustomerId = '';
 let createdCastId = '';
+let createdCastName = '';
 let createdShiftId = '';
 let createdOrderId = '';
+
+/**
+ * 未処理の予約申請のうち、このシナリオの会員が出したものの id を引く
+ * （GET /api/store/orders/reservation-requests）。UI から出した申請は応答を取り損ねると id が
+ * 手元に無いため、後片付けはこの引き直しを拠り所にする。
+ */
+async function findPendingRequestIds(
+  request: APIRequestContext,
+  token: string,
+  code: string
+): Promise<string[]> {
+  const res = await request.get('/api/store/orders/reservation-requests', {
+    headers: { ...STORE_HEADERS, Authorization: `Bearer ${token}` },
+    params: { size: 100 },
+  });
+  if (!res.ok()) {
+    throw new Error(`list reservation requests failed: ${res.status()} ${await res.text()}`);
+  }
+  const body = await res.json();
+  const rows = body.content as Array<{ id: string; requester_member_code: string | null }>;
+  return rows.filter(row => row.requester_member_code === code).map(row => row.id);
+}
+
+// 後片付けの失敗を黙って握り潰すと、消し残った申請が次の run を落とす連鎖になる。
+// 後続の片付けは続けたいのでテストは倒さず、痕跡だけ残す。
+const warnCleanupFailure = (error: unknown) => {
+  console.warn(`[member-reservation cleanup] ${String(error)}`);
+};
 
 Given('会員を登録し店舗側で顧客台帳に紐づける', async ({ request }) => {
   const suffix = Date.now();
   memberEmail = `member-reservation-e2e-${suffix}@kizuna.test`;
-  const memberCode = await registerMember(
-    request,
-    memberEmail,
-    MEMBER_PASSWORD,
-    `E2E会員-${suffix}`
-  );
+  memberCode = await registerMember(request, memberEmail, MEMBER_PASSWORD, `E2E会員-${suffix}`);
 
   const adminToken = await loginAsStoreAdmin(request);
   createdCustomerId = await createCustomer(
@@ -53,7 +82,8 @@ Given('会員を登録し店舗側で顧客台帳に紐づける', async ({ requ
 
 Given('予約用に本日の確定シフトを API で作成する', async ({ request }) => {
   const adminToken = await loginAsStoreAdmin(request);
-  createdCastId = await createCast(request, adminToken, `E2E予約キャスト-${Date.now()}`);
+  createdCastName = `E2E予約キャスト-${Date.now()}`;
+  createdCastId = await createCast(request, adminToken, createdCastName);
   createdShiftId = await createShift(request, adminToken, {
     castId: createdCastId,
     workDate: todayInTokyo(),
@@ -98,9 +128,11 @@ Then('予約申請画面に該当店舗がプリセレクトされる', async ({
 Then('指名候補に本日の出勤キャストが出る', async ({ page }) => {
   await page.getByLabel('利用日').fill(todayInTokyo());
   // 指名候補はその日の確定シフトから引くため、日付を入れて初めて選択肢が現れる。
-  await expect(page.getByLabel('指名（任意）').getByRole('option')).toHaveCount(2, {
-    timeout: 15000,
-  });
+  // 件数ではなく作成したキャスト自身を名指すのは、共有 dev 店舗に本日出勤の別キャストが
+  // 居ても成立させるため（選択肢の総数は他シナリオの残留シフトで動く）。
+  await expect(
+    page.getByLabel('指名（任意）').getByRole('option', { name: createdCastName })
+  ).toHaveCount(1, { timeout: 15000 });
 });
 
 When('人数 {string} で予約を申請する', async ({ page }, pax: string) => {
@@ -126,7 +158,12 @@ Then('予約一覧に {string} の予約が表示される', async ({ page }, st
 When('店舗管理者が予約受付 inbox で予約を確定する', async ({ page }) => {
   const storeId = await loginViaUiAndEnterStore(page);
   await page.goto(`${PLATFORM_URL}/store/${storeId}/orders`);
-  const request = page.getByRole('listitem').filter({ hasText: 'WEB申請' }).first();
+  // inbox は店舗共有かつ古い順に並ぶため、先頭を掴むと先に残っている他人の申請を確定してしまう。
+  // 行に出る会員コードでこのシナリオの申請だけを名指す。
+  const request = page
+    .getByRole('listitem')
+    .filter({ hasText: 'WEB申請' })
+    .filter({ hasText: memberCode });
   await expect(request).toBeVisible({ timeout: 15000 });
   await Promise.all([
     page.waitForResponse(
@@ -162,8 +199,19 @@ When('予約を取り下げる', async ({ page }) => {
 // 受注は顧客・キャストを参照する（FK RESTRICT）ため、必ず受注 → シフト → キャスト → 顧客の順で消す。
 After(async ({ request }) => {
   const adminToken = await loginAsStoreAdmin(request);
-  if (createdOrderId) {
-    await deleteOrder(request, adminToken, createdOrderId).catch(() => {});
+  // 未確定のまま終わった申請は削除が拒否される（謝絶で扱う設計）ので、まず謝絶して CANCELLED にする。
+  // 対象は id ではなく会員コードで引き直す — 申請の POST 応答を取り損ねた中断でも消し残さないため。
+  const pendingIds = memberCode
+    ? await findPendingRequestIds(request, adminToken, memberCode).catch(error => {
+        warnCleanupFailure(error);
+        return [] as string[];
+      })
+    : [];
+  for (const id of pendingIds) {
+    await declineOrder(request, adminToken, id).catch(warnCleanupFailure);
+  }
+  for (const id of new Set([...pendingIds, createdOrderId].filter(Boolean))) {
+    await deleteOrder(request, adminToken, id).catch(warnCleanupFailure);
   }
   if (createdShiftId) {
     await deleteShift(request, adminToken, createdShiftId).catch(() => {});
@@ -175,8 +223,10 @@ After(async ({ request }) => {
     await deleteCustomer(request, adminToken, createdCustomerId).catch(() => {});
   }
   memberEmail = '';
+  memberCode = '';
   createdCustomerId = '';
   createdCastId = '';
+  createdCastName = '';
   createdShiftId = '';
   createdOrderId = '';
 });

--- a/e2e/steps/store-api.ts
+++ b/e2e/steps/store-api.ts
@@ -339,6 +339,23 @@ export async function linkMemberToCustomer(
   }
 }
 
+/**
+ * 予約申請を謝絶する（POST /api/store/orders/{id}/decline, hasAuthority('ORDER_MANAGE')）。
+ * 未確定（CREATED）の申請は削除が拒否されるため、後片付けはこちらで CANCELLED にしてから削除する。
+ */
+export async function declineOrder(
+  request: APIRequestContext,
+  token: string,
+  id: string
+): Promise<void> {
+  const res = await request.post(`/api/store/orders/${id}/decline`, {
+    headers: { ...STORE_HEADERS, Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok()) {
+    throw new Error(`decline order failed: ${res.status()} ${await res.text()}`);
+  }
+}
+
 /** 受注を削除する（DELETE /api/store/orders/{id}, hasAuthority('ORDER_MANAGE')）。 */
 export async function deleteOrder(
   request: APIRequestContext,


### PR DESCRIPTION
## 概要

予約受付 inbox は店舗共有かつ `createdAt` 昇順で並ぶため、確定ステップの `.first()` は「そのシナリオが作った申請」ではなく先に残っていた無関係な申請を掴んでいた。行に出る会員コードで対象を名指すよう直し、併せて未確定のまま終わった申請を謝絶で片付ける後片付けの穴も塞ぐ。

Closes #567

## 変更内容

- 確定ステップの対象特定を `.first()` から会員コードによる絞り込みへ変更（`filter({ hasText: memberCode })`）。会員コードは `registerMember` の戻り値で、inbox の各行に描画されている（`ReservationRequestInbox.tsx` の「会員コード:」行）。`Order.isReservationRequest()` が `requesterMemberCode != null` を要求するため、inbox に並ぶ行は必ずこの値を持つ。
- `After` の後片付けを「会員コードで inbox を引き直す → 謝絶 → 削除」に変更。未確定（CREATED）の申請は削除が拒否される（#559 の設計判断）ため、まず `POST /store/orders/{id}/decline` で CANCELLED にしてから削除する。
- 引き直しの鍵を `createdOrderId` ではなく**会員コード**にしたのが要点。`createdOrderId` は申請の POST 応答をパースして初めて代入されるので、応答を取り損ねた中断では id が手元に無く、id だけを頼る後片付けでは受入基準「失敗・中断時も残らない」を構造的に満たせない。
- 後片付けの失敗を握り潰さず `console.warn` で痕跡を残すよう変更（沈黙が残留の自己増殖を招くのが本 issue の機序のため）。
- `declineOrder` を `e2e/steps/store-api.ts` に追加（二つ目の steps ファイルからも使える汎用操作のため。会員コードでの引き直しは本 teardown 専用なので steps ファイル側にローカル実装、ヘッダは `STORE_HEADERS` から組む）。
- 同型（`.first()` ではないが「共有 dev データに結合した断言」という同じ壊れ方）として、指名候補の `toHaveCount(2)` を作成したキャスト自身を名指す断言へ変更。共有店舗に本日出勤の別キャストが居ると選択肢の総数が動くため。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（frontend Jest + backend unit + integration）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全 24 シナリオ / 24 passed）
- [x] ローカルで code-review 実施済み（Standards / Spec 両軸、blocking なし）

### 赤→緑の構成（本修正が効いていることの実証）

受入基準①は「無関係な未処理の申請が先行して存在する状態」を作らないと確かめられないため、その状態を意図的に構成して確認した。

1. 使い捨て会員を登録し `POST /platform/me/orders` で未確定の申請を 1 件仕込む
2. **修正前**のステップで `member-reservation.feature` を実行 → **赤**。仕込んだ方の申請が確定され、会員側の断言が「申請中」のまま失敗（issue 記載の失敗モードと一致）
3. **修正後**のステップで、残留した申請が inbox に先行して存在する状態のまま実行 → **緑**。残留した申請は確定されず inbox にそのまま残っていることも確認
4. 中断経路の確認: 申請ステップの id 記録を一時的に外し、直後に例外を投げるよう改変して実行（リトライ含め 2 回失敗）→ 実行後の inbox は **0 件**。会員コードでの引き直しが id 不明の残骸を謝絶・削除できている。この改変は検証用の一時パッチで、コミットには含まれていない
5. `task e2e` 全量 → **exit 0 / 24 passed**

検証で共有 dev 店舗に生じた残骸（仕込んだ申請、赤実行が残した受注・顧客）は実行後に削除済み。inbox は 0 件。

## 決定ログ

- **対象特定の手段**: issue が挙げた候補（一意な備考 / 会員コード / 保持した order id）のうち**会員コード**を採用。既に inbox の行に描画されていて UI 変更が要らず、`isReservationRequest()` の定義上必ず存在し、後片付け側の引き直しの鍵としても同じものが使えるため。備考は UI に入力させる手間が増え、order id は上記の「中断で失われる」問題を解けない。
- **ページングは追わない（既知の妥協点）**: 確定ステップは inbox の 1 ページ目（`PAGE_SIZE = 20`）しか見ず「もっと見る」を押さない。後片付けの引き直しも `size: 100` 固定で `next_cursor` を辿らない。後片付けを塞いだ以上、残留の発生源は手動 QA 由来のみで小さく（今回の事故は 2 件）、`disabled={loading}` を持つボタンを押し続けるループは新たな不安定要因になる。20 件以上の未処理申請が先行する状態は「dev 店舗の掃除が必要」を意味し、テスト側で回り込む話ではないと判断した。なお修正前は**誤った行を確定**していたのが、修正後は**タイムアウト**に変わるため、失敗の質としては悪化しない。
- **謝絶 → 削除の順序**: `OrderService.delete` の拒否条件は `isReservationRequest() && status == CREATED` なので、謝絶で CANCELLED にした行は通常どおり削除できる。確定済み・キャンセル済みの行に対する謝絶は状態遷移で弾かれるが、その場合は削除がそのまま通るため経路として問題ない。

## 備考 / レビュー観点

- 指名候補の断言変更は issue のスコープ 3（「他の feature に同型が無いか一巡見る」）が名指した範囲の外（同じファイル内）だが、同じ壊れ方のクラスなので同時に潰した。切り離しが望ましければ分離する。
- `.first()` + 共有 dev データの組み合わせは `e2e/steps` 全体を確認済み。残りの `.first()` は一意な名前で絞った後の使用（`cast-custom-fields` / `cast-detail-404`）か、シナリオごとに新規作成した会員に閉じた一覧（`member-reservation` の取り下げ）で、共有状態には依存していない。
- 後片付けの `console.warn` は新設した受注まわりだけで、既存のシフト・キャスト・顧客の `.catch(() => {})` はそのまま残している（本 issue の対象外のため無用な差分を作らない方針）。統一した方がよければ別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
