### PR TITLE
fix(frontend): 直書き取得の在途リクエスト守衛を #595 の 10 ファイルへ横展開する

### DIFF
--- a/frontend/src/_pages/platform-settings/__tests__/page.test.tsx
+++ b/frontend/src/_pages/platform-settings/__tests__/page.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import React, { StrictMode } from 'react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { notify } from '@/shared/notify';
 import SystemSettingsPage from '../ui/SettingsPage';
 
@@ -125,6 +125,58 @@ describe('SystemSettingsPage', () => {
 
     expect(await screen.findByRole('switch', { name: 'maintenance_mode' })).toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  // Strict Mode は mount effect を二度走らせるので取得が二重に飛ぶ。失敗が一覧をクリアする
+  // 以上、遅れて着いた古い失敗が新しい成功を消してはいけない
+  it('二重 mount で古い失敗が後から着いても、新しい成功を消さないこと', async () => {
+    let failStale = (): void => {};
+    mockGetAllConfigs.mockReturnValueOnce(
+      new Promise((_, reject) => {
+        failStale = () => reject(new Error('stale'));
+      })
+    );
+
+    render(
+      <StrictMode>
+        <SystemSettingsPage />
+      </StrictMode>
+    );
+
+    expect(await screen.findByRole('switch', { name: 'maintenance_mode' })).toBeInTheDocument();
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByRole('switch', { name: 'maintenance_mode' })).toBeInTheDocument();
+    expect(screen.queryByText('設定の取得に失敗しました')).not.toBeInTheDocument();
+  });
+
+  // 上の 1 本は成功・catch の比較しか固定しない（どちらの飛行も着いた後で観測するため、在途の
+  // setLoading(false) は既に false の旗へ落ちる）。finally の比較は 2 度目を在途のまま留める
+  // この形でしか赤にならない
+  it('二度目が在途のまま古い失敗が着いても、読み込み表示を畳まないこと', async () => {
+    let failStale = (): void => {};
+    mockGetAllConfigs
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockReturnValueOnce(new Promise(() => {}));
+
+    render(
+      <StrictMode>
+        <SystemSettingsPage />
+      </StrictMode>
+    );
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
   });
 
   it('文字列設定は編集時に複数行入力欄になり現在値が初期表示される', async () => {

--- a/frontend/src/_pages/platform-settings/ui/SettingsPage.tsx
+++ b/frontend/src/_pages/platform-settings/ui/SettingsPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState, useEffect } from 'react';
+import { useCallback, useRef, useState, useEffect } from 'react';
 import { notify } from '@/shared/notify';
 import {
   SystemConfigResponse,
@@ -21,20 +21,28 @@ export default function SystemSettingsPage() {
   const [editingKey, setEditingKey] = useState<string | null>(null);
   const [editValue, setEditValue] = useState('');
   const [saving, setSaving] = useState(false);
+  // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する。失敗が
+  // 一覧をクリアするので、在途の古い失敗が新しい成功を消し得る
+  const requestIdRef = useRef(0);
 
   const fetchConfigs = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
     setLoading(true);
     try {
       const data = await systemConfigService.getAllConfigs();
-      setConfigs(data);
-      setFailed(false);
+      if (requestId === requestIdRef.current) {
+        setConfigs(data);
+        setFailed(false);
+      }
     } catch (error) {
       console.error('設定の取得に失敗しました', error);
       // 読めなかった一覧を残すと「設定項目がありません」に化ける
-      setConfigs([]);
-      setFailed(true);
+      if (requestId === requestIdRef.current) {
+        setConfigs([]);
+        setFailed(true);
+      }
     } finally {
-      setLoading(false);
+      if (requestId === requestIdRef.current) setLoading(false);
     }
   }, []);
 

--- a/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
+++ b/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { PageResult } from '@/shared/api';
 import { Store, platformStoreApi } from '@/entities/store';
 import StoresPage from '../ui/StoresPage';
@@ -304,6 +305,60 @@ describe('店舗管理 3 画面の挙動', () => {
     fireEvent.click(within(region).getByRole('button', { name: '再試行' }));
 
     expect(await screen.findByLabelText(/店舗名/)).toHaveValue('デルタ店');
+  });
+
+  // Strict Mode は mount effect を二度走らせるので取得が二重に飛ぶ。失敗が店舗をクリアする
+  // 以上、遅れて着いた古い失敗が新しい成功を消してはいけない
+  it('編集は二重 mount で古い失敗が後から着いても、新しい成功を消さないこと', async () => {
+    let failStale = (): void => {};
+    mockedApi.getById
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockResolvedValue(store({ id: '1', name: 'デルタ店' }));
+
+    render(
+      <StrictMode>
+        <StoreEditPage />
+      </StrictMode>
+    );
+
+    expect(await screen.findByLabelText(/店舗名/)).toHaveValue('デルタ店');
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByLabelText(/店舗名/)).toHaveValue('デルタ店');
+    expect(screen.queryByText('店舗情報の取得に失敗しました')).not.toBeInTheDocument();
+  });
+
+  // 上の 1 本は成功・catch の比較しか固定しない（どちらの飛行も着いた後で観測するため、在途の
+  // setLoading(false) は既に false の旗へ落ちる）。finally の比較は 2 度目を在途のまま留める
+  // この形でしか赤にならない
+  it('編集は二度目が在途のまま古い失敗が着いても、読み込み表示を畳まないこと', async () => {
+    let failStale = (): void => {};
+    mockedApi.getById
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockReturnValueOnce(new Promise(() => {}));
+
+    render(
+      <StrictMode>
+        <StoreEditPage />
+      </StrictMode>
+    );
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
   });
 
   it('編集は 404 では再試行を出さず、一覧への導線だけを出すこと', async () => {

--- a/frontend/src/_pages/platform-stores/ui/StoreEditPage.tsx
+++ b/frontend/src/_pages/platform-stores/ui/StoreEditPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { Store, UpdateStoreRequest, platformStoreApi } from '@/entities/store';
 import { isNotFound } from '@/shared/lib';
@@ -20,27 +20,35 @@ export default function EditStorePage() {
   });
   const [errors, setErrors] = useState<Partial<UpdateStoreRequest>>({});
   const [loadFailure, setLoadFailure] = useState<'notFound' | 'error' | null>(null);
+  // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する。失敗が
+  // 店舗をクリアするので、在途の古い失敗が新しい成功を消し得る
+  const requestIdRef = useRef(0);
 
   // 再試行から呼び直せるよう effect の外に置く。取得できなかったこの頁自身が失敗を名乗るので、
   // 一覧へは送り返さない
   const loadStore = useCallback(async (storeId: string) => {
+    const requestId = ++requestIdRef.current;
     try {
       setLoading(true);
       const res = await platformStoreApi.getById(storeId);
       const t = res as unknown as Store;
-      setStore(t);
-      setFormData({
-        name: t.name ?? '',
-        email: t.email ?? '',
-      });
-      setLoadFailure(null);
+      if (requestId === requestIdRef.current) {
+        setStore(t);
+        setFormData({
+          name: t.name ?? '',
+          email: t.email ?? '',
+        });
+        setLoadFailure(null);
+      }
     } catch (e) {
       console.error('Error loading store:', e);
-      setStore(null);
-      // 404 は何度押しても取れない。再試行ではなく一覧への導線だけを出す
-      setLoadFailure(isNotFound(e) ? 'notFound' : 'error');
+      if (requestId === requestIdRef.current) {
+        setStore(null);
+        // 404 は何度押しても取れない。再試行ではなく一覧への導線だけを出す
+        setLoadFailure(isNotFound(e) ? 'notFound' : 'error');
+      }
     } finally {
-      setLoading(false);
+      if (requestId === requestIdRef.current) setLoading(false);
     }
   }, []);
 

--- a/frontend/src/_pages/store-casts/__tests__/CastPagesPayload.test.tsx
+++ b/frontend/src/_pages/store-casts/__tests__/CastPagesPayload.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { notify } from '@/shared/notify';
 import CastCreatePage from '../ui/CastCreatePage';
 import CastEditPage from '../ui/CastEditPage';
@@ -195,6 +196,68 @@ describe('キャスト編集の取得失敗', () => {
 
     expect(await screen.findByRole('button', { name: '保存する' })).toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  // Strict Mode は mount effect を二度走らせるので取得が二重に飛ぶ。失敗がキャストをクリア
+  // する以上、遅れて着いた古い失敗が新しい成功を消してはいけない
+  it('二重 mount で古い失敗が後から着いても、新しい成功を消さないこと', async () => {
+    let failStale = (): void => {};
+    mockedCastApi.get
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockResolvedValue({
+        id: 'cast-1',
+        name: '花子',
+        status: 'ACTIVE',
+        display_order: 0,
+        invitation_status: 'NOT_INVITED',
+        created_at: '2026-07-01T00:00:00Z',
+        updated_at: '2026-07-01T00:00:00Z',
+      });
+
+    render(
+      <StrictMode>
+        <CastEditPage />
+      </StrictMode>
+    );
+
+    expect(await screen.findByRole('button', { name: '保存する' })).toBeInTheDocument();
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByRole('button', { name: '保存する' })).toBeInTheDocument();
+    expect(screen.queryByText('キャスト情報の取得に失敗しました')).not.toBeInTheDocument();
+  });
+
+  // 上の 1 本は成功・catch の比較しか固定しない（どちらの飛行も着いた後で観測するため、在途の
+  // setIsLoading(false) は既に false の旗へ落ちる）。finally の比較は 2 度目を在途のまま留める
+  // この形でしか赤にならない
+  it('二度目が在途のまま古い失敗が着いても、読み込み表示を畳まないこと', async () => {
+    let failStale = (): void => {};
+    mockedCastApi.get
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockReturnValueOnce(new Promise(() => {}));
+
+    render(
+      <StrictMode>
+        <CastEditPage />
+      </StrictMode>
+    );
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
   });
 
   it('404 では再試行を出さず、一覧への導線だけを出すこと', async () => {

--- a/frontend/src/_pages/store-casts/ui/CastEditPage.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastEditPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { CastForm, CastFormData } from './CastForm';
 import { CastResponse, CastUpdateRequest, castApi } from '@/entities/cast';
@@ -18,21 +18,29 @@ export default function CastEditPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [loadFailure, setLoadFailure] = useState<'notFound' | 'error' | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する。失敗が
+  // キャストをクリアするので、在途の古い失敗が新しい成功を消し得る
+  const requestIdRef = useRef(0);
 
   // 再試行から呼び直せるよう effect の外に置く。取得できなかったこの頁自身が失敗を名乗るので、
   // 一覧へ送り返さない — 離脱すると説明責任が着地先へ移り、開いていた頁で再試行できなくなる
   const fetchCast = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
     setIsLoading(true);
     try {
       const data = await castApi.get(id);
-      setCast(data);
-      setLoadFailure(null);
+      if (requestId === requestIdRef.current) {
+        setCast(data);
+        setLoadFailure(null);
+      }
     } catch (error) {
-      setCast(null);
-      // 404 は何度押しても取れない。再試行ではなく一覧への導線だけを出す
-      setLoadFailure(isNotFound(error) ? 'notFound' : 'error');
+      if (requestId === requestIdRef.current) {
+        setCast(null);
+        // 404 は何度押しても取れない。再試行ではなく一覧への導線だけを出す
+        setLoadFailure(isNotFound(error) ? 'notFound' : 'error');
+      }
     } finally {
-      setIsLoading(false);
+      if (requestId === requestIdRef.current) setIsLoading(false);
     }
   }, [id]);
 

--- a/frontend/src/_pages/store-customers/__tests__/CustomerEditPage.test.tsx
+++ b/frontend/src/_pages/store-customers/__tests__/CustomerEditPage.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { notify } from '@/shared/notify';
 import CustomerEditPage from '../ui/CustomerEditPage';
 import { customerApi } from '@/entities/customer';
@@ -65,6 +66,88 @@ describe('顧客編集ページの取得失敗', () => {
 
     expect(await screen.findByDisplayValue('山田太郎')).toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  // Strict Mode は mount effect を二度走らせるので取得が二重に飛ぶ。失敗が顧客・注文履歴を
+  // クリアする以上、遅れて着いた古い失敗が新しい成功を消してはいけない。
+  // 二つの取得は独立に走るので、守衛も別々に確かめる
+  it('二重 mount で古い失敗が後から着いても、顧客の取得結果を消さないこと', async () => {
+    let failStale = (): void => {};
+    mockedCustomerApi.get
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockResolvedValue(customer);
+
+    render(
+      <StrictMode>
+        <CustomerEditPage />
+      </StrictMode>
+    );
+
+    expect(await screen.findByDisplayValue('山田太郎')).toBeInTheDocument();
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByDisplayValue('山田太郎')).toBeInTheDocument();
+    expect(screen.queryByText('顧客情報の取得に失敗しました')).not.toBeInTheDocument();
+  });
+
+  // 上の 1 本は成功・catch の比較しか固定しない（どちらの飛行も着いた後で観測するため、在途の
+  // setIsLoading(false) は既に false の旗へ落ちる）。finally の比較は 2 度目を在途のまま留める
+  // この形でしか赤にならない（注文履歴の取得は finally を持たないので、対象は顧客の取得だけ）
+  it('二度目が在途のまま古い失敗が着いても、読み込み表示を畳まないこと', async () => {
+    let failStale = (): void => {};
+    mockedCustomerApi.get
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockReturnValueOnce(new Promise(() => {}));
+
+    render(
+      <StrictMode>
+        <CustomerEditPage />
+      </StrictMode>
+    );
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('二重 mount で古い失敗が後から着いても、注文履歴の取得結果を消さないこと', async () => {
+    mockedCustomerApi.get.mockResolvedValue(customer);
+    let failStale = (): void => {};
+    mockedOrderApi.list
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockResolvedValue(emptyOrderPage);
+
+    render(
+      <StrictMode>
+        <CustomerEditPage />
+      </StrictMode>
+    );
+
+    expect(await screen.findByText('注文履歴がありません')).toBeInTheDocument();
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByText('注文履歴がありません')).toBeInTheDocument();
+    expect(screen.queryByText('注文履歴の取得に失敗しました')).not.toBeInTheDocument();
   });
 
   it('404 では再試行を出さず、一覧への導線だけを出すこと', async () => {

--- a/frontend/src/_pages/store-customers/__tests__/MemberLinkSection.test.tsx
+++ b/frontend/src/_pages/store-customers/__tests__/MemberLinkSection.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { notify } from '@/shared/notify';
 import { MemberLinkSection } from '../ui/MemberLinkSection';
 import { customerApi } from '@/entities/customer';
@@ -132,6 +133,35 @@ describe('MemberLinkSection', () => {
       target: { value: '123456789012' },
     });
     expect(screen.getByRole('button', { name: '紐づける' })).toBeEnabled();
+  });
+
+  // Strict Mode は mount effect を二度走らせるので取得が二重に飛ぶ。失敗が履歴をクリアする
+  // 以上、遅れて着いた古い失敗が新しい成功を消してはいけない
+  it('二重 mount で古い失敗が後から着いても、新しい成功を消さないこと', async () => {
+    let failStale = (): void => {};
+    mockedApi.memberLinkHistory
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockResolvedValue([activeRow]);
+
+    render(
+      <StrictMode>
+        <MemberLinkSection customerId="c1" />
+      </StrictMode>
+    );
+
+    // 解除ボタンは ACTIVE の区間が読めているときだけ出る
+    expect(await screen.findByRole('button', { name: '解除' })).toBeInTheDocument();
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByRole('button', { name: '解除' })).toBeInTheDocument();
+    expect(screen.queryByText('会員紐づけの履歴取得に失敗しました')).not.toBeInTheDocument();
   });
 
   it('解除は確認ダイアログの実行でのみ API を呼ぶこと', async () => {

--- a/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState, useEffect } from 'react';
+import { useCallback, useRef, useState, useEffect } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { CustomerForm, CustomerFormData, toCustomerRequest } from './CustomerForm';
 import { MemberLinkSection } from './MemberLinkSection';
@@ -31,21 +31,31 @@ export default function CustomerEditPage() {
   const [loadFailure, setLoadFailure] = useState<'notFound' | 'error' | null>(null);
   const [ordersStatus, setOrdersStatus] = useState<'loading' | 'ready' | 'error'>('loading');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する。失敗が
+  // 顧客・注文履歴をクリアするので、在途の古い失敗が新しい成功を消し得る。
+  // 二つの取得は独立に走るので、カウンタも取得ごとに持つ
+  const customerRequestIdRef = useRef(0);
+  const ordersRequestIdRef = useRef(0);
 
   // 再試行から呼び直せるよう effect の外に置く。取得できなかったこの頁自身が失敗を名乗るので、
   // 一覧へ送り返さない — 離脱すると説明責任が着地先へ移り、開いていた頁で再試行できなくなる
   const fetchCustomer = useCallback(async () => {
+    const requestId = ++customerRequestIdRef.current;
     setIsLoading(true);
     try {
       const data = await customerApi.get(id);
-      setCustomer(data);
-      setLoadFailure(null);
+      if (requestId === customerRequestIdRef.current) {
+        setCustomer(data);
+        setLoadFailure(null);
+      }
     } catch (error) {
-      setCustomer(null);
-      // 404 は何度押しても取れない。再試行ではなく一覧への導線だけを出す
-      setLoadFailure(isNotFound(error) ? 'notFound' : 'error');
+      if (requestId === customerRequestIdRef.current) {
+        setCustomer(null);
+        // 404 は何度押しても取れない。再試行ではなく一覧への導線だけを出す
+        setLoadFailure(isNotFound(error) ? 'notFound' : 'error');
+      }
     } finally {
-      setIsLoading(false);
+      if (requestId === customerRequestIdRef.current) setIsLoading(false);
     }
   }, [id]);
 
@@ -53,14 +63,19 @@ export default function CustomerEditPage() {
   // 再試行の前に読み込み中へ戻す — 同じ姿のまま失敗を繰り返すと role="alert" が挿入されず、
   // 二度目の失敗が読み上げ利用者に届かない
   const fetchOrders = useCallback(async () => {
+    const requestId = ++ordersRequestIdRef.current;
     setOrdersStatus('loading');
     try {
       const page = await orderApi.list({ customer_id: id, size: 20, sort: 'businessDate,desc' });
-      setOrders(page.rows);
-      setOrdersStatus('ready');
+      if (requestId === ordersRequestIdRef.current) {
+        setOrders(page.rows);
+        setOrdersStatus('ready');
+      }
     } catch {
-      setOrders([]);
-      setOrdersStatus('error');
+      if (requestId === ordersRequestIdRef.current) {
+        setOrders([]);
+        setOrdersStatus('error');
+      }
     }
   }, [id]);
 

--- a/frontend/src/_pages/store-customers/ui/MemberLinkSection.tsx
+++ b/frontend/src/_pages/store-customers/ui/MemberLinkSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { notify } from '@/shared/notify';
 import { CustomerMemberLinkHistoryResponse, customerApi } from '@/entities/customer';
 import { getApiErrorMessage } from '@/shared/lib';
@@ -39,6 +39,9 @@ export function MemberLinkSection({ customerId }: MemberLinkSectionProps) {
   const [memberCode, setMemberCode] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isConfirmingUnlink, setIsConfirmingUnlink] = useState(false);
+  // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する。失敗が
+  // 履歴をクリアするので、在途の古い失敗が新しい成功を消し得る
+  const requestIdRef = useRef(0);
 
   // 現に有効な区間は高々 1 件で、履歴は新しい順に返る
   const activeLink = history.find(row => row.status === 'ACTIVE');
@@ -47,16 +50,22 @@ export function MemberLinkSection({ customerId }: MemberLinkSectionProps) {
   const isHistoryReady = historyStatus === 'ready';
 
   const reload = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
     // 再試行の前に読み込み中へ戻す。同じ姿のまま失敗を繰り返すと role="alert" が挿入されず、
     // 二度目の失敗が読み上げ利用者に届かない
     setHistoryStatus('loading');
     try {
-      setHistory(await customerApi.memberLinkHistory(customerId));
-      setHistoryStatus('ready');
+      const rows = await customerApi.memberLinkHistory(customerId);
+      if (requestId === requestIdRef.current) {
+        setHistory(rows);
+        setHistoryStatus('ready');
+      }
     } catch {
       // 読めなかった履歴を残すと「紐づけ履歴がありません」に化ける。区画自身が失敗を名乗る
-      setHistory([]);
-      setHistoryStatus('error');
+      if (requestId === requestIdRef.current) {
+        setHistory([]);
+        setHistoryStatus('error');
+      }
     }
   }, [customerId]);
 

--- a/frontend/src/_pages/store-orders/__tests__/OrderFormPayload.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrderFormPayload.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react';
 import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
 import { OrderForm, OrderFormData } from '../ui/OrderForm';
 import * as castEntity from '@/entities/cast';
@@ -273,5 +274,39 @@ describe('オーダーフォームの受付候補の取得失敗', () => {
     await selectReceptionist();
     const body = await submitAndGetBody(onSubmit);
     expect(body.receptionistId).toBe('7');
+  });
+
+  // Strict Mode は mount effect を二度走らせるので取得が二重に飛ぶ。失敗が選択肢をクリアする
+  // 以上、遅れて着いた古い失敗が新しい成功を消してはいけない
+  it('二重 mount で古い失敗が後から着いても、新しい成功を消さないこと', async () => {
+    let failStale = (): void => {};
+    mockedOrderApi.listReceptionists
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockResolvedValue([{ id: 7, display_name: '受付花子' }]);
+
+    render(
+      <StrictMode>
+        <OrderForm
+          initialData={{ castId: 'cast-1' }}
+          onSubmit={jest.fn<void, [OrderFormData]>()}
+          isSubmitting={false}
+        />
+      </StrictMode>
+    );
+
+    // 候補から選べた時点で、2 度目の成功が着いている
+    await selectReceptionist();
+
+    await act(async () => {
+      failStale();
+    });
+
+    // 引き金の文言は候補一覧から引かれる。古い失敗が候補を消すと選択ごと表示が戻る
+    expect(screen.getByRole('combobox', { name: /受付(?!経路)/ })).toHaveTextContent('受付花子');
+    expect(screen.queryByText('受付担当者の取得に失敗しました')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/_pages/store-orders/__tests__/ReservationRequestEditModal.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/ReservationRequestEditModal.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { notify } from '@/shared/notify';
 import { ReservationRequestEditModal } from '../ui/ReservationRequestEditModal';
@@ -144,6 +145,40 @@ describe('ReservationRequestEditModal', () => {
       )
     );
     expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  // Strict Mode は mount effect を二度走らせるので取得が二重に飛ぶ。失敗が選択肢をクリアする
+  // 以上、遅れて着いた古い失敗が新しい成功を消してはいけない
+  it('二重 mount で古い失敗が後から着いても、新しい成功を消さないこと', async () => {
+    let failStale = (): void => {};
+    mockedReceptionists
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockResolvedValue([{ id: 7, display_name: '受付花子' }]);
+
+    render(
+      <StrictMode>
+        <ReservationRequestEditModal
+          request={{ ...nominationFreeRequest, receptionist_id: 7 }}
+          onClose={jest.fn()}
+          onSaved={jest.fn()}
+        />
+      </StrictMode>
+    );
+
+    // 引き金の文言は候補一覧から引かれるので、これが出ていれば 2 度目の成功が着いている
+    const trigger = await screen.findByRole('combobox', { name: '受付担当' });
+    await waitFor(() => expect(trigger).toHaveTextContent('受付花子'));
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(trigger).toHaveTextContent('受付花子');
+    expect(screen.queryByText('受付担当者の取得に失敗しました')).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/_pages/store-orders/ui/OrderForm.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import { OrderReceptionist, ReceptionRoute, orderApi } from '@/entities/order';
@@ -133,19 +133,27 @@ export function OrderForm({ initialData, castName, onSubmit, isSubmitting }: Ord
       .filter(o => o.id !== undefined)
       .map(o => ({ value: String(o.id), label: o.display_name ?? '' })),
   ];
+  // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する。失敗が
+  // 選択肢をクリアするので、在途の古い失敗が新しい成功を消し得る
+  const requestIdRef = useRef(0);
 
   // 再試行から呼び直せるよう effect の外に置く。取り直しの前に失敗を畳むのは、同じ姿のまま
   // 失敗を繰り返すと role="alert" が挿入されず二度目の失敗が読み上げ利用者に届かないため
   const loadReceptionists = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
     setReceptionistsFailed(false);
     try {
       const receptionists = await orderApi.listReceptionists();
-      setReceptionistOptions(receptionists);
-      setReceptionistsFailed(false);
+      if (requestId === requestIdRef.current) {
+        setReceptionistOptions(receptionists);
+        setReceptionistsFailed(false);
+      }
     } catch {
       // 選択肢が「－－－」だけの状態は「受付が 1 人も居ない」と区別がつかない
-      setReceptionistOptions([]);
-      setReceptionistsFailed(true);
+      if (requestId === requestIdRef.current) {
+        setReceptionistOptions([]);
+        setReceptionistsFailed(true);
+      }
     }
   }, []);
 

--- a/frontend/src/_pages/store-orders/ui/ReservationRequestEditModal.tsx
+++ b/frontend/src/_pages/store-orders/ui/ReservationRequestEditModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { notify } from '@/shared/notify';
 import { Order, OrderReceptionist, orderApi } from '@/entities/order';
@@ -84,6 +84,9 @@ export function ReservationRequestEditModal({
       .filter(o => o.id !== undefined)
       .map(o => ({ value: String(o.id), label: o.display_name ?? '' })),
   ];
+  // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する。失敗が
+  // 選択肢をクリアするので、在途の古い失敗が新しい成功を消し得る
+  const requestIdRef = useRef(0);
 
   const castName = request?.cast_name ?? request?.cast_id ?? '';
 
@@ -102,14 +105,20 @@ export function ReservationRequestEditModal({
   // 失敗を繰り返すと role="alert" が挿入されず二度目の失敗が読み上げ利用者に届かないため
   const loadReceptionists = useCallback(async () => {
     if (!request) return;
+    const requestId = ++requestIdRef.current;
     setReceptionistsFailed(false);
     try {
-      setReceptionistOptions(await orderApi.listReceptionists());
-      setReceptionistsFailed(false);
+      const receptionists = await orderApi.listReceptionists();
+      if (requestId === requestIdRef.current) {
+        setReceptionistOptions(receptionists);
+        setReceptionistsFailed(false);
+      }
     } catch {
       // 選択肢が「未設定」だけの状態は「受付が 1 人も居ない」と区別がつかない
-      setReceptionistOptions([]);
-      setReceptionistsFailed(true);
+      if (requestId === requestIdRef.current) {
+        setReceptionistOptions([]);
+        setReceptionistsFailed(true);
+      }
     }
   }, [request]);
 

--- a/frontend/src/_pages/store-settings/__tests__/AccountPage.test.tsx
+++ b/frontend/src/_pages/store-settings/__tests__/AccountPage.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { notify } from '@/shared/notify';
 import AccountPage from '../ui/AccountPage';
 import { platformAuthApi } from '@/entities/user';
@@ -41,6 +42,60 @@ describe('店舗アカウント設定の取得失敗', () => {
 
     expect(await screen.findByLabelText('ニックネーム *')).toHaveValue('店長太郎');
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  // Strict Mode は mount effect を二度走らせるので取得が二重に飛ぶ。失敗が欄をクリアする
+  // 以上、遅れて着いた古い失敗が新しい成功を消してはいけない
+  it('二重 mount で古い失敗が後から着いても、新しい成功を消さないこと', async () => {
+    let failStale = (): void => {};
+    mockedAuthApi.me
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockResolvedValue(me as never);
+
+    render(
+      <StrictMode>
+        <AccountPage />
+      </StrictMode>
+    );
+
+    expect(await screen.findByLabelText('ニックネーム *')).toHaveValue('店長太郎');
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByLabelText('ニックネーム *')).toHaveValue('店長太郎');
+    expect(screen.queryByText('アカウント情報の取得に失敗しました')).not.toBeInTheDocument();
+  });
+
+  // 上の 1 本は成功・catch の比較しか固定しない（どちらの飛行も着いた後で観測するため、在途の
+  // setIsLoading(false) は既に false の旗へ落ちる）。finally の比較は 2 度目を在途のまま留める
+  // この形でしか赤にならない
+  it('二度目が在途のまま古い失敗が着いても、読み込み表示を畳まないこと', async () => {
+    let failStale = (): void => {};
+    mockedAuthApi.me
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockReturnValueOnce(new Promise(() => {}));
+
+    render(
+      <StrictMode>
+        <AccountPage />
+      </StrictMode>
+    );
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
   });
 
   it('取得に失敗してもパスワード変更は使えたままであること', async () => {

--- a/frontend/src/_pages/store-settings/ui/AccountPage.tsx
+++ b/frontend/src/_pages/store-settings/ui/AccountPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { notify } from '@/shared/notify';
 import { platformAuthApi } from '@/entities/user';
 import { PasswordChangeForm } from '@/features/password-change';
@@ -23,22 +23,30 @@ export default function AccountPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [failed, setFailed] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する。失敗が
+  // 欄をクリアするので、在途の古い失敗が新しい成功を消し得る
+  const requestIdRef = useRef(0);
 
   // 再試行から呼び直せるよう effect の外に置く
   const fetchMe = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
     setIsLoading(true);
     try {
       const me = await platformAuthApi.me();
-      setNickname(me.display_name ?? '');
-      setEmail(me.email ?? '');
-      setFailed(false);
+      if (requestId === requestIdRef.current) {
+        setNickname(me.display_name ?? '');
+        setEmail(me.email ?? '');
+        setFailed(false);
+      }
     } catch {
       // 空欄のまま出すと「ニックネーム未設定」に見え、保存するとその空欄が本当になる
-      setNickname('');
-      setEmail('');
-      setFailed(true);
+      if (requestId === requestIdRef.current) {
+        setNickname('');
+        setEmail('');
+        setFailed(true);
+      }
     } finally {
-      setIsLoading(false);
+      if (requestId === requestIdRef.current) setIsLoading(false);
     }
   }, []);
 

--- a/frontend/src/_pages/store-shifts/ui/ShiftRequestInbox.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftRequestInbox.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { notify } from '@/shared/notify';
 import { CastResponse } from '@/entities/cast';
 import { StoreShiftRequestItem, shiftApi } from '@/entities/shift';
@@ -20,25 +20,33 @@ export function ShiftRequestInbox({ casts, onApproved }: ShiftRequestInboxProps)
   const [loading, setLoading] = useState(true);
   const [failed, setFailed] = useState(false);
   const [processingId, setProcessingId] = useState<string | null>(null);
+  // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する。失敗が
+  // 一覧をクリアするので、在途の古い失敗が新しい成功を消し得る
+  const requestIdRef = useRef(0);
 
   // castId が未指定のとき、id を持たないキャストと undefined 同士で一致してしまうのを防ぐ
   const castName = (castId: string | undefined) =>
     (castId === undefined ? undefined : casts.find(c => c.id === castId)?.name) ?? castId;
 
   const load = () => {
+    const requestId = ++requestIdRef.current;
     setLoading(true);
     shiftApi
       .listShiftRequests({ status: 'PENDING' })
       .then(rows => {
+        if (requestId !== requestIdRef.current) return;
         setRequests(rows);
         setFailed(false);
       })
       .catch(() => {
+        if (requestId !== requestIdRef.current) return;
         // 読めなかった一覧を残すと「受付中の出勤希望はありません」に化け、未処理の希望を見落とす
         setRequests([]);
         setFailed(true);
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (requestId === requestIdRef.current) setLoading(false);
+      });
   };
 
   useEffect(() => {

--- a/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { CalendarDaysIcon, ClockIcon, InboxIcon } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CastResponse, castApi } from '@/entities/cast';
 import { ShiftResponse, shiftApi } from '@/entities/shift';
 import { RegionError, Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/ui';
@@ -30,9 +30,14 @@ export default function ShiftsPage() {
   const [castsFailed, setCastsFailed] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [editing, setEditing] = useState<ShiftResponse | null>(null);
+  // 並行リクエストが順不同で完了しても、最新のリクエストだけが state を更新する。失敗が
+  // 名簿をクリアするので、在途の古い失敗が新しい成功を消し得る
+  // （シフト側の同じ守衛は effect 内の ignore が担う）
+  const castsRequestIdRef = useRef(0);
 
   // キャスト一覧（フォームの選択肢 + タイムラインの名前解決）。101 人以上でも氏名を解決できるよう全ページ取得する。
   const loadAllCasts = useCallback(async () => {
+    const requestId = ++castsRequestIdRef.current;
     // 再試行の前に畳む。同じ姿のまま失敗を繰り返すと role="alert" が挿入されず、二度目の
     // 失敗が読み上げ利用者に届かない
     setCastsFailed(false);
@@ -44,12 +49,16 @@ export default function ShiftsPage() {
         all.push(...res.rows);
         if (res.rows.length < size) break; // 最終ページ
       }
-      setCasts(all);
-      setCastsFailed(false);
+      if (requestId === castsRequestIdRef.current) {
+        setCasts(all);
+        setCastsFailed(false);
+      }
     } catch {
       // 途中まで読めた分も捨てる — 欠けた名簿は「そのキャストは居ない」と読める
-      setCasts([]);
-      setCastsFailed(true);
+      if (requestId === castsRequestIdRef.current) {
+        setCasts([]);
+        setCastsFailed(true);
+      }
     }
   }, []);
 

--- a/frontend/src/_pages/store-shifts/ui/__tests__/ShiftRequestInbox.test.tsx
+++ b/frontend/src/_pages/store-shifts/ui/__tests__/ShiftRequestInbox.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { notify } from '@/shared/notify';
 import { ShiftRequestInbox } from '../ShiftRequestInbox';
 import { CastResponse } from '@/entities/cast';
@@ -85,6 +86,60 @@ describe('ShiftRequestInbox', () => {
 
     expect(await screen.findByText('キャストA')).toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  // Strict Mode は mount effect を二度走らせるので取得が二重に飛ぶ。失敗が一覧をクリアする
+  // 以上、遅れて着いた古い失敗が新しい成功を消してはいけない
+  it('二重 mount で古い失敗が後から着いても、新しい成功を消さないこと', async () => {
+    let failStale = (): void => {};
+    mockedList
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockResolvedValue([REQUEST]);
+
+    render(
+      <StrictMode>
+        <ShiftRequestInbox casts={CASTS} onApproved={jest.fn()} />
+      </StrictMode>
+    );
+
+    expect(await screen.findByText('キャストA')).toBeInTheDocument();
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByText('キャストA')).toBeInTheDocument();
+    expect(screen.queryByText('出勤希望の取得に失敗しました')).not.toBeInTheDocument();
+  });
+
+  // 上の 1 本は成功・catch の比較しか固定しない（どちらの飛行も着いた後で観測するため、在途の
+  // setLoading(false) は既に false の旗へ落ちる）。finally の比較は 2 度目を在途のまま留める
+  // この形でしか赤にならない
+  it('二度目が在途のまま古い失敗が着いても、読み込み表示を畳まないこと', async () => {
+    let failStale = (): void => {};
+    mockedList
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockReturnValueOnce(new Promise(() => {}));
+
+    render(
+      <StrictMode>
+        <ShiftRequestInbox casts={CASTS} onApproved={jest.fn()} />
+      </StrictMode>
+    );
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
   });
 
   it('status=PENDING で一覧を取得し、cast 名・日時・備考を表示する', async () => {

--- a/frontend/src/_pages/store-shifts/ui/__tests__/ShiftsPage.test.tsx
+++ b/frontend/src/_pages/store-shifts/ui/__tests__/ShiftsPage.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import ShiftsPage from '../ShiftsPage';
 import { castApi } from '@/entities/cast';
 import { shiftApi } from '@/entities/shift';
@@ -99,5 +100,45 @@ describe('ShiftsPage の取得失敗', () => {
     fireEvent.click(within(region).getByRole('button', { name: '再試行' }));
 
     await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+  });
+
+  // Strict Mode は mount effect を二度走らせるので取得が二重に飛ぶ。失敗が名簿をクリアする
+  // 以上、遅れて着いた古い失敗が新しい成功を消してはいけない
+  // （シフト側の同じ守衛は effect 内の ignore が既に担っている）
+  it('二重 mount で古い失敗が後から着いても、名簿を消さないこと', async () => {
+    mockedShiftList.mockResolvedValue([
+      {
+        id: 'sh1',
+        cast_id: 'cast-1',
+        work_date: toDateStr(new Date()),
+        start_time: '18:00:00',
+        end_time: '23:00:00',
+      },
+    ]);
+    let failStale = (): void => {};
+    mockedCastList
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          failStale = () => reject(new Error('stale'));
+        })
+      )
+      .mockResolvedValue(castPage([{ id: 'cast-1', name: 'キャストA' }]));
+
+    render(
+      <StrictMode>
+        <ShiftsPage />
+      </StrictMode>
+    );
+
+    // タイムラインの名前解決は名簿を読む。名簿が消えると「不明」に化ける
+    fireEvent.click(await screen.findByRole('button', { name: String(DAY_IN_MONTH) }));
+    expect(await screen.findByText('キャストA')).toBeInTheDocument();
+
+    await act(async () => {
+      failStale();
+    });
+
+    expect(screen.getByText('キャストA')).toBeInTheDocument();
+    expect(screen.queryByText('キャストの取得に失敗しました')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概要

#611（PR #615）が `DashboardPage` / `ProfilePage` へ入れた在途リクエスト守衛（`requestIdRef`）を、同じ危険を持ったまま守衛の無い #595 の直書き取得へ広げる。取得に失敗した領域をクリアするため、遅れて着いた古い失敗が新しい成功を消して `RegionError` を出しうる。二重飛行の源は Strict Mode の mount effect 二度走りだけで、**届く範囲は開発ビルドに限られる**（利用者影響ではなく、開発時に嘘の失敗表示が出る問題）。

Closes #614

## 変更内容

### 射程は実測で確定した（票の「12 ファイル」は鵜呑みにしていない）

#595 が外した①該当は **15 箇所**。内訳:

| 分類 | 箇所 | 対応 |
| --- | --- | --- |
| 守衛が要る | **11 箇所 / 10 ファイル** | 本 PR で追加 |
| 既に同等の守衛を持つ | 3 箇所 | 触らない |
| 取得ですらない | 1 箇所 | 触らない |

- **追加した 11 箇所** — `SettingsPage` / `StoreEditPage` / `CastEditPage` / `CustomerEditPage`（顧客・注文履歴の **2 箇所**）/ `MemberLinkSection` / `OrderForm` / `ReservationRequestEditModal` / `AccountPage` / `ShiftRequestInbox` / `ShiftsPage`（名簿）
- **既に守衛を持つ 3 箇所** — `RoleFormModal`（詳細取得は自前の `requestIdRef`、権限目録は `useManagedList` 経由）、`CastSearchCombobox`、`ShiftsPage` のシフト取得（effect 内の `ignore`）
- **取得ですらない 1 箇所** — `StoreEditPage` の id 欠落分岐（`useEffect` が先に門を持つ、取りに行かない枝）

**票が名指しした `CastSearchCombobox` は個別に確かめた上で「不要」と判定した。** 取得が debounce の中にあり `attempt` を deps に持つため形が違うが、effect ごとの `superseded` フラグを cleanup で立てており成功・`catch`・`finally` の三箇所すべてを守っている。その上 Strict Mode では **1 度目の cleanup が 250ms の debounce タイマーを消すので二重飛行自体が起きない**。

### 守衛の形

`shared/lib/hooks/useListPage.ts` と同じで、新しい書き方は発明していない。

- 関数の先頭で `const requestId = ++requestIdRef.current`
- **成功・`catch`・`finally` の三箇所すべてで比較**（`finally` を落とすと在途のまま読み込み表示が畳まれる）
- `finally` を持つ取得は 11 箇所中 **6 箇所**。持たない 5 箇所へ `finally` を足してはいない（元の形のまま二箇所の守衛）
- **effect cleanup での加算は入れていない** — 頁・区画のいずれも unmount 後に守るべき state が無く、`eslint-disable-next-line react-hooks/exhaustive-deps` の費用に見合わない（`useListPage` / `useManagedList` との唯一の差）
- `CustomerEditPage` は独立に走る二つの取得を持つのでカウンタも 2 つに分けた（`customerRequestIdRef` / `ordersRequestIdRef`）
- `ShiftRequestInbox` の `load` は本体関数のまま置き、`useCallback` へ格上げしていない（deps 配列と lint 面を動かさないため）

## 検証

いずれも**本 PR の枝（`master` の直上）で取り直した**。

- [x] `task lint` exit 0（frontend。0 errors / 50 warnings はすべて既存、Steiger も clean）
- [x] `task test` exit 0（frontend 単体 103 suites・**797 tests** / backend 単体 + カバレッジ + 統合）
- [x] `task build` exit 0（production build）
- [x] `task e2e` exit 0（実行シナリオ: **全 24 シナリオ、4.4m**。この枝で実施）
- [x] ローカルで code-review 実施済み（`mattpocock-skills:code-review`、Standards・Spec 二軸）

### 新テストの赤緑両方向 — 三箇所を分けて実測した

追加したのは **17 本**（二重 mount 11 本 + `finally` 6 本）。**比較の三箇所は固定できる強さが違う**ので、まとめて「三箇所とも確認済み」とは書けない。

| 比較の箇所 | 外したもの | 結果 |
| --- | --- | --- |
| **`catch`** | 全ファイルから比較を摘出して全量 1 回 | 二重 mount の **11 本だけ**が落ちる（`11 failed, 780 passed`）。既存 780 本は 1 本も落ちない |
| **`finally`** | `finally` の比較だけを 6 箇所から | この **6 本だけ**が落ちる（`6 failed, 791 passed`） |
| **成功** | 条件を `true` に潰す（`CastEditPage` で実測） | **緑のまま** — 固定するテストは置いていない |

- **`catch`**: 既存テストは `<StrictMode>` で包んでいないので単一飛行になり、守衛の有無が結果を変えない。おかげで**ファイルとテストが 1 対 1 で対応**し、赤の確認が全量 1 回で済んだ。
- **`finally`**: 二重 mount の 11 本は**これを固定しない**。どちらの飛行も着いた後に観測するため、在途の `setLoading(false)` が既に `false` の旗へ落ちるだけで緑のままになる。そこで「**2 度目を在途のまま留めて古い失敗を着かせ、読み込み表示が残ることを見る**」形を、`finally` を持つ 6 ファイルすべてに置いた。代表 1 本では AC の「各ファイルに」を満たさない。
- **成功**: 在途の飛行は reject する側なので成功の枝を通らず、テストでは赤にできない。**赤にできるのは payload を違えた作り物の場面だけ**で、実際の二重飛行は同じ引数で同じ読み口を叩く以上、在途の成功が書く内容は新しい成功と同一で観測差が出ない。作り物のテストを足すより「固定していない」と明記する方が強い主張なので、そうした。

### テストの組み方

- **`<StrictMode>` 下で構成した。** 実際の引き金がそれなので代用ではなく**本番の再現**。利用者操作から二重飛行を作ろうとすると守衛の有無に関わらず緑になる（mount は 1 回、再試行ボタンは読み込み中に unmount される）。
- **断言は `role` ではなく文言で置いた。** 1 画面に `RegionError` が複数立ちうるファイル（`ShiftsPage` / `CustomerEditPage` / `OrderForm`）では、`queryByRole('alert')` が別の理由で通ってしまう。
- `ShiftsPage` の名簿はページングループなので、成功側の mock は `size` 未満の 1 ページを返して打ち切らせている。名簿が生きていることは**タイムラインの名前解決**（消えると「不明」に化ける）で見る。

## 決定ログ

**共通フックへ抽出していない。** 票が「形が `shared/lib/hooks/useListPage.ts` と一致している（新しい書き方を発明しない）」と明記している。加えて形が揃っていない — 5 箇所は `finally` を持たず、`ShiftRequestInbox` は `.then/.catch` チェーン、`CustomerEditPage` はカウンタが 2 つ要る。ローカル review でも「11 箇所の重複 → `useRequestGuard`」の提案が出たが、上記の理由で見送った。

**`StoreEditPage` の id 欠落分岐でカウンタを進めていない。** `id` が在途取得の最中に消える遷移は同一 mount では起こらない（route が変われば remount）。本票の射程は「在途の古い失敗が新しい成功を消す」ことなので、そこまでは広げていない。

**`DESIGN.md` は触っていない。** 本 PR は `notify` の呼び出し数を 1 つも動かさないので、台帳（79 / 37）は変わらない。

## 備考 / レビュー観点

- **見てほしいのは「成功の比較は固定していない」の判断**（上表 3 行目）。テストを足す代わりに理由を書く選択をしている。
- **`CastSearchCombobox` を対象外にした判定**も同様。「守衛が無い」ではなく「別の形の等価な守衛がある + そもそも二重飛行が起きない」という 2 段の根拠で外している。
- master の `DashboardPage.tsx` / `ProfilePage.tsx`（#611 で入った 2 箇所）のコメントは「〜するようになった」という**変化の語り**のままで、`CLAUDE.md` の「Never narrate history」に触れる。本 PR で足したコメントは「〜するので」に直してあるが、既存 2 箇所は射程外なので触っていない（気になるなら別 issue へ）。
