### PR TITLE
refactor(frontend): 検証の指摘を入力の傍へ — ②5 箇所のインライン化とフォーム構造の作り替え

### DIFF
--- a/frontend/src/_pages/platform-roles/ui/RoleFormModal.tsx
+++ b/frontend/src/_pages/platform-roles/ui/RoleFormModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import {
@@ -11,10 +11,25 @@ import {
   platformRoleApi,
 } from '@/entities/user';
 import { getApiErrorMessage, isConflict, useManagedList } from '@/shared/lib';
-import { Button, Dialog, DialogContent, DialogTitle, Input, Label } from '@/shared/ui';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Label,
+} from '@/shared/ui';
 
 interface RoleFormValues {
   name: string;
+  permissions: PlatformPermission[];
 }
 
 interface RoleFormModalProps {
@@ -66,13 +81,14 @@ function groupByConsole(
  * mount 時 = 開いた時点に遅延される。
  */
 export function RoleFormModal({ onClose, editingId, onSaved }: RoleFormModalProps) {
+  const form = useForm<RoleFormValues>({ defaultValues: { name: '', permissions: [] } });
   const {
-    register,
+    control,
     handleSubmit,
     reset,
     formState: { isSubmitting },
-  } = useForm<RoleFormValues>({ defaultValues: { name: '' } });
-  const [permissions, setPermissions] = useState<PlatformPermission[]>([]);
+  } = form;
+  const permissionsLabelId = useId();
   const [editingRole, setEditingRole] = useState<RoleResponse | null>(null);
   // 初回の詳細取得に失敗したときの再試行導線用。閉じて開き直す以外の回復手段を残す。
   const [detailLoadFailed, setDetailLoadFailed] = useState(false);
@@ -96,8 +112,7 @@ export function RoleFormModal({ onClose, editingId, onSaved }: RoleFormModalProp
       const role = await platformRoleApi.get(editingId);
       if (requestId !== requestIdRef.current) return;
       setEditingRole(role);
-      reset({ name: role.name ?? '' });
-      setPermissions(role.permissions ?? []);
+      reset({ name: role.name ?? '', permissions: role.permissions ?? [] });
     } catch (error) {
       if (requestId !== requestIdRef.current) return;
       toast.error(getApiErrorMessage(error, 'ロール情報の取得に失敗しました'));
@@ -112,29 +127,19 @@ export function RoleFormModal({ onClose, editingId, onSaved }: RoleFormModalProp
   // 編集モードで詳細が未着のうちは保存させない（version 無しで送る事故を防ぐ）
   const editingLoading = editingId !== null && editingRole === null;
 
-  const toggle = (code: PlatformPermission) => {
-    setPermissions(current =>
-      current.includes(code) ? current.filter(item => item !== code) : [...current, code]
-    );
-  };
-
   const submit = async (values: RoleFormValues) => {
-    if (permissions.length === 0) {
-      toast.error('権限を 1 つ以上選択してください');
-      return;
-    }
     try {
       if (editingId !== null) {
         if (editingRole === null) return;
         await platformRoleApi.update(editingId, {
           name: values.name,
-          permissions,
+          permissions: values.permissions,
           // 楽観ロック用バージョン（詳細応答の version をそのまま往復する）
           version: editingRole.version,
         });
         toast.success('ロールを更新しました');
       } else {
-        await platformRoleApi.create({ name: values.name, permissions });
+        await platformRoleApi.create({ name: values.name, permissions: values.permissions });
         toast.success('ロールを追加しました');
       }
       onSaved();
@@ -176,72 +181,135 @@ export function RoleFormModal({ onClose, editingId, onSaved }: RoleFormModalProp
         <DialogTitle className="border-b px-6 py-4 text-lg font-semibold text-foreground">
           {title}
         </DialogTitle>
-        {/* submit は取り直し（requestIdRef を読む）へ繋がるため、handleSubmit の適用を
-            イベント時まで遅らせる — 描画中の適用は react-hooks/refs が ref 読みとして拒む */}
-        <form onSubmit={event => void handleSubmit(submit)(event)} className="space-y-4 px-6 py-5">
-          <div className="grid gap-1">
-            <Label htmlFor="role-name">ロール名</Label>
-            <Input
-              id="role-name"
-              type="text"
-              maxLength={100}
-              // 詳細が届く前に入力させると、到着時の reset が入力を黙って上書きする
-              disabled={editingLoading}
-              {...register('name', { required: true })}
+        <Form {...form}>
+          {/* submit は取り直し（requestIdRef を読む）へ繋がるため、handleSubmit の適用を
+              イベント時まで遅らせる — 描画中の適用は react-hooks/refs が ref 読みとして拒む。
+              noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+              我々の文言は永久に描かれない。執行は下の各 rules が担う */}
+          <form
+            onSubmit={event => void handleSubmit(submit)(event)}
+            noValidate
+            className="space-y-4 px-6 py-5"
+          >
+            <FormField
+              control={control}
+              name="name"
+              rules={{ required: 'ロール名を入力してください' }}
+              render={({ field }) => (
+                <FormItem className="gap-1">
+                  <FormLabel>ロール名</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="text"
+                      maxLength={100}
+                      {...field}
+                      // 詳細が届く前に入力させると、到着時の reset が入力を黙って上書きする
+                      disabled={editingLoading}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
-          <div>
-            <span className="mb-1 block text-sm font-medium text-foreground">権限</span>
-            {/* 詳細取得の失敗（初回・409 後の取り直しとも）は「読み込み中」に固着させず、
-                ダイアログ内で再試行できるようにする */}
-            {editingLoading && detailLoadFailed ? (
-              <div className="space-y-2 rounded-md border p-3">
-                <p className="text-sm text-destructive-strong">ロール情報の取得に失敗しました</p>
-                <Button type="button" variant="outline" onClick={() => void reloadEditingRole()}>
-                  再試行
-                </Button>
-              </div>
-            ) : catalogLoading || editingLoading ? (
-              <p className="text-sm text-muted-foreground">読み込み中...</p>
-            ) : (
-              <div className="space-y-4 rounded-md border p-3">
-                {groupByConsole(catalog).map(group => {
-                  return (
-                    <div key={group.key}>
-                      <p className="mb-1 text-xs font-semibold tracking-widest text-muted-foreground uppercase">
-                        {group.label}
-                      </p>
-                      <div className="space-y-1">
-                        {group.items.map(entry => {
-                          const code = entry.code;
-                          if (code === undefined) return null;
-                          return (
-                            <Label key={code} className="font-normal">
-                              <input
-                                type="checkbox"
-                                checked={permissions.includes(code)}
-                                onChange={() => toggle(code)}
-                              />
-                              {code}
-                            </Label>
-                          );
-                        })}
-                      </div>
-                    </div>
+            <FormField
+              control={control}
+              name="permissions"
+              rules={{ validate: value => value.length > 0 || '権限を 1 つ以上選択してください' }}
+              render={({ field }) => {
+                const groups = groupByConsole(catalog);
+                // 焦点は組の先頭が受ける
+                const firstCode = groups[0]?.items.find(entry => entry.code !== undefined)?.code;
+                const toggle = (code: PlatformPermission) => {
+                  field.onChange(
+                    field.value.includes(code)
+                      ? field.value.filter(item => item !== code)
+                      : [...field.value, code]
                   );
-                })}
-              </div>
-            )}
-          </div>
-          <div className="flex justify-end gap-3 border-t pt-4">
-            <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
-              キャンセル
-            </Button>
-            <Button type="submit" disabled={isSubmitting || editingLoading}>
-              {isSubmitting ? '保存中...' : '保存する'}
-            </Button>
-          </div>
-        </form>
+                };
+                return (
+                  <FormItem className="gap-1">
+                    <span
+                      id={permissionsLabelId}
+                      className="block text-sm font-medium text-foreground"
+                    >
+                      権限
+                    </span>
+                    {/* 詳細取得の失敗（初回・409 後の取り直しとも）は「読み込み中」に固着させず、
+                        ダイアログ内で再試行できるようにする */}
+                    {editingLoading && detailLoadFailed ? (
+                      <div className="space-y-2 rounded-md border p-3">
+                        <p className="text-sm text-destructive-strong">
+                          ロール情報の取得に失敗しました
+                        </p>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => void reloadEditingRole()}
+                        >
+                          再試行
+                        </Button>
+                      </div>
+                    ) : (
+                      <FormControl>
+                        {/* 目録の到着前も組そのものは立てる。新規作成では目録の読み込み中でも
+                            保存が押せるため、組が無いと指摘が欄と結び付かないまま出る */}
+                        <div
+                          role="group"
+                          aria-labelledby={permissionsLabelId}
+                          className="space-y-4 rounded-md border p-3"
+                        >
+                          {catalogLoading || editingLoading ? (
+                            // 詳細の到着前に選ばせると、到着時の reset が選択を黙って上書きする
+                            <p className="text-sm text-muted-foreground">読み込み中...</p>
+                          ) : (
+                            groups.map(group => {
+                              return (
+                                <div key={group.key}>
+                                  <p className="mb-1 text-xs font-semibold tracking-widest text-muted-foreground uppercase">
+                                    {group.label}
+                                  </p>
+                                  <div className="space-y-1">
+                                    {group.items.map(entry => {
+                                      const code = entry.code;
+                                      if (code === undefined) return null;
+                                      return (
+                                        <Label key={code} className="font-normal">
+                                          <input
+                                            type="checkbox"
+                                            checked={field.value.includes(code)}
+                                            onChange={() => toggle(code)}
+                                            ref={code === firstCode ? field.ref : undefined}
+                                          />
+                                          {code}
+                                        </Label>
+                                      );
+                                    })}
+                                  </div>
+                                </div>
+                              );
+                            })
+                          )}
+                        </div>
+                      </FormControl>
+                    )}
+                    <FormDescription className="text-xs">
+                      1 つ以上を選択してください。
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                );
+              }}
+            />
+            <div className="flex justify-end gap-3 border-t pt-4">
+              <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
+                キャンセル
+              </Button>
+              <Button type="submit" disabled={isSubmitting || editingLoading}>
+                {isSubmitting ? '保存中...' : '保存する'}
+              </Button>
+            </div>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/_pages/platform-roles/ui/__tests__/RoleFormModal.test.tsx
+++ b/frontend/src/_pages/platform-roles/ui/__tests__/RoleFormModal.test.tsx
@@ -189,17 +189,36 @@ describe('ロール編集モーダル', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it('権限を全て外すと保存 API を呼ばず警告する', async () => {
+  it('権限を全て外すと、その組の傍に文言を出し保存 API を呼ばない', async () => {
     renderModal();
+    await screen.findByLabelText('ORDER_MANAGE');
+
+    fireEvent.click(screen.getByLabelText('ORDER_MANAGE'));
+    const submitButton = screen.getByRole('button', { name: '保存する' });
+    fireEvent.click(submitButton);
+
+    const message = await screen.findByText('権限を 1 つ以上選択してください');
+    expect(mockedToast.error).not.toHaveBeenCalled();
+    expect(mockedRoleApi.update).not.toHaveBeenCalled();
+    // 必須は「N のうち 1 つ以上」＝組の性質なので、指摘も個々の項目ではなく組に紐づく
+    const group = screen.getByRole('group', { name: '権限' });
+    expect(group).toHaveAttribute('aria-invalid', 'true');
+    expect(group.getAttribute('aria-describedby')).toContain(message.id);
+    expect(submitButton).toBeEnabled();
+    // handleSubmit は登録済みの ref を焦点にする。組の先頭まで ref が届いていないと、
+    // 他の症状を出さずに焦点移動だけが失われる
+    expect(document.activeElement).toBe(screen.getByLabelText('STAFF_MANAGE'));
+  });
+
+  it('ロール名が空なら欄の傍に文言を出し保存 API を呼ばない', async () => {
+    renderModal({ editingId: null });
     await screen.findByLabelText('ORDER_MANAGE');
 
     fireEvent.click(screen.getByLabelText('ORDER_MANAGE'));
     fireEvent.click(screen.getByRole('button', { name: '保存する' }));
 
-    await waitFor(() =>
-      expect(mockedToast.error).toHaveBeenCalledWith('権限を 1 つ以上選択してください')
-    );
-    expect(mockedRoleApi.update).not.toHaveBeenCalled();
+    expect(await screen.findByText('ロール名を入力してください')).toBeInTheDocument();
+    expect(mockedRoleApi.create).not.toHaveBeenCalled();
   });
 
   it('409 は詳細と一覧を取り直してモーダルを開いたままにする（version 固着で詰まないこと）', async () => {

--- a/frontend/src/features/password-change/ui/PasswordChangeForm.tsx
+++ b/frontend/src/features/password-change/ui/PasswordChangeForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { platformAuthApi, useAuth } from '@/entities/user';
 import { getApiErrorMessage } from '@/shared/lib';
@@ -12,96 +13,126 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
   Input,
-  Label,
 } from '@/shared/ui';
+
+interface PasswordChangeFormValues {
+  current_password: string;
+  new_password: string;
+  confirm_password: string;
+}
 
 /** パスワード変更フォーム。成功するとトークンが失効するため、ログアウトして再ログインを促す。 */
 export function PasswordChangeForm() {
   const { logout } = useAuth();
-  const [currentPassword, setCurrentPassword] = useState('');
-  const [newPassword, setNewPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const form = useForm<PasswordChangeFormValues>({
+    defaultValues: { current_password: '', new_password: '', confirm_password: '' },
+  });
+  const {
+    control,
+    handleSubmit,
+    formState: { isSubmitting },
+  } = form;
+  // 成功後はログアウトの遷移が進行中で、この画面はまだ立っている。isSubmitting は
+  // ハンドラの完了で戻るため、それだけを見ると遷移の間だけボタンが再び押せてしまう。
+  // react-hook-form の isSubmitSuccessful は使えない — ハンドラが自分で握り潰した
+  // 失敗も「成功」と数えるため、失敗後もボタンが塞がったままになる。
+  const [changed, setChanged] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (newPassword !== confirmPassword) {
-      toast.error('新しいパスワードが一致しません');
-      return;
-    }
-    if (newPassword.length < 8) {
-      toast.error('新しいパスワードは8文字以上で入力してください');
-      return;
-    }
-    setIsSubmitting(true);
+  const pending = isSubmitting || changed;
+
+  const submit = async (values: PasswordChangeFormValues) => {
     try {
       await platformAuthApi.changePassword({
-        current_password: currentPassword,
-        new_password: newPassword,
+        current_password: values.current_password,
+        new_password: values.new_password,
       });
       toast.success('パスワードを変更しました。再度ログインしてください');
+      setChanged(true);
       logout();
     } catch (error) {
       toast.error(getApiErrorMessage(error, 'パスワードの変更に失敗しました'));
-      setIsSubmitting(false);
     }
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <Card>
-        <CardHeader>
-          <CardTitle role="heading" aria-level={2}>
-            パスワード変更
-          </CardTitle>
-          <CardDescription>
-            変更後は自動的にログアウトされ、新しいパスワードでの再ログインが必要です。
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="grid gap-2">
-            <Label htmlFor="current-password">現在のパスワード *</Label>
-            <Input
-              id="current-password"
-              type="password"
-              value={currentPassword}
-              onChange={e => setCurrentPassword(e.target.value)}
-              required
-              autoComplete="current-password"
+    <Form {...form}>
+      {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+          我々の文言は永久に描かれない。執行は下の各 rules が担う */}
+      <form onSubmit={handleSubmit(submit)} noValidate>
+        <Card>
+          <CardHeader>
+            <CardTitle role="heading" aria-level={2}>
+              パスワード変更
+            </CardTitle>
+            <CardDescription>
+              変更後は自動的にログアウトされ、新しいパスワードでの再ログインが必要です。
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <FormField
+              control={control}
+              name="current_password"
+              rules={{ required: '現在のパスワードを入力してください' }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>現在のパスワード *</FormLabel>
+                  <FormControl>
+                    <Input type="password" autoComplete="current-password" required {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
-          <div className="grid gap-2">
-            <Label htmlFor="new-password">新しいパスワード（8文字以上）*</Label>
-            <Input
-              id="new-password"
-              type="password"
-              value={newPassword}
-              onChange={e => setNewPassword(e.target.value)}
-              required
-              minLength={8}
-              autoComplete="new-password"
+            <FormField
+              control={control}
+              name="new_password"
+              rules={{
+                required: '新しいパスワードを入力してください',
+                minLength: { value: 8, message: '新しいパスワードは8文字以上で入力してください' },
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>新しいパスワード（8文字以上）*</FormLabel>
+                  <FormControl>
+                    <Input type="password" autoComplete="new-password" required {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
-          <div className="grid gap-2">
-            <Label htmlFor="confirm-password">新しいパスワード（確認）*</Label>
-            <Input
-              id="confirm-password"
-              type="password"
-              value={confirmPassword}
-              onChange={e => setConfirmPassword(e.target.value)}
-              required
-              minLength={8}
-              autoComplete="new-password"
+            <FormField
+              control={control}
+              name="confirm_password"
+              rules={{
+                required: '確認用のパスワードを入力してください',
+                validate: (value, values) =>
+                  value === values.new_password || '新しいパスワードが一致しません',
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>新しいパスワード（確認）*</FormLabel>
+                  <FormControl>
+                    <Input type="password" autoComplete="new-password" required {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
-        </CardContent>
-        <CardFooter className="justify-end">
-          <Button type="submit" disabled={isSubmitting}>
-            {isSubmitting ? '変更中...' : 'パスワードを変更する'}
-          </Button>
-        </CardFooter>
-      </Card>
-    </form>
+          </CardContent>
+          <CardFooter className="justify-end">
+            <Button type="submit" disabled={pending}>
+              {pending ? '変更中...' : 'パスワードを変更する'}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </Form>
   );
 }

--- a/frontend/src/features/password-change/ui/__tests__/PasswordChangeForm.test.tsx
+++ b/frontend/src/features/password-change/ui/__tests__/PasswordChangeForm.test.tsx
@@ -51,7 +51,7 @@ describe('パスワード変更フォーム', () => {
     await waitFor(() => expect(mockLogout).toHaveBeenCalledTimes(1));
   });
 
-  it('確認用パスワードが一致しない場合は API を呼ばないこと', async () => {
+  it('確認用パスワードが一致しない場合は、その欄の傍に文言を出し API を呼ばないこと', async () => {
     const { container } = render(<PasswordChangeForm />);
     const { current, next, confirm } = fields(container);
 
@@ -60,22 +60,72 @@ describe('パスワード変更フォーム', () => {
     fireEvent.change(confirm, { target: { value: 'other12345' } });
     fireEvent.click(screen.getByRole('button', { name: 'パスワードを変更する' }));
 
-    await waitFor(() =>
-      expect(mockedToastError).toHaveBeenCalledWith('新しいパスワードが一致しません')
-    );
+    const message = await screen.findByText('新しいパスワードが一致しません');
+    expect(mockedToastError).not.toHaveBeenCalled();
     expect(mockedChangePassword).not.toHaveBeenCalled();
     expect(mockLogout).not.toHaveBeenCalled();
+    // 「入力の傍」は視覚的な近さだけでなく、読み上げが欄と指摘を結べることまで含む
+    expect(confirm).toHaveAttribute('aria-invalid', 'true');
+    expect(confirm.getAttribute('aria-describedby')).toContain(message.id);
   });
 
-  it('ブラウザ側の入力制約（type / required / minLength）が維持されていること', () => {
+  it('未入力のまま送信すると各欄の傍に必須の文言が出て、ボタンは無効化されないこと', async () => {
+    render(<PasswordChangeForm />);
+    const submitButton = screen.getByRole('button', { name: 'パスワードを変更する' });
+
+    fireEvent.click(submitButton);
+
+    expect(await screen.findByText('現在のパスワードを入力してください')).toBeInTheDocument();
+    expect(screen.getByText('新しいパスワードを入力してください')).toBeInTheDocument();
+    expect(screen.getByText('確認用のパスワードを入力してください')).toBeInTheDocument();
+    expect(mockedChangePassword).not.toHaveBeenCalled();
+    // 押させて指摘を出す方が、押せない理由の分からないボタンより情報が多い
+    expect(submitButton).toBeEnabled();
+  });
+
+  it('8 文字未満は新しいパスワードの欄が文言で拒むこと', async () => {
+    const { container } = render(<PasswordChangeForm />);
+    const { current, next, confirm } = fields(container);
+
+    fireEvent.change(current, { target: { value: 'oldpass123' } });
+    fireEvent.change(next, { target: { value: 'short7' } });
+    fireEvent.change(confirm, { target: { value: 'short7' } });
+    fireEvent.click(screen.getByRole('button', { name: 'パスワードを変更する' }));
+
+    expect(
+      await screen.findByText('新しいパスワードは8文字以上で入力してください')
+    ).toBeInTheDocument();
+    expect(mockedChangePassword).not.toHaveBeenCalled();
+  });
+
+  // 成功後はログアウトの遷移が進むので押させないが、失敗したときの画面はまだ立っている。
+  // 押し直せないと、リロード以外に回復手段が無くなる
+  it('変更に失敗したらボタンを押し直せること', async () => {
+    mockedChangePassword.mockRejectedValue({ response: { status: 400 } });
+    const { container } = render(<PasswordChangeForm />);
+    const { current, next, confirm } = fields(container);
+
+    fireEvent.change(current, { target: { value: 'oldpass123' } });
+    fireEvent.change(next, { target: { value: 'newpass123' } });
+    fireEvent.change(confirm, { target: { value: 'newpass123' } });
+    fireEvent.click(screen.getByRole('button', { name: 'パスワードを変更する' }));
+
+    await waitFor(() => expect(mockedToastError).toHaveBeenCalled());
+    expect(mockLogout).not.toHaveBeenCalled();
+    expect(await screen.findByRole('button', { name: 'パスワードを変更する' })).toBeEnabled();
+  });
+
+  it('type / required は維持され、執行しなくなった minLength は外れていること', () => {
     const { container } = render(<PasswordChangeForm />);
     const { current, next, confirm } = fields(container);
 
     for (const input of [current, next, confirm]) {
       expect(input.type).toBe('password');
+      // 執行は react-hook-form の規則、属性は必須であることを支援技術へ伝えるヒント
       expect(input.required).toBe(true);
     }
-    expect(next.minLength).toBe(8);
-    expect(confirm.minLength).toBe(8);
+    // noValidate の下では何も執行せず何も告知しないため、残すと守っているように誤読される
+    expect(next.hasAttribute('minlength')).toBe(false);
+    expect(confirm.hasAttribute('minlength')).toBe(false);
   });
 });

--- a/frontend/src/features/staff-management/ui/RolePicker.tsx
+++ b/frontend/src/features/staff-management/ui/RolePicker.tsx
@@ -1,46 +1,69 @@
 'use client';
 
+import { useId, type Ref } from 'react';
 import { RoleSummaryResponse } from '@/entities/user';
-import { Label } from '@/shared/ui';
+import { FormControl, FormDescription, FormItem, FormMessage, Label } from '@/shared/ui';
 
 interface RolePickerProps {
   roles: RoleSummaryResponse[];
   isLoading: boolean;
   roleIds: number[];
   onChange: (roleIds: number[]) => void;
+  /**
+   * 検証で最初の問題になったときに焦点を受ける先。handleSubmit は登録済みの ref を焦点にするため、
+   * 値だけを受け取った組は他の症状を出さずに焦点移動だけを失う。
+   */
+  ref?: Ref<HTMLInputElement>;
 }
 
 /**
  * ロールのチェックボックス複数選択（ロールはデータ — 選択肢は GET /platform/roles から取得）。
  * 一覧の取得は親（モーダル）が行い、要約表示と選択肢で同じデータを共有する。
+ *
+ * 必須は「N のうち 1 つ以上」＝組の性質で、各項目に aria-required を撒くと「全部入れよ」に
+ * なってしまう。要求は組の見出しと説明が担い、指摘も個々の項目ではなく組に紐づく。
+ * そのため FormField の render の中でしか描けない（外では FormMessage が文脈を失う）。
  */
-export function RolePicker({ roles, isLoading, roleIds, onChange }: RolePickerProps) {
+export function RolePicker({ roles, isLoading, roleIds, onChange, ref }: RolePickerProps) {
+  const labelId = useId();
   const toggle = (id: number) => {
     onChange(roleIds.includes(id) ? roleIds.filter(roleId => roleId !== id) : [...roleIds, id]);
   };
+  // 焦点は組の先頭が受ける
+  const firstId = roles.find(role => role.id !== undefined)?.id;
 
   return (
-    <div>
-      <span className="mb-1 block text-sm font-medium text-foreground">ロール</span>
-      <div className="space-y-1 rounded-md border p-3">
-        {isLoading ? (
-          <p className="text-sm text-muted-foreground">読み込み中...</p>
-        ) : (
-          roles.map(role => {
-            const id = role.id;
-            if (id === undefined) return null;
-            return (
-              <Label key={id} className="font-normal">
-                <input type="checkbox" checked={roleIds.includes(id)} onChange={() => toggle(id)} />
-                {role.name}
-              </Label>
-            );
-          })
-        )}
-      </div>
-      <p className="mt-1 text-xs text-muted-foreground">
+    <FormItem className="gap-1">
+      <span id={labelId} className="block text-sm font-medium text-foreground">
+        ロール
+      </span>
+      <FormControl>
+        <div role="group" aria-labelledby={labelId} className="space-y-1 rounded-md border p-3">
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground">読み込み中...</p>
+          ) : (
+            roles.map(role => {
+              const id = role.id;
+              if (id === undefined) return null;
+              return (
+                <Label key={id} className="font-normal">
+                  <input
+                    type="checkbox"
+                    checked={roleIds.includes(id)}
+                    onChange={() => toggle(id)}
+                    ref={id === firstId ? ref : undefined}
+                  />
+                  {role.name}
+                </Label>
+              );
+            })
+          )}
+        </div>
+      </FormControl>
+      <FormDescription className="text-xs">
         1 つ以上を選択してください（兼務は複数選択）。
-      </p>
-    </div>
+      </FormDescription>
+      <FormMessage />
+    </FormItem>
   );
 }

--- a/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
+++ b/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import {
   PlatformStore,
@@ -11,7 +10,19 @@ import {
   platformStaffApi,
 } from '@/entities/user';
 import { getApiErrorMessage, useManagedList } from '@/shared/lib';
-import { Button, Dialog, DialogContent, DialogTitle, Input, Label } from '@/shared/ui';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+} from '@/shared/ui';
 import { RolePicker } from './RolePicker';
 import { StoreSetPicker } from './StoreSetPicker';
 
@@ -26,11 +37,19 @@ interface StaffCreateModalProps {
   onCreated: () => void;
 }
 
+/** 値はそのまま作成リクエストになるため、欄名は wire のキーに合わせる。 */
 interface StaffCreateFormValues {
   email: string;
   password: string;
   display_name: string;
+  role_ids: number[];
+  store_scope_type: PlatformStoreScopeType;
+  store_ids: number[];
 }
+
+// noValidate で type="email" の執行が止まるぶんを規則で引き継ぐ。ドメインに .
+// を求める点で原生より厳しいが、これは既に StoreEditPage が採っている形。
+const EMAIL_PATTERN = /^([^\s@])+@([^\s@])+\.[^\s@]+$/;
 
 /**
  * スタッフの新規作成モーダル（メール・初期パスワード・氏名・ロール・担当店舗）。
@@ -43,33 +62,33 @@ export function StaffCreateModal({
   onClose,
   onCreated,
 }: StaffCreateModalProps) {
-  const {
-    register,
-    handleSubmit,
-    formState: { isSubmitting },
-  } = useForm<StaffCreateFormValues>({
-    defaultValues: { email: '', password: '', display_name: '' },
+  const form = useForm<StaffCreateFormValues>({
+    defaultValues: {
+      email: '',
+      password: '',
+      display_name: '',
+      role_ids: [],
+      store_scope_type: 'ALL_STORES',
+      store_ids: [],
+    },
   });
-  const [roleIds, setRoleIds] = useState<number[]>([]);
-  const [storeScopeType, setStoreScopeType] = useState<PlatformStoreScopeType>('ALL_STORES');
-  const [storeIds, setStoreIds] = useState<number[]>([]);
+  const {
+    control,
+    handleSubmit,
+    setValue,
+    formState: { isSubmitting },
+  } = form;
+  // 店舗集合は検証を持たないが、値は他の欄と同じ場所に置く（送信も初期化も一箇所で済む）
+  const storeScopeType = useWatch({ control, name: 'store_scope_type' });
+  const storeIds = useWatch({ control, name: 'store_ids' });
   const { items: roles, isLoading: rolesLoading } = useManagedList<RoleSummaryResponse>(
     () => platformRoleApi.list(),
     'ロール一覧の取得に失敗しました'
   );
 
   const submit = async (values: StaffCreateFormValues) => {
-    if (roleIds.length === 0) {
-      toast.error('ロールを 1 つ以上選択してください');
-      return;
-    }
     try {
-      await platformStaffApi.create({
-        ...values,
-        role_ids: roleIds,
-        store_scope_type: storeScopeType,
-        store_ids: storeIds,
-      });
+      await platformStaffApi.create(values);
       toast.success('スタッフを追加しました');
       onCreated();
       onClose();
@@ -95,58 +114,95 @@ export function StaffCreateModal({
         <DialogTitle className="border-b px-6 py-4 text-lg font-semibold text-foreground">
           スタッフを追加
         </DialogTitle>
-        <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
-          <div className="grid gap-1">
-            <Label htmlFor="staff-email">メールアドレス</Label>
-            <Input
-              id="staff-email"
-              type="email"
-              maxLength={127}
-              {...register('email', { required: true })}
+        <Form {...form}>
+          {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+              我々の文言は永久に描かれない。執行は下の各 rules が担う */}
+          <form onSubmit={handleSubmit(submit)} noValidate className="space-y-4 px-6 py-5">
+            <FormField
+              control={control}
+              name="email"
+              rules={{
+                required: 'メールアドレスを入力してください',
+                pattern: {
+                  value: EMAIL_PATTERN,
+                  message: 'メールアドレスの形式が正しくありません',
+                },
+              }}
+              render={({ field }) => (
+                <FormItem className="gap-1">
+                  <FormLabel>メールアドレス</FormLabel>
+                  <FormControl>
+                    <Input type="email" maxLength={127} {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
-          <div className="grid gap-1">
-            <Label htmlFor="staff-password">初期パスワード</Label>
-            <Input
-              id="staff-password"
-              type="password"
-              {...register('password', { required: true })}
+            <FormField
+              control={control}
+              name="password"
+              rules={{ required: '初期パスワードを入力してください' }}
+              render={({ field }) => (
+                <FormItem className="gap-1">
+                  <FormLabel>初期パスワード</FormLabel>
+                  <FormControl>
+                    <Input type="password" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
-          <div className="grid gap-1">
-            <Label htmlFor="staff-display-name">氏名</Label>
-            <Input
-              id="staff-display-name"
-              type="text"
-              {...register('display_name', { required: true })}
+            <FormField
+              control={control}
+              name="display_name"
+              rules={{ required: '氏名を入力してください' }}
+              render={({ field }) => (
+                <FormItem className="gap-1">
+                  <FormLabel>氏名</FormLabel>
+                  <FormControl>
+                    <Input type="text" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
-          <RolePicker
-            roles={roles}
-            isLoading={rolesLoading}
-            roleIds={roleIds}
-            onChange={setRoleIds}
-          />
-          <StoreSetPicker
-            stores={stores}
-            isLoading={storesLoading}
-            onReload={onReloadStores}
-            storeScopeType={storeScopeType}
-            storeIds={storeIds}
-            onChange={next => {
-              setStoreScopeType(next.storeScopeType);
-              setStoreIds(next.storeIds);
-            }}
-          />
-          <div className="flex justify-end gap-3 border-t pt-4">
-            <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
-              キャンセル
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? '追加中...' : '追加する'}
-            </Button>
-          </div>
-        </form>
+            <FormField
+              control={control}
+              name="role_ids"
+              rules={{
+                validate: value => value.length > 0 || 'ロールを 1 つ以上選択してください',
+              }}
+              render={({ field }) => (
+                <RolePicker
+                  roles={roles}
+                  isLoading={rolesLoading}
+                  roleIds={field.value}
+                  onChange={field.onChange}
+                  ref={field.ref}
+                />
+              )}
+            />
+            <StoreSetPicker
+              stores={stores}
+              isLoading={storesLoading}
+              onReload={onReloadStores}
+              storeScopeType={storeScopeType}
+              storeIds={storeIds}
+              onChange={next => {
+                setValue('store_scope_type', next.storeScopeType);
+                setValue('store_ids', next.storeIds);
+              }}
+            />
+            <div className="flex justify-end gap-3 border-t pt-4">
+              <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
+                キャンセル
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? '追加中...' : '追加する'}
+              </Button>
+            </div>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/features/staff-management/ui/StaffEditModal.tsx
+++ b/frontend/src/features/staff-management/ui/StaffEditModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import {
   PlatformStaffResponse,
@@ -11,7 +12,7 @@ import {
   platformStaffApi,
 } from '@/entities/user';
 import { getApiErrorMessage, isConflict, useManagedList } from '@/shared/lib';
-import { Button, Dialog, DialogContent, DialogTitle, Label } from '@/shared/ui';
+import { Button, Dialog, DialogContent, DialogTitle, Form, FormField, Label } from '@/shared/ui';
 import { roleSetLabel } from '../lib/roleSetLabel';
 import { storeSetLabel } from '../lib/storeSetLabel';
 import { RolePicker } from './RolePicker';
@@ -30,6 +31,26 @@ interface StaffEditModalProps {
   onUpdated: () => void;
 }
 
+/** 値はそのまま更新リクエストになるため（version を除く）、欄名は wire のキーに合わせる。 */
+interface StaffEditFormValues {
+  role_ids: number[];
+  store_scope_type: PlatformStoreScopeType;
+  store_ids: number[];
+  enabled: boolean;
+}
+
+/** 対象スタッフからフォームの初期値を作る。prop が差し替わるたびにこれで組み直す。 */
+function toFormValues(staff: PlatformStaffResponse): StaffEditFormValues {
+  return {
+    role_ids: (staff.roles ?? []).flatMap(role => (role.id === undefined ? [] : [role.id])),
+    // 欠落時は全店舗ではなく個別店舗（storeIds 空 = どの店舗にも及ばない）へ倒す。
+    // 既定を全店舗にすると、保存操作がそのまま作用域の拡大になる。
+    store_scope_type: staff.store_scope_type ?? 'SPECIFIC_STORES',
+    store_ids: staff.store_ids ?? [],
+    enabled: staff.enabled,
+  };
+}
+
 /**
  * スタッフの授権編集モーダル（ロール・店舗集合・停止/再開。「この設定の結果」要約付き）。
  * 開いたときだけ mount される前提。ロール目録の取得は mount 時 = 開いた時点に遅延される。
@@ -42,24 +63,27 @@ export function StaffEditModal({
   onClose,
   onUpdated,
 }: StaffEditModalProps) {
-  const [roleIds, setRoleIds] = useState<number[]>([]);
-  const [storeScopeType, setStoreScopeType] = useState<PlatformStoreScopeType>('ALL_STORES');
-  const [storeIds, setStoreIds] = useState<number[]>([]);
-  const [enabled, setEnabled] = useState(true);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const form = useForm<StaffEditFormValues>({ defaultValues: toFormValues(staff) });
+  const {
+    control,
+    handleSubmit,
+    reset,
+    setValue,
+    formState: { isSubmitting },
+  } = form;
+  const roleIds = useWatch({ control, name: 'role_ids' });
+  const storeScopeType = useWatch({ control, name: 'store_scope_type' });
+  const storeIds = useWatch({ control, name: 'store_ids' });
+  const enabled = useWatch({ control, name: 'enabled' });
   const { items: roles, isLoading: rolesLoading } = useManagedList<RoleSummaryResponse>(
     () => platformRoleApi.list(),
     'ロール一覧の取得に失敗しました'
   );
 
+  // 409 の再取得で staff が差し替わったら、ローカル編集は捨てて最新値で組み直す
   useEffect(() => {
-    setRoleIds((staff.roles ?? []).flatMap(role => (role.id === undefined ? [] : [role.id])));
-    // 欠落時は全店舗ではなく個別店舗（storeIds 空 = どの店舗にも及ばない）へ倒す。
-    // 既定を全店舗にすると、保存操作がそのまま作用域の拡大になる。
-    setStoreScopeType(staff.store_scope_type ?? 'SPECIFIC_STORES');
-    setStoreIds(staff.store_ids ?? []);
-    setEnabled(staff.enabled);
-  }, [staff]);
+    reset(toFormValues(staff));
+  }, [staff, reset]);
 
   const summary = useMemo(() => {
     const scopeLabel = storeSetLabel(storeScopeType, storeIds, stores);
@@ -67,18 +91,10 @@ export function StaffEditModal({
     return `${staff.display_name ?? ''}さんは ${roleSetLabel(selectedRoles)} として ${scopeLabel} のデータにアクセスできます`;
   }, [roles, roleIds, storeScopeType, storeIds, stores, staff]);
 
-  const submit = async () => {
-    if (roleIds.length === 0) {
-      toast.error('ロールを 1 つ以上選択してください');
-      return;
-    }
-    setIsSubmitting(true);
+  const submit = async (values: StaffEditFormValues) => {
     try {
       await platformStaffApi.update(staff.id ?? 0, {
-        role_ids: roleIds,
-        store_scope_type: storeScopeType,
-        store_ids: storeIds,
-        enabled,
+        ...values,
         // 楽観ロック用バージョン（応答の version をそのまま往復する）
         version: staff.version,
       });
@@ -88,14 +104,12 @@ export function StaffEditModal({
     } catch (error) {
       if (isConflict(error)) {
         // 楽観ロック競合: 固定文言の toast を出し、一覧を再取得してモーダルの内容を
-        // 最新値へ自動リフレッシュする（staff prop の更新で useEffect が再初期化。ローカル編集は破棄、モーダルは開いたまま）。
+        // 最新値へ自動リフレッシュする（staff prop の更新で上の reset が走る。ローカル編集は破棄、モーダルは開いたまま）。
         toast.error('他の管理者が更新しました。最新の内容を確認してください');
         onUpdated();
       } else {
         toast.error(getApiErrorMessage(error, '権限の更新に失敗しました'));
       }
-    } finally {
-      setIsSubmitting(false);
     }
   };
 
@@ -116,63 +130,77 @@ export function StaffEditModal({
         <DialogTitle className="border-b px-6 py-4 text-lg font-semibold text-foreground">
           {staff.display_name} の権限を編集
         </DialogTitle>
-        <div className="space-y-4 px-6 py-5">
-          <RolePicker
-            roles={roles}
-            isLoading={rolesLoading}
-            roleIds={roleIds}
-            onChange={setRoleIds}
-          />
-          <StoreSetPicker
-            stores={stores}
-            isLoading={storesLoading}
-            onReload={onReloadStores}
-            storeScopeType={storeScopeType}
-            storeIds={storeIds}
-            onChange={next => {
-              setStoreScopeType(next.storeScopeType);
-              setStoreIds(next.storeIds);
-            }}
-          />
-          <div>
-            <span className="mb-1 block text-sm font-medium text-foreground">状態</span>
-            <div className="flex items-center gap-4">
-              <Label className="font-normal">
-                <input
-                  type="radio"
-                  name="staff-enabled"
-                  checked={enabled}
-                  onChange={() => setEnabled(true)}
+        <Form {...form}>
+          {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+              我々の文言は永久に描かれない。執行は下の rules が担う */}
+          <form onSubmit={handleSubmit(submit)} noValidate className="space-y-4 px-6 py-5">
+            <FormField
+              control={control}
+              name="role_ids"
+              rules={{
+                validate: value => value.length > 0 || 'ロールを 1 つ以上選択してください',
+              }}
+              render={({ field }) => (
+                <RolePicker
+                  roles={roles}
+                  isLoading={rolesLoading}
+                  roleIds={field.value}
+                  onChange={field.onChange}
+                  ref={field.ref}
                 />
-                有効
-              </Label>
-              <Label className="font-normal">
-                <input
-                  type="radio"
-                  name="staff-enabled"
-                  checked={!enabled}
-                  onChange={() => setEnabled(false)}
-                />
-                停止
-              </Label>
+              )}
+            />
+            <StoreSetPicker
+              stores={stores}
+              isLoading={storesLoading}
+              onReload={onReloadStores}
+              storeScopeType={storeScopeType}
+              storeIds={storeIds}
+              onChange={next => {
+                setValue('store_scope_type', next.storeScopeType);
+                setValue('store_ids', next.storeIds);
+              }}
+            />
+            <div>
+              <span className="mb-1 block text-sm font-medium text-foreground">状態</span>
+              <div className="flex items-center gap-4">
+                <Label className="font-normal">
+                  <input
+                    type="radio"
+                    name="staff-enabled"
+                    checked={enabled}
+                    onChange={() => setValue('enabled', true)}
+                  />
+                  有効
+                </Label>
+                <Label className="font-normal">
+                  <input
+                    type="radio"
+                    name="staff-enabled"
+                    checked={!enabled}
+                    onChange={() => setValue('enabled', false)}
+                  />
+                  停止
+                </Label>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                停止してもアカウントは削除されず、過去の操作記録は保持されます。
+              </p>
             </div>
-            <p className="mt-1 text-xs text-muted-foreground">
-              停止してもアカウントは削除されず、過去の操作記録は保持されます。
-            </p>
-          </div>
-          <div>
-            <p className="mb-1 text-sm font-medium text-foreground">この設定の結果</p>
-            <p className="rounded-md bg-primary/10 p-3 text-sm text-primary-strong">{summary}</p>
-          </div>
-          <div className="flex justify-end gap-3 border-t pt-4">
-            <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
-              キャンセル
-            </Button>
-            <Button type="button" onClick={submit} disabled={isSubmitting}>
-              {isSubmitting ? '保存中...' : '保存する'}
-            </Button>
-          </div>
-        </div>
+            <div>
+              <p className="mb-1 text-sm font-medium text-foreground">この設定の結果</p>
+              <p className="rounded-md bg-primary/10 p-3 text-sm text-primary-strong">{summary}</p>
+            </div>
+            <div className="flex justify-end gap-3 border-t pt-4">
+              <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
+                キャンセル
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? '保存中...' : '保存する'}
+              </Button>
+            </div>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/features/staff-management/ui/__tests__/StaffCreateModal.test.tsx
+++ b/frontend/src/features/staff-management/ui/__tests__/StaffCreateModal.test.tsx
@@ -96,27 +96,53 @@ describe('スタッフ新規作成モーダル', () => {
     });
   });
 
-  it('ロールが未選択なら作成 API を呼ばず警告する', async () => {
+  it('ロールが未選択なら、その組の傍に文言を出し作成 API を呼ばない', async () => {
     renderModal();
     await screen.findByLabelText('店長');
 
     fillBasics();
-    fireEvent.click(screen.getByRole('button', { name: '追加する' }));
+    const submitButton = screen.getByRole('button', { name: '追加する' });
+    fireEvent.click(submitButton);
 
-    await waitFor(() =>
-      expect(mockedToast.error).toHaveBeenCalledWith('ロールを 1 つ以上選択してください')
-    );
+    const message = await screen.findByText('ロールを 1 つ以上選択してください');
+    expect(mockedToast.error).not.toHaveBeenCalled();
     expect(mockedStaffApi.create).not.toHaveBeenCalled();
+    // 必須は「N のうち 1 つ以上」＝組の性質なので、指摘も個々の項目ではなく組に紐づく
+    const group = screen.getByRole('group', { name: 'ロール' });
+    expect(group).toHaveAttribute('aria-invalid', 'true');
+    expect(group.getAttribute('aria-describedby')).toContain(message.id);
+    expect(submitButton).toBeEnabled();
+    // handleSubmit は登録済みの ref を焦点にする。組の先頭まで ref が届いていないと、
+    // 他の症状を出さずに焦点移動だけが失われる
+    expect(document.activeElement).toBe(screen.getByLabelText('店長'));
   });
 
-  it('必須項目が空なら作成 API を呼ばない', async () => {
+  it('必須項目が空なら各欄の傍に文言を出し作成 API を呼ばない', async () => {
     renderModal();
     await screen.findByLabelText('店長');
 
     fireEvent.click(screen.getByLabelText('店長'));
     fireEvent.click(screen.getByRole('button', { name: '追加する' }));
 
-    await waitFor(() => expect(mockedRoleApi.list).toHaveBeenCalled());
+    expect(await screen.findByText('メールアドレスを入力してください')).toBeInTheDocument();
+    expect(screen.getByText('初期パスワードを入力してください')).toBeInTheDocument();
+    expect(screen.getByText('氏名を入力してください')).toBeInTheDocument();
+    expect(mockedStaffApi.create).not.toHaveBeenCalled();
+  });
+
+  // noValidate で type="email" の執行が止まるため、同じ検査を規則が引き継ぐ
+  it('メールアドレスの形式が不正なら文言を出し作成 API を呼ばない', async () => {
+    renderModal();
+    await screen.findByLabelText('店長');
+
+    fillBasics();
+    fireEvent.change(screen.getByLabelText('メールアドレス'), {
+      target: { value: 'not-an-email' },
+    });
+    fireEvent.click(screen.getByLabelText('店長'));
+    fireEvent.click(screen.getByRole('button', { name: '追加する' }));
+
+    expect(await screen.findByText('メールアドレスの形式が正しくありません')).toBeInTheDocument();
     expect(mockedStaffApi.create).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/features/staff-management/ui/__tests__/StaffEditModal.test.tsx
+++ b/frontend/src/features/staff-management/ui/__tests__/StaffEditModal.test.tsx
@@ -91,16 +91,20 @@ describe('スタッフ授権編集モーダル', () => {
     expect(mockedStaffApi.update.mock.calls[0][1]).toMatchObject({ enabled: false });
   });
 
-  it('ロールの選択を全て外すと更新 API を呼ばず警告する', async () => {
+  it('ロールの選択を全て外すと、その組の傍に文言を出し更新 API を呼ばない', async () => {
     renderModal({ staff: staff({ roles: [] }) });
     await screen.findByRole('dialog');
 
-    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+    const submitButton = screen.getByRole('button', { name: '保存する' });
+    fireEvent.click(submitButton);
 
-    await waitFor(() =>
-      expect(mockedToast.error).toHaveBeenCalledWith('ロールを 1 つ以上選択してください')
-    );
+    const message = await screen.findByText('ロールを 1 つ以上選択してください');
+    expect(mockedToast.error).not.toHaveBeenCalled();
     expect(mockedStaffApi.update).not.toHaveBeenCalled();
+    const group = screen.getByRole('group', { name: 'ロール' });
+    expect(group).toHaveAttribute('aria-invalid', 'true');
+    expect(group.getAttribute('aria-describedby')).toContain(message.id);
+    expect(submitButton).toBeEnabled();
   });
 
   it('保存成功で完了トーストを出し onUpdated と onClose を呼ぶ', async () => {


### PR DESCRIPTION
## 概要

必須項目の指摘が、ブラウザ既定の吹き出しや toast ではなく **我々の日本語で、その欄の傍に** 出るようにした。対象は提示面の条項②に落ちる 5 箇所（`RoleFormModal` の権限 / `StaffCreateModal`・`StaffEditModal` のロール / `PasswordChangeForm` の不一致と桁数）。うち 2 ファイルはフォーム構造の作り替えを伴う。

Closes #591

## 変更内容

- **触った 4 つの `<form>` に `noValidate`** を付け、原生の執行（`required` / `minLength` / `type="email"`）を一括で中和した。執行は react-hook-form の規則へ移し、**どの規則も自分の文言を持つ**（文言なしの `required: true` は送信だけ止めて画面が何も言わない状態を作るため）
- 中和で執行を失う **`minLength={8}` ×2 は外した**。`type="email"` の形式検査は pattern 規則が引き継ぐ。**原生 `required` ×3 は残した** — `FormControl` は `aria-required` を出さないので、必須であることを支援技術へ伝える唯一の無償な手段。**規則が執行、属性はヒント**
- 「N のうち 1 つ以上」は組の性質なので、ロール／権限は **`role="group"` + `aria-labelledby`** の組に作り替え、指摘（`FormMessage`）と説明（`FormDescription`）を **個々の項目ではなく組へ** 紐づけた。`field.ref` は組の先頭のチェックボックスまで配線している（`handleSubmit` の焦点移動は登録済み ref を焦点にするため）
- `StaffEditModal` に `<form>` と `useForm` を入れ、手書きの送信中フラグと `staff` prop の再初期化 `useEffect` を RHF の `isSubmitting` / `reset` へ移した
- `PasswordChangeForm` を素の `useState` から RHF へ移し、3 欄ぶんの必須文言を起草した
- **検証を理由にした送信ボタンの無効化は入れていない**（押させ、文言を出し、最初の問題へ焦点を移す）
- スキーマ検証ライブラリは導入していない

## 検証

- [x] `task lint service=frontend` exit 0（eslint 0 error / prettier / steiger、いずれも緑）
- [x] `task test service=frontend` exit 0（coverage 込み・98 suites / 732 tests）
- [x] `task build service=frontend` exit 0
- [x] `task e2e` exit 0（全 24 シナリオ passed / 4.4m。本 PR が触ったモーダルを直接通るのは `staff-management`（新規作成・店舗集合の編集）と `roles`）
- [x] ローカルで code-review 実施済み（Standards / Spec の 2 軸）

補足 2 点:
- `tsc --noEmit` は `src/shared/api/__tests__/file.test.ts` の axios 型エラー 1 件で落ちるが、**`HEAD` に対して実行した結果と逐字一致**（既存問題であり本 PR の混入ではない）。
- バックエンドは無変更のため、バックエンド側の門禁は回していない。

### 視覚確認（UI 変更時）

実ブラウザ（起栈 → ログイン → 各画面）で以下を確認済み。スクリーンショットは手元にあるが CLI からは添付できないため、確認内容を記す:

- **スタッフを追加**（空のまま送信）: 3 欄とも赤枠 + 欄の直下に赤字、ロールの組は説明の下に指摘、ボタンは押せるまま、焦点はメールアドレスへ移動
- **権限を編集**（ロールを全て外して保存）: 組の傍に指摘、要約「この設定の結果」は `useWatch` 経由で 未選択 へ即時追従、状態ラジオ・担当店舗は従来どおり
- **ロールを追加**（空のまま保存）: ロール名の欄下と権限の組の下、双方に指摘
- **パスワード変更**（空のまま送信）: 3 欄とも指摘、ボタンは押せるまま
- **暗色**: スタッフ追加モーダルで確認。新規に持ち込んだ配色は `FormMessage` の `text-destructive`（DESIGN.md の表に既載・両モード認証済み）だけで、未計測の対が増えていないこと

## 決定ログ

- **`noValidate` を付ける以上、そのフォームの原生制約は全て規則で置き換えるのが前提**（DESIGN.md:490）。よって `RoleFormModal` のロール名と `StaffCreateModal` の 3 欄にも文言を起草した。票が「3 本」と数えているのは `PasswordChangeForm` のぶんで、他は `noValidate` の前提条件として不可分。
- **`EMAIL_PATTERN` を新設した**。`type="email"` は中和されるとこの欄で唯一の形式検査を失うため。正規表現と文言は `StoreEditPage.tsx:57` の既存実装をそのまま採った（＝原生よりわずかに厳しく、ドメインに `.` を要求する）。**仓内 3 つ目の複製**であり、`shared/lib` への抽出は本票の射程外として見送った。
- **原生 `required` を持たない欄に属性を足すことはしなかった**。DESIGN.md:495 が禁じているのは「規則の無い `required`」であって逆ではなく、受入基準も ×3 で数を固定しているため。
- **実装判断（票が委ねた点）: `store_scope_type` / `store_ids` / `enabled` も RHF へ移した**。`StaffEditModal` は `staff` prop の再初期化を `reset` 一本に寄せる必要があり、かつ同じ 2 つの picker が姉妹ファイルに出るので、片方だけ二機構が残る形を避けた。検証を持たない値なので `FormField` は使わず `useWatch` + `setValue`（DESIGN.md:512「それ以外に `FormField` は要らない」に従う）。
- **群の見出しに `FormLabel` は使えない**。`FormLabel` は `htmlFor={formItemId}` を出すが、その id は組の `<div>` に載る＝ labelable でない要素を指す不正な関連付けになるため、`<span id>` + `aria-labelledby` を採った。
- **`isSubmitSuccessful` は採らなかった**（下記「備考」に理由。当初は採っていて、レビューで倒した）。

## 備考 / レビュー観点

- **重点的に見てほしい箇所**: `PasswordChangeForm` の `changed` フラグ。当初 RHF の `formState.isSubmitSuccessful` で「成功後はログアウト遷移中も押させない」を書いたが、これは**退行**だった。7.83 の実装は `isSubmitSuccessful: isEmptyObject(errors) && !onValidError` で、`onValidError` は **ハンドラが外へ throw したときだけ** 立つ。本リポジトリのハンドラは例外を自分で握り潰して toast にするため、**API 失敗も「成功」と数えられ、ボタンが永久に disabled**（リロード以外に回復手段なし）になる。フォーム値ではなく成功後の画面状態なので、意味の明確な `useState` 一つに戻した。失敗経路の RTL ケース（`mockRejectedValue` → ボタンが `toBeEnabled()`）を追加し、修正前後を実ブラウザでも対照している。
- **既知の妥協点**: `aria-invalid` は `role="group"` の supported states に入らないため、組の 2 箇所では支援技術に対して不活性の可能性が高い。効いているのは `aria-describedby` → `FormMessage` の側で、DESIGN.md:493 が規定しているのもそちら。テストがこの属性を断言しているのは**配線の断言**であって、「組が無効を告知する」という主張ではない。
- **切り出し候補**: `EMAIL_PATTERN` の 3 重複（`StoreEditPage` / `StoreCreatePage` / 本 PR）を `shared/lib` へ寄せる小票。
- 既存の toast（API 失敗・成功）は `react-hot-toast` のまま。呼び出し側の `notify` への移行は #592 の射程で、本 PR は **新規の import を足していない**。
