### PR TITLE
fix(frontend): 顧客編集の注文履歴ステータスを受注一覧と同じ和訳ラベルで表示する

### DIFF
--- a/frontend/src/_pages/store-customers/__tests__/CustomerEditPage.test.tsx
+++ b/frontend/src/_pages/store-customers/__tests__/CustomerEditPage.test.tsx
@@ -17,6 +17,8 @@ jest.mock('@/entities/customer', () => ({
 }));
 
 jest.mock('@/entities/order', () => ({
+  // 表示ラベル等の定数は本物を使う（API だけを差し替える）
+  ...jest.requireActual('@/entities/order/model/types'),
   orderApi: { list: jest.fn() },
 }));
 
@@ -114,5 +116,27 @@ describe('顧客編集ページの取得失敗', () => {
 
     expect(await screen.findByText('注文履歴がありません')).toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+describe('顧客編集ページの注文履歴', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCustomerApi.get.mockResolvedValue(customer);
+    mockedCustomerApi.memberLinkHistory.mockResolvedValue([]);
+  });
+
+  it('受注ステータスを enum 生値ではなく受注一覧と同じ日本語ラベルで表示すること', async () => {
+    mockedOrderApi.list.mockResolvedValue({
+      rows: [{ id: 'ord-1', business_date: '2026-08-01', status: 'CONFIRMED', used_points: 0 }],
+      page: 0,
+      pageCount: 1,
+      total: 1,
+    });
+
+    render(<CustomerEditPage />);
+
+    expect(await screen.findByText('確定')).toBeInTheDocument();
+    expect(screen.queryByText('CONFIRMED')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
@@ -5,7 +5,7 @@ import { useRouter, useParams } from 'next/navigation';
 import { CustomerForm, CustomerFormData, toCustomerRequest } from './CustomerForm';
 import { MemberLinkSection } from './MemberLinkSection';
 import { customerApi } from '@/entities/customer';
-import { orderApi } from '@/entities/order';
+import { ORDER_STATUS_LABELS, orderApi } from '@/entities/order';
 import { notify } from '@/shared/notify';
 import { storePath, useResource } from '@/shared/lib';
 import {
@@ -160,7 +160,9 @@ export default function CustomerEditPage() {
                     {(order.extension_minutes ?? 0) > 0 && ` (+延長${order.extension_minutes}分)`}
                   </TableCell>
                   <TableCell className="text-muted-foreground">{order.used_points}</TableCell>
-                  <TableCell className="text-muted-foreground">{order.status}</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {order.status ? ORDER_STATUS_LABELS[order.status] : '-'}
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>


### PR DESCRIPTION
## 概要

顧客編集ページの注文履歴テーブルが受注ステータスをバックエンド enum の生値（CREATED/CONFIRMED/COMPLETED/CANCELLED）のまま表示していたため、受注一覧と同じ `ORDER_STATUS_LABELS` の和訳（未確定/確定/完了/キャンセル）に統一した。

## 変更内容

- `CustomerEditPage.tsx`: ステータス列を `{order.status}` から `{order.status ? ORDER_STATUS_LABELS[order.status] : '-'}` へ変更（`OrdersPage.tsx` と同一式。status 欠落時のフォールバック「-」も揃えた）
- `CustomerEditPage.test.tsx`: `@/entities/order` のモックを `...jest.requireActual('@/entities/order/model/types')` で表示ラベル定数を残す既存流儀（OrdersPage.test と同形）に改修し、CONFIRMED の注文で「確定」が表示され生値 `CONFIRMED` が現れないことを固定する用例を追加

## 検証

- [x] `task lint service=frontend` exit 0（差分は frontend のみ）
- [x] `task test service=frontend` exit 0（追加用例は修正前に赤を確認済み。test イメージに新コードが含まれることも grep で確認）
- [x] `task build service=frontend` exit 0
- [ ] `task e2e` 未実施（表示文言のみの変更）
- [ ] ローカルで code-review 未実施

### 視覚確認（UI 変更時）

未実施。文言写像のみの変更で、式は受注一覧で稼働実績のあるものと同一のため、単体テストの固定で代えた。

## 決定ログ

- 指示にあった「既存テストの fixture 断言の更新」は、実読の結果 store-customers 配下に status 付き注文 fixture も生値断言も存在しなかった（enum 字面 4 種 grep 零件、既存 4 用例は全て空の注文頁）。更新対象が無いため、和訳表示を固定する用例の新規追加で代替した。
- モック改修は部分差し替え（`ORDER_STATUS_LABELS` だけ実体を足す）ではなく、`OrdersPage.test.tsx` が既に確立している requireActual 流儀へ寄せた。

## 備考 / レビュー観点

- 会員ポータル用の `MEMBER_ORDER_STATUS_LABELS`（CREATED=申請中）ではなく店舗既定の `ORDER_STATUS_LABELS`（CREATED=未確定）を使っている。本頁は店舗コンソールなので受注一覧と同じ既定側が正。