### PR TITLE
fix: 同店同号の重複顧客で受注録入の電話照合が 500 になるのを直す

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/order/OrderPhoneLinkingIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/OrderPhoneLinkingIT.java
@@ -1,0 +1,138 @@
+package com.kizuna.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kizuna.shared.CrossStoreTestSupport;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * 受注録入の電話照合を本物の PostgreSQL で検証する統合テスト。
+ *
+ * <p>固定するのは照合の 3 分岐 — 0 件＝顧客を新規作成して紐づけ、1 件＝その顧客に紐づけ、2 件以上＝自動照合を断念して顧客未設定のまま成立。
+ *
+ * <p>2 件以上の分岐は単体テストでは守れない。台帳照合は派生クエリの戻り値の形（{@code Optional} か {@code List} か）で決まり、複数行を {@code
+ * Optional} に詰める失敗は Spring Data が実行時に起こすものなので、モックした repository は 1 行だけ返す前提のまま緑になる。
+ *
+ * <p>照合キーの電話番号は実行ごとに変える。同店同号の重複を意図的に作るテストであり、固定値だと他の実行の残りと混ざって分岐の前提が崩れる。
+ */
+class OrderPhoneLinkingIT extends CrossStoreTestSupport {
+
+  /** v0.5.0 の山田次郎シード（STORE_STAFF・授権店舗 = 店舗1）。 */
+  private static final long SEED_RECEPTIONIST_ID = 3L;
+
+  private final long nonce = System.nanoTime();
+
+  @Test
+  @DisplayName("同店同号の顧客が複数あると自動照合を断念し、顧客未設定のまま受注が成立して連絡先が残ること")
+  void severalMatchesLeaveTheCustomerUnsetAndKeepTheReportedContact() {
+    String phone = phone("dup");
+    createCustomer("重複照合A-" + nonce, phone);
+    createCustomer("重複照合B-" + nonce, phone);
+
+    ResponseEntity<JsonNode> created = createOrderByPhone("重複照合の来客", phone);
+
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    // 一致行の中に会員関連付きの行があり得るため、機械が 1 行を選ぶことはしない（ADR 0009）
+    assertThat(created.getBody().hasNonNull("customer_id")).as("顧客は未設定のままであること").isFalse();
+    // 顧客未設定で成立させる以上、録入された連絡先は受注側に残さないと消える
+    assertThat(created.getBody().path("contact_name").asString()).isEqualTo("重複照合の来客");
+    assertThat(created.getBody().path("contact_phone_number").asString()).isEqualTo(phone);
+  }
+
+  @Test
+  @DisplayName("同店同号が 1 件だけならその顧客に紐づき、連絡先の写しは残らないこと")
+  void theOnlyMatchIsLinkedAndNeedsNoContactCopy() {
+    String phone = phone("one");
+    String customerId = createCustomer("単一照合-" + nonce, phone);
+
+    ResponseEntity<JsonNode> created = createOrderByPhone("単一照合の来客", phone);
+
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(created.getBody().path("customer_id").asString()).isEqualTo(customerId);
+    // 台帳の行が連絡先を持つので、受注側の写しは要らない
+    assertThat(created.getBody().hasNonNull("contact_name")).as("写しは残さないこと").isFalse();
+    assertThat(created.getBody().hasNonNull("contact_phone_number")).as("写しは残さないこと").isFalse();
+  }
+
+  @Test
+  @DisplayName("同店同号が無ければ顧客が新規作成されて紐づくこと")
+  void noMatchCreatesTheCustomer() {
+    String phone = phone("new");
+
+    ResponseEntity<JsonNode> created = createOrderByPhone("新規照合の来客", phone);
+
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    String customerId = created.getBody().path("customer_id").asString();
+    assertThat(customerId).isNotBlank();
+    assertThat(created.getBody().hasNonNull("contact_name")).as("写しは残さないこと").isFalse();
+
+    JsonNode customer = getCustomer(customerId);
+    assertThat(customer.path("name").asString()).isEqualTo("新規照合の来客");
+    assertThat(customer.path("phone_number").asString()).isEqualTo(phone);
+  }
+
+  // ==================== 準備 ====================
+
+  /** 実行ごと・分岐ごとに異なる照合キー。列は VARCHAR(50)。 */
+  private String phone(String label) {
+    return "090" + Math.abs((label + nonce).hashCode()) + nonce;
+  }
+
+  private ResponseEntity<JsonNode> createOrderByPhone(String customerName, String phone) {
+    String castId = createCast("電話照合IT-" + customerName + "-" + nonce);
+    String body =
+        "{\"receptionist_id\": "
+            + SEED_RECEPTIONIST_ID
+            + ", \"business_date\": \""
+            + LocalDate.now()
+            + "\", \"cast_id\": \""
+            + castId
+            + "\", \"customer_name\": \""
+            + customerName
+            + "\", \"phone_number\": \""
+            + phone
+            + "\"}";
+    return rest.postForEntity(
+        "/store/orders", new HttpEntity<>(body, storeHeaders(STORE_A)), JsonNode.class);
+  }
+
+  private String createCustomer(String name, String phone) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/store/customers",
+            new HttpEntity<>(
+                "{\"name\": \"" + name + "\", \"phone_number\": \"" + phone + "\"}",
+                storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful()).as("前提: 顧客作成が成功すること").isTrue();
+    return created.getBody().path("id").asString();
+  }
+
+  private String createCast(String name) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/store/casts",
+            new HttpEntity<>("{\"name\": \"" + name + "\"}", storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful()).as("前提: キャスト作成が成功すること").isTrue();
+    return created.getBody().path("id").asString();
+  }
+
+  private JsonNode getCustomer(String customerId) {
+    ResponseEntity<JsonNode> res =
+        rest.exchange(
+            "/store/customers/" + customerId,
+            HttpMethod.GET,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).as("前提: 作成された顧客を読めること").isEqualTo(HttpStatus.OK);
+    return res.getBody();
+  }
+}

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
@@ -1,6 +1,7 @@
 package com.kizuna.customer.domain;
 
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -44,5 +45,13 @@ public interface CustomerRepository
 
   Optional<Customer> findByPhoneNumber(String phoneNumber);
 
-  Optional<Customer> findByPhoneNumberAndStoreId(String phoneNumber, Long storeId);
+  /**
+   * 店舗台帳のうち電話番号が一致する顧客。索引 {@code idx_t_customers_phone (phone_number, store_id)}
+   * は非一意で、同店同号の行は正規に起こりうる — 同伴者が連絡先を共有する場合や旧システムからの移行分がそれにあたる。
+   *
+   * <p>だから戻り値は複数行を許す形でなければならない。1 件に絞る形（{@code Optional}）で受けると、重複のある番号を引いた瞬間に {@code
+   * IncorrectResultSizeDataAccessException} で呼出側ごと落ちる。複数一致をどう扱うかは呼出側の判断で、 電話番号は台帳内の検索の手がかりに留まる（ADR
+   * 0009）。
+   */
+  List<Customer> findByPhoneNumberAndStoreId(String phoneNumber, Long storeId);
 }

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderCreateRequest.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderCreateRequest.java
@@ -4,6 +4,7 @@ import com.kizuna.order.domain.ReceptionRoute;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -20,8 +21,16 @@ public class OrderCreateRequest {
   private LocalTime arrivalScheduledEndTime;
 
   private String customerId;
+
+  // 上限は行き先の列と同じ（t_customers.name / t_orders.contact_name = VARCHAR(255)、
+  // t_customers.phone_number / t_orders.contact_phone_number = VARCHAR(50)）。契約で撥ねないと、
+  // 溢れた値が挿入時の SQLSTATE 22001 になり、理由の分かる 400 ではなく 500 で返る。
+  @Size(max = 255, message = "お客様名は 255 文字以内です")
   private String customerName;
+
+  @Size(max = 50, message = "電話番号は 50 文字以内です")
   private String phoneNumber;
+
   private String phoneNumber2;
   private String address;
   private String buildingName;

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderMapper.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderMapper.java
@@ -38,6 +38,9 @@ public interface OrderMapper {
   @Mapping(target = "totalFee", ignore = true)
   @Mapping(target = "usedPoints", ignore = true)
   @Mapping(target = "autoGrantPoints", ignore = true)
+  // 連絡先の写しは顧客に着かなかった受注にだけ入る（判定はサービス層）
+  @Mapping(target = "contactName", ignore = true)
+  @Mapping(target = "contactPhoneNumber", ignore = true)
   // 関連 ID - サービス層で存在確認後に割り当て
   @Mapping(target = "customerId", ignore = true)
   @Mapping(target = "castId", ignore = true)

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderResponse.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderResponse.java
@@ -21,6 +21,9 @@ public class OrderResponse {
   private LocalTime arrivalScheduledEndTime;
   private String customerId;
   private String customerName; // Helper
+  // 受付で録入された連絡先。顧客が着かなかった受注にだけ入る（着いた受注では台帳の行が名乗りを持つ）
+  private String contactName;
+  private String contactPhoneNumber;
   private String castId;
   private String castName; // Helper
   private Integer pax;

--- a/backend/src/main/java/com/kizuna/order/application/OrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderService.java
@@ -544,24 +544,35 @@ public class OrderService {
     orderRepository.deleteById(id);
   }
 
+  /**
+   * 受注を店舗台帳の顧客に着ける。顧客 ID の指定があればそれを、無ければ電話番号で当店の台帳を照合する。
+   *
+   * <p>電話番号の照合は一致件数で 3 分岐する。0 件なら録入内容で顧客を起こして紐づけ、1 件ならその顧客に紐づけ、 <b>2
+   * 件以上なら自動照合を断念して顧客未設定のまま成立させる</b>（無帰属受注は正規の状態）。同店同号は正規に起こりうる —
+   * 同伴者の連絡先共有や旧システムからの移行分がそれで、一致行の中に会員関連付きの行があり得る以上、機械が 1 行を選ぶことは 誤帰属の入口になる（ADR 0009）。並び順で 1
+   * 行に決める形も同じ理由で採らない。
+   *
+   * <p>顧客に着かなかった受注には、録入された連絡先を受注側へ写す。写さないと、台帳にも受注にも残らないまま入力が消える。
+   */
   private void handleCustomerLinking(OrderCreateRequest req, Order order) {
     if (req.getCustomerId() != null && !req.getCustomerId().isEmpty()) {
       if (!customerRepository.existsById(req.getCustomerId())) {
         throw new NotFoundException("顧客が見つかりません: " + req.getCustomerId());
       }
       order.linkCustomer(req.getCustomerId());
-    } else if (req.getPhoneNumber() != null && !req.getPhoneNumber().isEmpty()) {
-      // 顧客の検索または作成
-      Customer customer =
-          customerRepository
-              .findByPhoneNumberAndStoreId(req.getPhoneNumber(), storeContext.getStoreId())
-              .orElseGet(
-                  () -> {
-                    // store_id は StoreScopeStampListener が @PrePersist で採番する
-                    Customer newCustomer = orderMapper.toCustomer(req);
-                    return customerRepository.save(newCustomer);
-                  });
-      order.linkCustomer(customer.getId());
+      return;
     }
+    if (req.getPhoneNumber() != null && !req.getPhoneNumber().isEmpty()) {
+      List<Customer> matched =
+          customerRepository.findByPhoneNumberAndStoreId(
+              req.getPhoneNumber(), storeContext.getStoreId());
+      if (matched.isEmpty()) {
+        // store_id は StoreScopeStampListener が @PrePersist で採番する
+        order.linkCustomer(customerRepository.save(orderMapper.toCustomer(req)).getId());
+      } else if (matched.size() == 1) {
+        order.linkCustomer(matched.get(0).getId());
+      }
+    }
+    order.recordContactIfUnlinked(req.getCustomerName(), req.getPhoneNumber());
   }
 }

--- a/backend/src/main/java/com/kizuna/order/domain/Order.java
+++ b/backend/src/main/java/com/kizuna/order/domain/Order.java
@@ -42,6 +42,18 @@ public class Order extends StoreScopedEntity {
   @Column(name = "customer_id")
   private String customerId;
 
+  /**
+   * 受付で録入された連絡先の氏名。台帳の顧客に着かなかった受注にだけ入る。
+   *
+   * <p>顧客が着いた受注では台帳の行が連絡先を持つのでここは空のままで、名乗りの正本は常に台帳の側にある。
+   */
+  @Column(name = "contact_name")
+  private String contactName;
+
+  /** 受付で録入された連絡先の電話番号。{@link #contactName} と同じく顧客が着かなかった受注にだけ入る。 */
+  @Column(name = "contact_phone_number", length = 50)
+  private String contactPhoneNumber;
+
   @Column(name = "cast_id")
   private String castId;
 
@@ -132,6 +144,23 @@ public class Order extends StoreScopedEntity {
   /** 顧客を紐付ける（存在確認・検索/作成は application 層の責務）。 */
   public void linkCustomer(String customerId) {
     this.customerId = customerId;
+  }
+
+  /**
+   * 顧客が着いていなければ、受付で録入された連絡先を受注に写す。着いている受注では何もしない。
+   *
+   * <p>受注は本来 連絡先を自身に持たず、顧客の名乗りは台帳の行が引き受ける。それでも写しを残すのは、 電話番号が同店の複数の顧客に一致して自動照合を断念した受注（無帰属受注は正規の状態）で、
+   * 写しが無いと録入された氏名・電話番号がどこにも残らず、店舗が折り返す手立てを失うため。
+   *
+   * <p>着いているかの判定を呼び手に委ねず自分で見るのは、判定の材料である顧客参照をこの集約が持っているから。
+   * 委ねると「台帳の行と受注の写しが両方名乗る」状態を誰でも作れてしまい、どちらが正本かが読み手から消える。
+   */
+  public void recordContactIfUnlinked(String name, String phoneNumber) {
+    if (customerId != null) {
+      return;
+    }
+    this.contactName = name;
+    this.contactPhoneNumber = phoneNumber;
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
@@ -32,6 +32,7 @@ public interface OrderRepository
              o.arrivalScheduledStartTime as arrivalScheduledStartTime,
              o.arrivalScheduledEndTime as arrivalScheduledEndTime,
              o.customerId as customerId, c.name as customerName,
+             o.contactName as contactName, o.contactPhoneNumber as contactPhoneNumber,
              o.castId as castId, k.name as castName,
              o.pax as pax,
              o.courseMinutes as courseMinutes, o.extensionMinutes as extensionMinutes,

--- a/backend/src/main/java/com/kizuna/order/domain/OrderView.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderView.java
@@ -24,6 +24,11 @@ public interface OrderView {
 
   String getCustomerName();
 
+  /** 受付で録入された連絡先の氏名。顧客が着いた受注では空（名乗りの正本は台帳の側にある）。 */
+  String getContactName();
+
+  String getContactPhoneNumber();
+
   String getCastId();
 
   String getCastName();

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -41,6 +41,9 @@ databaseChangeLog:
   - include:
       file: releases/v0.14.0/master.yaml
       relativeToChangelogFile: true
+  - include:
+      file: releases/v0.15.0/master.yaml
+      relativeToChangelogFile: true
   # reconcile/ は版に属さない恒久的な写像取り直しで、必ず全 release の後に置く（毎回実行されるため、
   # ロールの改名など release 側の移行より先に走ると、移行前の状態を見て齟齬と判定してしまう）。
   # 新しい release の include は必ずこの include より前に足すこと。

--- a/backend/src/main/resources/db/changelog/releases/v0.15.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.15.0/master.yaml
@@ -1,0 +1,5 @@
+# v0.15.0 = 受付で録入された連絡先の受注側への写し。store 層のみ。
+databaseChangeLog:
+  - include:
+      file: store/01-order-reported-contact.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.15.0/store/01-order-reported-contact.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.15.0/store/01-order-reported-contact.yaml
@@ -1,0 +1,32 @@
+databaseChangeLog:
+  - changeSet:
+      id: store-v01500-001-order-reported-contact
+      author: kanghouchao
+      # 受付で録入された連絡先を受注そのものに残すための列。
+      # 電話番号が当店の台帳で複数の顧客に一致すると自動照合を断念して顧客未設定で成立させるため
+      # （一致行に会員関連付きの行があり得る以上、機械が 1 行を選ぶのは誤帰属の入口 — ADR 0009）、
+      # 写しが無いと録入された氏名・電話番号がどこにも残らず、店舗が折り返す手立てを失う。
+      # 顧客が着いた受注では台帳の行が名乗りを持つので、この 2 列は空のままになる。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - addColumn:
+            tableName: t_orders
+            columns:
+              - column:
+                  name: contact_name
+                  type: VARCHAR(255)
+                  remarks: 受付で録入された連絡先の氏名（顧客未設定の受注にのみ入る）
+              - column:
+                  name: contact_phone_number
+                  type: VARCHAR(50)
+                  remarks: 受付で録入された連絡先の電話番号（顧客未設定の受注にのみ入る）
+      rollback:
+        - dropColumn:
+            tableName: t_orders
+            columns:
+              - column:
+                  name: contact_name
+              - column:
+                  name: contact_phone_number

--- a/backend/src/test/java/com/kizuna/order/api/store/OrderControllerTest.java
+++ b/backend/src/test/java/com/kizuna/order/api/store/OrderControllerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -233,6 +234,24 @@ class OrderControllerTest {
     mockMvc
         .perform(storePut("/store/orders/o1", "{\"cast_id\": \"cast-1\", \"pax\": 3}"))
         .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("列に収まらない連絡先は契約で撥ねられること")
+  @WithMockUser(authorities = "PERM_ORDER_MANAGE")
+  void orderCreateRejectsContactLongerThanItsColumn() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+
+    // 顧客が着かない受注では録入された連絡先が t_orders へ入る。契約で撥ねないと、溢れた値は
+    // 挿入時の SQLSTATE 22001 になり、理由の分かる 400 ではなく 500 で返る
+    String body =
+        "{\"receptionist_id\": 1, \"business_date\": \"2026-08-12\", \"cast_id\": \"cast-1\""
+            + ", \"customer_name\": \""
+            + "あ".repeat(256)
+            + "\"}";
+
+    mockMvc.perform(storePost("/store/orders", body)).andExpect(status().isBadRequest());
+    verifyNoInteractions(orderService);
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
@@ -228,11 +228,12 @@ class OrderServiceTest {
     req.setReceptionistId(1L);
 
     Customer newCustomer = Customer.builder().phoneNumber("09012345678").build();
+    // 保存で採番される id（@SnowflakeId）。受注はこの id で顧客に着く
+    newCustomer.setId("c-new");
 
     when(storeContext.getStoreId()).thenReturn(1L);
     when(orderMapper.toEntity(req)).thenReturn(Order.builder().build());
-    when(customerRepository.findByPhoneNumberAndStoreId("09012345678", 1L))
-        .thenReturn(Optional.empty());
+    when(customerRepository.findByPhoneNumberAndStoreId("09012345678", 1L)).thenReturn(List.of());
     when(nominatableCast.find(STORE_ID, "g1")).thenReturn(Optional.of(nominatable("g1")));
     when(platformUserRepository.findById(1L)).thenReturn(Optional.of(authorizedReceptionist()));
 
@@ -248,6 +249,97 @@ class OrderServiceTest {
 
     verify(customerRepository).save(customerCaptor.capture());
     assertThat(customerCaptor.getValue().getPhoneNumber()).isEqualTo("09012345678");
+    verify(orderRepository).save(orderCaptor.capture());
+    assertThat(orderCaptor.getValue().getCustomerId()).isEqualTo("c-new");
+    // 台帳に行を起こした以上、受注側の写しは要らない
+    assertThat(orderCaptor.getValue().getContactName()).isNull();
+    assertThat(orderCaptor.getValue().getContactPhoneNumber()).isNull();
+  }
+
+  @Test
+  void createLinksTheOnlyCustomerMatchingThePhone() {
+    OrderCreateRequest req = phoneOrderRequest("09012345678", "常連さん");
+
+    when(storeContext.getStoreId()).thenReturn(STORE_ID);
+    when(orderMapper.toEntity(req)).thenReturn(Order.builder().build());
+    when(customerRepository.findByPhoneNumberAndStoreId("09012345678", STORE_ID))
+        .thenReturn(List.of(customerWithId("c1")));
+    stubCreateHappyPath();
+
+    service.create(req);
+
+    verify(orderRepository).save(orderCaptor.capture());
+    assertThat(orderCaptor.getValue().getCustomerId()).isEqualTo("c1");
+    // 台帳の行が連絡先を持つので、受注側の写しは残さない
+    assertThat(orderCaptor.getValue().getContactName()).isNull();
+    verify(customerRepository, never()).save(any());
+  }
+
+  @Test
+  void createLeavesTheCustomerUnsetWhenThePhoneMatchesSeveral() {
+    // 同店同号は正規に起こりうる（同伴者の連絡先共有・移行データ）。一致行に会員関連付きの行が
+    // あり得る以上、機械が 1 行を選ぶのは誤帰属の入口なので、自動照合を断念して顧客未設定で成立させる
+    OrderCreateRequest req = phoneOrderRequest("09012345678", "重複照合の来客");
+
+    when(storeContext.getStoreId()).thenReturn(STORE_ID);
+    when(orderMapper.toEntity(req)).thenReturn(Order.builder().build());
+    when(customerRepository.findByPhoneNumberAndStoreId("09012345678", STORE_ID))
+        .thenReturn(List.of(customerWithId("c1"), customerWithId("c2")));
+    stubCreateHappyPath();
+
+    service.create(req);
+
+    verify(orderRepository).save(orderCaptor.capture());
+    assertThat(orderCaptor.getValue().getCustomerId()).isNull();
+    // 顧客を起こして重複を増やすこともしない
+    verify(customerRepository, never()).save(any());
+    // 顧客未設定で成立させる以上、録入された連絡先は受注側に残さないと消える
+    assertThat(orderCaptor.getValue().getContactName()).isEqualTo("重複照合の来客");
+    assertThat(orderCaptor.getValue().getContactPhoneNumber()).isEqualTo("09012345678");
+  }
+
+  @Test
+  void createKeepsTheReportedContactWhenNoPhoneIsGiven() {
+    // 電話番号を録入しなければ照合も顧客の作成も起きない。名前だけの録入もこの経路を通るので、
+    // 写しの条件は「照合が複数一致したか」ではなく「顧客が着いたか」で決める
+    OrderCreateRequest req = phoneOrderRequest(null, "電話番号なしの来客");
+
+    when(storeContext.getStoreId()).thenReturn(STORE_ID);
+    when(orderMapper.toEntity(req)).thenReturn(Order.builder().build());
+    stubCreateHappyPath();
+
+    service.create(req);
+
+    verify(orderRepository).save(orderCaptor.capture());
+    assertThat(orderCaptor.getValue().getCustomerId()).isNull();
+    assertThat(orderCaptor.getValue().getContactName()).isEqualTo("電話番号なしの来客");
+    assertThat(orderCaptor.getValue().getContactPhoneNumber()).isNull();
+    verifyNoInteractions(customerRepository);
+  }
+
+  private OrderCreateRequest phoneOrderRequest(String phoneNumber, String customerName) {
+    OrderCreateRequest req = new OrderCreateRequest();
+    req.setPhoneNumber(phoneNumber);
+    req.setCustomerName(customerName);
+    req.setCastId("g1");
+    req.setReceptionistId(1L);
+    return req;
+  }
+
+  private Customer customerWithId(String id) {
+    Customer customer = Customer.builder().phoneNumber("09012345678").build();
+    customer.setId(id);
+    return customer;
+  }
+
+  /** 顧客照合の後に続く検証（指名・受付担当）と応答の組み立てを通す stub。 */
+  private void stubCreateHappyPath() {
+    when(nominatableCast.find(STORE_ID, "g1")).thenReturn(Optional.of(nominatable("g1")));
+    when(platformUserRepository.findById(1L)).thenReturn(Optional.of(authorizedReceptionist()));
+    when(orderRepository.save(any(Order.class))).thenAnswer(i -> i.getArgument(0));
+    when(orderRepository.findViewById(nullable(String.class)))
+        .thenReturn(Optional.of(mock(OrderView.class)));
+    when(orderMapper.toResponse(any(OrderView.class))).thenReturn(OrderResponse.builder().build());
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/order/domain/OrderTest.java
+++ b/backend/src/test/java/com/kizuna/order/domain/OrderTest.java
@@ -162,6 +162,23 @@ class OrderTest {
   }
 
   @Test
+  @DisplayName("連絡先の写しは顧客が着いていない受注にだけ入ること")
+  void recordContactIfUnlinked_onlyWhenNoCustomer() {
+    Order unlinked = Order.builder().build();
+
+    unlinked.recordContactIfUnlinked("重複照合の来客", "09012345678");
+    assertThat(unlinked.getContactName()).isEqualTo("重複照合の来客");
+    assertThat(unlinked.getContactPhoneNumber()).isEqualTo("09012345678");
+
+    // 台帳の行が名乗りを持つ受注に写しを重ねると、どちらが正本かが読み手から消える
+    Order linked = Order.builder().customerId("c1").build();
+
+    linked.recordContactIfUnlinked("重複照合の来客", "09012345678");
+    assertThat(linked.getContactName()).isNull();
+    assertThat(linked.getContactPhoneNumber()).isNull();
+  }
+
+  @Test
   @DisplayName("申請の書き換えは渡した値で置き換え、null は未設定にすること")
   void revise_replacesInsteadOfPatching() {
     Order order =

--- a/frontend/src/_pages/store-orders/__tests__/OrderCompletionModal.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrderCompletionModal.test.tsx
@@ -54,6 +54,18 @@ describe('OrderCompletionModal', () => {
     expect(mockedPreview).not.toHaveBeenCalled();
   });
 
+  it('顧客未設定の受注は録入された連絡先で見出しに出す', async () => {
+    // 会計の相手が誰か分からないまま完了させないため、台帳に着かなかった受注でも呼び名を出す
+    const unlinked: Order = {
+      ...confirmedOrder,
+      customer_name: undefined,
+      contact_name: '重複照合の来客',
+    };
+    render(<OrderCompletionModal order={unlinked} onClose={jest.fn()} onCompleted={jest.fn()} />);
+
+    expect(await screen.findByText(/重複照合の来客（顧客未設定）/)).toBeInTheDocument();
+  });
+
   it('開いた時点の事前計算は会計金額 0 で取る', async () => {
     renderModal();
 

--- a/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrdersPage.test.tsx
@@ -149,6 +149,53 @@ describe('店側オーダー画面の描画', () => {
     expect(await screen.findByText('フリー')).toBeInTheDocument();
   });
 
+  it('顧客未設定の受注は録入された連絡先で呼ぶこと', async () => {
+    // 電話番号が同店で複数の顧客に一致すると自動照合は断念され、受注は顧客未設定で成立する。
+    // 台帳の顧客名が無いからと '-' で出すと、受付が録入した連絡先がどこにも見えなくなる。
+    mockedOrderApi.list.mockResolvedValue({
+      rows: [
+        {
+          id: '10',
+          business_date: '2026-08-12',
+          // customer_name は顧客未設定なのでキーごと応答から消える
+          contact_name: '重複照合の来客',
+          contact_phone_number: '09012345678',
+          status: 'CREATED',
+        },
+      ],
+      page: 0,
+      pageCount: 1,
+      total: 1,
+    });
+
+    render(<OrderListPage />);
+
+    expect(await screen.findByText('重複照合の来客')).toBeInTheDocument();
+    // 台帳に行を持たない申告のままの値なので、注記は他を説明する文字の体裁で添える
+    expect(screen.getByText('（顧客未設定）')).toHaveClass('text-muted-foreground');
+  });
+
+  it('連絡先が氏名を持たなければ電話番号で呼ぶこと', async () => {
+    mockedOrderApi.list.mockResolvedValue({
+      rows: [
+        {
+          id: '11',
+          business_date: '2026-08-12',
+          contact_phone_number: '09012345678',
+          status: 'CREATED',
+        },
+      ],
+      page: 0,
+      pageCount: 1,
+      total: 1,
+    });
+
+    render(<OrderListPage />);
+
+    expect(await screen.findByText('09012345678')).toBeInTheDocument();
+    expect(screen.getByText('（顧客未設定）')).toBeInTheDocument();
+  });
+
   it('オーダーが0件なら不在メッセージを表示すること', async () => {
     mockedOrderApi.list.mockResolvedValue({
       rows: [],

--- a/frontend/src/_pages/store-orders/lib/customerLabel.ts
+++ b/frontend/src/_pages/store-orders/lib/customerLabel.ts
@@ -1,0 +1,26 @@
+import { Order } from '@/entities/order';
+
+/** 台帳の顧客に着いていない受注の呼び名に添える注記。 */
+export const UNLINKED_NOTE = '（顧客未設定）';
+
+export interface OrderCustomerLabel {
+  /** 呼び名。台帳の顧客名か、それが無ければ受付で録入された連絡先（氏名、無ければ電話番号）。 */
+  name: string;
+  /** 呼び名が台帳の顧客名ではなく録入された連絡先であること。注記を添えるかの判定に使う。 */
+  unlinked: boolean;
+}
+
+/**
+ * 受注の顧客の呼び名。どちらも無ければ null で、空欄の出し方は呼び出し側が決める。
+ *
+ * 録入された連絡先と台帳の顧客名を呼び出し側が見分けられる形で返すのは、前者が台帳に行を持たない
+ * 申告のままの文字列だから。それでも出すのは、電話番号が同店で複数の顧客に一致した受注
+ * （自動照合を断念して顧客未設定で成立する）は、録入した連絡先を出さないと画面のどこにも現れないため。
+ */
+export function customerLabel(order: Order): OrderCustomerLabel | null {
+  if (order.customer_name) {
+    return { name: order.customer_name, unlinked: false };
+  }
+  const reported = order.contact_name || order.contact_phone_number;
+  return reported ? { name: reported, unlinked: true } : null;
+}

--- a/frontend/src/_pages/store-orders/ui/OrderCompletionModal.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderCompletionModal.tsx
@@ -5,6 +5,7 @@ import { useForm } from 'react-hook-form';
 import { notify } from '@/shared/notify';
 import { Order, OrderCompletionPreview, orderApi } from '@/entities/order';
 import { getApiErrorMessage, integerRule, useResource } from '@/shared/lib';
+import { UNLINKED_NOTE, customerLabel } from '../lib/customerLabel';
 import {
   Button,
   Dialog,
@@ -22,6 +23,18 @@ import {
 
 /** 空欄と 0 は別物なので、未入力の文言は 1 箇所に持って両方の規則から指す。 */
 const TOTAL_FEE_REQUIRED = '会計金額を入力してください';
+
+/**
+ * 見出しに出す顧客の呼び名。会計の相手が誰か分からないまま完了させないため、顧客未設定の受注も
+ * 録入された連絡先で呼ぶ。見出しの行はすでに全体が注記の体裁なので、注記だけを分けて装飾しない。
+ */
+function customerText(order: Order | null): string {
+  const label = order === null ? null : customerLabel(order);
+  if (label === null) {
+    return 'お客様名なし';
+  }
+  return label.unlinked ? `${label.name}${UNLINKED_NOTE}` : label.name;
+}
 
 interface OrderCompletionFormValues {
   /** 空欄は NaN。「未入力」と 0 円の会計を取り違えないため、valueAsNumber の写像をそのまま持つ。 */
@@ -137,7 +150,7 @@ export function OrderCompletionModal({ order, onClose, onCompleted }: OrderCompl
         <div className="border-b px-6 py-4">
           <DialogTitle>完了処理</DialogTitle>
           <p className="mt-1 text-sm text-muted-foreground">
-            {order?.business_date ?? '-'} / {order?.customer_name || 'お客様名なし'}
+            {order?.business_date ?? '-'} / {customerText(order)}
           </p>
         </div>
         <Form {...form}>

--- a/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
@@ -7,6 +7,7 @@ import { CircleCheckIcon, PlusIcon, SquarePenIcon } from 'lucide-react';
 import { ORDER_STATUS_LABELS, Order, OrderStatus, orderApi } from '@/entities/order';
 import { storePath, useListPage } from '@/shared/lib';
 import { ListPage } from '@/widgets/list-page';
+import { UNLINKED_NOTE, customerLabel } from '../lib/customerLabel';
 import { OrderCompletionModal } from './OrderCompletionModal';
 import { ReservationRequestInbox } from './ReservationRequestInbox';
 import {
@@ -39,6 +40,23 @@ const STATUS_BADGE_CLASS: Record<OrderStatus, string> = {
   COMPLETED: 'border-transparent bg-primary/10 text-primary-strong',
   CANCELLED: 'border-transparent bg-destructive/10 text-destructive-strong',
 };
+
+/**
+ * 一覧の「お客様名」欄。台帳の顧客名が無ければ受付で録入された連絡先で呼び、台帳に行を持たない
+ * 申告のままの値であることを注記で添える（注記は他を説明する文字なので muted）。
+ */
+function CustomerCell({ order }: { order: Order }) {
+  const label = customerLabel(order);
+  if (label === null) {
+    return <>-</>;
+  }
+  return (
+    <>
+      <span>{label.name}</span>
+      {label.unlinked && <span className="text-muted-foreground">{UNLINKED_NOTE}</span>}
+    </>
+  );
+}
 
 export default function OrderListPage() {
   const params = useParams();
@@ -93,7 +111,9 @@ export default function OrderListPage() {
             {orders.map(order => (
               <TableRow key={order.id}>
                 <TableCell className="text-muted-foreground">{order.business_date}</TableCell>
-                <TableCell className="text-foreground">{order.customer_name || '-'}</TableCell>
+                <TableCell className="text-foreground">
+                  <CustomerCell order={order} />
+                </TableCell>
                 <TableCell>
                   <Badge
                     variant="outline"

--- a/frontend/src/entities/order/model/types.ts
+++ b/frontend/src/entities/order/model/types.ts
@@ -59,6 +59,12 @@ export interface Order {
   requester_member_code?: string;
   location_address?: string;
   location_building?: string;
+  /**
+   * 受付で録入された連絡先。台帳の顧客に着かなかった受注にだけ残る（顧客が着いた受注では
+   * 台帳の行が連絡先を持つため、応答から消える）。
+   */
+  contact_name?: string;
+  contact_phone_number?: string;
 }
 
 export interface OrderReceptionist {


### PR DESCRIPTION
## 概要

受注録入の電話照合を `Optional` 受けから複数行許容（`List`）に変え、一致件数で 3 分岐させる。顧客に着かなかった受注には録入された連絡先を写して、入力が消えないようにする。

Closes #645

## 変更内容

- **照合の 3 分岐**（`OrderService.handleCustomerLinking`）: 0 件＝録入内容で顧客を起こして紐づけ / 1 件＝その顧客に紐づけ / 2 件以上＝自動照合を断念して顧客未設定のまま成立。判定は `size()` だけで行い、並べ替えも添字取り出しもしない
- **`CustomerRepository.findByPhoneNumberAndStoreId` を `List` 戻り**に（派生クエリのまま。索引 `idx_t_customers_phone` が非一意である事実を契約に反映）
- **連絡先の写し**: `t_orders` に `contact_name` / `contact_phone_number` を追加（release **v0.15.0**）。書き込みは `Order.recordContactIfUnlinked()` で、顧客参照を持つ集約自身が「着いていないこと」を判定する
- **契約の上限**: `customer_name` / `phone_number` に列と同じ上限（255 / 50）の `@Size` を追加
- **読み口**: `OrderView` / `OrderResponse` に載せ、一覧の「お客様名」欄と完了処理モーダルの見出しが写しで呼ぶ（注記 `（顧客未設定）` は muted）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task test-unit` / `task -d backend test-integration` をそれぞれ exit 0 で実行）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（24 passed。実行シナリオ: 既存の全 feature）
- [x] ローカルで code-review 実施済み（Standards / Spec の 2 軸）

赤→緑の実測:

- `OrderPhoneLinkingIT` を修正前に実行し、複数一致のケースが **500 INTERNAL_SERVER_ERROR** で失敗（他 2 分岐は緑）→ 修正後に 3 件とも緑
- 一覧・モーダルの表示 3 件は、`customerLabel` から写しの分岐を外すと **3 failed / 84 passed** になることを確認してから復元
- `@Size` の契約テストは、注釈を外すと単独で FAILED になることを確認

### 視覚確認（UI 変更時）

`task up` の実スタックで、同店同号の顧客 2 件を作ってから電話番号指定で受注を録入し、実ブラウザで確認（確認後に作成データは削除済み）:

- 一覧の「お客様名」欄: `重複照合の来客（顧客未設定）`。`getComputedStyle` で氏名 `lab(2.51 …)` / 注記 `lab(47.9 …)` と色が分かれており、注記が実際に `text-muted-foreground` で描かれていることを確認
- 完了処理モーダルの見出し: `2026-08-12 / 重複照合の来客（顧客未設定）`
- API 応答も実スタックで確認: 201・`customer_id` 不在・`contact_name` / `contact_phone_number` あり

（スクリーンショットは添付できないため、上記の実測値で代えています）

## 決定ログ

**追補（#645 のコメント）の二択のうち「受注側への連絡先の写しの保持」を採った。**

「店員の明示選択の要求（400）」を採らなかったのは、受注作成画面が `customer_id` を一切送らず（`OrderCreatePage.tsx`）、顧客一覧が `PERM_CUSTOMER_MANAGE` 限定であるため、`ORDER_MANAGE` だけを持つ受付には顧客を選ぶ手段が無いから。バックエンドだけで 400 に変えると、500 が「設計された行き止まり」に変わるだけになる。票の期待挙動（顧客未設定で成立）とも一致する。

**写す項目は氏名と電話番号の 2 つだけ。** ADR 0009 の文言（「録入された連絡先（氏名・電話番号）」）に合わせた。区分・目印・ペット・NG は 1 件一致の経路でも従来から捨てられており、本票の退行ではないので広げない。`phone_number2` は `OrderForm` に入力欄が無く常に未送信のため、同様に対象外とした。

**写しの条件は「照合が複数一致したか」ではなく「顧客が着いたか」。** 電話番号を録入しなかった（氏名だけの）受注も同じ根因で入力が消えるため、分岐ではなく結果で判定した。挙動は加算的で、従来落としていた値を残すだけ。

**`@Size` を足したのは、写しの行き先が増えたことによる新しい 500 を塞ぐため。** 従来「電話番号なし・氏名 256 文字以上」は氏名が捨てられて 201 になっていたが、写しを持つと挿入時に SQLSTATE 22001 になる。500 を消す票が別の 500 を生まないよう、契約で 400 にした（0 件一致の経路が持っていた同種の露出も同時に塞がる）。

**採らなかった案**（#640 の裁定どおり）: 「最新行を決定的に選ぶ」＝一致行に会員関連付きの行があり得るため誤帰属の入口。「同店同号を部分一意制約で禁じる」＝同伴者の連絡先共有・移行データを制約で頂き返す。

## 備考 / レビュー観点

- ADR 0009 は編集していない。写しの具体形はもともと ADR が実装に委ねており（「店員の明示選択を求めるか受注側に写しを残すか、具体の形は実装で決める」）、模型の裁定自体は変わらないため。採用理由はコミットメッセージと本 PR の決定ログに残す
- **`OrderUpdateRequest` に `customerId` が無く、成立後に顧客を手で指定する経路は今も存在しない**（既存の欠落）。票の「店員は必要なら手動で顧客を指定する」はこの PR では満たせないため、写しで入力を保全する形を採っている。手動指定が要るなら別票
- 完了処理モーダルの見出しにも写しを出しているのは、会計の相手を確認する画面で「お客様名なし」と出ると、追補が禁じた「入力が見えない」状態がそこで再現するため
