### PR TITLE
fix(frontend): useCursorList に在途リクエスト守衛を入れ、一覧フック 3 本の守り方を揃える

### DIFF
--- a/frontend/src/shared/lib/__tests__/useCursorList.test.tsx
+++ b/frontend/src/shared/lib/__tests__/useCursorList.test.tsx
@@ -52,6 +52,57 @@ describe('useCursorList', () => {
     expect(fetcher).toHaveBeenNthCalledWith(2, '2');
   });
 
+  it('古いリクエストの遅延応答は新しい結果を上書きしない', async () => {
+    // 在途の追加読み込みが後から届くと、取り直した先頭に続きが二重で継ぎ足される
+    let resolveStale!: (value: CursorPageResult<string>) => void;
+    let resolveLatest!: (value: CursorPageResult<string>) => void;
+    const fetcher = jest
+      .fn<Promise<CursorPageResult<string>>, [string?]>()
+      .mockResolvedValueOnce({ rows: ['row0', 'row1'], nextCursor: '2' })
+      .mockImplementationOnce(() => new Promise(resolve => (resolveStale = resolve)))
+      .mockImplementationOnce(() => new Promise(resolve => (resolveLatest = resolve)));
+    const { result } = renderHook(() => useCursorList(fetcher));
+    await waitFor(() => expect(result.current.hasMore).toBe(true));
+
+    // 追加読み込みを在途のまま先頭から取り直し、取り直し → 追加読み込みの順に解決する
+    act(() => result.current.loadMore());
+    act(() => result.current.reload());
+    await act(async () => {
+      resolveLatest({ rows: ['row0', 'row1'], nextCursor: '2' });
+    });
+    await act(async () => {
+      resolveStale({ rows: ['row2', 'row3'], nextCursor: '4' });
+    });
+
+    expect(result.current.rows).toEqual(['row0', 'row1']);
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+
+  it('古いリクエストの遅延失敗は新しい結果を消さない', async () => {
+    // 失敗が行と位置の両方を起点へ戻すため、守衛を落とすと在途の古い失敗が新しく
+    // 届いた一覧を丸ごと消し、「もっと見る」ごと領域をエラー態へ倒してしまう
+    let rejectStale!: (reason?: unknown) => void;
+    let resolveLatest!: (value: CursorPageResult<string>) => void;
+    const fetcher = jest
+      .fn<Promise<CursorPageResult<string>>, [string?]>()
+      .mockImplementationOnce(() => new Promise((_, reject) => (rejectStale = reject)))
+      .mockImplementationOnce(() => new Promise(resolve => (resolveLatest = resolve)));
+    const { result } = renderHook(() => useCursorList(fetcher));
+
+    // マウント時の取得を在途のまま取り直し、取り直し → マウント時の順に解決する
+    act(() => result.current.reload());
+    await act(async () => {
+      resolveLatest({ rows: ['row0', 'row1'], nextCursor: '2' });
+    });
+    await act(async () => {
+      rejectStale(new Error('network'));
+    });
+
+    expect(result.current.rows).toEqual(['row0', 'row1']);
+    expect(result.current.failed).toBe(false);
+    expect(result.current.hasMore).toBe(true);
+  });
+
   it('先頭の取得に失敗したら、空表示と区別できる失敗として伝える', async () => {
     const fetcher = jest.fn(async () => {
       throw new Error('network');

--- a/frontend/src/shared/lib/hooks/useCursorList.ts
+++ b/frontend/src/shared/lib/hooks/useCursorList.ts
@@ -34,6 +34,8 @@ export function useCursorList<T>(
   useEffect(() => {
     fetcherRef.current = fetcher;
   });
+  // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する
+  const requestIdRef = useRef(0);
 
   const [rows, setRows] = useState<T[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -41,27 +43,37 @@ export function useCursorList<T>(
   const [nextCursor, setNextCursor] = useState<string | null>(null);
 
   const load = useCallback((cursor: string | null) => {
+    const requestId = ++requestIdRef.current;
     setIsLoading(true);
     // 再読み込み中は失敗表示を畳む。残したままだと、押した再読み込みが効いているのか分からない。
     setFailed(false);
     fetcherRef
       .current(cursor ?? undefined)
       .then(page => {
+        if (requestId !== requestIdRef.current) return;
         setRows(prev => (cursor === null ? page.rows : [...prev, ...page.rows]));
         setNextCursor(page.nextCursor);
       })
       .catch(() => {
+        if (requestId !== requestIdRef.current) return;
         // 追加読み込みの失敗も先頭取得と同じ扱いにする。行と位置の両方を起点へ戻すのは、
         // 途中の位置を残したまま再試行すると 1〜20 行目を欠いた 21 行目以降だけが返るため。
         setRows([]);
         setNextCursor(null);
         setFailed(true);
       })
-      .finally(() => setIsLoading(false));
+      .finally(() => {
+        if (requestId === requestIdRef.current) setIsLoading(false);
+      });
   }, []);
 
   useEffect(() => {
     load(null);
+    return () => {
+      // requestIdRef はリクエストカウンタであり DOM ref ではない
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      requestIdRef.current++;
+    };
   }, [load]);
 
   return {


### PR DESCRIPTION
## 概要

一覧取得フック 3 本のうち `useCursorList` だけが持っていなかった在途リクエスト守衛
（`requestIdRef`）を入れ、`useListPage` / `useManagedList` と守り方を揃える。

## 変更内容

- `useCursorList` の `load` に `requestIdRef` カウンタを導入。`.then` / `.catch` / `.finally`
  はいずれも自分が最新の発火であるときだけ state を更新する
- マウント effect の cleanup でカウンタを進め、アンマウント後に決着する在途を見捨てる（兄弟 2 本と同形）
- 単体テストを 2 本追加。題名は兄弟のものに揃えた
  - 「古いリクエストの遅延失敗は新しい結果を消さない」
  - 「古いリクエストの遅延応答は新しい結果を上書きしない」

## 検証

- [x] `task lint service=frontend` exit 0
- [x] `task test service=frontend` exit 0（100 suites / 761 tests）
- [x] `task build service=frontend` exit 0
- [ ] `task e2e` — 該当なし。二重発火は `disabled={loading}` のボタン越しには作れず、ブラウザ操作で踏める面が無い
- [ ] ローカルで code-review 実施済み — 未実施

赤の確認は守衛を外して 1 本ずつ個別に実行した（ファイル単位の赤では片方しか噛んでいない可能性が残るため）:

| テスト | 守衛なしの結果 |
| --- | --- |
| 遅延応答は新しい結果を上書きしない | `rows` が `['row0','row1','row2','row3']`（二重に継ぎ足される） |
| 遅延失敗は新しい結果を消さない | `rows` が `[]`（新着一覧が消え `failed` が立つ） |

## 決定ログ

**守衛の形は兄弟 2 本に合わせた。** 兄弟は async/await の try/catch/finally、本フックは
promise チェーンなので、判定の書き方だけ早期 return に変え、意味を揃えている。

**副作用として先行不具合を 1 件閉じる。** 在途の `loadMore` が後から届くと、取り直した
先頭へ続きが二重に継ぎ足される。これは #594 以前から在った面で、#594 の担当範囲では
なかったため見送っていた。守衛は成功・失敗の両方に効くので同時に閉じる。追加した
「遅延応答は新しい結果を上書きしない」がこれを固定する。テストは `reload` 2 本ではなく
`loadMore` → `reload` の順で組んだ——`reload` 同士だと両方が `cursor === null` の上書き
経路を通り、継ぎ足し経路を一度も踏まないまま守衛なしでも緑になるため。

**#594 で見送った理由は変わっていない。** #594 では到達性の追跡を 3 回（レビュー
sub-agent 2 本＋手動 1 回）行い、いずれも実在の二重発火を構成できなかった。今回もその
結論は同じで、これは共有フックの契約として塞ぐ変更。消費者の見た目は変わらない。

## 備考 / レビュー観点

消費者 2 本を読み直して到達性を再確認した。いずれも今日は二重発火しない:

- `ReservationRequestInbox` — 「もっと見る」は `disabled={loading}`、再試行は `failed` の
  間だけ描かれる `RegionError` の中。`load` は先頭で `setFailed(false)` するので、押した
  時点で `RegionError` 自体が消える
- `MemberReservationsPage` — 同上。ただし「もっと見る」は failed/loading の三項の**外**に
  あり `hasMore` だけで描かれる。`RegionError` と同時に出ないのはマークアップではなく
  「失敗時にフックが `nextCursor` を null へ戻す」ことに依存している。守衛はこの依存を
  無害化する
