### PR TITLE
refactor(frontend): クライアント検証規範の全域適用 — 沈黙する required 30 箇所に文言を与える

### DIFF
--- a/frontend/src/_pages/cast-portal/ui/CastRequestsPage.tsx
+++ b/frontend/src/_pages/cast-portal/ui/CastRequestsPage.tsx
@@ -20,8 +20,8 @@ import {
   FormField,
   FormItem,
   FormLabel,
+  FormMessage,
   Input,
-  Label,
   Select,
   SelectContent,
   SelectItem,
@@ -99,12 +99,11 @@ export function CastRequestsPage() {
 
   const form = useForm<RequestFormValues>({ defaultValues: defaultValues('') });
   const {
-    register,
     handleSubmit,
     reset,
     setValue,
     control,
-    formState: { errors, isSubmitting },
+    formState: { isSubmitting },
   } = form;
 
   const loadHistory = () => {
@@ -166,13 +165,15 @@ export function CastRequestsPage() {
       </div>
 
       <Form {...form}>
-        <form onSubmit={handleSubmit(submit)}>
+        {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+            我々の文言は永久に描かれない。執行は各 rules が担う */}
+        <form onSubmit={handleSubmit(submit)} noValidate>
           <Card>
             <CardContent className="space-y-4">
               <FormField
                 control={control}
                 name="store_id"
-                rules={{ required: true }}
+                rules={{ required: '店舗を選択してください' }}
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>店舗</FormLabel>
@@ -180,9 +181,12 @@ export function CastRequestsPage() {
                       items={storeOptions}
                       value={field.value || null}
                       onValueChange={field.onChange}
+                      required
                     >
                       <FormControl>
-                        <SelectTrigger className="w-full">
+                        {/* handleSubmit の焦点移動は登録された ref を叩く。ref が trigger へ
+                            届かないと、文言だけ出て焦点が動かない。 */}
+                        <SelectTrigger className="w-full" ref={field.ref}>
                           {/* 所属店舗が無いときは選択肢自体が無く、値は空のままなので placeholder が出る。 */}
                           <SelectValue placeholder="所属店舗がありません" />
                         </SelectTrigger>
@@ -195,54 +199,73 @@ export function CastRequestsPage() {
                         ))}
                       </SelectContent>
                     </Select>
+                    <FormMessage />
                   </FormItem>
                 )}
               />
-              <div className="grid gap-2">
-                <Label htmlFor="request-work-date">日付</Label>
-                <Input
-                  id="request-work-date"
-                  type="date"
-                  {...register('work_date', {
-                    required: true,
-                    validate: v => v >= todayStr() || '本日以降の日付を指定してください',
-                  })}
-                />
-                {errors.work_date && (
-                  <p className="text-xs text-destructive-strong">{errors.work_date.message}</p>
+              <FormField
+                control={control}
+                name="work_date"
+                rules={{
+                  required: '希望する日付を指定してください',
+                  validate: v => v >= todayStr() || '本日以降の日付を指定してください',
+                }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>日付</FormLabel>
+                    <FormControl>
+                      <Input type="date" required {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
                 )}
-              </div>
+              />
               <div className="grid grid-cols-2 gap-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="request-start-time">開始</Label>
-                  <Input
-                    id="request-start-time"
-                    type="time"
-                    {...register('start_time', { required: true })}
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="request-end-time">終了</Label>
-                  <Input
-                    id="request-end-time"
-                    type="time"
-                    {...register('end_time', { required: true })}
-                  />
-                </div>
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="request-note">備考</Label>
-                <Textarea
-                  id="request-note"
-                  {...register('note', {
-                    maxLength: { value: 500, message: '備考は500文字以内で入力してください' },
-                  })}
-                  rows={3}
+                <FormField
+                  control={control}
+                  name="start_time"
+                  rules={{ required: '開始時刻を入力してください' }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>開始</FormLabel>
+                      <FormControl>
+                        <Input type="time" required {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
                 />
-                {errors.note && (
-                  <p className="text-xs text-destructive-strong">{errors.note.message}</p>
-                )}
+                <FormField
+                  control={control}
+                  name="end_time"
+                  rules={{ required: '終了時刻を入力してください' }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>終了</FormLabel>
+                      <FormControl>
+                        <Input type="time" required {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
               </div>
+              <FormField
+                control={control}
+                name="note"
+                rules={{
+                  maxLength: { value: 500, message: '備考は500文字以内で入力してください' },
+                }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>備考</FormLabel>
+                    <FormControl>
+                      <Textarea rows={3} {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
               <Button
                 type="submit"
                 className="w-full"

--- a/frontend/src/_pages/cast-portal/ui/ShiftChangeRequestModal.tsx
+++ b/frontend/src/_pages/cast-portal/ui/ShiftChangeRequestModal.tsx
@@ -4,7 +4,20 @@ import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { notify } from '@/shared/notify';
 import { CastScheduleItem, ShiftChangeRequestCreateRequest, shiftApi } from '@/entities/shift';
-import { Button, Dialog, DialogContent, DialogTitle, Input, Label, Textarea } from '@/shared/ui';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Textarea,
+} from '@/shared/ui';
 import { formatEndTime, formatTime, toDateStr } from '../lib/week';
 
 interface ChangeFormValues {
@@ -27,14 +40,15 @@ function todayStr(): string {
 
 /** 確定シフトへの変更申請モーダル。現行の日時を初期値に、希望する日時・備考を提出する。 */
 export function ShiftChangeRequestModal({ item, onClose }: ShiftChangeRequestModalProps) {
-  const {
-    register,
-    handleSubmit,
-    reset,
-    formState: { errors, isSubmitting },
-  } = useForm<ChangeFormValues>({
+  const form = useForm<ChangeFormValues>({
     defaultValues: { work_date: '', start_time: '', end_time: '', note: '' },
   });
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { isSubmitting },
+  } = form;
 
   useEffect(() => {
     if (!item) return;
@@ -77,65 +91,87 @@ export function ShiftChangeRequestModal({ item, onClose }: ShiftChangeRequestMod
         className="gap-0 rounded-[10px] p-0 sm:max-w-md"
       >
         <DialogTitle className="border-b px-6 py-4">シフトの変更申請</DialogTitle>
-        <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
-          <p className="text-xs text-muted-foreground">
-            現行: {item?.work_date} {formatTime(item?.start_time)}–{formatEndTime(item?.end_time)}（
-            {item?.store_name}）
-          </p>
-          <div className="grid gap-2">
-            <Label htmlFor="change-work-date">日付</Label>
-            <Input
-              id="change-work-date"
-              type="date"
-              {...register('work_date', {
-                required: true,
+        <Form {...form}>
+          {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+              我々の文言は永久に描かれない。執行は各 rules が担う */}
+          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5" noValidate>
+            <p className="text-xs text-muted-foreground">
+              現行: {item?.work_date} {formatTime(item?.start_time)}–{formatEndTime(item?.end_time)}
+              （{item?.store_name}）
+            </p>
+            <FormField
+              control={control}
+              name="work_date"
+              rules={{
+                required: '希望する日付を指定してください',
                 validate: v => v >= todayStr() || '本日以降の日付を指定してください',
-              })}
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>日付</FormLabel>
+                  <FormControl>
+                    <Input type="date" required {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.work_date && (
-              <p className="text-xs text-destructive-strong">{errors.work_date.message}</p>
-            )}
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="grid gap-2">
-              <Label htmlFor="change-start-time">開始</Label>
-              <Input
-                id="change-start-time"
-                type="time"
-                {...register('start_time', { required: true })}
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={control}
+                name="start_time"
+                rules={{ required: '開始時刻を入力してください' }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>開始</FormLabel>
+                    <FormControl>
+                      <Input type="time" required {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={control}
+                name="end_time"
+                rules={{ required: '終了時刻を入力してください' }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>終了</FormLabel>
+                    <FormControl>
+                      <Input type="time" required {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
               />
             </div>
-            <div className="grid gap-2">
-              <Label htmlFor="change-end-time">終了</Label>
-              <Input
-                id="change-end-time"
-                type="time"
-                {...register('end_time', { required: true })}
-              />
-            </div>
-          </div>
-          <div className="grid gap-2">
-            <Label htmlFor="change-note">備考</Label>
-            <Textarea
-              id="change-note"
-              {...register('note', {
+            <FormField
+              control={control}
+              name="note"
+              rules={{
                 maxLength: { value: 500, message: '備考は500文字以内で入力してください' },
-              })}
-              rows={3}
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>備考</FormLabel>
+                  <FormControl>
+                    <Textarea rows={3} {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.note && (
-              <p className="text-xs text-destructive-strong">{errors.note.message}</p>
-            )}
-          </div>
-          <div className="flex justify-end gap-2 pt-1">
-            <Button type="button" variant="outline" onClick={onClose}>
-              キャンセル
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? '提出中...' : '変更を申請する'}
-            </Button>
-          </div>
-        </form>
+            <div className="flex justify-end gap-2 pt-1">
+              <Button type="button" variant="outline" onClick={onClose}>
+                キャンセル
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? '提出中...' : '変更を申請する'}
+              </Button>
+            </div>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/_pages/member-portal/ui/MemberReservationNewPage.tsx
+++ b/frontend/src/_pages/member-portal/ui/MemberReservationNewPage.tsx
@@ -9,7 +9,7 @@ import { useRouter } from 'next/navigation';
 import { memberOrderApi } from '@/entities/order';
 import { ConfirmedShiftCast, shiftApi } from '@/entities/shift';
 import { Store, platformStoreApi } from '@/entities/store';
-import { isNotFound } from '@/shared/lib';
+import { integerRule, isNotFound } from '@/shared/lib';
 import {
   Button,
   Card,
@@ -215,6 +215,9 @@ export function MemberReservationNewPage() {
                   rules={{
                     required: '人数を入力してください',
                     min: { value: 1, message: '人数は 1 以上です' },
+                    // noValidate は type="number" の暗黙の step=1 も止める。これが無いと 1.5 が
+                    // Integer の pax へ届く
+                    validate: integerRule('人数'),
                   }}
                   render={({ field }) => (
                     <FormItem className="gap-1">

--- a/frontend/src/_pages/member-portal/ui/MemberReservationNewPage.tsx
+++ b/frontend/src/_pages/member-portal/ui/MemberReservationNewPage.tsx
@@ -16,6 +16,12 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
   Input,
   Label,
   Textarea,
@@ -53,13 +59,7 @@ export function MemberReservationNewPage() {
   const [castsReloadNonce, setCastsReloadNonce] = useState(0);
   const [submitting, setSubmitting] = useState(false);
 
-  const {
-    register,
-    handleSubmit,
-    setValue,
-    watch,
-    formState: { errors },
-  } = useForm<ReservationFormValues>({
+  const form = useForm<ReservationFormValues>({
     defaultValues: {
       business_date: '',
       arrival_scheduled_start_time: '',
@@ -68,6 +68,7 @@ export function MemberReservationNewPage() {
       remarks: '',
     },
   });
+  const { register, handleSubmit, setValue, watch, control } = form;
 
   const businessDate = watch('business_date');
 
@@ -182,109 +183,121 @@ export function MemberReservationNewPage() {
               店舗が特定できませんでした。店舗公式サイトの予約ボタンからお進みください。
             </p>
           ) : (
-            <form onSubmit={handleSubmit(submit)} className="space-y-4">
-              <div>
-                <Label htmlFor="business_date">利用日</Label>
-                <Input
-                  id="business_date"
-                  type="date"
-                  {...register('business_date', { required: '利用日を選択してください' })}
+            <Form {...form}>
+              {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+                  我々の文言は永久に描かれない。人数の min={1} は下の min 規則が引き継ぐ */}
+              <form onSubmit={handleSubmit(submit)} className="space-y-4" noValidate>
+                <FormField
+                  control={control}
+                  name="business_date"
+                  rules={{ required: '利用日を選択してください' }}
+                  render={({ field }) => (
+                    <FormItem className="gap-1">
+                      <FormLabel>利用日</FormLabel>
+                      <FormControl>
+                        <Input type="date" required {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
                 />
-                {errors.business_date && (
-                  <p className="mt-1 text-xs text-destructive-strong">
-                    {errors.business_date.message}
-                  </p>
-                )}
-              </div>
-              <div>
-                <Label htmlFor="arrival_scheduled_start_time">希望時刻</Label>
-                <Input
-                  id="arrival_scheduled_start_time"
-                  type="time"
-                  {...register('arrival_scheduled_start_time')}
-                />
-              </div>
-              <div>
-                <Label htmlFor="pax">人数</Label>
-                <Input
-                  id="pax"
-                  type="number"
-                  min={1}
-                  {...register('pax', {
+                <div>
+                  <Label htmlFor="arrival_scheduled_start_time">希望時刻</Label>
+                  <Input
+                    id="arrival_scheduled_start_time"
+                    type="time"
+                    {...register('arrival_scheduled_start_time')}
+                  />
+                </div>
+                <FormField
+                  control={control}
+                  name="pax"
+                  rules={{
                     required: '人数を入力してください',
                     min: { value: 1, message: '人数は 1 以上です' },
-                  })}
+                  }}
+                  render={({ field }) => (
+                    <FormItem className="gap-1">
+                      <FormLabel>人数</FormLabel>
+                      <FormControl>
+                        <Input type="number" min={1} required {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
                 />
-                {errors.pax && (
-                  <p className="mt-1 text-xs text-destructive-strong">{errors.pax.message}</p>
-                )}
-              </div>
-              <div>
-                <Label htmlFor="cast_id">指名（任意）</Label>
-                {/* 指名候補はその日の確定シフトに限る。ネイティブ select を使うのは、フォーム値をそのまま扱えるため。 */}
-                <select
-                  id="cast_id"
-                  className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
-                  {...register('cast_id')}
-                >
-                  <option value="">指名なし</option>
-                  {casts.map(cast => (
-                    <option key={cast.cast_id} value={cast.cast_id}>
-                      {cast.cast_name}
-                      {cast.start_time ? `（${cast.start_time.slice(0, 5)}〜）` : ''}
-                    </option>
-                  ))}
-                </select>
-                {businessDate && castsLoading && (
-                  <p className="mt-1 text-xs text-muted-foreground">出勤情報を確認しています...</p>
-                )}
-                {businessDate && !castsLoading && castsFailed && (
-                  <div className="mt-1 flex items-center gap-2">
-                    <p className="text-xs text-destructive-strong">
-                      出勤情報を取得できませんでした。
+                <div>
+                  <Label htmlFor="cast_id">指名（任意）</Label>
+                  {/* 指名候補はその日の確定シフトに限る。ネイティブ select を使うのは、フォーム値をそのまま扱えるため。 */}
+                  <select
+                    id="cast_id"
+                    className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                    {...register('cast_id')}
+                  >
+                    <option value="">指名なし</option>
+                    {casts.map(cast => (
+                      <option key={cast.cast_id} value={cast.cast_id}>
+                        {cast.cast_name}
+                        {cast.start_time ? `（${cast.start_time.slice(0, 5)}〜）` : ''}
+                      </option>
+                    ))}
+                  </select>
+                  {businessDate && castsLoading && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      出勤情報を確認しています...
                     </p>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setCastsReloadNonce(nonce => nonce + 1)}
-                    >
-                      再読み込み
-                    </Button>
-                  </div>
-                )}
-                {/* 取得が終わるまで「出勤なし」と言い切らない — 未解決の間に空表示を出すと、
+                  )}
+                  {businessDate && !castsLoading && castsFailed && (
+                    <div className="mt-1 flex items-center gap-2">
+                      <p className="text-xs text-destructive-strong">
+                        出勤情報を取得できませんでした。
+                      </p>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setCastsReloadNonce(nonce => nonce + 1)}
+                      >
+                        再読み込み
+                      </Button>
+                    </div>
+                  )}
+                  {/* 取得が終わるまで「出勤なし」と言い切らない — 未解決の間に空表示を出すと、
                     指名するつもりの会員が誤った空き情報のまま指名なしで申請してしまう。 */}
-                {businessDate && !castsLoading && !castsFailed && casts.length === 0 && (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    この日に出勤予定のキャストはいません。
-                  </p>
-                )}
-              </div>
-              <div>
-                <Label htmlFor="remarks">ご要望（任意）</Label>
-                <Textarea
-                  id="remarks"
-                  rows={3}
-                  {...register('remarks', {
+                  {businessDate && !castsLoading && !castsFailed && casts.length === 0 && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      この日に出勤予定のキャストはいません。
+                    </p>
+                  )}
+                </div>
+                <FormField
+                  control={control}
+                  name="remarks"
+                  rules={{
                     maxLength: { value: 500, message: 'ご要望は 500 文字以内で入力してください' },
-                  })}
+                  }}
+                  render={({ field }) => (
+                    <FormItem className="gap-1">
+                      <FormLabel>ご要望（任意）</FormLabel>
+                      <FormControl>
+                        <Textarea rows={3} {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
                 />
-                {errors.remarks && (
-                  <p className="mt-1 text-xs text-destructive-strong">{errors.remarks.message}</p>
-                )}
-              </div>
-              {/* 候補が確定するまで送信させない。取得中も失敗中も「その日に誰が出勤するか」は
+                {/* 候補が確定するまで送信させない。取得中も失敗中も「その日に誰が出勤するか」は
                   未確定であり、指名を選ぶ機会が無いまま「指名なし」で申請が通ってしまう。
                   失敗のときは再読み込みが復帰の手段になる。 */}
-              <Button
-                type="submit"
-                className="w-full"
-                disabled={submitting || castsLoading || castsFailed}
-              >
-                この内容で申請する
-              </Button>
-            </form>
+                <Button
+                  type="submit"
+                  className="w-full"
+                  disabled={submitting || castsLoading || castsFailed}
+                >
+                  この内容で申請する
+                </Button>
+              </form>
+            </Form>
           )}
         </CardContent>
       </Card>

--- a/frontend/src/_pages/member-portal/ui/__tests__/MemberReservationNewPage.test.tsx
+++ b/frontend/src/_pages/member-portal/ui/__tests__/MemberReservationNewPage.test.tsx
@@ -219,4 +219,35 @@ describe('MemberReservationNewPage', () => {
     expect(await screen.findByText('ご要望は 500 文字以内で入力してください')).toBeInTheDocument();
     expect(mockedCreate).not.toHaveBeenCalled();
   });
+
+  // noValidate は type="number" の暗黙の step=1 まで止める。引き継ぎが無いと 1.5 が Integer の
+  // pax へ届き、欄の傍ではなくサーバからの失敗として返ってくる。
+  it('人数に小数を入れると文言を出して申請しないこと', async () => {
+    mockedLookup.mockResolvedValue({ id: '1', name: 'サンプル店舗' });
+
+    render(<MemberReservationNewPage />);
+
+    fireEvent.change(await screen.findByLabelText('利用日'), { target: { value: '2026-08-10' } });
+    await waitFor(() => expect(submitButton()).toBeEnabled());
+    fireEvent.change(screen.getByLabelText('人数'), { target: { value: '1.5' } });
+    fireEvent.click(submitButton());
+
+    expect(await screen.findByText('人数は整数で入力してください')).toBeInTheDocument();
+    expect(mockedCreate).not.toHaveBeenCalled();
+  });
+
+  it('人数が整数なら従来どおり申請できること', async () => {
+    mockedLookup.mockResolvedValue({ id: '1', name: 'サンプル店舗' });
+    mockedCreate.mockResolvedValue({});
+
+    render(<MemberReservationNewPage />);
+
+    fireEvent.change(await screen.findByLabelText('利用日'), { target: { value: '2026-08-10' } });
+    await waitFor(() => expect(submitButton()).toBeEnabled());
+    fireEvent.change(screen.getByLabelText('人数'), { target: { value: '2' } });
+    fireEvent.click(submitButton());
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    expect(mockedCreate.mock.calls[0][0].pax).toBe(2);
+  });
 });

--- a/frontend/src/_pages/platform-line-callback/ui/LineRegisterStep.tsx
+++ b/frontend/src/_pages/platform-line-callback/ui/LineRegisterStep.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useForm } from 'react-hook-form';
+import { EMAIL_PATTERN, EMAIL_PATTERN_MESSAGE } from '@/shared/lib';
 
 export interface LineRegisterValues {
   display_name: string;
@@ -27,7 +28,9 @@ export default function LineRegisterStep({ defaultDisplayName, onSubmit }: LineR
   });
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-7">
+    // noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、我々の文言は
+    // 永久に描かれない。type="email" の執行もここで止まるため、下の pattern が引き継ぐ。
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-7" noValidate>
       <div className="auth-field">
         <label
           htmlFor="line-register-display-name"
@@ -42,9 +45,19 @@ export default function LineRegisterStep({ defaultDisplayName, onSubmit }: LineR
           maxLength={150}
           className="auth-field__input"
           placeholder="表示名を入力"
-          {...register('display_name', { required: true, maxLength: 150 })}
+          aria-invalid={!!errors.display_name}
+          aria-describedby={errors.display_name ? 'line-register-display-name-error' : undefined}
+          {...register('display_name', {
+            required: '表示名を入力してください',
+            maxLength: { value: 150, message: '表示名は150文字以内で入力してください' },
+          })}
         />
         <span className="auth-field__accent" />
+        {errors.display_name && (
+          <p id="line-register-display-name-error" className="auth-field__error">
+            {errors.display_name.message}
+          </p>
+        )}
       </div>
 
       <div className="auth-field">
@@ -62,9 +75,20 @@ export default function LineRegisterStep({ defaultDisplayName, onSubmit }: LineR
           maxLength={127}
           className="auth-field__input"
           placeholder="example@mail.com"
-          {...register('email', { required: true, maxLength: 127 })}
+          aria-invalid={!!errors.email}
+          aria-describedby={errors.email ? 'line-register-email-error' : undefined}
+          {...register('email', {
+            required: 'メールアドレスを入力してください',
+            pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
+            maxLength: { value: 127, message: 'メールアドレスは127文字以内で入力してください' },
+          })}
         />
         <span className="auth-field__accent" />
+        {errors.email && (
+          <p id="line-register-email-error" className="auth-field__error">
+            {errors.email.message}
+          </p>
+        )}
       </div>
 
       <div className="space-y-2">
@@ -76,12 +100,17 @@ export default function LineRegisterStep({ defaultDisplayName, onSubmit }: LineR
             id="line-register-consent"
             type="checkbox"
             className="auth-check mt-0.5"
-            {...register('consent', { required: true })}
+            required
+            aria-invalid={!!errors.consent}
+            aria-describedby={errors.consent ? 'line-register-consent-error' : undefined}
+            {...register('consent', { required: '同意いただける場合のみ登録できます' })}
           />
           <span>利用規約およびプライバシーポリシーに同意します</span>
         </label>
         {errors.consent && (
-          <p className="text-xs text-[#dc2626]">同意いただける場合のみ登録できます</p>
+          <p id="line-register-consent-error" className="auth-field__error">
+            {errors.consent.message}
+          </p>
         )}
       </div>
 

--- a/frontend/src/_pages/platform-line-callback/ui/LineRegisterStep.tsx
+++ b/frontend/src/_pages/platform-line-callback/ui/LineRegisterStep.tsx
@@ -31,28 +31,32 @@ export default function LineRegisterStep({ defaultDisplayName, onSubmit }: LineR
     // noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、我々の文言は
     // 永久に描かれない。type="email" の執行もここで止まるため、下の pattern が引き継ぐ。
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-7" noValidate>
-      <div className="auth-field">
-        <label
-          htmlFor="line-register-display-name"
-          className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
-        >
-          表示名
-        </label>
-        <input
-          id="line-register-display-name"
-          type="text"
-          required
-          maxLength={150}
-          className="auth-field__input"
-          placeholder="表示名を入力"
-          aria-invalid={!!errors.display_name}
-          aria-describedby={errors.display_name ? 'line-register-display-name-error' : undefined}
-          {...register('display_name', {
-            required: '表示名を入力してください',
-            maxLength: { value: 150, message: '表示名は150文字以内で入力してください' },
-          })}
-        />
-        <span className="auth-field__accent" />
+      {/* 文言は .auth-field の外に置く。中に入れると下線（bottom:0 の絶対配置）が
+          伸びた入れ物の底へ移り、文言を貫いて描かれる */}
+      <div>
+        <div className="auth-field">
+          <label
+            htmlFor="line-register-display-name"
+            className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
+          >
+            表示名
+          </label>
+          <input
+            id="line-register-display-name"
+            type="text"
+            required
+            maxLength={150}
+            className="auth-field__input"
+            placeholder="表示名を入力"
+            aria-invalid={!!errors.display_name}
+            aria-describedby={errors.display_name ? 'line-register-display-name-error' : undefined}
+            {...register('display_name', {
+              required: '表示名を入力してください',
+              maxLength: { value: 150, message: '表示名は150文字以内で入力してください' },
+            })}
+          />
+          <span className="auth-field__accent" />
+        </div>
         {errors.display_name && (
           <p id="line-register-display-name-error" className="auth-field__error">
             {errors.display_name.message}
@@ -60,30 +64,32 @@ export default function LineRegisterStep({ defaultDisplayName, onSubmit }: LineR
         )}
       </div>
 
-      <div className="auth-field">
-        <label
-          htmlFor="line-register-email"
-          className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
-        >
-          メールアドレス
-        </label>
-        <input
-          id="line-register-email"
-          type="email"
-          autoComplete="email"
-          required
-          maxLength={127}
-          className="auth-field__input"
-          placeholder="example@mail.com"
-          aria-invalid={!!errors.email}
-          aria-describedby={errors.email ? 'line-register-email-error' : undefined}
-          {...register('email', {
-            required: 'メールアドレスを入力してください',
-            pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
-            maxLength: { value: 127, message: 'メールアドレスは127文字以内で入力してください' },
-          })}
-        />
-        <span className="auth-field__accent" />
+      <div>
+        <div className="auth-field">
+          <label
+            htmlFor="line-register-email"
+            className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
+          >
+            メールアドレス
+          </label>
+          <input
+            id="line-register-email"
+            type="email"
+            autoComplete="email"
+            required
+            maxLength={127}
+            className="auth-field__input"
+            placeholder="example@mail.com"
+            aria-invalid={!!errors.email}
+            aria-describedby={errors.email ? 'line-register-email-error' : undefined}
+            {...register('email', {
+              required: 'メールアドレスを入力してください',
+              pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
+              maxLength: { value: 127, message: 'メールアドレスは127文字以内で入力してください' },
+            })}
+          />
+          <span className="auth-field__accent" />
+        </div>
         {errors.email && (
           <p id="line-register-email-error" className="auth-field__error">
             {errors.email.message}

--- a/frontend/src/_pages/store-cast-fields/__tests__/CastFieldEditModal.test.tsx
+++ b/frontend/src/_pages/store-cast-fields/__tests__/CastFieldEditModal.test.tsx
@@ -104,7 +104,7 @@ describe('カスタムフィールド定義の編集モーダル', () => {
     expect(body.is_public).toBe(true);
   });
 
-  it('label が空なら更新 API を呼ばない', async () => {
+  it('label が空なら文言を欄の傍に出し、更新 API を呼ばない', async () => {
     render(
       <CastFieldEditModal
         open
@@ -117,7 +117,30 @@ describe('カスタムフィールド定義の編集モーダル', () => {
     fireEvent.change(screen.getByLabelText('label'), { target: { value: '' } });
     fireEvent.click(screen.getByRole('button', { name: '保存する' }));
 
-    await waitFor(() => expect(screen.getByRole('button', { name: '保存する' })).toBeEnabled());
+    const message = await screen.findByText('label を入力してください');
+    expect(screen.getByLabelText('label')).toHaveAttribute(
+      'aria-describedby',
+      expect.stringContaining(message.id)
+    );
+    expect(mockedApi.update).not.toHaveBeenCalled();
+  });
+
+  // 空欄の数値入力は NaN であって null でも空文字でもないため required 単独では素通りし、
+  // display_order: null が送信されてしまう。文言を出せているのは validate の側。
+  it('表示順が空なら文言を出し、display_order を欠いたまま送らないこと', async () => {
+    render(
+      <CastFieldEditModal
+        open
+        definition={definition()}
+        onClose={jest.fn()}
+        onUpdated={jest.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('表示順'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    expect(await screen.findByText('表示順を入力してください')).toBeInTheDocument();
     expect(mockedApi.update).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/_pages/store-cast-fields/__tests__/CastFieldEditModal.test.tsx
+++ b/frontend/src/_pages/store-cast-fields/__tests__/CastFieldEditModal.test.tsx
@@ -169,4 +169,23 @@ describe('カスタムフィールド定義の編集モーダル', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(mockedApi.update).not.toHaveBeenCalled();
   });
+
+  // noValidate は type="number" の暗黙の step=1 まで止める。引き継ぎが無いと 1.5 が
+  // Integer の displayOrder へ届き、欄の傍ではなくサーバから返ってくる。
+  it('表示順に小数を入れると文言を出して更新を呼ばないこと', async () => {
+    render(
+      <CastFieldEditModal
+        open
+        definition={definition()}
+        onClose={jest.fn()}
+        onUpdated={jest.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('表示順'), { target: { value: '1.5' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    expect(await screen.findByText('表示順は整数で入力してください')).toBeInTheDocument();
+    expect(mockedApi.update).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldCreateModal.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldCreateModal.tsx
@@ -5,7 +5,21 @@ import { useForm } from 'react-hook-form';
 import { notify } from '@/shared/notify';
 import { CastFieldDefinitionCreateRequest, castFieldDefinitionApi } from '@/entities/cast';
 import { getApiErrorMessage } from '@/shared/lib';
-import { Button, Dialog, DialogContent, DialogTitle, Input, Label } from '@/shared/ui';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Label,
+} from '@/shared/ui';
 
 interface CastFieldCreateModalProps {
   open: boolean;
@@ -22,12 +36,14 @@ interface CastFieldCreateFormValues {
 
 /** カスタムフィールド定義の新規作成モーダル(key・label・公開設定)。 */
 export function CastFieldCreateModal({ open, onClose, onCreated }: CastFieldCreateModalProps) {
+  const form = useForm<CastFieldCreateFormValues>();
   const {
+    control,
     register,
     handleSubmit,
     reset,
     formState: { isSubmitting },
-  } = useForm<CastFieldCreateFormValues>();
+  } = form;
 
   useEffect(() => {
     if (!open) return;
@@ -65,41 +81,65 @@ export function CastFieldCreateModal({ open, onClose, onCreated }: CastFieldCrea
         <DialogTitle className="border-b px-6 py-4 text-lg font-semibold text-foreground">
           フィールドを追加
         </DialogTitle>
-        <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
-          <div className="grid gap-1">
-            <Label htmlFor="field-key">key</Label>
-            <Input
-              id="field-key"
-              type="text"
-              {...register('key', {
-                required: true,
+        <Form {...form}>
+          {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+              我々の文言は永久に描かれない。執行は各 rules が担う */}
+          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5" noValidate>
+            <FormField
+              control={control}
+              name="key"
+              rules={{
+                required: 'key を入力してください',
                 // バックエンドの @Pattern と同期。constructor・prototype は
                 // react-hook-form の register 内部予約名で、定義化するとキャスト
                 // 編集フォームの描画をクラッシュさせるため作成時に拒否する。
-                pattern: /^(?!constructor$|prototype$)[a-z][a-z0-9_]*$/,
-              })}
+                pattern: {
+                  value: /^(?!constructor$|prototype$)[a-z][a-z0-9_]*$/,
+                  message:
+                    'key は英小文字で始まり、英小文字・数字・アンダースコアのみ使用できます(constructor・prototype は使えません)',
+                },
+              }}
+              render={({ field }) => (
+                <FormItem className="gap-1">
+                  <FormLabel>key</FormLabel>
+                  <FormControl>
+                    <Input type="text" required {...field} />
+                  </FormControl>
+                  <FormDescription className="text-xs">
+                    英小文字で始まり、英小文字・数字・アンダースコアのみ使用できます(作成後は変更できません)
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            <p className="text-xs text-muted-foreground">
-              英小文字で始まり、英小文字・数字・アンダースコアのみ使用できます(作成後は変更できません)
-            </p>
-          </div>
-          <div className="grid gap-1">
-            <Label htmlFor="field-label">label</Label>
-            <Input id="field-label" type="text" {...register('label', { required: true })} />
-          </div>
-          <Label className="font-normal">
-            <input type="checkbox" {...register('is_public')} />
-            公開する(公開詳細ページに表示)
-          </Label>
-          <div className="flex justify-end gap-3 border-t pt-4">
-            <Button type="button" variant="outline" onClick={onClose}>
-              キャンセル
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? '追加中...' : '追加する'}
-            </Button>
-          </div>
-        </form>
+            <FormField
+              control={control}
+              name="label"
+              rules={{ required: 'label を入力してください' }}
+              render={({ field }) => (
+                <FormItem className="gap-1">
+                  <FormLabel>label</FormLabel>
+                  <FormControl>
+                    <Input type="text" required {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Label className="font-normal">
+              <input type="checkbox" {...register('is_public')} />
+              公開する(公開詳細ページに表示)
+            </Label>
+            <div className="flex justify-end gap-3 border-t pt-4">
+              <Button type="button" variant="outline" onClick={onClose}>
+                キャンセル
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? '追加中...' : '追加する'}
+              </Button>
+            </div>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldEditModal.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldEditModal.tsx
@@ -8,7 +8,7 @@ import {
   CastFieldDefinitionUpdateRequest,
   castFieldDefinitionApi,
 } from '@/entities/cast';
-import { getApiErrorMessage } from '@/shared/lib';
+import { getApiErrorMessage, integerRule } from '@/shared/lib';
 import {
   Button,
   Dialog,
@@ -125,9 +125,14 @@ export function CastFieldEditModal({
               name="display_order"
               rules={{
                 required: DISPLAY_ORDER_REQUIRED,
-                // 空欄は NaN であって null でも空文字でもないため required は素通りする。
-                // 実測で、required だけだと空欄のまま display_order: null が送信される。
-                validate: value => !Number.isNaN(value) || DISPLAY_ORDER_REQUIRED,
+                validate: {
+                  // 空欄は NaN であって null でも空文字でもないため required は素通りする。
+                  // 実測で、required だけだと空欄のまま display_order: null が送信される。
+                  notEmpty: value => !Number.isNaN(value) || DISPLAY_ORDER_REQUIRED,
+                  // noValidate は type="number" の暗黙の step=1 も止める。これが無いと 1.5 が
+                  // Integer の displayOrder へ届く
+                  integer: integerRule('表示順'),
+                },
               }}
               render={({ field }) => (
                 <FormItem className="gap-1">

--- a/frontend/src/_pages/store-cast-fields/ui/CastFieldEditModal.tsx
+++ b/frontend/src/_pages/store-cast-fields/ui/CastFieldEditModal.tsx
@@ -9,7 +9,20 @@ import {
   castFieldDefinitionApi,
 } from '@/entities/cast';
 import { getApiErrorMessage } from '@/shared/lib';
-import { Button, Dialog, DialogContent, DialogTitle, Input, Label } from '@/shared/ui';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Label,
+} from '@/shared/ui';
 
 interface CastFieldEditModalProps {
   open: boolean;
@@ -26,6 +39,8 @@ interface CastFieldEditFormValues {
   is_public: boolean;
 }
 
+const DISPLAY_ORDER_REQUIRED = '表示順を入力してください';
+
 /** カスタムフィールド定義の編集モーダル(label・表示順・公開設定のみ、key は不変のため編集不可)。 */
 export function CastFieldEditModal({
   open,
@@ -33,12 +48,14 @@ export function CastFieldEditModal({
   definition,
   onUpdated,
 }: CastFieldEditModalProps) {
+  const form = useForm<CastFieldEditFormValues>();
   const {
+    control,
     register,
     handleSubmit,
     reset,
     formState: { isSubmitting },
-  } = useForm<CastFieldEditFormValues>();
+  } = form;
 
   useEffect(() => {
     if (!open || !definition) return;
@@ -81,36 +98,69 @@ export function CastFieldEditModal({
         <DialogTitle className="border-b px-6 py-4 text-lg font-semibold text-foreground">
           フィールドを編集
         </DialogTitle>
-        <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
-          <div>
-            <span className="mb-1 block text-sm font-medium text-foreground">key</span>
-            <p className="text-sm text-muted-foreground">{definition?.key}</p>
-          </div>
-          <div className="grid gap-1">
-            <Label htmlFor="field-edit-label">label</Label>
-            <Input id="field-edit-label" type="text" {...register('label', { required: true })} />
-          </div>
-          <div className="grid gap-1">
-            <Label htmlFor="field-edit-display-order">表示順</Label>
-            <Input
-              id="field-edit-display-order"
-              type="number"
-              {...register('display_order', { valueAsNumber: true, required: true })}
+        <Form {...form}>
+          {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+              我々の文言は永久に描かれない。執行は各 rules が担う */}
+          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5" noValidate>
+            <div>
+              <span className="mb-1 block text-sm font-medium text-foreground">key</span>
+              <p className="text-sm text-muted-foreground">{definition?.key}</p>
+            </div>
+            <FormField
+              control={control}
+              name="label"
+              rules={{ required: 'label を入力してください' }}
+              render={({ field }) => (
+                <FormItem className="gap-1">
+                  <FormLabel>label</FormLabel>
+                  <FormControl>
+                    <Input type="text" required {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
-          <Label className="font-normal">
-            <input type="checkbox" {...register('is_public')} />
-            公開する(公開詳細ページに表示)
-          </Label>
-          <div className="flex justify-end gap-3 border-t pt-4">
-            <Button type="button" variant="outline" onClick={onClose}>
-              キャンセル
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? '保存中...' : '保存する'}
-            </Button>
-          </div>
-        </form>
+            <FormField
+              control={control}
+              name="display_order"
+              rules={{
+                required: DISPLAY_ORDER_REQUIRED,
+                // 空欄は NaN であって null でも空文字でもないため required は素通りする。
+                // 実測で、required だけだと空欄のまま display_order: null が送信される。
+                validate: value => !Number.isNaN(value) || DISPLAY_ORDER_REQUIRED,
+              }}
+              render={({ field }) => (
+                <FormItem className="gap-1">
+                  <FormLabel>表示順</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      required
+                      {...field}
+                      // register の valueAsNumber と同じ写像。Number() は空欄を 0 にしてしまい、
+                      // 「未入力」を表す NaN が失われる。
+                      value={Number.isNaN(field.value) ? '' : field.value}
+                      onChange={event => field.onChange(event.target.valueAsNumber)}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Label className="font-normal">
+              <input type="checkbox" {...register('is_public')} />
+              公開する(公開詳細ページに表示)
+            </Label>
+            <div className="flex justify-end gap-3 border-t pt-4">
+              <Button type="button" variant="outline" onClick={onClose}>
+                キャンセル
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? '保存中...' : '保存する'}
+              </Button>
+            </div>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/_pages/store-casts/__tests__/CastForm.test.tsx
+++ b/frontend/src/_pages/store-casts/__tests__/CastForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { CastForm } from '../ui/CastForm';
 import { CastFieldDefinitionResponse, castFieldDefinitionApi } from '@/entities/cast';
 
@@ -67,5 +67,58 @@ describe('カスタムフィールドの初期値は自身が所有するキー�
 
     const input = (await screen.findByLabelText('血液型')) as HTMLInputElement;
     expect(input.value).toBe('A');
+  });
+});
+
+/**
+ * noValidate は type="number" の暗黙の step=1 まで止める。プロフィールの数値欄はいずれも
+ * サーバ側が Integer なので、引き継ぎが無いと小数がそのまま届く。
+ */
+describe('プロフィールの数値欄は整数のみ受け付ける', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApi.list.mockResolvedValue([]);
+  });
+
+  it.each([
+    ['年齢', '年齢は整数で入力してください'],
+    ['身長 (cm)', '身長は整数で入力してください'],
+    ['バスト (cm)', 'バストは整数で入力してください'],
+    ['ウエスト (cm)', 'ウエストは整数で入力してください'],
+    ['ヒップ (cm)', 'ヒップは整数で入力してください'],
+    ['表示順', '表示順は整数で入力してください'],
+  ])('%s に小数を入れると文言を出して送信しないこと', async (label, message) => {
+    const onSubmit = jest.fn();
+    render(<CastForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(label), { target: { value: '1.5' } });
+    fireEvent.change(screen.getByLabelText('名前 *'), { target: { value: '花子' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    expect(await screen.findByText(message)).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('整数なら従来どおり送信できること', async () => {
+    const onSubmit = jest.fn();
+    render(<CastForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText('名前 *'), { target: { value: '花子' } });
+    fireEvent.change(screen.getByLabelText('年齢'), { target: { value: '25' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0].age).toBe(25);
+  });
+
+  it('空欄のままなら整数規則は黙っていること（任意項目を塞がない）', async () => {
+    const onSubmit = jest.fn();
+    render(<CastForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText('名前 *'), { target: { value: '花子' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText(/整数で入力してください/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/_pages/store-casts/ui/CastForm.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastForm.tsx
@@ -14,6 +14,7 @@ import {
   FormField,
   FormItem,
   FormLabel,
+  FormMessage,
   ImageUpload,
   Input,
   Label,
@@ -100,7 +101,9 @@ export function CastForm({
 
   return (
     <Form {...form}>
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+      {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+          我々の文言は永久に描かれない。執行は各 rules が担う */}
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6" noValidate>
         {/* 基本情報 */}
         <Card>
           <CardHeader>
@@ -119,10 +122,20 @@ export function CastForm({
                 />
               </div>
               <div className="flex-1 space-y-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="name">名前 *</Label>
-                  <Input id="name" type="text" {...register('name', { required: true })} />
-                </div>
+                <FormField
+                  control={control}
+                  name="name"
+                  rules={{ required: '名前を入力してください' }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>名前 *</FormLabel>
+                      <FormControl>
+                        <Input type="text" required {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
                 <FormField
                   control={control}
                   name="status"

--- a/frontend/src/_pages/store-casts/ui/CastForm.tsx
+++ b/frontend/src/_pages/store-casts/ui/CastForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useForm } from 'react-hook-form';
+import { Control, useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import { CastFieldDefinitionResponse, castFieldDefinitionApi } from '@/entities/cast';
 import {
@@ -26,7 +26,7 @@ import {
   SelectValue,
   Textarea,
 } from '@/shared/ui';
-import { useManagedList } from '@/shared/lib';
+import { integerRule, useManagedList } from '@/shared/lib';
 
 /** キャストフォームのデータ型 */
 export interface CastFormData {
@@ -59,6 +59,48 @@ const STATUS_OPTIONS = [
   { value: 'ACTIVE', label: '在籍中' },
   { value: 'INACTIVE', label: '在籍停止' },
 ];
+
+/**
+ * プロフィールの任意数値欄。いずれもサーバ側は Integer で、noValidate によって原生の step=1 が
+ * 執行されなくなったぶんを規則で引き継ぐ。
+ *
+ * 空欄の valueAsNumber は NaN で、そのまま value に載せるとブラウザが警告を出すため表示だけ
+ * 空文字へ戻す。未入力は許すので required は持たない。
+ */
+function NumericProfileField({
+  control,
+  name,
+  label,
+  unit,
+}: {
+  control: Control<CastFormData>;
+  name: 'age' | 'height' | 'bust' | 'waist' | 'hip';
+  label: string;
+  unit?: string;
+}) {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      rules={{ validate: integerRule(label) }}
+      render={({ field }) => (
+        <FormItem className="gap-2">
+          <FormLabel>{unit ? `${label} (${unit})` : label}</FormLabel>
+          <FormControl>
+            {/* id は FormControl が持つ。ここで与えると FormLabel の htmlFor と食い違う */}
+            <Input
+              type="number"
+              {...field}
+              value={field.value === null || Number.isNaN(field.value) ? '' : field.value}
+              onChange={event => field.onChange(event.target.valueAsNumber)}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
 
 /** キャスト登録・編集フォームコンポーネント */
 export function CastForm({
@@ -163,14 +205,25 @@ export function CastForm({
                     </FormItem>
                   )}
                 />
-                <div className="grid gap-2">
-                  <Label htmlFor="display_order">表示順</Label>
-                  <Input
-                    id="display_order"
-                    type="number"
-                    {...register('display_order', { valueAsNumber: true })}
-                  />
-                </div>
+                <FormField
+                  control={control}
+                  name="display_order"
+                  rules={{ validate: integerRule('表示順') }}
+                  render={({ field }) => (
+                    <FormItem className="gap-2">
+                      <FormLabel>表示順</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          {...field}
+                          value={Number.isNaN(field.value) ? '' : field.value}
+                          onChange={event => field.onChange(event.target.valueAsNumber)}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
               </div>
             </div>
           </CardContent>
@@ -185,28 +238,13 @@ export function CastForm({
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-              <div className="grid gap-2">
-                <Label htmlFor="age">年齢</Label>
-                <Input id="age" type="number" {...register('age', { valueAsNumber: true })} />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="height">身長 (cm)</Label>
-                <Input id="height" type="number" {...register('height', { valueAsNumber: true })} />
-              </div>
+              <NumericProfileField control={control} name="age" label="年齢" />
+              <NumericProfileField control={control} name="height" label="身長" unit="cm" />
             </div>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-              <div className="grid gap-2">
-                <Label htmlFor="bust">バスト (cm)</Label>
-                <Input id="bust" type="number" {...register('bust', { valueAsNumber: true })} />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="waist">ウエスト (cm)</Label>
-                <Input id="waist" type="number" {...register('waist', { valueAsNumber: true })} />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="hip">ヒップ (cm)</Label>
-                <Input id="hip" type="number" {...register('hip', { valueAsNumber: true })} />
-              </div>
+              <NumericProfileField control={control} name="bust" label="バスト" unit="cm" />
+              <NumericProfileField control={control} name="waist" label="ウエスト" unit="cm" />
+              <NumericProfileField control={control} name="hip" label="ヒップ" unit="cm" />
             </div>
           </CardContent>
         </Card>

--- a/frontend/src/_pages/store-customers/__tests__/CustomersPage.test.tsx
+++ b/frontend/src/_pages/store-customers/__tests__/CustomersPage.test.tsx
@@ -59,7 +59,6 @@ describe('店側顧客画面と API JSON（snake_case）の整合', () => {
     mockedCustomerApi.create.mockResolvedValue({} as never);
 
     render(<CustomerCreatePage />);
-    // name は required のため、未入力だと create が呼ばれない
     fireEvent.change(screen.getByLabelText('名前 *'), { target: { value: '田中花子' } });
     fireEvent.click(screen.getByRole('button', { name: '保存する' }));
 
@@ -76,6 +75,21 @@ describe('店側顧客画面と API JSON（snake_case）の整合', () => {
     expect(body).not.toHaveProperty('phoneNumber');
     expect(body).not.toHaveProperty('hasPet');
     expect(body).not.toHaveProperty('lineId');
+  });
+
+  it('名前が未入力なら文言を欄の傍に出し、create を呼ばないこと', async () => {
+    mockedCustomerApi.create.mockResolvedValue({} as never);
+
+    render(<CustomerCreatePage />);
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    const message = await screen.findByText('名前を入力してください');
+    const input = screen.getByLabelText('名前 *');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby', expect.stringContaining(message.id));
+    expect(mockedCustomerApi.create).not.toHaveBeenCalled();
+    // 検証を理由にボタンを塞がない
+    expect(screen.getByRole('button', { name: '保存する' })).toBeEnabled();
   });
 
   it('編集時の has_pet:true が controlled チェックボックスに反映されること', () => {

--- a/frontend/src/_pages/store-customers/ui/CustomerForm.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerForm.tsx
@@ -15,6 +15,7 @@ import {
   FormField,
   FormItem,
   FormLabel,
+  FormMessage,
   Input,
   Label,
   Textarea,
@@ -87,7 +88,9 @@ export function CustomerForm({ initialData, onSubmit, isSubmitting }: CustomerFo
 
   return (
     <Form {...form}>
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+      {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+          我々の文言は永久に描かれない。執行は各 rules が担う */}
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6" noValidate>
         {/* 基本情報 */}
         <Card>
           <CardHeader>
@@ -97,10 +100,20 @@ export function CustomerForm({ initialData, onSubmit, isSubmitting }: CustomerFo
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div className="grid gap-2">
-                <Label htmlFor="name">名前 *</Label>
-                <Input id="name" type="text" {...register('name', { required: true })} />
-              </div>
+              <FormField
+                control={control}
+                name="name"
+                rules={{ required: '名前を入力してください' }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>名前 *</FormLabel>
+                    <FormControl>
+                      <Input type="text" required {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
               <div className="grid gap-2">
                 <Label htmlFor="classification">区分</Label>
                 <Input id="classification" type="text" {...register('classification')} />

--- a/frontend/src/_pages/store-orders/__tests__/OrderCreatePage.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrderCreatePage.test.tsx
@@ -63,4 +63,18 @@ describe('新規オーダー登録の送信ペイロード', () => {
     await waitFor(() => expect(mockedOrderApi.create).toHaveBeenCalledTimes(1));
     expect(mockedOrderApi.create.mock.calls[0][0].pax).toBe(3);
   });
+
+  // 指名の焦点要素は popup の中の入力ではなく引き金の button。文言を出すだけでは
+  // 「どの欄が」が読み上げ環境へ届かず、焦点も動かない。
+  it('キャスト未選択の文言が引き金と結び付き、焦点がそこへ移ること', async () => {
+    render(<CreateOrderPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: '登録する' }));
+
+    const message = await screen.findByText('キャストを候補から選択してください');
+    const trigger = screen.getByRole('combobox', { name: /キャスト/ });
+    expect(trigger).toHaveAttribute('aria-invalid', 'true');
+    expect(trigger).toHaveAttribute('aria-describedby', expect.stringContaining(message.id));
+    expect(mockedOrderApi.create).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/_pages/store-orders/__tests__/OrderCreatePage.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrderCreatePage.test.tsx
@@ -77,4 +77,13 @@ describe('新規オーダー登録の送信ペイロード', () => {
     expect(trigger).toHaveAttribute('aria-describedby', expect.stringContaining(message.id));
     expect(mockedOrderApi.create).not.toHaveBeenCalled();
   });
+
+  // aria-invalid は「今まちがっている」しか言わない。「入れる必要がある」は誤りが起きる前から
+  // 要る情報で、引き金は button なので原生 required では持てない。
+  it('キャストの引き金が最初から必須を名乗ること', async () => {
+    render(<CreateOrderPage />);
+
+    const trigger = await screen.findByRole('combobox', { name: /キャスト/ });
+    expect(trigger).toHaveAttribute('aria-required', 'true');
+  });
 });

--- a/frontend/src/_pages/store-orders/__tests__/ReservationRequestEditModal.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/ReservationRequestEditModal.test.tsx
@@ -378,3 +378,36 @@ describe('ReservationRequestEditModal の指名の差し替え', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });
+
+/**
+ * noValidate は type="number" の暗黙の step=1 まで止める。引き継ぎが無いと 1.5 が Integer の
+ * pax へ届き、欄の傍ではなくサーバからの失敗として返ってくる。
+ */
+describe('人数は整数のみ受け付ける', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedReceptionists.mockResolvedValue([]);
+    mockedCastCandidates.mockResolvedValue([]);
+    mockedUpdate.mockResolvedValue(nominationFreeRequest);
+  });
+
+  it('小数を入れると文言を出して更新を呼ばないこと', async () => {
+    renderModal(nominationFreeRequest);
+
+    fireEvent.change(screen.getByLabelText('人数'), { target: { value: '1.5' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    expect(await screen.findByText('人数は整数で入力してください')).toBeInTheDocument();
+    expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+
+  it('整数なら従来どおり更新できること', async () => {
+    renderModal(nominationFreeRequest);
+
+    fireEvent.change(screen.getByLabelText('人数'), { target: { value: '4' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(1));
+    expect(mockedUpdate.mock.calls[0][1].pax).toBe(4);
+  });
+});

--- a/frontend/src/_pages/store-orders/ui/CastSearchCombobox.tsx
+++ b/frontend/src/_pages/store-orders/ui/CastSearchCombobox.tsx
@@ -26,6 +26,12 @@ interface CastSearchComboboxProps {
   /** FormControl が差し込む欄の状態。引き金は button で原生の制約を持てないため props で受ける。 */
   'aria-invalid'?: boolean;
   'aria-describedby'?: string;
+  /**
+   * 必須の指名かどうか。引き金へ aria-required として手で載せる。
+   * Combobox.Root の required は使えない——この構成は value を null に固定して選択を出来事としてだけ
+   * 受け取るため、Root 側の必須は永久に未充足のままになり、実測で送信そのものが通らなくなった。
+   */
+  required?: boolean;
 }
 
 /**
@@ -43,6 +49,7 @@ export function CastSearchCombobox({
   triggerRef,
   'aria-invalid': ariaInvalid,
   'aria-describedby': ariaDescribedby,
+  required,
 }: CastSearchComboboxProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [keyword, setKeyword] = useState('');
@@ -132,6 +139,7 @@ export function CastSearchCombobox({
               ref={triggerRef}
               aria-invalid={ariaInvalid}
               aria-describedby={ariaDescribedby}
+              aria-required={required}
             />
           }
         >

--- a/frontend/src/_pages/store-orders/ui/CastSearchCombobox.tsx
+++ b/frontend/src/_pages/store-orders/ui/CastSearchCombobox.tsx
@@ -18,6 +18,14 @@ interface CastSearchComboboxProps {
   /** 候補を選んだときだけ鳴る。 */
   onChange: (castId: string) => void;
   disabled?: boolean;
+  /**
+   * handleSubmit の焦点移動が叩く先。焦点要素は popup の中の入力ではなく引き金の button なので、
+   * ここへ届かないと文言だけ出て焦点が動かない（他に症状が出ない）。
+   */
+  triggerRef?: React.Ref<HTMLButtonElement>;
+  /** FormControl が差し込む欄の状態。引き金は button で原生の制約を持てないため props で受ける。 */
+  'aria-invalid'?: boolean;
+  'aria-describedby'?: string;
 }
 
 /**
@@ -32,6 +40,9 @@ export function CastSearchCombobox({
   castName,
   onChange,
   disabled,
+  triggerRef,
+  'aria-invalid': ariaInvalid,
+  'aria-describedby': ariaDescribedby,
 }: CastSearchComboboxProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [keyword, setKeyword] = useState('');
@@ -118,6 +129,9 @@ export function CastSearchCombobox({
               type="button"
               variant="outline"
               className="w-full justify-between font-normal"
+              ref={triggerRef}
+              aria-invalid={ariaInvalid}
+              aria-describedby={ariaDescribedby}
             />
           }
         >

--- a/frontend/src/_pages/store-orders/ui/OrderForm.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderForm.tsx
@@ -117,13 +117,7 @@ export function OrderForm({ initialData, castName, onSubmit, isSubmitting }: Ord
       ...initialData,
     },
   });
-  const {
-    register,
-    handleSubmit,
-    setValue,
-    control,
-    formState: { errors },
-  } = form;
+  const { register, handleSubmit, control } = form;
 
   const [receptionistOptions, setReceptionistOptions] = useState<OrderReceptionist[]>([]);
   const [receptionistsFailed, setReceptionistsFailed] = useState(false);
@@ -323,24 +317,23 @@ export function OrderForm({ initialData, castName, onSubmit, isSubmitting }: Ord
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-              <div className="grid gap-2">
-                <CastSearchCombobox
-                  id="castName"
-                  label="キャスト *"
-                  castName={castName ?? ''}
-                  onChange={castId =>
-                    setValue('castId', castId, { shouldValidate: true, shouldDirty: true })
-                  }
-                />
-                {/* キャストはサーバ側が @NotBlank。候補から選ばないと 400 になるため送信前に止める */}
-                <input
-                  type="hidden"
-                  {...register('castId', { required: 'キャストを候補から選択してください' })}
-                />
-                {errors.castId && (
-                  <p className="text-sm text-destructive">{errors.castId.message}</p>
+              {/* キャストはサーバ側が @NotBlank。候補から選ばないと 400 になるため送信前に止める */}
+              <FormField
+                control={control}
+                name="castId"
+                rules={{ required: 'キャストを候補から選択してください' }}
+                render={({ field }) => (
+                  <FormItem>
+                    <CastSearchCombobox
+                      id="castName"
+                      label="キャスト *"
+                      castName={castName ?? ''}
+                      onChange={field.onChange}
+                    />
+                    <FormMessage />
+                  </FormItem>
                 )}
-              </div>
+              />
               <FormField
                 control={control}
                 name="courseMinutes"

--- a/frontend/src/_pages/store-orders/ui/OrderForm.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderForm.tsx
@@ -331,6 +331,7 @@ export function OrderForm({ initialData, castName, onSubmit, isSubmitting }: Ord
                         castName={castName ?? ''}
                         onChange={field.onChange}
                         triggerRef={field.ref}
+                        required
                       />
                     </FormControl>
                     <FormMessage />

--- a/frontend/src/_pages/store-orders/ui/OrderForm.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderForm.tsx
@@ -324,12 +324,15 @@ export function OrderForm({ initialData, castName, onSubmit, isSubmitting }: Ord
                 rules={{ required: 'キャストを候補から選択してください' }}
                 render={({ field }) => (
                   <FormItem>
-                    <CastSearchCombobox
-                      id="castName"
-                      label="キャスト *"
-                      castName={castName ?? ''}
-                      onChange={field.onChange}
-                    />
+                    <FormControl>
+                      <CastSearchCombobox
+                        id="castName"
+                        label="キャスト *"
+                        castName={castName ?? ''}
+                        onChange={field.onChange}
+                        triggerRef={field.ref}
+                      />
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}

--- a/frontend/src/_pages/store-orders/ui/ReservationRequestEditModal.tsx
+++ b/frontend/src/_pages/store-orders/ui/ReservationRequestEditModal.tsx
@@ -19,7 +19,6 @@ import {
   FormLabel,
   FormMessage,
   Input,
-  Label,
   RegionError,
   Select,
   SelectContent,
@@ -68,13 +67,12 @@ export function ReservationRequestEditModal({
     defaultValues: { receptionist_id: '', pax: 1, remarks: '', cast_id: '', clear_cast: false },
   });
   const {
-    register,
     handleSubmit,
     reset,
     control,
     watch,
     setValue,
-    formState: { errors, isSubmitting },
+    formState: { isSubmitting },
   } = form;
   const [receptionistOptions, setReceptionistOptions] = useState<OrderReceptionist[]>([]);
   const [receptionistsFailed, setReceptionistsFailed] = useState(false);
@@ -162,7 +160,9 @@ export function ReservationRequestEditModal({
       >
         <DialogTitle className="border-b px-6 py-4">予約申請を編集</DialogTitle>
         <Form {...form}>
-          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
+          {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+              我々の文言は永久に描かれない。人数の min={1} は下の min 規則が引き継ぐ */}
+          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5" noValidate>
             <FormField
               control={control}
               name="receptionist_id"
@@ -247,20 +247,23 @@ export function ReservationRequestEditModal({
                 />
               )}
             </div>
-            <div className="grid gap-2">
-              <Label htmlFor="remarks">備考</Label>
-              {/* 上限はサーバ側の @Size(max = 500) に合わせる（会員の申請画面と同じ） */}
-              <Textarea
-                id="remarks"
-                rows={3}
-                {...register('remarks', {
-                  maxLength: { value: 500, message: '備考は 500 文字以内で入力してください' },
-                })}
-              />
-              {errors.remarks && (
-                <p className="text-xs text-destructive-strong">{errors.remarks.message}</p>
+            {/* 上限はサーバ側の @Size(max = 500) に合わせる（会員の申請画面と同じ） */}
+            <FormField
+              control={control}
+              name="remarks"
+              rules={{
+                maxLength: { value: 500, message: '備考は 500 文字以内で入力してください' },
+              }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>備考</FormLabel>
+                  <FormControl>
+                    <Textarea rows={3} {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
+            />
             <div className="flex justify-end gap-3 border-t pt-4">
               <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
                 キャンセル

--- a/frontend/src/_pages/store-orders/ui/ReservationRequestEditModal.tsx
+++ b/frontend/src/_pages/store-orders/ui/ReservationRequestEditModal.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { notify } from '@/shared/notify';
 import { Order, OrderReceptionist, orderApi } from '@/entities/order';
-import { getApiErrorMessage } from '@/shared/lib';
+import { getApiErrorMessage, integerRule } from '@/shared/lib';
 import { CastSearchCombobox } from './CastSearchCombobox';
 import {
   Button,
@@ -205,6 +205,9 @@ export function ReservationRequestEditModal({
               rules={{
                 required: '人数を入力してください',
                 min: { value: 1, message: '人数は 1 以上です' },
+                // noValidate は type="number" の暗黙の step=1 も止める。これが無いと 1.5 が
+                // Integer の pax へ届く
+                validate: integerRule('人数'),
               }}
               render={({ field }) => (
                 <FormItem>

--- a/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftFormModal.tsx
@@ -17,8 +17,8 @@ import {
   FormField,
   FormItem,
   FormLabel,
+  FormMessage,
   Input,
-  Label,
   Select,
   SelectContent,
   SelectItem,
@@ -83,7 +83,6 @@ export function ShiftFormModal({
     },
   });
   const {
-    register,
     handleSubmit,
     reset,
     control,
@@ -172,11 +171,13 @@ export function ShiftFormModal({
           {editing ? 'シフトを編集' : 'シフトを追加'}
         </DialogTitle>
         <Form {...form}>
-          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5">
+          {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+              我々の文言は永久に描かれない。執行は各 rules が担う */}
+          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5" noValidate>
             <FormField
               control={control}
               name="cast_id"
-              rules={{ required: true }}
+              rules={{ required: 'キャストを選択してください' }}
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>キャスト</FormLabel>
@@ -184,9 +185,12 @@ export function ShiftFormModal({
                     items={castOptions}
                     value={castValue(field.value, castOptions)}
                     onValueChange={v => field.onChange(v === SELECT_NONE ? '' : v)}
+                    required
                   >
                     <FormControl>
-                      <SelectTrigger className="w-full">
+                      {/* handleSubmit の焦点移動は登録された ref を叩く。ref が trigger へ
+                          届かないと、文言だけ出て焦点が動かない。 */}
+                      <SelectTrigger className="w-full" ref={field.ref}>
                         <SelectValue />
                       </SelectTrigger>
                     </FormControl>
@@ -198,26 +202,53 @@ export function ShiftFormModal({
                       ))}
                     </SelectContent>
                   </Select>
+                  <FormMessage />
                 </FormItem>
               )}
             />
-            <div className="grid gap-2">
-              <Label htmlFor="work_date">日付</Label>
-              <Input id="work_date" type="date" {...register('work_date', { required: true })} />
-            </div>
+            <FormField
+              control={control}
+              name="work_date"
+              rules={{ required: '日付を入力してください' }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>日付</FormLabel>
+                  <FormControl>
+                    <Input type="date" required {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
             <div className="grid grid-cols-2 gap-4">
-              <div className="grid gap-2">
-                <Label htmlFor="start_time">開始</Label>
-                <Input
-                  id="start_time"
-                  type="time"
-                  {...register('start_time', { required: true })}
-                />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="end_time">終了</Label>
-                <Input id="end_time" type="time" {...register('end_time', { required: true })} />
-              </div>
+              <FormField
+                control={control}
+                name="start_time"
+                rules={{ required: '開始時刻を入力してください' }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>開始</FormLabel>
+                    <FormControl>
+                      <Input type="time" required {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={control}
+                name="end_time"
+                rules={{ required: '終了時刻を入力してください' }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>終了</FormLabel>
+                    <FormControl>
+                      <Input type="time" required {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             </div>
             <p className="text-xs text-muted-foreground">
               終了が開始以前のときは翌日にまたがる勤務として扱います。

--- a/frontend/src/_pages/store-shifts/ui/__tests__/ShiftFormModal.test.tsx
+++ b/frontend/src/_pages/store-shifts/ui/__tests__/ShiftFormModal.test.tsx
@@ -248,6 +248,32 @@ describe('シフトフォームのセレクト配線と送信ペイロード', (
     expect(onSaved).not.toHaveBeenCalled();
   });
 
+  it('時刻を消して保存すると欄ごとの文言を出し、作成を呼ばないこと', async () => {
+    renderModal();
+
+    fireEvent.change(screen.getByLabelText('開始'), { target: { value: '' } });
+    fireEvent.change(screen.getByLabelText('終了'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    expect(await screen.findByText('開始時刻を入力してください')).toBeInTheDocument();
+    expect(screen.getByText('終了時刻を入力してください')).toBeInTheDocument();
+    expect(mockedCreate).not.toHaveBeenCalled();
+    // 検証を理由にボタンを塞がない
+    expect(screen.getByRole('button', { name: '保存する' })).toBeEnabled();
+  });
+
+  // Select は button が焦点要素で、field.ref が trigger へ届かないと handleSubmit の
+  // 焦点移動だけが静かに落ちる（文言は出るので他の症状が無い）。
+  it('キャストが未登録なら理由を名乗り、その trigger へ焦点が移ること', async () => {
+    renderModal({ casts: [] });
+
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    expect(await screen.findByText('キャストを選択してください')).toBeInTheDocument();
+    expect(mockedCreate).not.toHaveBeenCalled();
+    expect(selectAt(CAST_SELECT)).toHaveFocus();
+  });
+
   it('削除は確認を経て呼ばれ、取り消すと呼ばれないこと', async () => {
     const { onSaved } = renderModal({ editing: EDITING });
 

--- a/frontend/src/features/cast-invite-accept/ui/ExistingLoginForm.tsx
+++ b/frontend/src/features/cast-invite-accept/ui/ExistingLoginForm.tsx
@@ -81,28 +81,32 @@ export function ExistingLoginForm({ token, onSuccess, onBack }: ExistingLoginFor
     // noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、我々の文言は
     // 永久に描かれない。type="email" の執行もここで止まるため、下の pattern が引き継ぐ。
     <form onSubmit={handleSubmit(submit)} className="space-y-7" noValidate>
-      <div className="auth-field">
-        <label
-          htmlFor="invite-login-email"
-          className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
-        >
-          メールアドレス
-        </label>
-        <input
-          id="invite-login-email"
-          type="email"
-          autoComplete="email"
-          required
-          className="auth-field__input"
-          placeholder="example@mail.com"
-          aria-invalid={!!errors.email}
-          aria-describedby={errors.email ? 'invite-login-email-error' : undefined}
-          {...register('email', {
-            required: 'メールアドレスを入力してください',
-            pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
-          })}
-        />
-        <span className="auth-field__accent" />
+      {/* 文言は .auth-field の外に置く。中に入れると下線（bottom:0 の絶対配置）が
+          伸びた入れ物の底へ移り、文言を貫いて描かれる */}
+      <div>
+        <div className="auth-field">
+          <label
+            htmlFor="invite-login-email"
+            className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
+          >
+            メールアドレス
+          </label>
+          <input
+            id="invite-login-email"
+            type="email"
+            autoComplete="email"
+            required
+            className="auth-field__input"
+            placeholder="example@mail.com"
+            aria-invalid={!!errors.email}
+            aria-describedby={errors.email ? 'invite-login-email-error' : undefined}
+            {...register('email', {
+              required: 'メールアドレスを入力してください',
+              pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
+            })}
+          />
+          <span className="auth-field__accent" />
+        </div>
         {errors.email && (
           <p id="invite-login-email-error" className="auth-field__error">
             {errors.email.message}
@@ -110,25 +114,27 @@ export function ExistingLoginForm({ token, onSuccess, onBack }: ExistingLoginFor
         )}
       </div>
 
-      <div className="auth-field">
-        <label
-          htmlFor="invite-login-password"
-          className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
-        >
-          パスワード
-        </label>
-        <input
-          id="invite-login-password"
-          type="password"
-          autoComplete="current-password"
-          required
-          className="auth-field__input"
-          placeholder="パスワードを入力"
-          aria-invalid={!!errors.password}
-          aria-describedby={errors.password ? 'invite-login-password-error' : undefined}
-          {...register('password', { required: 'パスワードを入力してください' })}
-        />
-        <span className="auth-field__accent" />
+      <div>
+        <div className="auth-field">
+          <label
+            htmlFor="invite-login-password"
+            className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
+          >
+            パスワード
+          </label>
+          <input
+            id="invite-login-password"
+            type="password"
+            autoComplete="current-password"
+            required
+            className="auth-field__input"
+            placeholder="パスワードを入力"
+            aria-invalid={!!errors.password}
+            aria-describedby={errors.password ? 'invite-login-password-error' : undefined}
+            {...register('password', { required: 'パスワードを入力してください' })}
+          />
+          <span className="auth-field__accent" />
+        </div>
         {errors.password && (
           <p id="invite-login-password-error" className="auth-field__error">
             {errors.password.message}

--- a/frontend/src/features/cast-invite-accept/ui/ExistingLoginForm.tsx
+++ b/frontend/src/features/cast-invite-accept/ui/ExistingLoginForm.tsx
@@ -6,6 +6,8 @@ import { notify } from '@/shared/notify';
 import { CastAcceptanceResponse, castInvitationAcceptanceApi } from '@/entities/cast';
 import { PlatformLoginRequest, platformAuthApi } from '@/entities/user';
 import {
+  EMAIL_PATTERN,
+  EMAIL_PATTERN_MESSAGE,
   clearPlatformSession,
   getApiErrorMessage,
   getPlatformConsole,
@@ -28,7 +30,7 @@ export function ExistingLoginForm({ token, onSuccess, onBack }: ExistingLoginFor
   const {
     register,
     handleSubmit,
-    formState: { isSubmitting },
+    formState: { errors, isSubmitting },
   } = useForm<PlatformLoginRequest>({ defaultValues: { email: '', password: '' } });
 
   const submit = async (values: PlatformLoginRequest) => {
@@ -76,7 +78,9 @@ export function ExistingLoginForm({ token, onSuccess, onBack }: ExistingLoginFor
   };
 
   return (
-    <form onSubmit={handleSubmit(submit)} className="space-y-7">
+    // noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、我々の文言は
+    // 永久に描かれない。type="email" の執行もここで止まるため、下の pattern が引き継ぐ。
+    <form onSubmit={handleSubmit(submit)} className="space-y-7" noValidate>
       <div className="auth-field">
         <label
           htmlFor="invite-login-email"
@@ -91,9 +95,19 @@ export function ExistingLoginForm({ token, onSuccess, onBack }: ExistingLoginFor
           required
           className="auth-field__input"
           placeholder="example@mail.com"
-          {...register('email', { required: true })}
+          aria-invalid={!!errors.email}
+          aria-describedby={errors.email ? 'invite-login-email-error' : undefined}
+          {...register('email', {
+            required: 'メールアドレスを入力してください',
+            pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
+          })}
         />
         <span className="auth-field__accent" />
+        {errors.email && (
+          <p id="invite-login-email-error" className="auth-field__error">
+            {errors.email.message}
+          </p>
+        )}
       </div>
 
       <div className="auth-field">
@@ -110,9 +124,16 @@ export function ExistingLoginForm({ token, onSuccess, onBack }: ExistingLoginFor
           required
           className="auth-field__input"
           placeholder="パスワードを入力"
-          {...register('password', { required: true })}
+          aria-invalid={!!errors.password}
+          aria-describedby={errors.password ? 'invite-login-password-error' : undefined}
+          {...register('password', { required: 'パスワードを入力してください' })}
         />
         <span className="auth-field__accent" />
+        {errors.password && (
+          <p id="invite-login-password-error" className="auth-field__error">
+            {errors.password.message}
+          </p>
+        )}
       </div>
 
       <div className="pt-2 space-y-3">

--- a/frontend/src/features/cast-invite-accept/ui/RegisterForm.tsx
+++ b/frontend/src/features/cast-invite-accept/ui/RegisterForm.tsx
@@ -42,29 +42,33 @@ export function RegisterForm({ token, initialDisplayName, onSuccess, onBack }: R
     // noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、我々の文言は
     // 永久に描かれない。type="email" の執行もここで止まるため、下の pattern が引き継ぐ。
     <form onSubmit={handleSubmit(submit)} className="space-y-7" noValidate>
-      <div className="auth-field">
-        <label
-          htmlFor="invite-email"
-          className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
-        >
-          メールアドレス
-        </label>
-        <input
-          id="invite-email"
-          type="email"
-          autoComplete="email"
-          required
-          maxLength={127}
-          className="auth-field__input"
-          placeholder="example@mail.com"
-          aria-invalid={!!errors.email}
-          aria-describedby={errors.email ? 'invite-email-error' : undefined}
-          {...register('email', {
-            required: 'メールアドレスを入力してください',
-            pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
-          })}
-        />
-        <span className="auth-field__accent" />
+      {/* 文言は .auth-field の外に置く。中に入れると下線（bottom:0 の絶対配置）が
+          伸びた入れ物の底へ移り、文言を貫いて描かれる */}
+      <div>
+        <div className="auth-field">
+          <label
+            htmlFor="invite-email"
+            className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
+          >
+            メールアドレス
+          </label>
+          <input
+            id="invite-email"
+            type="email"
+            autoComplete="email"
+            required
+            maxLength={127}
+            className="auth-field__input"
+            placeholder="example@mail.com"
+            aria-invalid={!!errors.email}
+            aria-describedby={errors.email ? 'invite-email-error' : undefined}
+            {...register('email', {
+              required: 'メールアドレスを入力してください',
+              pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
+            })}
+          />
+          <span className="auth-field__accent" />
+        </div>
         {errors.email && (
           <p id="invite-email-error" className="auth-field__error">
             {errors.email.message}
@@ -72,25 +76,27 @@ export function RegisterForm({ token, initialDisplayName, onSuccess, onBack }: R
         )}
       </div>
 
-      <div className="auth-field">
-        <label
-          htmlFor="invite-password"
-          className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
-        >
-          パスワード
-        </label>
-        <input
-          id="invite-password"
-          type="password"
-          autoComplete="new-password"
-          required
-          className="auth-field__input"
-          placeholder="パスワードを入力"
-          aria-invalid={!!errors.password}
-          aria-describedby={errors.password ? 'invite-password-error' : undefined}
-          {...register('password', { required: 'パスワードを入力してください' })}
-        />
-        <span className="auth-field__accent" />
+      <div>
+        <div className="auth-field">
+          <label
+            htmlFor="invite-password"
+            className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
+          >
+            パスワード
+          </label>
+          <input
+            id="invite-password"
+            type="password"
+            autoComplete="new-password"
+            required
+            className="auth-field__input"
+            placeholder="パスワードを入力"
+            aria-invalid={!!errors.password}
+            aria-describedby={errors.password ? 'invite-password-error' : undefined}
+            {...register('password', { required: 'パスワードを入力してください' })}
+          />
+          <span className="auth-field__accent" />
+        </div>
         {errors.password && (
           <p id="invite-password-error" className="auth-field__error">
             {errors.password.message}
@@ -98,23 +104,25 @@ export function RegisterForm({ token, initialDisplayName, onSuccess, onBack }: R
         )}
       </div>
 
-      <div className="auth-field">
-        <label
-          htmlFor="invite-display-name"
-          className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
-        >
-          表示名
-        </label>
-        <input
-          id="invite-display-name"
-          type="text"
-          required
-          className="auth-field__input"
-          aria-invalid={!!errors.display_name}
-          aria-describedby={errors.display_name ? 'invite-display-name-error' : undefined}
-          {...register('display_name', { required: '表示名を入力してください' })}
-        />
-        <span className="auth-field__accent" />
+      <div>
+        <div className="auth-field">
+          <label
+            htmlFor="invite-display-name"
+            className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
+          >
+            表示名
+          </label>
+          <input
+            id="invite-display-name"
+            type="text"
+            required
+            className="auth-field__input"
+            aria-invalid={!!errors.display_name}
+            aria-describedby={errors.display_name ? 'invite-display-name-error' : undefined}
+            {...register('display_name', { required: '表示名を入力してください' })}
+          />
+          <span className="auth-field__accent" />
+        </div>
         {errors.display_name && (
           <p id="invite-display-name-error" className="auth-field__error">
             {errors.display_name.message}

--- a/frontend/src/features/cast-invite-accept/ui/RegisterForm.tsx
+++ b/frontend/src/features/cast-invite-accept/ui/RegisterForm.tsx
@@ -3,7 +3,7 @@
 import { useForm } from 'react-hook-form';
 import { notify } from '@/shared/notify';
 import { CastAcceptanceResponse, castInvitationAcceptanceApi } from '@/entities/cast';
-import { getApiErrorMessage } from '@/shared/lib';
+import { EMAIL_PATTERN, EMAIL_PATTERN_MESSAGE, getApiErrorMessage } from '@/shared/lib';
 
 interface RegisterFormProps {
   token: string;
@@ -24,7 +24,7 @@ export function RegisterForm({ token, initialDisplayName, onSuccess, onBack }: R
   const {
     register,
     handleSubmit,
-    formState: { isSubmitting },
+    formState: { errors, isSubmitting },
   } = useForm<RegisterFormValues>({
     defaultValues: { email: '', password: '', display_name: initialDisplayName },
   });
@@ -39,7 +39,9 @@ export function RegisterForm({ token, initialDisplayName, onSuccess, onBack }: R
   };
 
   return (
-    <form onSubmit={handleSubmit(submit)} className="space-y-7">
+    // noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、我々の文言は
+    // 永久に描かれない。type="email" の執行もここで止まるため、下の pattern が引き継ぐ。
+    <form onSubmit={handleSubmit(submit)} className="space-y-7" noValidate>
       <div className="auth-field">
         <label
           htmlFor="invite-email"
@@ -55,9 +57,19 @@ export function RegisterForm({ token, initialDisplayName, onSuccess, onBack }: R
           maxLength={127}
           className="auth-field__input"
           placeholder="example@mail.com"
-          {...register('email', { required: true })}
+          aria-invalid={!!errors.email}
+          aria-describedby={errors.email ? 'invite-email-error' : undefined}
+          {...register('email', {
+            required: 'メールアドレスを入力してください',
+            pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
+          })}
         />
         <span className="auth-field__accent" />
+        {errors.email && (
+          <p id="invite-email-error" className="auth-field__error">
+            {errors.email.message}
+          </p>
+        )}
       </div>
 
       <div className="auth-field">
@@ -74,9 +86,16 @@ export function RegisterForm({ token, initialDisplayName, onSuccess, onBack }: R
           required
           className="auth-field__input"
           placeholder="パスワードを入力"
-          {...register('password', { required: true })}
+          aria-invalid={!!errors.password}
+          aria-describedby={errors.password ? 'invite-password-error' : undefined}
+          {...register('password', { required: 'パスワードを入力してください' })}
         />
         <span className="auth-field__accent" />
+        {errors.password && (
+          <p id="invite-password-error" className="auth-field__error">
+            {errors.password.message}
+          </p>
+        )}
       </div>
 
       <div className="auth-field">
@@ -91,9 +110,16 @@ export function RegisterForm({ token, initialDisplayName, onSuccess, onBack }: R
           type="text"
           required
           className="auth-field__input"
-          {...register('display_name', { required: true })}
+          aria-invalid={!!errors.display_name}
+          aria-describedby={errors.display_name ? 'invite-display-name-error' : undefined}
+          {...register('display_name', { required: '表示名を入力してください' })}
         />
         <span className="auth-field__accent" />
+        {errors.display_name && (
+          <p id="invite-display-name-error" className="auth-field__error">
+            {errors.display_name.message}
+          </p>
+        )}
       </div>
 
       <div className="pt-2 space-y-3">

--- a/frontend/src/features/member-register/ui/MemberRegisterForm.tsx
+++ b/frontend/src/features/member-register/ui/MemberRegisterForm.tsx
@@ -55,30 +55,34 @@ export function MemberRegisterForm() {
     // noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、我々の文言は
     // 永久に描かれない。type="email" の執行もここで止まるため、下の pattern が引き継ぐ。
     <form onSubmit={handleSubmit(submit)} className="space-y-7" noValidate>
-      <div className="auth-field">
-        <label
-          htmlFor="register-email"
-          className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
-        >
-          メールアドレス
-        </label>
-        <input
-          id="register-email"
-          type="email"
-          autoComplete="email"
-          required
-          maxLength={127}
-          className="auth-field__input"
-          placeholder="example@mail.com"
-          aria-invalid={!!errors.email}
-          aria-describedby={errors.email ? 'register-email-error' : undefined}
-          {...register('email', {
-            required: 'メールアドレスを入力してください',
-            pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
-            maxLength: { value: 127, message: 'メールアドレスは127文字以内で入力してください' },
-          })}
-        />
-        <span className="auth-field__accent" />
+      {/* 文言は .auth-field の外に置く。中に入れると下線（bottom:0 の絶対配置）が
+          伸びた入れ物の底へ移り、文言を貫いて描かれる */}
+      <div>
+        <div className="auth-field">
+          <label
+            htmlFor="register-email"
+            className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
+          >
+            メールアドレス
+          </label>
+          <input
+            id="register-email"
+            type="email"
+            autoComplete="email"
+            required
+            maxLength={127}
+            className="auth-field__input"
+            placeholder="example@mail.com"
+            aria-invalid={!!errors.email}
+            aria-describedby={errors.email ? 'register-email-error' : undefined}
+            {...register('email', {
+              required: 'メールアドレスを入力してください',
+              pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
+              maxLength: { value: 127, message: 'メールアドレスは127文字以内で入力してください' },
+            })}
+          />
+          <span className="auth-field__accent" />
+        </div>
         {errors.email && (
           <p id="register-email-error" className="auth-field__error">
             {errors.email.message}
@@ -86,30 +90,32 @@ export function MemberRegisterForm() {
         )}
       </div>
 
-      <div className="auth-field">
-        <label
-          htmlFor="register-password"
-          className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
-        >
-          パスワード
-        </label>
-        {/* 原生 minLength は外す。noValidate の下では何も執行せず何も告知しないため、
-            残すと「まだ何かを守っている」と読者を誤解させるだけになる。 */}
-        <input
-          id="register-password"
-          type="password"
-          autoComplete="new-password"
-          required
-          className="auth-field__input"
-          placeholder="8文字以上のパスワード"
-          aria-invalid={!!errors.password}
-          aria-describedby={errors.password ? 'register-password-error' : undefined}
-          {...register('password', {
-            required: 'パスワードを入力してください',
-            minLength: { value: 8, message: 'パスワードは8文字以上で入力してください' },
-          })}
-        />
-        <span className="auth-field__accent" />
+      <div>
+        <div className="auth-field">
+          <label
+            htmlFor="register-password"
+            className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
+          >
+            パスワード
+          </label>
+          {/* 原生 minLength は外す。noValidate の下では何も執行せず何も告知しないため、
+              残すと「まだ何かを守っている」と読者を誤解させるだけになる。 */}
+          <input
+            id="register-password"
+            type="password"
+            autoComplete="new-password"
+            required
+            className="auth-field__input"
+            placeholder="8文字以上のパスワード"
+            aria-invalid={!!errors.password}
+            aria-describedby={errors.password ? 'register-password-error' : undefined}
+            {...register('password', {
+              required: 'パスワードを入力してください',
+              minLength: { value: 8, message: 'パスワードは8文字以上で入力してください' },
+            })}
+          />
+          <span className="auth-field__accent" />
+        </div>
         {errors.password && (
           <p id="register-password-error" className="auth-field__error">
             {errors.password.message}
@@ -117,28 +123,30 @@ export function MemberRegisterForm() {
         )}
       </div>
 
-      <div className="auth-field">
-        <label
-          htmlFor="register-display-name"
-          className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
-        >
-          表示名
-        </label>
-        <input
-          id="register-display-name"
-          type="text"
-          required
-          maxLength={150}
-          className="auth-field__input"
-          placeholder="表示名を入力"
-          aria-invalid={!!errors.display_name}
-          aria-describedby={errors.display_name ? 'register-display-name-error' : undefined}
-          {...register('display_name', {
-            required: '表示名を入力してください',
-            maxLength: { value: 150, message: '表示名は150文字以内で入力してください' },
-          })}
-        />
-        <span className="auth-field__accent" />
+      <div>
+        <div className="auth-field">
+          <label
+            htmlFor="register-display-name"
+            className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
+          >
+            表示名
+          </label>
+          <input
+            id="register-display-name"
+            type="text"
+            required
+            maxLength={150}
+            className="auth-field__input"
+            placeholder="表示名を入力"
+            aria-invalid={!!errors.display_name}
+            aria-describedby={errors.display_name ? 'register-display-name-error' : undefined}
+            {...register('display_name', {
+              required: '表示名を入力してください',
+              maxLength: { value: 150, message: '表示名は150文字以内で入力してください' },
+            })}
+          />
+          <span className="auth-field__accent" />
+        </div>
         {errors.display_name && (
           <p id="register-display-name-error" className="auth-field__error">
             {errors.display_name.message}

--- a/frontend/src/features/member-register/ui/MemberRegisterForm.tsx
+++ b/frontend/src/features/member-register/ui/MemberRegisterForm.tsx
@@ -6,7 +6,12 @@ import Cookies from 'js-cookie';
 import { notify } from '@/shared/notify';
 import { memberApi, MemberRegisterRequest } from '@/entities/member';
 import { platformAuthApi } from '@/entities/user';
-import { getApiErrorMessage, startPlatformSession } from '@/shared/lib';
+import {
+  EMAIL_PATTERN,
+  EMAIL_PATTERN_MESSAGE,
+  getApiErrorMessage,
+  startPlatformSession,
+} from '@/shared/lib';
 
 /**
  * 会員の新規登録フォーム（メール + パスワード + 表示名の 3 項目）。
@@ -17,7 +22,7 @@ export function MemberRegisterForm() {
   const {
     register,
     handleSubmit,
-    formState: { isSubmitting },
+    formState: { errors, isSubmitting },
   } = useForm<MemberRegisterRequest>({
     defaultValues: { email: '', password: '', display_name: '' },
   });
@@ -47,7 +52,9 @@ export function MemberRegisterForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit(submit)} className="space-y-7">
+    // noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、我々の文言は
+    // 永久に描かれない。type="email" の執行もここで止まるため、下の pattern が引き継ぐ。
+    <form onSubmit={handleSubmit(submit)} className="space-y-7" noValidate>
       <div className="auth-field">
         <label
           htmlFor="register-email"
@@ -63,9 +70,20 @@ export function MemberRegisterForm() {
           maxLength={127}
           className="auth-field__input"
           placeholder="example@mail.com"
-          {...register('email', { required: true, maxLength: 127 })}
+          aria-invalid={!!errors.email}
+          aria-describedby={errors.email ? 'register-email-error' : undefined}
+          {...register('email', {
+            required: 'メールアドレスを入力してください',
+            pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
+            maxLength: { value: 127, message: 'メールアドレスは127文字以内で入力してください' },
+          })}
         />
         <span className="auth-field__accent" />
+        {errors.email && (
+          <p id="register-email-error" className="auth-field__error">
+            {errors.email.message}
+          </p>
+        )}
       </div>
 
       <div className="auth-field">
@@ -75,17 +93,28 @@ export function MemberRegisterForm() {
         >
           パスワード
         </label>
+        {/* 原生 minLength は外す。noValidate の下では何も執行せず何も告知しないため、
+            残すと「まだ何かを守っている」と読者を誤解させるだけになる。 */}
         <input
           id="register-password"
           type="password"
           autoComplete="new-password"
           required
-          minLength={8}
           className="auth-field__input"
           placeholder="8文字以上のパスワード"
-          {...register('password', { required: true, minLength: 8 })}
+          aria-invalid={!!errors.password}
+          aria-describedby={errors.password ? 'register-password-error' : undefined}
+          {...register('password', {
+            required: 'パスワードを入力してください',
+            minLength: { value: 8, message: 'パスワードは8文字以上で入力してください' },
+          })}
         />
         <span className="auth-field__accent" />
+        {errors.password && (
+          <p id="register-password-error" className="auth-field__error">
+            {errors.password.message}
+          </p>
+        )}
       </div>
 
       <div className="auth-field">
@@ -102,9 +131,19 @@ export function MemberRegisterForm() {
           maxLength={150}
           className="auth-field__input"
           placeholder="表示名を入力"
-          {...register('display_name', { required: true, maxLength: 150 })}
+          aria-invalid={!!errors.display_name}
+          aria-describedby={errors.display_name ? 'register-display-name-error' : undefined}
+          {...register('display_name', {
+            required: '表示名を入力してください',
+            maxLength: { value: 150, message: '表示名は150文字以内で入力してください' },
+          })}
         />
         <span className="auth-field__accent" />
+        {errors.display_name && (
+          <p id="register-display-name-error" className="auth-field__error">
+            {errors.display_name.message}
+          </p>
+        )}
       </div>
 
       <div className="pt-2">

--- a/frontend/src/features/platform-login/ui/PlatformLoginForm.tsx
+++ b/frontend/src/features/platform-login/ui/PlatformLoginForm.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import Cookies from 'js-cookie';
 import { notify } from '@/shared/notify';
 import { platformAuthApi, PlatformLoginRequest } from '@/entities/user';
-import { getApiErrorMessage } from '@/shared/lib';
+import { EMAIL_PATTERN, EMAIL_PATTERN_MESSAGE, getApiErrorMessage } from '@/shared/lib';
 import { completePlatformLogin } from '../model/completePlatformLogin';
 
 /** 統一ログイン動作。ログイン成功後はロールに応じて自動的に適切なコンソールへ遷移する。 */
@@ -14,7 +14,7 @@ export default function PlatformLoginForm() {
   const {
     register,
     handleSubmit,
-    formState: { isSubmitting },
+    formState: { errors, isSubmitting },
   } = useForm<PlatformLoginRequest>({ defaultValues: { email: '', password: '' } });
 
   const onSubmit = async (data: PlatformLoginRequest) => {
@@ -35,7 +35,9 @@ export default function PlatformLoginForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-7">
+    // noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、我々の文言は
+    // 永久に描かれない。type="email" の執行もここで止まるため、下の pattern が引き継ぐ。
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-7" noValidate>
       {/* メールアドレス */}
       <div className="auth-field">
         <label
@@ -51,9 +53,19 @@ export default function PlatformLoginForm() {
           required
           className="auth-field__input"
           placeholder="example@mail.com"
-          {...register('email', { required: true })}
+          aria-invalid={!!errors.email}
+          aria-describedby={errors.email ? 'email-error' : undefined}
+          {...register('email', {
+            required: 'メールアドレスを入力してください',
+            pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
+          })}
         />
         <span className="auth-field__accent" />
+        {errors.email && (
+          <p id="email-error" className="auth-field__error">
+            {errors.email.message}
+          </p>
+        )}
       </div>
 
       {/* パスワード */}
@@ -71,9 +83,16 @@ export default function PlatformLoginForm() {
           required
           className="auth-field__input"
           placeholder="パスワードを入力"
-          {...register('password', { required: true })}
+          aria-invalid={!!errors.password}
+          aria-describedby={errors.password ? 'password-error' : undefined}
+          {...register('password', { required: 'パスワードを入力してください' })}
         />
         <span className="auth-field__accent" />
+        {errors.password && (
+          <p id="password-error" className="auth-field__error">
+            {errors.password.message}
+          </p>
+        )}
       </div>
 
       {/* ログインボタン */}

--- a/frontend/src/features/platform-login/ui/PlatformLoginForm.tsx
+++ b/frontend/src/features/platform-login/ui/PlatformLoginForm.tsx
@@ -39,28 +39,32 @@ export default function PlatformLoginForm() {
     // 永久に描かれない。type="email" の執行もここで止まるため、下の pattern が引き継ぐ。
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-7" noValidate>
       {/* メールアドレス */}
-      <div className="auth-field">
-        <label
-          htmlFor="email"
-          className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
-        >
-          メールアドレス
-        </label>
-        <input
-          id="email"
-          type="email"
-          autoComplete="email"
-          required
-          className="auth-field__input"
-          placeholder="example@mail.com"
-          aria-invalid={!!errors.email}
-          aria-describedby={errors.email ? 'email-error' : undefined}
-          {...register('email', {
-            required: 'メールアドレスを入力してください',
-            pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
-          })}
-        />
-        <span className="auth-field__accent" />
+      {/* 文言は .auth-field の外に置く。中に入れると下線（bottom:0 の絶対配置）が
+          伸びた入れ物の底へ移り、文言を貫いて描かれる */}
+      <div>
+        <div className="auth-field">
+          <label
+            htmlFor="email"
+            className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
+          >
+            メールアドレス
+          </label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            required
+            className="auth-field__input"
+            placeholder="example@mail.com"
+            aria-invalid={!!errors.email}
+            aria-describedby={errors.email ? 'email-error' : undefined}
+            {...register('email', {
+              required: 'メールアドレスを入力してください',
+              pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
+            })}
+          />
+          <span className="auth-field__accent" />
+        </div>
         {errors.email && (
           <p id="email-error" className="auth-field__error">
             {errors.email.message}
@@ -69,25 +73,27 @@ export default function PlatformLoginForm() {
       </div>
 
       {/* パスワード */}
-      <div className="auth-field">
-        <label
-          htmlFor="password"
-          className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
-        >
-          パスワード
-        </label>
-        <input
-          id="password"
-          type="password"
-          autoComplete="current-password"
-          required
-          className="auth-field__input"
-          placeholder="パスワードを入力"
-          aria-invalid={!!errors.password}
-          aria-describedby={errors.password ? 'password-error' : undefined}
-          {...register('password', { required: 'パスワードを入力してください' })}
-        />
-        <span className="auth-field__accent" />
+      <div>
+        <div className="auth-field">
+          <label
+            htmlFor="password"
+            className="block text-xs font-medium text-[#8a8580] uppercase tracking-wider mb-1.5"
+          >
+            パスワード
+          </label>
+          <input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            required
+            className="auth-field__input"
+            placeholder="パスワードを入力"
+            aria-invalid={!!errors.password}
+            aria-describedby={errors.password ? 'password-error' : undefined}
+            {...register('password', { required: 'パスワードを入力してください' })}
+          />
+          <span className="auth-field__accent" />
+        </div>
         {errors.password && (
           <p id="password-error" className="auth-field__error">
             {errors.password.message}

--- a/frontend/src/features/platform-login/ui/__tests__/PlatformLoginForm.test.tsx
+++ b/frontend/src/features/platform-login/ui/__tests__/PlatformLoginForm.test.tsx
@@ -109,3 +109,46 @@ describe('PlatformLoginForm CAST/MEMBER 分岐（#328）', () => {
     expect(mockedNotifyError).not.toHaveBeenCalled();
   });
 });
+
+describe('PlatformLoginForm のクライアント検証（#598）', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('未入力のまま押すと欄ごとの文言が出て、送信は行われないこと', async () => {
+    render(<PlatformLoginForm />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+
+    expect(await screen.findByText('メールアドレスを入力してください')).toBeInTheDocument();
+    expect(screen.getByText('パスワードを入力してください')).toBeInTheDocument();
+    expect(mockedAuthApi.login).not.toHaveBeenCalled();
+    // 検証を理由にボタンを塞がない（押させて文言を出す）
+    expect(screen.getByRole('button', { name: 'ログイン' })).toBeEnabled();
+  });
+
+  it('文言が欄と結び付いていること（読み上げ環境で「どの欄が」まで届く）', async () => {
+    render(<PlatformLoginForm />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+
+    const message = await screen.findByText('メールアドレスを入力してください');
+    const input = screen.getByLabelText('メールアドレス');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby', message.id);
+    expect(message.id).toBeTruthy();
+  });
+
+  it('形式違反のメールアドレスは送信せず形式の文言を出すこと（noValidate で原生 type=email は執行されない）', async () => {
+    render(<PlatformLoginForm />);
+
+    fireEvent.change(screen.getByLabelText('メールアドレス'), {
+      target: { value: 'not-an-email' },
+    });
+    fireEvent.change(screen.getByLabelText('パスワード'), { target: { value: 'pass' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+
+    expect(await screen.findByText('メールアドレスの形式が正しくありません')).toBeInTheDocument();
+    expect(mockedAuthApi.login).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
+++ b/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
@@ -9,7 +9,12 @@ import {
   platformRoleApi,
   platformStaffApi,
 } from '@/entities/user';
-import { getApiErrorMessage, useManagedList } from '@/shared/lib';
+import {
+  EMAIL_PATTERN,
+  EMAIL_PATTERN_MESSAGE,
+  getApiErrorMessage,
+  useManagedList,
+} from '@/shared/lib';
 import {
   Button,
   Dialog,
@@ -48,10 +53,6 @@ interface StaffCreateFormValues {
   store_scope_type: PlatformStoreScopeType;
   store_ids: number[];
 }
-
-// noValidate で type="email" の執行が止まるぶんを規則で引き継ぐ。ドメインに .
-// を求める点で原生より厳しいが、これは既に StoreEditPage が採っている形。
-const EMAIL_PATTERN = /^([^\s@])+@([^\s@])+\.[^\s@]+$/;
 
 /**
  * スタッフの新規作成モーダル（メール・初期パスワード・氏名・ロール・担当店舗）。
@@ -128,10 +129,7 @@ export function StaffCreateModal({
               name="email"
               rules={{
                 required: 'メールアドレスを入力してください',
-                pattern: {
-                  value: EMAIL_PATTERN,
-                  message: 'メールアドレスの形式が正しくありません',
-                },
+                pattern: { value: EMAIL_PATTERN, message: EMAIL_PATTERN_MESSAGE },
               }}
               render={({ field }) => (
                 <FormItem className="gap-1">

--- a/frontend/src/shared/lib/__tests__/validation.test.ts
+++ b/frontend/src/shared/lib/__tests__/validation.test.ts
@@ -1,0 +1,72 @@
+import { EMAIL_PATTERN, integerRule } from '../validation';
+
+/**
+ * この規則は noValidate で執行が止まった原生 type="email" の代役であり、原生が弾いていたものを
+ * 通してしまうと、サーバの @Email から toast で返る——欄の傍に文言を出すという目的の裏返しになる。
+ */
+describe('EMAIL_PATTERN', () => {
+  it.each([
+    ['ごく普通の宛先', 'user@example.com'],
+    ['副アドレス表記と多段ドメイン', 'user.name+tag@example.co.jp'],
+    ['ハイフン入りドメイン', 'user@my-store.example.com'],
+  ])('%s は通す（%s）', (_name, address) => {
+    expect(EMAIL_PATTERN.test(address)).toBe(true);
+  });
+
+  it.each([
+    ['ラベルが空のドメイン', 'user@foo..com'],
+    ['ドットで始まるドメイン', 'user@.example.com'],
+    ['ドットで終わるドメイン', 'user@example.com.'],
+    ['下線入りドメイン', 'user@foo_bar.com'],
+    ['ハイフンで始まるラベル', 'user@-example.com'],
+  ])('原生 type="email" が弾いていた %s は弾く（%s）', (_name, address) => {
+    expect(EMAIL_PATTERN.test(address)).toBe(false);
+  });
+
+  it.each([
+    ['@ が無い', 'no-at-sign'],
+    ['ドメインにドットが無い', 'user@localhost'],
+    ['局所部が空', '@example.com'],
+    ['空白入り', 'user name@example.com'],
+  ])('従来どおり %s は弾く（%s）', (_name, address) => {
+    expect(EMAIL_PATTERN.test(address)).toBe(false);
+  });
+});
+
+/**
+ * 欄によって「空」の姿が違う（valueAsNumber は NaN、素の register は空文字）ため、
+ * どの姿でも通ることを固定する。通さないと required の無い任意欄が空のまま送れなくなる。
+ */
+describe('integerRule', () => {
+  const rule = integerRule('人数');
+
+  it.each([
+    ['数値の小数', 1.5],
+    ['文字列の小数', '1.5'],
+    ['負の小数', -0.5],
+  ])('%s は文言を返す（%s）', (_name, value) => {
+    expect(rule(value)).toBe('人数は整数で入力してください');
+  });
+
+  it.each([
+    ['数値の整数', 3],
+    ['文字列の整数', '3'],
+    ['負の整数（範囲は min の担当）', -2],
+    ['零', 0],
+  ])('%s は通す（%s）', (_name, value) => {
+    expect(rule(value)).toBe(true);
+  });
+
+  it.each([
+    ['valueAsNumber の空欄', NaN],
+    ['素の register の空欄', ''],
+    ['未設定', undefined],
+    ['null', null],
+  ])('%s は通す（未入力を弾くのは required の仕事）', (_name, value) => {
+    expect(rule(value)).toBe(true);
+  });
+
+  it('文言は欄の名前を名乗る', () => {
+    expect(integerRule('表示順')(1.5)).toBe('表示順は整数で入力してください');
+  });
+});

--- a/frontend/src/shared/lib/email.ts
+++ b/frontend/src/shared/lib/email.ts
@@ -1,8 +1,0 @@
-/**
- * noValidate で type="email" の執行が止まるぶんを引き継ぐ検証規則の値。
- * ドメインに . を求める点で原生より厳しいが、これは既に StoreEditPage が採っている形。
- */
-export const EMAIL_PATTERN = /^([^\s@])+@([^\s@])+\.[^\s@]+$/;
-
-/** 形式違反のときに欄の傍へ出す文言。全フォームで同一。 */
-export const EMAIL_PATTERN_MESSAGE = 'メールアドレスの形式が正しくありません';

--- a/frontend/src/shared/lib/email.ts
+++ b/frontend/src/shared/lib/email.ts
@@ -1,0 +1,8 @@
+/**
+ * noValidate で type="email" の執行が止まるぶんを引き継ぐ検証規則の値。
+ * ドメインに . を求める点で原生より厳しいが、これは既に StoreEditPage が採っている形。
+ */
+export const EMAIL_PATTERN = /^([^\s@])+@([^\s@])+\.[^\s@]+$/;
+
+/** 形式違反のときに欄の傍へ出す文言。全フォームで同一。 */
+export const EMAIL_PATTERN_MESSAGE = 'メールアドレスの形式が正しくありません';

--- a/frontend/src/shared/lib/index.ts
+++ b/frontend/src/shared/lib/index.ts
@@ -28,6 +28,7 @@ export {
   storeEntryPath,
 } from './store-route';
 export { cn } from './utils';
+export { EMAIL_PATTERN, EMAIL_PATTERN_MESSAGE } from './email';
 export { isPublicPlatformPath } from './app-area';
 export {
   LINE_AUTHORIZE_ENDPOINT,

--- a/frontend/src/shared/lib/index.ts
+++ b/frontend/src/shared/lib/index.ts
@@ -28,7 +28,7 @@ export {
   storeEntryPath,
 } from './store-route';
 export { cn } from './utils';
-export { EMAIL_PATTERN, EMAIL_PATTERN_MESSAGE } from './email';
+export { EMAIL_PATTERN, EMAIL_PATTERN_MESSAGE, integerRule } from './validation';
 export { isPublicPlatformPath } from './app-area';
 export {
   LINE_AUTHORIZE_ENDPOINT,

--- a/frontend/src/shared/lib/validation.ts
+++ b/frontend/src/shared/lib/validation.ts
@@ -1,0 +1,27 @@
+/**
+ * noValidate で type="email" の執行が止まるぶんを引き継ぐ検証規則の値。
+ *
+ * 形は HTML 仕様が type="email" に定める正規表現そのもので、原生が弾いていたもの（ラベルの空いた
+ * ドメイン・下線・先頭のハイフン）をそのまま弾く。仕様との違いはドメインにドットを求める一点だけで、
+ * これは社内アドレスのような単一ラベル宛先を受け付けないという既存の判断を引き継いだもの。
+ */
+export const EMAIL_PATTERN =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/;
+
+/** 形式違反のときに欄の傍へ出す文言。全フォームで同一。 */
+export const EMAIL_PATTERN_MESSAGE = 'メールアドレスの形式が正しくありません';
+
+/**
+ * 整数以外を弾く規則を作る。noValidate は type="number" の暗黙の step=1 まで無効化するため、
+ * これが無いと 1.5 が Integer の項目へそのまま届く。
+ *
+ * 空欄は通す。「未入力かどうか」を決めるのは required の仕事で、valueAsNumber の空欄は NaN、
+ * 素の register なら空文字と、欄ごとに姿が違う——どれも「まだ何も入っていない」であって
+ * 「整数でない」ではない。
+ */
+export const integerRule = (label: string) => (value: unknown) => {
+  if (value === null || value === undefined || value === '') return true;
+  const numeric = typeof value === 'number' ? value : Number(value);
+  if (Number.isNaN(numeric)) return true;
+  return Number.isInteger(numeric) || `${label}は整数で入力してください`;
+};

--- a/frontend/src/styles/auth.css
+++ b/frontend/src/styles/auth.css
@@ -264,6 +264,21 @@
   width: 100%;
 }
 
+/* 欄ごとの検証文言。ページ全体に掛かる .auth-alert--error は流用しない——あちらは
+   #dc2626 on #fef2f2 で 4.42 しかなく、この寸法（13px）の普通文字が要る 4.5 に届かない。
+   #b91c1c on #faf9f7（フォーム面の地色）は 6.15。 */
+.auth-field__error {
+  margin-top: 6px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #b91c1c;
+}
+
+/* 文言だけだと誤りの在り処が下の一行にしか無い。下線を同じ赤へ倒して欄自身にも持たせる。 */
+.auth-field__input[aria-invalid='true'] {
+  border-bottom-color: #b91c1c;
+}
+
 /* ========== ボタン ========== */
 
 .auth-btn {


### PR DESCRIPTION
## 概要

#588 が立てた検証規範（`frontend/DESIGN.md` の Client-side validation 節）を全域へ適用する。押しても何も起きずに送信が止まる RHF `required: true` を、文言を持つ規則と `FormMessage`（auth 世界は `auth.css` 語彙）へ移した。日本語文言は現状ゼロ本だったため新規に起草している。

Closes #598

## 変更内容

- **admin 7 ファイル 17 箇所**を `FormField` + `rules` + `FormMessage` へ。`CastRequestsPage` / `ShiftChangeRequestModal` の**空の赤い段落**もここで消える。
- **auth 5 ファイル 13 箇所**は `auth.css` に新設した `.auth-field__error` と手書きの `aria-invalid` / `aria-describedby`。`FormMessage` が発する `text-destructive` は admin トークンで、`DESIGN.md` の三世界規則が auth 画面への持ち込みを禁じているため。
- 各 `<form>` に **`noValidate`**。原生 `required` / `type="email"` / `min` は `aria-required`・キーボード・スピナー下限のために残し、**`minLength` のみ外す**。執行が止まる `type="email"` 5 箇所は `EMAIL_PATTERN` の規則が引き継ぐ。
- #581 が名指しした**クラス名不一致**（`OrderForm` の castId ＝ `text-sm text-destructive`、`ReservationRequestEditModal` の remarks ＝ `text-xs text-destructive-strong`）を `FormMessage` へ寄せた。castId の hidden input は `DESIGN.md:497` が先例として禁じている形なので `FormField` へ置き換えている。
- #581 の「ほか」に当たる `MemberReservationNewPage` の手書き段落 3 つも同様に寄せ、`noValidate` を付けた（`min={1}` は文言付き規則が既に存在していた）。
- `StaffCreateModal` の局所 `EMAIL_PATTERN` を `shared/lib/email.ts` へ畳んだ（本票が同じ正規表現を 5 箇所へ増やしたため）。

基線 `9b445d25` の 34 箇所のうち 4 箇所（StaffCreateModal ×3 / RoleFormModal ×1）は #591 が既に片付けているため、本票の射程は **30 箇所 / 12 ファイル**。全仓の `required: true`（テスト除く）は 0 になった。

### レビュー指摘の反映（追加 2 コミット）

- **`noValidate` は `type="number"` の暗黙の `step=1` まで無効化する** — これが本 PR の回帰だった。実測（Chromium）で、検証する form は `1.5` で submit 処理器を走らせないのに対し、`noValidate` の form は走らせ、`valueAsNumber` は `1.5` のまま。届く先はいずれもサーバ側 `Integer`（`pax` / `displayOrder` / `age` ほか）で、`ACCEPT_FLOAT_AS_INT` は本仓で覆されていないため静かに丸まるか 400 で返る。
  - 指摘は 4 箇所だったが、**`step` は既定値で grep に出ない**ため、属性の棚卸しではなく「その控件型が何を暗黙に持つか」で数え直し、`noValidate` を得た全ての `type="number"` = **9 欄 / 4 ファイル**へ横展開した。
  - 共有の `integerRule(label)` を `shared/lib/validation.ts`（`email.ts` から改名）に置いた。**空欄は通す** — 未入力を弾くのは `required` の担当で、空欄の姿は `valueAsNumber` なら `NaN`、素の `register` なら空文字と欄ごとに違う。
  - `CastForm` のプロフィール数値欄 6 件は素の `register` で文言を描く場所が無かったため `FormField` + `FormMessage` へ寄せ、共通部分を `NumericProfileField` に畳んだ。**`id` は `FormControl` に持たせる**（こちらで与えると `FormLabel` の `htmlFor` と食い違い、欄とラベルの結び付きが切れる）。
- **`EMAIL_PATTERN` を HTML 仕様が `type="email"` に定める正規表現へ収斂**させた。従来の緩い形は `user@foo..com` / `user@.example.com` / 下線入りドメイン / 先頭ハイフンのラベルを通しており、`noValidate` の下ではそれがそのままサーバの `@Email` まで届いていた。ドメインのドット必須は従来どおり維持。**共有定数のため `StaffCreateModal` / `StoreEditPage` にも及び**（どちらも master 時点で既に緩い形を `noValidate` 下で使っていた）、そちらでは非 ASCII の局所部が新たに弾かれる。
- **`CastSearchCombobox` の引き金へ `aria-required`** — 必須の指名欄が読み上げ環境へ「任意」と伝わっていた。`Combobox.Root` の `required` は使えない: この構成は `value` を `null` に固定して選択を出来事としてだけ受け取るため、Root 側の必須が永久に未充足になり、**実測で送信そのものが通らなくなった**（同ファイルの既存送信テスト 3 本が落ちて判明）。`DESIGN.md:492` が「原語へ渡せ・手書きするな」と定める対象は Select / Checkbox / RadioGroup / Switch で Combobox は入らないため、引き金へ手で載せている。

## 検証

レビュー指摘の反映後に**四門とも取り直した**（下記はいずれも最新コミットでの結果）。

- [x] `task lint` exit 0
- [x] `task test` exit 0（frontend 843 / 843、backend BUILD SUCCESSFUL）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（24 / 24、4.5m。ログイン欄を作り替えているため全シナリオが通る `メール … でログインする` ステップの回帰確認が主目的。`人数` は member-reservation のステップがラベル経由で入力するため、`FormField` 化の影響もここで見ている）
- [x] ローカルで code-review 実施済み（Standards / Spec 二軸。指摘は下記「備考」）

新規テストはすべて**両向きで証明**した（修正を外すと赤 / 戻すと緑、赤側は 1 対 1 対応を確認）。

### 視覚確認（UI 変更時）

実ブラウザで確認した面：**ログイン画面（明）／店舗コンソールの顧客フォーム（明・暗）／受注新規作成**。

実測値（ログイン画面）: 文言色 `rgb(185,28,28)` on 面地色 `rgb(250,249,247)` = **6.15**、`aria-describedby` が文言 id と一致、`aria-invalid=true`、原生 `required` 維持、`noValidate` 有効、送信ボタンは非活性化されない。

**実ブラウザで見ていない面**（テストと構造のみ）: 残り 4 つの auth フォーム、`LineRegisterStep` の同意チェック（構造が異なる／文言が 12px→13px）、`MemberReservationNewPage`（`FormItem` の間隔が変わる）。

## 決定ログ

### 票の受入基準 1 件に**従っていない**

票は「原生 `required` / `minLength` 属性が除去されている」と書くが、これは #581 の **2026-08-06 補記**（機構を `noValidate` へ覆した裁定）より前の文面で、票面が回写されていない。規範の正本である `DESIGN.md:488-495` に従い、`noValidate` ＋ 属性維持 ＋ `minLength` のみ除去とした。

### 沈黙する required 34 箇所の割り直し（地雷 3）

#581 の「表示要素なし 約 22 ＋ 空の赤い段落 数箇所」は二分できず、実際は三形態:

| 形 | 件数 | 内容 |
| --- | --- | --- |
| 表示要素なし | **31** | その欄の誤りを描く要素がそもそも無い |
| 空の赤い段落 | **2** | `CastRequestsPage` / `ShiftChangeRequestModal` の work_date。ただし**平坦に空ではない** — `required: true` と文言つき `validate` が同居し、段落は required 枝でだけ空で validate 枝では埋まる |
| 文言が規則の外 | **1** | `LineRegisterStep` の consent。文言はあるが JSX 直書きで、生の hex `#dc2626`（どちらの語彙にも属さない） |

31 + 2 + 1 = 34 で合致。#581 の「約 22」は 9 件ほど少なく見ており、「数箇所」は実際には 2 件だった。

### 見送った代替案

- **auth 側も `FormMessage` を使う** — `DESIGN.md:498` が admin トークンの auth 画面持ち込みを禁じている。既存の `auth-alert--error` の流用も不可（`#dc2626` on `#fef2f2` = **4.42** で 4.5 に届かない）。
- **auth 13 箇所の包み形を共通部品へ** — 唯一の置き場が `shared/ui`（凍結された vendored ＋ parallel-PR contract）になるため見送り。`DESIGN.md:498` も「by hand」と明記している。
- **配色を `DESIGN.md` へ回写** — #589 が `DESIGN.md` を parallel-PR contract の共有ファイルと定め「slice PR に混ぜない」としているため、`auth-alert--neutral` の先例に倣って `auth.css` のコメントに実測値ごと記録した。
- **`OrderForm` に `noValidate`** — 本 PR では付けていない。当初「規則化すると空欄の意味が変わる」を理由に挙げていたが、これは**実測で誤りだった**: 原生 `min` は空欄で `rangeUnderflow: false`、RHF 側も min/max 分岐が `!isEmpty`（`inputValue === ''` を含む）で守られているため、`min` 規則を足しても「空欄なら `pax` を送らない」は壊れない。付けなかった本当の理由は射程で、`pax` は `required: true` を持たず票面の 34 箇所に入らない。悪化もしていない（後述）。

## 備考 / レビュー観点

**重点的に見てほしい箇所**

1. **`CastFieldEditModal` の `display_order`** — 空欄の数値入力は `NaN` で、`null` でも空文字でもないため **`required` 単独では素通りする**（実測で `display_order: null` が送信された）。文言を出しているのは `validate` 側。`valueAsNumber` の復元は `DESIGN.md:516` の指示どおり `event.target.valueAsNumber` を使い、`Number()` は使っていない（`Number('')` は 0 で「未入力」が失われる）。
2. **Select 2 箇所の `field.ref`** — 焦点要素が button のため、`ref` が trigger へ届かないと文言だけ出て焦点が動かない（他に症状が出ない）。`ShiftFormModal` にテストで固定済み。`Select.Root` の `required` → trigger の `aria-required` は Base UI 1.7.0 のソースを実読して確認した。
3. **`CastSearchCombobox` の props 追加** — 上と同じ理由。二軸レビューが両方ともここの欠落を独立に指摘したため、`FormControl` の aria と `field.ref` を引き金へ通すようにした。

4. **`CastForm` の `NumericProfileField`** — 5 箇所の同型を畳んだ新設の局所部品。`field.value` が `null`（初期値）と `NaN`（入力を消した直後）の両方を取りうるため、表示だけ空文字へ戻している。

**既知の限界（いずれも master と同一で、本 PR で悪化していない）**

- **`OrderForm` は `pax` に `0` を入れると原生 `min={1}` が submit を先取りし、`受付` / `キャスト` の文言がどちらも描かれない。** 実測で submit 処理器が 1 度も走らないことを確認済み。master でも `受付` の文言つき規則と `FormMessage` は同じ form に既にあり、先取り面は逐字同一（castId は master では hidden input に載っていて、そもそも描かれ得なかった）。閉じるなら `pax` へ文言つき `min` 規則 ＋ `noValidate` で、上記のとおり空欄の意味は壊れない。
- **`CastForm` の `表示順` は空欄のまま送ると `display_order: null` になる。** 整数規則は設計上そこを通し（未入力は `required` の担当）、`JSON.stringify` が `NaN` を `null` にするため。DB 列は `INTEGER default 0` で `nullable: false` を持たず、エンティティも `Integer`、`CastCreateRequest` に `@NotNull` は無いのでサーバは受け付ける。master でも `valueAsNumber` 経由で同じ結果になるため据え置いた（`required` を足すのは票外の新しい振る舞い）。

**既知の妥協点**

- `text-xs text-destructive-strong` の手書き段落は `StoreCreatePage` / `StoreEditPage` に残る。これらは `useState` フォームで、RHF 化は #581 が射程に含めた 2 ファイル（`StaffEditModal` / `PasswordChangeForm`、#591 で実施済み）に限られるため本票の外。`DESIGN.md:64` の「手書きは `-strong`」には適合している。
- `備考は500文字…` と `備考は 500 文字…` の空白揺れは既存のもので、本票では触っていない。

**リポジトリ直下の `01-staff.png`** は #602 が誤って入れた截図と思われる。本 PR では触っていないが、別票で消すか要判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
