### PR TITLE
refactor(backend): 整合性違反の制約名抽出を getConstraintName 等値比較の共有パイプラインへ下ろす (#626)

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -407,6 +407,8 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
   void unknownStoreIdRejected() {
     String hq = platformToken(SEED_EMAIL, PASSWORD);
 
+    // create は店舗 id を事前検証しないため、実 DB の FK 違反が決定的に踏める。制約名の抽出が失灵すれば
+    // 兜底へ溢れて 500 になり、誤った制約へ帰属すれば文言が変わる — 実ドライバから制約名が取れることの機械証明。
     ResponseEntity<JsonNode> res =
         rest.postForEntity(
             "/platform/staff",
@@ -419,6 +421,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
                 bearerJson(hq)),
             JsonNode.class);
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(res.getBody().path("error").asString()).isEqualTo("指定された店舗が存在しません");
   }
 
   // 検索語は STAFF 限定と AND で重なる。両者の email に共通する接頭辞で引くことで、

--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -407,7 +407,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
   void unknownStoreIdRejected() {
     String hq = platformToken(SEED_EMAIL, PASSWORD);
 
-    // create は店舗 id を事前検証しないため、実 DB の FK 違反が決定的に踏める。制約名の抽出が失灵すれば
+    // create は店舗 id を事前検証しないため、実 DB の FK 違反が決定的に踏める。制約名の抽出が機能しなくなれば
     // 兜底へ溢れて 500 になり、誤った制約へ帰属すれば文言が変わる — 実ドライバから制約名が取れることの機械証明。
     ResponseEntity<JsonNode> res =
         rest.postForEntity(

--- a/backend/src/main/java/com/kizuna/auth/application/LineAuthService.java
+++ b/backend/src/main/java/com/kizuna/auth/application/LineAuthService.java
@@ -12,11 +12,14 @@ import com.kizuna.auth.infrastructure.LineIdentity;
 import com.kizuna.auth.infrastructure.LineRegistrationTicketStore;
 import com.kizuna.member.application.MemberRegistrationService;
 import com.kizuna.shared.exception.ConflictException;
+import com.kizuna.shared.exception.DbConstraint;
+import com.kizuna.shared.exception.IntegrityViolations;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.exception.ServiceUnavailableException;
 import com.kizuna.shared.exception.StaleSessionException;
 import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.DisabledException;
@@ -39,7 +42,6 @@ public class LineAuthService {
   private static final String LINE_DISABLED_MESSAGE = "LINE ログインは利用できません";
   private static final String INVALID_TICKET_MESSAGE = "登録チケットが無効または期限切れです。最初からやり直してください";
   private static final String LINE_TAKEN_MESSAGE = "この LINE アカウントは既に別の身分と連携済みです";
-  private static final String LINE_USER_UNIQUE_CONSTRAINT = "uq_t_users_line_user_id";
 
   private final LineChannelResolver channelResolver;
   private final LineApiClient lineApiClient;
@@ -104,11 +106,11 @@ public class LineAuthService {
     } catch (DataIntegrityViolationException ex) {
       // 事前チェックを擦り抜けた並行連携。ここで違反し得る一意制約は LINE ユーザー ID だけであり、
       // 「先に確定した別要求と衝突した」なので 409 に写像する。
-      String cause = ex.getMostSpecificCause().getMessage();
-      if (cause != null && cause.contains(LINE_USER_UNIQUE_CONSTRAINT)) {
-        throw new ConflictException(LINE_TAKEN_MESSAGE);
-      }
-      throw ex;
+      throw IntegrityViolations.translate(
+          ex,
+          Map.of(
+              DbConstraint.UQ_T_USERS_LINE_USER_ID,
+              () -> new ConflictException(LINE_TAKEN_MESSAGE)));
     }
   }
 

--- a/backend/src/main/java/com/kizuna/cast/application/CastInvitationAcceptanceService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastInvitationAcceptanceService.java
@@ -8,6 +8,8 @@ import com.kizuna.cast.domain.CastInvitation;
 import com.kizuna.cast.domain.CastInvitationRepository;
 import com.kizuna.cast.domain.CastInvitationStateException;
 import com.kizuna.cast.domain.CastRepository;
+import com.kizuna.shared.exception.DbConstraint;
+import com.kizuna.shared.exception.IntegrityViolations;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.store.domain.Store;
@@ -19,6 +21,7 @@ import com.kizuna.user.domain.UserType;
 import java.time.OffsetDateTime;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -36,7 +39,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CastInvitationAcceptanceService {
 
-  private static final String EMAIL_UNIQUE_CONSTRAINT = "uq_t_users_email";
   private static final String DUPLICATE_EMAIL_MESSAGE =
       "このメールアドレスは既に登録されています。既存アカウントでログインして受諾してください";
 
@@ -169,11 +171,10 @@ public class CastInvitationAcceptanceService {
     try {
       return platformUserRepository.save(user);
     } catch (DataIntegrityViolationException ex) {
-      String cause = ex.getMostSpecificCause().getMessage();
-      if (cause != null && cause.contains(EMAIL_UNIQUE_CONSTRAINT)) {
-        throw new ServiceException(DUPLICATE_EMAIL_MESSAGE);
-      }
-      throw ex;
+      throw IntegrityViolations.translate(
+          ex,
+          Map.of(
+              DbConstraint.UQ_T_USERS_EMAIL, () -> new ServiceException(DUPLICATE_EMAIL_MESSAGE)));
     }
   }
 }

--- a/backend/src/main/java/com/kizuna/cast/application/CastInvitationService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastInvitationService.java
@@ -7,6 +7,8 @@ import com.kizuna.cast.domain.CastInvitationRepository;
 import com.kizuna.cast.domain.CastInvitationStateException;
 import com.kizuna.cast.domain.CastInvitationStatus;
 import com.kizuna.cast.domain.CastRepository;
+import com.kizuna.shared.exception.DbConstraint;
+import com.kizuna.shared.exception.IntegrityViolations;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.storescope.StoreScoped;
 import java.security.SecureRandom;
@@ -29,9 +31,6 @@ public class CastInvitationService {
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
   private static final int TOKEN_BYTES = 32;
   private static final String ALREADY_LINKED_MESSAGE = "この档案は既に平台身分と連携済みのため招待を発行できません";
-
-  /** 招待の宛先档案が実在することを保証する t_cast_invitations の FK。冒頭の findById 通過後の並行档案削除で当たる。 */
-  private static final String CAST_FK_CONSTRAINT = "fk_t_cast_invitations_cast";
 
   private final CastRepository castRepository;
   private final CastInvitationRepository castInvitationRepository;
@@ -91,11 +90,11 @@ public class CastInvitationService {
       CastInvitation saved = castInvitationRepository.saveAndFlush(invitation);
       return new CastInvitationResponse(saved.getToken(), saved.getExpiresAt());
     } catch (DataIntegrityViolationException ex) {
-      String cause = ex.getMostSpecificCause().getMessage();
-      if (cause != null && cause.contains(CAST_FK_CONSTRAINT)) {
-        throw new NotFoundException("キャストが見つかりません: " + castId);
-      }
-      throw ex;
+      throw IntegrityViolations.translate(
+          ex,
+          Map.of(
+              DbConstraint.FK_T_CAST_INVITATIONS_CAST,
+              () -> new NotFoundException("キャストが見つかりません: " + castId)));
     }
   }
 

--- a/backend/src/main/java/com/kizuna/member/application/MemberRegistrationService.java
+++ b/backend/src/main/java/com/kizuna/member/application/MemberRegistrationService.java
@@ -6,6 +6,8 @@ import com.kizuna.member.domain.Member;
 import com.kizuna.member.domain.MemberCodes;
 import com.kizuna.member.domain.MemberRepository;
 import com.kizuna.shared.exception.ConflictException;
+import com.kizuna.shared.exception.DbConstraint;
+import com.kizuna.shared.exception.IntegrityViolations;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
@@ -14,6 +16,7 @@ import com.kizuna.user.domain.UserType;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -31,8 +34,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberRegistrationService {
 
-  private static final String EMAIL_UNIQUE_CONSTRAINT = "uq_t_users_email";
-  private static final String LINE_USER_UNIQUE_CONSTRAINT = "uq_t_users_line_user_id";
   private static final String DUPLICATE_EMAIL_MESSAGE = "このメールアドレスは既に登録されています。ログインしてご利用ください";
   private static final String DUPLICATE_LINE_USER_MESSAGE = "この LINE アカウントは既に別の身分と連携済みです";
 
@@ -131,11 +132,10 @@ public class MemberRegistrationService {
     try {
       return platformUserRepository.saveAndFlush(user);
     } catch (DataIntegrityViolationException ex) {
-      String cause = ex.getMostSpecificCause().getMessage();
-      if (cause != null && cause.contains(EMAIL_UNIQUE_CONSTRAINT)) {
-        throw new ServiceException(DUPLICATE_EMAIL_MESSAGE);
-      }
-      throw ex;
+      throw IntegrityViolations.translate(
+          ex,
+          Map.of(
+              DbConstraint.UQ_T_USERS_EMAIL, () -> new ServiceException(DUPLICATE_EMAIL_MESSAGE)));
     }
   }
 
@@ -147,14 +147,13 @@ public class MemberRegistrationService {
     try {
       return platformUserRepository.saveAndFlush(user);
     } catch (DataIntegrityViolationException ex) {
-      String cause = ex.getMostSpecificCause().getMessage();
-      if (cause != null && cause.contains(EMAIL_UNIQUE_CONSTRAINT)) {
-        throw new ConflictException(DUPLICATE_EMAIL_MESSAGE);
-      }
-      if (cause != null && cause.contains(LINE_USER_UNIQUE_CONSTRAINT)) {
-        throw new ConflictException(DUPLICATE_LINE_USER_MESSAGE);
-      }
-      throw ex;
+      throw IntegrityViolations.translate(
+          ex,
+          Map.of(
+              DbConstraint.UQ_T_USERS_EMAIL,
+              () -> new ConflictException(DUPLICATE_EMAIL_MESSAGE),
+              DbConstraint.UQ_T_USERS_LINE_USER_ID,
+              () -> new ConflictException(DUPLICATE_LINE_USER_MESSAGE)));
     }
   }
 }

--- a/backend/src/main/java/com/kizuna/shared/exception/DbConstraint.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/DbConstraint.java
@@ -1,0 +1,41 @@
+package com.kizuna.shared.exception;
+
+/**
+ * 業務例外へ写像する対象となる DB 制約の目録。字面は DDL（changelog）の制約名そのもので、{@link IntegrityViolations} が Hibernate
+ * の報告する制約名と等値比較する。
+ *
+ * <p>収録するのは実際に写像している制約だけで、DDL 上の全制約は載せない — 写像先を持たない制約は実装欠陥として大きく失敗させる側であり、 ここに現れると「扱える違反」に見えてしまう。
+ *
+ * <p>各成員の字面が DDL に実在することは適応度テスト（{@code DbConstraintLiteralTests}）が機械検証する。
+ */
+public enum DbConstraint {
+
+  /** t_users.email の一意制約。 */
+  UQ_T_USERS_EMAIL("uq_t_users_email"),
+
+  /** t_users.line_user_id の一意制約。 */
+  UQ_T_USERS_LINE_USER_ID("uq_t_users_line_user_id"),
+
+  /** t_roles.name の一意制約。 */
+  UQ_T_ROLES_NAME("uq_t_roles_name"),
+
+  /** t_user_roles → t_roles の FK（RESTRICT）。 */
+  FK_T_USER_ROLES_ROLE("fk_t_user_roles_role"),
+
+  /** t_user_stores → t_stores の FK。 */
+  FK_T_USER_STORES_STORE("fk_t_user_stores_store"),
+
+  /** t_cast_invitations → t_casts の FK。 */
+  FK_T_CAST_INVITATIONS_CAST("fk_t_cast_invitations_cast");
+
+  private final String sqlName;
+
+  DbConstraint(String sqlName) {
+    this.sqlName = sqlName;
+  }
+
+  /** DDL 上の制約名。 */
+  public String sqlName() {
+    return sqlName;
+  }
+}

--- a/backend/src/main/java/com/kizuna/shared/exception/IntegrityViolations.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/IntegrityViolations.java
@@ -1,0 +1,58 @@
+package com.kizuna.shared.exception;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+
+/**
+ * 整合性違反を、違反した制約の名前で業務例外へ写像する共通抽出。
+ *
+ * <p>制約名は Hibernate の {@link ConstraintViolationException#getConstraintName()}
+ * から取り、字面と等値比較する。ドライバの報錯文言への 部分一致は使わない — 文言はドライバとロケールに依存し、別種の違反（列長超過など）を偶然含んでしまえば誤った業務例外へ帰属する。
+ *
+ * <p>「どの制約をどの業務例外へ写像するか」の決定は呼出側に残す。同じ制約でも操作の向きによって適切な分類は異なる（授与中ロールの削除は競合、 存在しないロールの授与は要求誤り）ため、対応表は
+ * call site が持つ。
+ *
+ * <p>写像に無い違反は元の例外をそのまま返す（fail-loud）。呼出側が {@code throw} することで、全域ハンドラの分類（一意違反のみ 409、他は 500）へ落ちる。
+ */
+public final class IntegrityViolations {
+
+  private IntegrityViolations() {}
+
+  /**
+   * 違反した制約に対応する業務例外を返す。対応が無い場合・制約名を取れない場合は {@code ex} 自身を返す。
+   *
+   * @param ex 整合性違反
+   * @param table 制約から業務例外の生成への対応表
+   * @return 呼出側が送出すべき例外
+   */
+  public static RuntimeException translate(
+      DataIntegrityViolationException ex, Map<DbConstraint, Supplier<RuntimeException>> table) {
+    String violated = violatedConstraintName(ex);
+    if (violated == null) {
+      return ex;
+    }
+    for (Map.Entry<DbConstraint, Supplier<RuntimeException>> mapping : table.entrySet()) {
+      if (mapping.getKey().sqlName().equals(violated)) {
+        return mapping.getValue().get();
+      }
+    }
+    return ex;
+  }
+
+  /**
+   * 違反した制約の名前を取り出す。Spring の変換で包まれた層数は経路によって異なるため、原因連鎖を辿って Hibernate の例外を探す（最深層は JDBC
+   * ドライバの例外であり、制約名を型で持たない）。
+   *
+   * @return 制約名。連鎖に Hibernate の整合性違反が無い場合、または DB が制約名を報告しなかった場合は null
+   */
+  private static String violatedConstraintName(DataIntegrityViolationException ex) {
+    for (Throwable cause = ex; cause != null; cause = cause.getCause()) {
+      if (cause instanceof ConstraintViolationException violation) {
+        return violation.getConstraintName();
+      }
+    }
+    return null;
+  }
+}

--- a/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
+++ b/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
@@ -1,5 +1,7 @@
 package com.kizuna.user.application;
 
+import com.kizuna.shared.exception.DbConstraint;
+import com.kizuna.shared.exception.IntegrityViolations;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.api.dto.PlatformStaffCreateRequest;
@@ -41,14 +43,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class PlatformStaffService {
-
-  private static final String EMAIL_UNIQUE_CONSTRAINT = "uq_t_users_email";
-
-  /** 担当店舗集合が実在店舗を指すことを保証する t_user_stores の FK。FK 違反は全域ハンドラで 4xx にならないため、ここで照合して変換する。 */
-  private static final String STORE_FK_CONSTRAINT = "fk_t_user_stores_store";
-
-  /** 授与ロールが実在することを保証する t_user_roles の FK。requireRoles 通過後の並行ロール削除で当たる。 */
-  private static final String ROLE_FK_CONSTRAINT = "fk_t_user_roles_role";
 
   /** LIKE パターンのエスケープ規則。派生クエリが内部で使うものと同一で、手書きの cb.like にも同じ規則を適用する。 */
   private static final EscapeCharacter LIKE_ESCAPE = EscapeCharacter.DEFAULT;
@@ -191,7 +185,8 @@ public class PlatformStaffService {
 
   /**
    * 保存時の整合性違反を制約名で分類する。email 一意制約違反（同一メール二重送信レース）は重複エラー、店舗 FK 違反（存在しない店舗 id）は店舗エラー、ロール FK
-   * 違反（requireRoles 通過後の並行ロール削除）はロール不存在エラーへ変換する（いずれも 400）。それ以外の整合性違反は実装欠陥であり、握りつぶさず全域ハンドラの分類に委ねる。
+   * 違反（requireRoles 通過後の並行ロール削除）はロール不存在エラーへ変換する（いずれも 400）。FK 違反は全域ハンドラでは 4xx にならない（一意違反のみが兜底の対象）ため、
+   * ここで写像する必要がある。それ以外の整合性違反は実装欠陥であり、握りつぶさず全域ハンドラの分類に委ねる。
    *
    * <p>店舗集合等の @ElementCollection 行はトランザクション commit 時に flush されるため、{@code save} だけでは FK 違反が この try
    * を突き抜けて 500 になる。{@code saveAndFlush} で違反をここで顕在化させ 400 へ変換する。
@@ -200,17 +195,15 @@ public class PlatformStaffService {
     try {
       return repository.saveAndFlush(user);
     } catch (DataIntegrityViolationException ex) {
-      String cause = ex.getMostSpecificCause().getMessage();
-      if (cause != null && cause.contains(EMAIL_UNIQUE_CONSTRAINT)) {
-        throw new DuplicateStaffEmailException("このメールアドレスは既に登録されています");
-      }
-      if (cause != null && cause.contains(STORE_FK_CONSTRAINT)) {
-        throw new InvalidStoreScopeException("指定された店舗が存在しません");
-      }
-      if (cause != null && cause.contains(ROLE_FK_CONSTRAINT)) {
-        throw new ServiceException("指定されたロールが存在しません");
-      }
-      throw ex;
+      throw IntegrityViolations.translate(
+          ex,
+          Map.of(
+              DbConstraint.UQ_T_USERS_EMAIL,
+              () -> new DuplicateStaffEmailException("このメールアドレスは既に登録されています"),
+              DbConstraint.FK_T_USER_STORES_STORE,
+              () -> new InvalidStoreScopeException("指定された店舗が存在しません"),
+              DbConstraint.FK_T_USER_ROLES_ROLE,
+              () -> new ServiceException("指定されたロールが存在しません")));
     }
   }
 

--- a/backend/src/main/java/com/kizuna/user/application/RoleService.java
+++ b/backend/src/main/java/com/kizuna/user/application/RoleService.java
@@ -1,5 +1,7 @@
 package com.kizuna.user.application;
 
+import com.kizuna.shared.exception.DbConstraint;
+import com.kizuna.shared.exception.IntegrityViolations;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.api.dto.RoleCreateRequest;
@@ -32,11 +34,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class RoleService {
-
-  private static final String NAME_UNIQUE_CONSTRAINT = "uq_t_roles_name";
-
-  /** 授与中ロールの削除を拒否する t_user_roles の RESTRICT 制約。FK 違反は全域ハンドラで 409 にならないため、ここで照合して変換する。 */
-  private static final String ROLE_IN_USE_FK_CONSTRAINT = "fk_t_user_roles_role";
 
   private final RoleRepository roleRepository;
   private final PermissionRepository permissionRepository;
@@ -103,12 +100,12 @@ public class RoleService {
       roleRepository.delete(role);
       roleRepository.flush();
     } catch (DataIntegrityViolationException ex) {
-      String cause = ex.getMostSpecificCause().getMessage();
-      if (cause != null && cause.contains(ROLE_IN_USE_FK_CONSTRAINT)) {
-        throw new RoleInUseException("授与中のロールは削除できません");
-      }
+      // 授与 FK 違反は全域ハンドラでは 409 にならない（一意違反のみが兜底の対象）ため、ここで写像する。
       // 授与 FK 以外の整合性違反は実装欠陥であり、握りつぶさず全域ハンドラの分類に委ねる。
-      throw ex;
+      throw IntegrityViolations.translate(
+          ex,
+          Map.of(
+              DbConstraint.FK_T_USER_ROLES_ROLE, () -> new RoleInUseException("授与中のロールは削除できません")));
     }
   }
 
@@ -135,11 +132,8 @@ public class RoleService {
     try {
       return roleRepository.saveAndFlush(role);
     } catch (DataIntegrityViolationException ex) {
-      String cause = ex.getMostSpecificCause().getMessage();
-      if (cause != null && cause.contains(NAME_UNIQUE_CONSTRAINT)) {
-        throw new ServiceException("このロール名は既に使われています");
-      }
-      throw ex;
+      throw IntegrityViolations.translate(
+          ex, Map.of(DbConstraint.UQ_T_ROLES_NAME, () -> new ServiceException("このロール名は既に使われています")));
     }
   }
 

--- a/backend/src/test/java/com/kizuna/DbConstraintLiteralTests.java
+++ b/backend/src/test/java/com/kizuna/DbConstraintLiteralTests.java
@@ -1,0 +1,69 @@
+package com.kizuna;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kizuna.shared.exception.DbConstraint;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link DbConstraint} の制約名字面と changelog の実 DDL の整合を機械検証する。
+ *
+ * <p>制約名は Java 側では単なる文字列で、DDL とのコンパイル期関連が一切ない。綴りの誤りや DDL 側の改名は「決して命中しない写像」を静默に生む — 変換されるはずの整合性違反が
+ * 全域ハンドラの兜底へ落ち、利用者には 500 や汎用文言として現れる。{@link PermissionLiteralTests} と同型の fitness test でこの欠陥類を閉じる。
+ *
+ * <p>走査は changelog 全域（版付き release と reconcile の双方）で、Liquibase が制約名を宣言する 2 つのキー {@code
+ * constraintName} / {@code uniqueConstraintName} の値を集める。「enum の名前が DDL に実在すること」だけを見る片方向の検査で、DDL
+ * 側に写像先の無い制約が あることは正常（写像を持たない違反は実装欠陥として大きく失敗させる側）。
+ */
+class DbConstraintLiteralTests {
+
+  private static final Path CHANGELOG_ROOT = Paths.get("src/main/resources/db/changelog");
+
+  /** Liquibase が制約名を宣言するキーとその値。行末までを名前とし、YAML のクォートは現状使われていないため素の値で取る。 */
+  private static final Pattern DECLARED_CONSTRAINT =
+      Pattern.compile("(?:constraintName|uniqueConstraintName):\\s*(\\S+)");
+
+  @Test
+  @DisplayName("DbConstraint の全成員の制約名が changelog の DDL に実在すること")
+  void allDbConstraintNamesExistInChangelog() throws Exception {
+    List<Path> changelogFiles;
+    try (Stream<Path> paths = Files.walk(CHANGELOG_ROOT)) {
+      changelogFiles =
+          paths
+              .filter(Files::isRegularFile)
+              .filter(path -> path.toString().endsWith(".yaml"))
+              .toList();
+    }
+
+    Set<String> declared = new HashSet<>();
+    for (Path file : changelogFiles) {
+      Matcher matcher = DECLARED_CONSTRAINT.matcher(Files.readString(file));
+      while (matcher.find()) {
+        declared.add(matcher.group(1));
+      }
+    }
+
+    // 暗黙の no-op 防止: 走査が実際に DDL を捉えていることを担保する。
+    assertThat(changelogFiles).as("changelog 配下の .yaml").isNotEmpty();
+    assertThat(declared).as("DDL が宣言する制約名").isNotEmpty();
+
+    List<String> missing =
+        Arrays.stream(DbConstraint.values())
+            .map(DbConstraint::sqlName)
+            .filter(name -> !declared.contains(name))
+            .toList();
+
+    assertThat(missing).as("changelog の DDL に実在しない DbConstraint の制約名").isEmpty();
+  }
+}

--- a/backend/src/test/java/com/kizuna/JsonPropertyAbsenceTests.java
+++ b/backend/src/test/java/com/kizuna/JsonPropertyAbsenceTests.java
@@ -1,0 +1,57 @@
+package com.kizuna;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ワイヤ名の写像源が命名戦略ひとつであることを機械検証する。
+ *
+ * <p>{@code CommonExceptionHandler} は検証エラーの details のキーを、Bean のプロパティパスに {@code
+ * spring.jackson.property-naming-strategy} と同一の実装を適用して組み立てる。個別に {@code @JsonProperty}
+ * で別名を与えた項目があると、その項目だけ実際の JSON と details のキーが食い違い、前端がフィールドを引けなくなる — 型でも実行時でも検出されない静默の食い違いなので、
+ * {@link PermissionLiteralTests} と同型の fitness test で注解の不在そのものを固定する。
+ *
+ * <p>検出は {@code @JsonProperty} の import 宣言で行う。裸の字面照合では javadoc 中の言及（{@code CommonExceptionHandler}
+ * のワイヤ名解説）を誤検知するため。この方式が成立する前提は 2 つとも本倉のコード規約である — 行内 FQCN を書かないこと、 ワイルドカード import
+ * を使わないこと。どちらかが崩れると、この検査は注解の使用を見落とす。
+ */
+class JsonPropertyAbsenceTests {
+
+  private static final Path MAIN_SOURCES = Paths.get("src/main/java");
+
+  private static final String JSON_PROPERTY_IMPORT =
+      "import com.fasterxml.jackson.annotation.JsonProperty;";
+
+  @Test
+  @DisplayName("src/main/java に @JsonProperty の使用が無いこと")
+  void mainSourcesDeclareNoJsonProperty() throws Exception {
+    List<Path> javaFiles;
+    try (Stream<Path> paths = Files.walk(MAIN_SOURCES)) {
+      javaFiles =
+          paths
+              .filter(Files::isRegularFile)
+              .filter(path -> path.toString().endsWith(".java"))
+              .toList();
+    }
+
+    List<String> offenders = new ArrayList<>();
+    for (Path file : javaFiles) {
+      if (Files.readString(file).contains(JSON_PROPERTY_IMPORT)) {
+        offenders.add(MAIN_SOURCES.relativize(file).toString());
+      }
+    }
+
+    // 暗黙の no-op 防止: 走査が実際にソースを読めていることを担保する。
+    assertThat(javaFiles).as("src/main/java 配下の .java ソース").isNotEmpty();
+
+    assertThat(offenders).as("@JsonProperty を import しているソース").isEmpty();
+  }
+}

--- a/backend/src/test/java/com/kizuna/JsonPropertyAbsenceTests.java
+++ b/backend/src/test/java/com/kizuna/JsonPropertyAbsenceTests.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
  * {@link PermissionLiteralTests} と同型の fitness test で注解の不在そのものを固定する。
  *
  * <p>検出は {@code @JsonProperty} の import 宣言で行う。裸の字面照合では javadoc 中の言及（{@code CommonExceptionHandler}
- * のワイヤ名解説）を誤検知するため。この方式が成立する前提は 2 つとも本倉のコード規約である — 行内 FQCN を書かないこと、 ワイルドカード import
+ * のワイヤ名解説）を誤検知するため。この方式が成立する前提は 2 つとも本リポジトリのコード規約である — 行内 FQCN を書かないこと、 ワイルドカード import
  * を使わないこと。どちらかが崩れると、この検査は注解の使用を見落とす。
  */
 class JsonPropertyAbsenceTests {

--- a/backend/src/test/java/com/kizuna/auth/application/LineAuthServiceTest.java
+++ b/backend/src/test/java/com/kizuna/auth/application/LineAuthServiceTest.java
@@ -26,8 +26,10 @@ import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
+import java.sql.SQLException;
 import java.util.Optional;
 import java.util.Set;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -234,9 +236,10 @@ class LineAuthServiceTest {
         .thenThrow(
             new DataIntegrityViolationException(
                 "could not execute statement",
-                new RuntimeException(
-                    "ERROR: duplicate key value violates unique constraint"
-                        + " \"uq_t_users_line_user_id\"")));
+                new ConstraintViolationException(
+                    "could not execute statement",
+                    new SQLException("duplicate key value violates unique constraint"),
+                    "uq_t_users_line_user_id")));
 
     assertThatThrownBy(() -> lineAuthService.link("member@kizuna.test", authorizationRequest()))
         .isInstanceOf(ConflictException.class);

--- a/backend/src/test/java/com/kizuna/cast/application/CastInvitationAcceptanceServiceTest.java
+++ b/backend/src/test/java/com/kizuna/cast/application/CastInvitationAcceptanceServiceTest.java
@@ -23,15 +23,18 @@ import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
+import java.sql.SQLException;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.Set;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -206,6 +209,32 @@ class CastInvitationAcceptanceServiceTest {
         .hasMessageContaining("既に登録されています");
     assertThat(invitation.getStatus()).isEqualTo(CastInvitation.Status.PENDING);
     verify(platformUserRepository, never()).save(any());
+  }
+
+  @Test
+  void acceptAsNewUser_translatesConcurrentDuplicateEmailViolationToServiceException() {
+    CastInvitation invitation =
+        invitation("c1", 1L, CastInvitation.Status.PENDING, OffsetDateTime.now().plusHours(1));
+    when(castInvitationRepository.findByToken("tok")).thenReturn(Optional.of(invitation));
+    when(castRepository.findById("c1")).thenReturn(Optional.of(cast("c1", "花子档案")));
+    when(platformUserRepository.findByEmail("race@example.com")).thenReturn(Optional.empty());
+    when(castInvitationRepository.claimPending(
+            any(), any(), eq(CastInvitation.Status.PENDING), eq(CastInvitation.Status.ACCEPTED)))
+        .thenReturn(1);
+    when(passwordEncoder.encode("password1")).thenReturn("encoded");
+    // 事前チェックを擦り抜けた並行登録の敗者側。email 一意制約違反が事前チェックと同じ重複エラーへ写像される。
+    when(platformUserRepository.save(any()))
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "save failed",
+                new ConstraintViolationException(
+                    "save failed",
+                    new SQLException("duplicate key value violates unique constraint"),
+                    "uq_t_users_email")));
+
+    assertThatThrownBy(() -> service.acceptAsNewUser("tok", acceptRequest("race@example.com")))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("既に登録されています");
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/cast/application/CastInvitationServiceTest.java
+++ b/backend/src/test/java/com/kizuna/cast/application/CastInvitationServiceTest.java
@@ -16,11 +16,13 @@ import com.kizuna.cast.domain.CastInvitationStateException;
 import com.kizuna.cast.domain.CastInvitationStatus;
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.exception.NotFoundException;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
@@ -111,7 +113,12 @@ class CastInvitationServiceTest {
     // サービス層で 400 に変換すると FK 等の実装欠陥まで「競合」に化けてしまう。
     when(castRepository.findById("c1")).thenReturn(Optional.of(cast("c1", null)));
     DataIntegrityViolationException violation =
-        new DataIntegrityViolationException("uq_t_cast_invitations_pending_cast");
+        new DataIntegrityViolationException(
+            "save failed",
+            new ConstraintViolationException(
+                "save failed",
+                new SQLException("duplicate key value violates unique constraint"),
+                "uq_t_cast_invitations_pending_cast"));
     when(castInvitationRepository.saveAndFlush(any())).thenThrow(violation);
 
     assertThatThrownBy(() -> castInvitationService.issue("c1")).isSameAs(violation);
@@ -127,9 +134,10 @@ class CastInvitationServiceTest {
         .thenThrow(
             new DataIntegrityViolationException(
                 "save failed",
-                new RuntimeException(
-                    "ERROR: insert or update on table \"t_cast_invitations\" violates foreign key"
-                        + " constraint \"fk_t_cast_invitations_cast\"")));
+                new ConstraintViolationException(
+                    "save failed",
+                    new SQLException("insert or update violates foreign key constraint"),
+                    "fk_t_cast_invitations_cast")));
 
     assertThatThrownBy(() -> castInvitationService.issue("c1"))
         .isInstanceOf(NotFoundException.class)

--- a/backend/src/test/java/com/kizuna/member/application/MemberRegistrationServiceTest.java
+++ b/backend/src/test/java/com/kizuna/member/application/MemberRegistrationServiceTest.java
@@ -19,8 +19,10 @@ import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
+import java.sql.SQLException;
 import java.util.Optional;
 import java.util.Set;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -109,7 +111,11 @@ class MemberRegistrationServiceTest {
     when(platformUserRepository.saveAndFlush(any()))
         .thenThrow(
             new DataIntegrityViolationException(
-                "duplicate key value violates unique constraint \"uq_t_users_email\""));
+                "save failed",
+                new ConstraintViolationException(
+                    "save failed",
+                    new SQLException("duplicate key value violates unique constraint"),
+                    "uq_t_users_email")));
 
     assertThatThrownBy(() -> service.register(request())).isInstanceOf(ServiceException.class);
 
@@ -177,7 +183,11 @@ class MemberRegistrationServiceTest {
     when(platformUserRepository.saveAndFlush(any()))
         .thenThrow(
             new DataIntegrityViolationException(
-                "duplicate key value violates unique constraint \"uq_t_users_line_user_id\""));
+                "save failed",
+                new ConstraintViolationException(
+                    "save failed",
+                    new SQLException("duplicate key value violates unique constraint"),
+                    "uq_t_users_line_user_id")));
 
     assertThatThrownBy(() -> service.registerWithLine("member@example.com", "会員 花子", "U-line-1"))
         .isInstanceOf(ConflictException.class);
@@ -194,7 +204,11 @@ class MemberRegistrationServiceTest {
     when(platformUserRepository.saveAndFlush(any()))
         .thenThrow(
             new DataIntegrityViolationException(
-                "duplicate key value violates unique constraint \"uq_t_users_email\""));
+                "save failed",
+                new ConstraintViolationException(
+                    "save failed",
+                    new SQLException("duplicate key value violates unique constraint"),
+                    "uq_t_users_email")));
 
     assertThatThrownBy(() -> service.registerWithLine("member@example.com", "会員 花子", "U-line-1"))
         .isInstanceOf(ConflictException.class);

--- a/backend/src/test/java/com/kizuna/shared/exception/IntegrityViolationsTest.java
+++ b/backend/src/test/java/com/kizuna/shared/exception/IntegrityViolationsTest.java
@@ -1,0 +1,111 @@
+package com.kizuna.shared.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.util.Map;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+/** {@link IntegrityViolations} の抽出（制約名の取り出しと等値照合）を固定する単体テスト。 */
+class IntegrityViolationsTest {
+
+  private static ConstraintViolationException hibernateViolation(String constraintName) {
+    return new ConstraintViolationException(
+        "could not execute statement",
+        new SQLException("integrity constraint violation"),
+        constraintName);
+  }
+
+  @Test
+  @DisplayName("原因連鎖の途中にある Hibernate の違反から制約名を取り出し、対応する業務例外を返す")
+  void translatesConstraintFoundDeeperInCauseChain() {
+    // Spring の変換で包まれる層数は経路により異なるため、最深層だけを見る抽出では取りこぼす。
+    DataIntegrityViolationException ex =
+        new DataIntegrityViolationException(
+            "save failed",
+            new IllegalStateException(
+                "wrapped", hibernateViolation(DbConstraint.UQ_T_USERS_EMAIL.sqlName())));
+
+    RuntimeException translated =
+        IntegrityViolations.translate(
+            ex, Map.of(DbConstraint.UQ_T_USERS_EMAIL, () -> new ConflictException("重複しています")));
+
+    assertThat(translated).isInstanceOf(ConflictException.class).hasMessage("重複しています");
+  }
+
+  @Test
+  @DisplayName("対応表に複数の制約があっても、実際に違反した制約の写像だけを選ぶ")
+  void selectsMappingOfTheViolatedConstraintOnly() {
+    DataIntegrityViolationException ex =
+        new DataIntegrityViolationException(
+            "save failed", hibernateViolation(DbConstraint.FK_T_USER_STORES_STORE.sqlName()));
+
+    RuntimeException translated =
+        IntegrityViolations.translate(
+            ex,
+            Map.of(
+                DbConstraint.UQ_T_USERS_EMAIL,
+                () -> new ConflictException("メール重複"),
+                DbConstraint.FK_T_USER_STORES_STORE,
+                () -> new ServiceException("店舗が存在しません")));
+
+    assertThat(translated).isInstanceOf(ServiceException.class).hasMessage("店舗が存在しません");
+  }
+
+  @Test
+  @DisplayName("原因連鎖に Hibernate の違反が無ければ元の例外をそのまま返す")
+  void returnsOriginalWhenChainHasNoHibernateViolation() {
+    DataIntegrityViolationException ex =
+        new DataIntegrityViolationException("save failed", new SQLException("integrity violation"));
+
+    RuntimeException translated =
+        IntegrityViolations.translate(
+            ex, Map.of(DbConstraint.UQ_T_USERS_EMAIL, () -> new ConflictException("重複しています")));
+
+    assertThat(translated).isSameAs(ex);
+  }
+
+  @Test
+  @DisplayName("DB が制約名を報告しなかった場合は元の例外をそのまま返す")
+  void returnsOriginalWhenConstraintNameIsUnknown() {
+    DataIntegrityViolationException ex =
+        new DataIntegrityViolationException("save failed", hibernateViolation(null));
+
+    RuntimeException translated =
+        IntegrityViolations.translate(
+            ex, Map.of(DbConstraint.UQ_T_USERS_EMAIL, () -> new ConflictException("重複しています")));
+
+    assertThat(translated).isSameAs(ex);
+  }
+
+  @Test
+  @DisplayName("対応表に無い制約の違反は元の例外をそのまま返す（写像先の無い違反を握りつぶさない）")
+  void returnsOriginalWhenConstraintIsNotMapped() {
+    DataIntegrityViolationException ex =
+        new DataIntegrityViolationException(
+            "save failed", hibernateViolation("uq_t_some_other_table_key"));
+
+    RuntimeException translated =
+        IntegrityViolations.translate(
+            ex, Map.of(DbConstraint.UQ_T_USERS_EMAIL, () -> new ConflictException("重複しています")));
+
+    assertThat(translated).isSameAs(ex);
+  }
+
+  @Test
+  @DisplayName("制約名の照合は部分一致ではなく等値で行う")
+  void matchesConstraintNameByEqualityNotSubstring() {
+    DataIntegrityViolationException ex =
+        new DataIntegrityViolationException(
+            "save failed", hibernateViolation(DbConstraint.UQ_T_USERS_EMAIL.sqlName() + "_v2"));
+
+    RuntimeException translated =
+        IntegrityViolations.translate(
+            ex, Map.of(DbConstraint.UQ_T_USERS_EMAIL, () -> new ConflictException("重複しています")));
+
+    assertThat(translated).isSameAs(ex);
+  }
+}

--- a/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
@@ -27,9 +27,11 @@ import com.kizuna.user.domain.SelfStopNotAllowedException;
 import com.kizuna.user.domain.StaleStaffUpdateException;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -251,9 +253,10 @@ class PlatformStaffServiceTest {
         .thenThrow(
             new DataIntegrityViolationException(
                 "save failed",
-                new RuntimeException(
-                    "ERROR: insert or update on table \"t_user_stores\" violates foreign key"
-                        + " constraint \"fk_t_user_stores_store\"")));
+                new ConstraintViolationException(
+                    "save failed",
+                    new SQLException("insert or update violates foreign key constraint"),
+                    "fk_t_user_stores_store")));
 
     assertThatThrownBy(() -> service.create(req)).isInstanceOf(InvalidStoreScopeException.class);
   }
@@ -275,7 +278,12 @@ class PlatformStaffServiceTest {
     when(repository.findByEmail("fk@kizuna.test")).thenReturn(Optional.empty());
     when(encoder.encode("rawpass")).thenReturn("ENCODED");
     DataIntegrityViolationException violation =
-        new DataIntegrityViolationException("save failed", new RuntimeException("NOT NULL 違反"));
+        new DataIntegrityViolationException(
+            "save failed",
+            new ConstraintViolationException(
+                "save failed",
+                new SQLException("null value violates not-null constraint"),
+                "display_name"));
     when(repository.saveAndFlush(any())).thenThrow(violation);
 
     assertThatThrownBy(() -> service.create(req)).isSameAs(violation);
@@ -301,9 +309,10 @@ class PlatformStaffServiceTest {
         .thenThrow(
             new DataIntegrityViolationException(
                 "save failed",
-                new RuntimeException(
-                    "ERROR: insert or update on table \"t_user_roles\" violates foreign key"
-                        + " constraint \"fk_t_user_roles_role\"")));
+                new ConstraintViolationException(
+                    "save failed",
+                    new SQLException("insert or update violates foreign key constraint"),
+                    "fk_t_user_roles_role")));
 
     assertThatThrownBy(() -> service.create(req))
         .isInstanceOf(ServiceException.class)
@@ -328,9 +337,10 @@ class PlatformStaffServiceTest {
         .thenThrow(
             new DataIntegrityViolationException(
                 "save failed",
-                new RuntimeException(
-                    "ERROR: duplicate key value violates unique constraint"
-                        + " \"uq_t_users_email\"")));
+                new ConstraintViolationException(
+                    "save failed",
+                    new SQLException("duplicate key value violates unique constraint"),
+                    "uq_t_users_email")));
 
     assertThatThrownBy(() -> service.create(req)).isInstanceOf(DuplicateStaffEmailException.class);
   }
@@ -442,9 +452,10 @@ class PlatformStaffServiceTest {
         .thenThrow(
             new DataIntegrityViolationException(
                 "save failed",
-                new RuntimeException(
-                    "ERROR: insert or update on table \"t_user_stores\" violates foreign key"
-                        + " constraint \"fk_t_user_stores_store\"")));
+                new ConstraintViolationException(
+                    "save failed",
+                    new SQLException("insert or update violates foreign key constraint"),
+                    "fk_t_user_stores_store")));
 
     assertThatThrownBy(
             () ->
@@ -467,9 +478,10 @@ class PlatformStaffServiceTest {
         .thenThrow(
             new DataIntegrityViolationException(
                 "save failed",
-                new RuntimeException(
-                    "ERROR: duplicate key value violates unique constraint"
-                        + " \"uq_t_users_email\"")));
+                new ConstraintViolationException(
+                    "save failed",
+                    new SQLException("duplicate key value violates unique constraint"),
+                    "uq_t_users_email")));
 
     assertThatThrownBy(
             () ->

--- a/backend/src/test/java/com/kizuna/user/application/RoleServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/RoleServiceTest.java
@@ -24,9 +24,11 @@ import com.kizuna.user.domain.RoleRepository;
 import com.kizuna.user.domain.RoleSummary;
 import com.kizuna.user.domain.StaleRoleUpdateException;
 import com.kizuna.user.domain.SystemRoleImmutableException;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -184,8 +186,10 @@ class RoleServiceTest {
         .thenThrow(
             new DataIntegrityViolationException(
                 "save failed",
-                new RuntimeException(
-                    "ERROR: duplicate key value violates unique constraint \"uq_t_roles_name\"")));
+                new ConstraintViolationException(
+                    "save failed",
+                    new SQLException("duplicate key value violates unique constraint"),
+                    "uq_t_roles_name")));
 
     assertThatThrownBy(() -> service.create(createRequest("店長", Set.of("ORDER_MANAGE"))))
         .isInstanceOf(ServiceException.class)
@@ -292,7 +296,13 @@ class RoleServiceTest {
     Role existing = role(7L, "受付", false, Set.of(ORDER_MANAGE_ID));
     when(roleRepository.findById(7L)).thenReturn(Optional.of(existing));
     when(platformUserRepository.existsByRoleId(7L)).thenReturn(false);
-    doThrow(new DataIntegrityViolationException("fk_t_user_roles_role"))
+    doThrow(
+            new DataIntegrityViolationException(
+                "delete failed",
+                new ConstraintViolationException(
+                    "delete failed",
+                    new SQLException("update or delete violates foreign key constraint"),
+                    "fk_t_user_roles_role")))
         .when(roleRepository)
         .flush();
 
@@ -307,7 +317,12 @@ class RoleServiceTest {
     when(roleRepository.findById(7L)).thenReturn(Optional.of(existing));
     when(platformUserRepository.existsByRoleId(7L)).thenReturn(false);
     DataIntegrityViolationException violation =
-        new DataIntegrityViolationException("delete failed", new RuntimeException("CHECK 制約違反"));
+        new DataIntegrityViolationException(
+            "delete failed",
+            new ConstraintViolationException(
+                "delete failed",
+                new SQLException("new row violates check constraint"),
+                "ck_t_roles_name_not_blank"));
     doThrow(violation).when(roleRepository).flush();
 
     assertThatThrownBy(() -> service.delete(7L)).isSameAs(violation);
@@ -321,7 +336,12 @@ class RoleServiceTest {
     when(permissionRepository.findByCodeIn(Set.of("ORDER_MANAGE")))
         .thenReturn(List.of(permission(ORDER_MANAGE_ID, PermissionCode.ORDER_MANAGE)));
     DataIntegrityViolationException violation =
-        new DataIntegrityViolationException("save failed", new RuntimeException("NOT NULL 違反"));
+        new DataIntegrityViolationException(
+            "save failed",
+            new ConstraintViolationException(
+                "save failed",
+                new SQLException("null value violates not-null constraint"),
+                "name"));
     when(roleRepository.saveAndFlush(any())).thenThrow(violation);
 
     assertThatThrownBy(() -> service.create(createRequest("店長", Set.of("ORDER_MANAGE"))))

--- a/backend/src/test/java/com/kizuna/user/application/RoleServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/RoleServiceTest.java
@@ -321,8 +321,8 @@ class RoleServiceTest {
             "delete failed",
             new ConstraintViolationException(
                 "delete failed",
-                new SQLException("new row violates check constraint"),
-                "ck_t_roles_name_not_blank"));
+                new SQLException("update or delete violates foreign key constraint"),
+                "fk_t_role_permissions_role"));
     doThrow(violation).when(roleRepository).flush();
 
     assertThatThrownBy(() -> service.delete(7L)).isSameAs(violation);


### PR DESCRIPTION
## 概要

6 サービス 8 箇所の catch が `getMostSpecificCause().getMessage()` への部分一致で行っていた整合性違反の分類を、cause 連鎖上の Hibernate `ConstraintViolationException#getConstraintName()` との**等値**比較へ切り替え、抽出（探測・剥殻・fail-loud 伝播）を `shared/exception` の共有パイプラインへ下ろした。「どの制約をどの業務例外へ写像するか」の決定は従来どおり各 call site に残る。制約名字面は適応度テストで changelog の実 DDL に固定した。

Closes #626

## 変更内容

- 新設 `shared/exception/DbConstraint`（現用 6 名のみの enum）＋ `IntegrityViolations.translate(ex, Map<DbConstraint, Supplier<RuntimeException>>)`。命中→業務例外、CVE 不在・名前 null・非命中→原例外を返す（fail-loud 維持）
- 8 catch（LineAuthService / CastInvitationAcceptanceService / CastInvitationService / MemberRegistrationService ×2 / RoleService ×2 / PlatformStaffService）を translate 経由の単行へ改写。各サービス私有の `*_CONSTRAINT` 定数 10 件を全廃。`saveAndFlush` / `flush` の時機と既存注釈は原地不動
- 単体テスト 6 ファイルの違反偽造を、ドライバ報錯文言の模倣から実 Hibernate CVE 構築（コンストラクタは 7.4.1 sources で確認）へ変更。伝播断言側も実 CVE 化し、偽造していた実在しない制約名を実 DDL の制約へ差し替え。従前は違反偽造の無かった `CastInvitationAcceptanceServiceTest` にも並行重複の変換テストを追加し、8 箇所全ての translate 配線を単体で固定
- `IntegrityViolationsTest` 新設（命中 / CVE 不在 / 名前 null / 非命中の各枝）
- `PlatformStaffManagementIT.unknownStoreIdRejected` を文言断言まで強化 — 実 DB の FK 違反が「ドライバ→Hibernate CVE→制約名」の実链路で新パイプラインを通ることの機械証明
- 適応度テスト 2 本新設: `DbConstraint` 全成員 ⊆ changelog の `constraintName` / `uniqueConstraintName`、および `src/main/java` に `@JsonProperty` 不在（`wireNameOf` の前提の機械化、import 宣言で検出）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task test-unit` / `task test-integration` を個別実行、いずれも exit 0。統合は down 後の清潔スタックで実施）
- [x] `task build` exit 0（`task build service=backend`。frontend は無変更）
- [ ] `task e2e` — 未実施。wire 挙動（status・メッセージ）完全不変・frontend 無変更のため、ready 化前に必要なら実施
- [x] ローカルで code-review 実施済み — 二軸（Standards / Spec）で実施。指摘への対応は fdfcd134（注釈の中文語彙 2 箇所の是正＋招待受諾の並行重複変換の単体固定、注入で能紅性確認済み）。「404 写像の理由注釈が失われた」指摘は、try 直上の既存ブロック注釈が同内容をより詳しく保持しており誤検と判定

能紅性の実証（故障注入 3 回、いずれも復元済み）: ①translate の制約名を固定値に潰す → 写像単体テスト 12/12 赤 ②enum へダミー成員追加＋`@JsonProperty` import 注入 → 適応度テスト 2 本とも赤 ③`FK_T_USER_STORES_STORE` の字面を実在しない名前へ → 該当 IT のみ赤。

## 決定ログ

grilling 定稿（詳細は #626）:

- **抽出機制**: `getConstraintName()` 等値比較を採用。message 部分一致の温存案は、ドライバ文言依存（誤分類出荷の前科 #549・4 commit の相互反転）を残すため見送り
- **interface 形状**: catch 側 translate を採用。動作包裹 wrapper 案は、`RoleService.delete` の flush 時機の事務語義が lambda に隠れるため見送り
- **字面の宿主**: shared の enum 登記簿（`PermissionCode` 先例）。集中が許されるのは schema **事実**（名前）だけで、「制約→status」の**決定**は集中しない — 同一 `fk_t_user_roles_role` が削除方向 409 / 授与方向 400、`uq_t_users_email` が 400/400/409、`fk_t_cast_invitations_cast` が 404。いずれも正で、対応表は call site に残存
- **`CommonExceptionHandler` の SQLSTATE 23505 兜底は対象外・diff 空** — 類判定（制約名無関）は兜底語義の一部
- **検証戦略**: 実链路（ドライバが制約名を CVE へ運ぶこと)は仮定にせず、事前検証の無い店舗 FK 経路で決定的 IT により証明

指示からの偏差 2 点（実装時に判断・報告済み）:

1. IT は新設でなく既存 `unknownStoreIdRejected` の強化。同一シナリオ（`SPECIFIC_STORES`＋実在しない店舗 id）が既に存在し、差分は文言断言のみだったため
2. 伝播断言のテストも実 CVE 構築へ変換。平文 cause のままでは「連鎖に CVE 無し」枝しか検査できず、「対応表に無い制約は伝播する」を証明できないため

## 備考 / レビュー観点

- `CastInvitationAcceptanceService.saveUser` の違反経路には従前単体テストが無かった（既存の空隙）。code-review の指摘を受け fdfcd134 で変換テストを追加し、空隙は解消済み
- Hibernate の NOT_NULL 違反では `getConstraintName()` が列名を返す（7.4.1 javadoc 明記）。現行の対応表は制約名のみを鍵にするため影響なし
- 2026-08-09 アーキテクチャ評審の残候補 B2〜B4 は別 issue（#626 の対象外節を参照）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
