### PR TITLE
fix(backend): 検証エラー応答の details のキーをワイヤ名（snake_case）へ揃える

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -330,6 +330,28 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
   }
 
   @Test
+  @DisplayName("検証エラーの details のキーが、要求で送ったのと同じ綴り（snake_case）で返ること")
+  void validationDetailKeysMatchRequestSpelling() {
+    String hq = platformToken(SEED_EMAIL, PASSWORD);
+    // display_name は複数語なので、Bean のプロパティ名（displayName）で返れば往復で綴りが食い違う。
+    String body =
+        String.format(
+            "{\"email\":\"staff-it-wire-name@kizuna.test\",\"password\":\"%s\","
+                + "\"display_name\":\"\",\"role_ids\":%s,"
+                + "\"store_scope_type\":\"ALL_STORES\",\"store_ids\":[]}",
+            PASSWORD, rolesJson("店舗スタッフ"));
+
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/platform/staff", new HttpEntity<>(body, bearerJson(hq)), JsonNode.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    JsonNode details = res.getBody().path("details");
+    assertThat(details.has("display_name")).as("送信時と同じキーで返ること").isTrue();
+    assertThat(details.has("displayName")).as("Bean のプロパティ名を並記もしないこと").isFalse();
+  }
+
+  @Test
   @DisplayName("存在しない能力束 id での作成は 400 で拒否")
   void unknownRoleRejected() {
     String hq = platformToken(SEED_EMAIL, PASSWORD);

--- a/backend/src/main/java/com/kizuna/shared/exception/CommonExceptionHandler.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/CommonExceptionHandler.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.util.NamingStrategyImpls;
 
 @Slf4j
 @ControllerAdvice
@@ -46,6 +47,15 @@ public class CommonExceptionHandler {
     return "認証に失敗しました";
   }
 
+  /**
+   * 検証違反を 400 へ映射する。{@code details} のキーは、同じフィールドを要求で送るときの綴り（snake_case）へ揃える。
+   *
+   * <p>束縛結果が持つのは Bean のプロパティパス（camelCase）である。Jackson の命名戦略は POJO のプロパティにしか 効かず {@code Map}
+   * のキーには設計上効かないため、そのまま載せると同一フィールドが方向によって別名になる。
+   *
+   * <p>直しはこの組み立て時に閉じる。{@code Map} のキーを一律に変換する形（{@code addKeySerializer}）を採ると、 キー自体が利用者の定義したデータである
+   * {@code CastResponse.customFields}／{@code StoreProfileResponse.customTexts} が静かに壊れる。
+   */
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<Map<String, Object>> handle(MethodArgumentNotValidException ex) {
     log.warn(ex.getMessage());
@@ -55,9 +65,25 @@ public class CommonExceptionHandler {
     Map<String, String> fieldErrors = new HashMap<>();
     ex.getBindingResult()
         .getFieldErrors()
-        .forEach(fe -> fieldErrors.put(fe.getField(), fe.getDefaultMessage()));
+        .forEach(fe -> fieldErrors.put(wireNameOf(fe.getField()), fe.getDefaultMessage()));
     body.put("details", fieldErrors);
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+  }
+
+  /**
+   * Bean のプロパティパスをワイヤ上の名前へ写す。
+   *
+   * <p>{@code spring.jackson.property-naming-strategy: SNAKE_CASE} が使うのと同一の実装を呼ぶので、綴りは Jackson
+   * が実際に出す名前と一致する。前提は命名戦略が唯一の写像源であること — 個別に {@code @JsonProperty} で 別名を与えた項目があれば、その項目だけ一致しなくなる。
+   *
+   * <p>入れ子や添字を含むパス（{@code snsLinks[0].url}）も構造を保ったまま変換される。パスは丸ごと変換するので、
+   * これが安全なのは束縛パスに利用者の定義したキーが現れないことが前提 — キー自体がデータである {@code Map} の
+   * 要素へ制約を足すと、束縛パスの添字にそのキーが載り、書き換わってしまう。
+   *
+   * <p>他の {@code details} を返すハンドラはここを通さない — それらが持つのはクエリ／パス変数の宣言名や Jackson 適用後の名前で、いずれも既にワイヤ名だからである。
+   */
+  private static String wireNameOf(String propertyPath) {
+    return NamingStrategyImpls.SNAKE_CASE.translate(propertyPath);
   }
 
   /**

--- a/backend/src/test/java/com/kizuna/shared/exception/CommonExceptionHandlerTest.java
+++ b/backend/src/test/java/com/kizuna/shared/exception/CommonExceptionHandlerTest.java
@@ -1,12 +1,21 @@
 package com.kizuna.shared.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
 
+import com.kizuna.storeprofile.api.dto.StoreProfileUpdateRequest;
+import com.kizuna.storeprofile.domain.SnsLink;
 import com.kizuna.user.api.dto.PlatformStaffCreateRequest;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +24,9 @@ import org.springframework.mock.http.MockHttpInputMessage;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import tools.jackson.databind.PropertyNamingStrategies;
 import tools.jackson.databind.json.JsonMapper;
@@ -23,6 +35,20 @@ import tools.jackson.databind.json.JsonMapper;
 class CommonExceptionHandlerTest {
 
   private final CommonExceptionHandler handler = new CommonExceptionHandler();
+
+  private static ValidatorFactory factory;
+  private static SpringValidatorAdapter validator;
+
+  @BeforeAll
+  static void setUpValidator() {
+    factory = Validation.buildDefaultValidatorFactory();
+    validator = new SpringValidatorAdapter(factory.getValidator());
+  }
+
+  @AfterAll
+  static void tearDownValidator() {
+    factory.close();
+  }
 
   @Test
   @DisplayName("DisabledException は 401 かつ固定文言「アカウントが無効化されています」")
@@ -150,6 +176,57 @@ class CommonExceptionHandlerTest {
     assertThat(response.getBody()).extracting("details").isEqualTo(Map.of("domain", "必須です"));
     assertThat(response.getBody().toString()).doesNotContain("java.lang.String");
   }
+
+  @Test
+  @DisplayName("検証エラーの details のキーは、要求で送るのと同じ snake_case になる")
+  void validationDetailKeysUseWireNames() {
+    PlatformStaffCreateRequest request = new PlatformStaffCreateRequest();
+    request.setEmail("staff@kizuna.test");
+    request.setPassword("password");
+    request.setDisplayName("");
+
+    ResponseEntity<Map<String, Object>> response = handler.handle(invalid(request));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody())
+        .extracting("details", MAP)
+        .containsKeys("display_name", "role_ids", "store_scope_type")
+        .doesNotContainKeys("displayName", "roleIds", "storeScopeType");
+  }
+
+  @Test
+  @DisplayName("入れ子の検証エラーでも、details のキーは要素の添字を保ったまま snake_case になる")
+  void nestedValidationDetailKeysUseWireNames() {
+    StoreProfileUpdateRequest request = new StoreProfileUpdateRequest();
+    request.setSnsLinks(List.of(SnsLink.builder().platform("x").url("").build()));
+
+    ResponseEntity<Map<String, Object>> response = handler.handle(invalid(request));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody()).extracting("details", MAP).containsKey("sns_links[0].url");
+  }
+
+  /**
+   * 実際に Bean Validation を走らせて、本番と同じ束縛結果を持つ {@link MethodArgumentNotValidException} を組み立てる。
+   *
+   * <p>フィールドパスが Bean のプロパティ名（camelCase）で来ることがこの検証の対象そのものなので、束縛結果を手で組まず 実物の検証器に作らせる。
+   */
+  private MethodArgumentNotValidException invalid(Object request) {
+    BeanPropertyBindingResult binding = new BeanPropertyBindingResult(request, "request");
+    validator.validate(request, binding);
+    try {
+      return new MethodArgumentNotValidException(
+          new MethodParameter(
+              CommonExceptionHandlerTest.class.getDeclaredMethod("requestBody", Object.class), 0),
+          binding);
+    } catch (NoSuchMethodException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  /** {@link MethodArgumentNotValidException} が要求する {@link MethodParameter} の実体を得るためだけの宣言。 */
+  @SuppressWarnings("unused")
+  private void requestBody(Object body) {}
 
   /**
    * 実際に Jackson へ解釈させて、本番と同じ原因例外を持つ {@link HttpMessageNotReadableException} を組み立てる。


### PR DESCRIPTION
## 概要

検証エラー応答の `details` のキーだけが Bean のプロパティ名（camelCase）で、API 全体の snake_case 契約から外れていた。`details` を組み立てる箇所でワイヤ名へ写して揃える。

Closes #600

## 変更内容

- `CommonExceptionHandler` の `MethodArgumentNotValidException` ハンドラで、`fe.getField()` を `wireNameOf()` を通してから `details` のキーにする。`wireNameOf` は `spring.jackson.property-naming-strategy: SNAKE_CASE` が使うのと同一の実装（`NamingStrategyImpls.SNAKE_CASE.translate`）を呼ぶ。
- 単体テスト 2 件を追加（複数語フィールド `display_name` / `role_ids` / `store_scope_type`、入れ子＋添字 `sns_links[0].url`）。束縛結果は手組みせず、実 DTO を `SpringValidatorAdapter` に検証させて本物のプロパティパスを作る。
- 統合テスト 1 件を追加（`PlatformStaffManagementIT`）。`display_name` を送って同じキーが返ることと、`displayName` を並記もしないことを固定する。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [ ] `task e2e` exit 0（実行シナリオ: なし — 誤り応答の `details` は画面に現れず、既存シナリオに観測面が無い）
- [x] ローカルで code-review 実施済み

赤の確認は単体・統合の両層で取った。修正を戻すと単体は 13 中 2 件が落ち（実際の出力は `{"displayName"=…, "roleIds"=…, "storeScopeType"=…}` と `{"snsLinks[0].url"=…}`）、統合は `validationDetailKeysMatchRequestSpelling` が落ちる。戻し直すと両方緑。

## 決定ログ

**Jackson 側では直さない。** `SimpleModule#addKeySerializer` で `Map` キーを大域に変換する形は、キー自体が利用者の定義したデータである `CastResponse.customFields`（店舗管理者が定義）と `StoreProfileResponse.customTexts`（テンプレートが定義）を静かに壊すため採らない。誤り応答の組み立てに閉じれば、それらに一切触れない。

**他の 3 ハンドラは通していない。** 一貫性のために揃えたくなるが、`MissingServletRequestParameterException.getParameterName()` と `MethodArgumentTypeMismatchException.getName()` が持つのはクエリ／パス変数の**宣言名そのもの**、`HttpMessageNotReadableException` 側の `DatabindException.getPath()` は**命名戦略適用後**の名前で、いずれも既にワイヤ名。通せば逆に 3 つが壊れる。この理由は javadoc に残した。

**変換の実装は `tools.jackson.databind.util.NamingStrategyImpls`。** 公開面の `PropertyNamingStrategies.SnakeCaseStrategy.translate` は `protected` で、中身はこの enum への丸投げ（Jackson 3.1.4 の source を実読）。もう一つの公開面 `nameForField(null, null, name)` は `NamingBase` が引数を捨てる実装依存で、崩れ方が実行時 NPE（例外ハンドラ内なので 400 が 500 に化ける）。`util` 側なら消えたときコンパイルエラーになるので、そちらを採った。

## 備考 / レビュー観点

- javadoc に前提を 2 つ明記した。①命名戦略が唯一の写像源であること（`@JsonProperty` の個別上書きは `src/main` に一件も無いことを確認済み）②束縛パスに利用者定義のキーが現れないこと — キー自体がデータである `Map` の**要素**へ制約を足すと、添字にそのキーが載って書き換わる。現状そうした制約は無い。
- 既存 IT 2 件が `details.has("email")` を見ているが単一語なので影響なし。
- 射程外として切らなかったもの: `ConstraintViolationException`（クラス級 `@Validated` ＋ パラメータ制約）にハンドラが無く catch-all の 500 に落ちる。現状そうした使い方がリポジトリに無いため活きた欠陥ではないが、本件の射程外。別 issue にするかは要判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
