### PR TITLE
fix(frontend): js-yaml を 4.3.1 / 3.15.1 に更新し GHSA-5p4m-2wfm-xmqj を解消する

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1747,9 +1747,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8723,9 +8723,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## 概要

Dependabot の open アラート #122 / #123（どちらも GHSA-5p4m-2wfm-xmqj、js-yaml の `!!omap` 解決における二次計算量 CPU 消費、high）を、`frontend/package-lock.json` の更新のみで解消する。

## 変更内容

- `node_modules/js-yaml` 4.3.0 → **4.3.1**（`@eslint/eslintrc` の `^4.3.0`、`cosmiconfig` の `^4.1.0` 経由）
- `node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml` 3.15.0 → **3.15.1**（`@istanbuljs/load-nyc-config` の `^3.13.1` 経由）

差分は上記 2 エントリの `version` / `resolved` / `integrity` のみ（6 行 +/- 6 行）。周辺パッケージの再解決は発生していない。

## 検証

- [x] `task lint` exit 0 — フロントエンドのみ。`--no-cache-filter deps` を付けて deps レイヤを強制再ビルドし、新しい lockfile で `npm ci` が実際に走ったことを担保した上で実行（0 errors / 53 warnings は既存分）
- [x] `task test` exit 0 — フロントエンドのみ。100 suites / 761 tests 全通過、カバレッジ収集も正常
- [x] `task build` exit 0 — フロントエンドのみ。本番ビルド成功
- [ ] `task e2e` — **未実行**（理由は下記「備考」）
- [x] ローカルで差分レビュー実施済み

バックエンドは差分ゼロのため未実行。

### 視覚確認（UI 変更時）

UI 変更なし。

## 決定ログ

**採った案: lockfile のみの更新（`npm update js-yaml --package-lock-only`）**

両エントリとも修正版が既存の caret 範囲（`^4.3.0` / `^4.1.0` → 4.3.1、`^3.13.1` → 3.15.1）に収まるため、これだけで両方が上がる。

**見送った代替案:**

- `package.json` に `overrides` を追加して js-yaml を固定 — 既存の範囲指定で解決できる以上、余計な固定装置を残すことになり、上流が上がったときに逆に足枷になる。今回は不要。
- 直接依存（`eslint` / `jest` 等）ごとのメジャー更新 — 脆弱性解消に対して差分が過大。

## 備考 / レビュー観点

- **`task e2e` は未実行。** 今回上がった 2 つの js-yaml はいずれも lockfile 上 `dev: true` で、利用箇所は ESLint の設定読み込み（`@eslint/eslintrc`）と Jest のカバレッジ設定読み込み（`@istanbuljs/load-nyc-config`）の 2 経路のみ。どちらも実行時バンドルには入らず、e2e が通る経路と交差しない。実際にその 2 経路を踏む `lint` と `test`（カバレッジ付き）を上記の通り緑にしてある。
- **別件（本 PR では対応せず）: `npm audit` に `brace-expansion` の high が 1 件残っている。** ただし Dependabot 側ではアラート #118〜#121 が `auto_dismissed` 扱いになっており、今回の 2 件とは別系統のため手を付けていない。
- **設定面の指摘: この 2 件に対する Dependabot PR は自動生成されていない。** `.github/dependabot.yml` は *version updates*（monthly・grouped）しか定義しておらず、security updates はリポジトリ設定側の別項目のため。有効化はリポジトリ所有者の判断で。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
