### PR TITLE
feat: 会員へ帰属しない完了に伝票トークンを発行し店舗の完了画面で QR 提示する

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/order/OrderReceiptTokenIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/OrderReceiptTokenIT.java
@@ -1,0 +1,314 @@
+package com.kizuna.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kizuna.order.domain.OrderReceiptToken;
+import com.kizuna.order.domain.OrderReceiptTokenRepository;
+import com.kizuna.order.domain.OrderReceiptTokenStatus;
+import com.kizuna.shared.CrossStoreTestSupport;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * 伝票トークンの発行を本物の PostgreSQL で検証する統合テスト。
+ *
+ * <p>固定するのは「会員へ帰属しなかった完了だけがトークンを得る」ことと、「保存されるのはダイジェストだけで生値はデータベースの
+ * どこにも残らない」こと。後者はバックアップや診断経路の露出が未申領クレデンシャルの漏えいにならないための条件で、 実データ（information_schema
+ * から辿る全文字列列）に対して直接確かめる。
+ *
+ * <p>シード設定は「100 円ごとに 1 ポイント付与、利用は 100 ポイント単位」。
+ */
+class OrderReceiptTokenIT extends CrossStoreTestSupport {
+
+  private static final String PASSWORD = "password1234";
+
+  /** v0.5.0 の山田次郎シード（STORE_STAFF・授権店舗 = 店舗1）。店舗A の受付担当として使用。 */
+  private static final long SEED_RECEPTIONIST_ID = 3L;
+
+  private static final int TOTAL_FEE = 12000;
+
+  /** シード設定（100 円ごとに 1 ポイント）を {@link #TOTAL_FEE} に当てた付与額。 */
+  private static final int EXPECTED_PLANNED_POINTS = 120;
+
+  @Autowired private OrderReceiptTokenRepository orderReceiptTokenRepository;
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  private final long nonce = System.nanoTime();
+
+  @Test
+  @DisplayName("会員へ帰属しなかった完了はトークンを発行し、生値を完了応答へ一度だけ返すこと")
+  void completionThatReachesNoMemberIssuesAReceiptToken() {
+    String orderId = confirmedOrder(createCustomer("非会員"), "非会員");
+
+    ResponseEntity<JsonNode> completed = complete(orderId, TOTAL_FEE);
+
+    assertThat(completed.getStatusCode()).isEqualTo(HttpStatus.OK);
+    String raw = completed.getBody().path("receipt_token").asString();
+    assertThat(raw).as("完了応答が生値を運ぶこと").isNotBlank();
+
+    OrderReceiptToken token = tokenOf(orderId);
+    assertThat(token.getPlannedPoints()).isEqualTo(EXPECTED_PLANNED_POINTS);
+    assertThat(token.getStatus()).isEqualTo(OrderReceiptTokenStatus.ISSUED);
+    assertThat(token.getExpiresAt()).isEqualTo(token.getIssuedAt().plusDays(90));
+
+    // 二度目は読み口から取れない。応答を逃した生値を後から拾える経路があってはならない
+    assertThat(get(orderId).getBody().has("receipt_token")).as("受注の読み口は生値を返さないこと").isFalse();
+  }
+
+  @Test
+  @DisplayName("顧客に着いていない受注（無帰属受注）の完了でもトークンが発行されること")
+  void completionOfAnOrderWithoutAnyCustomerIssuesAReceiptToken() {
+    // 発行対象は「会員へ帰属しなかった受注」で、顧客の有無は問わない
+    String orderId = confirmedOrder(null, "無帰属");
+
+    ResponseEntity<JsonNode> completed = complete(orderId, TOTAL_FEE);
+
+    assertThat(completed.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(completed.getBody().path("receipt_token").asString()).isNotBlank();
+    assertThat(tokenOf(orderId).getPlannedPoints()).isEqualTo(EXPECTED_PLANNED_POINTS);
+  }
+
+  @Test
+  @DisplayName("0 円完了の無帰属受注にも付与予定額 0 でトークンが発行されること")
+  void zeroFeeCompletionIssuesATokenWithNoPlannedPoints() {
+    // 申領の効果は来店の可視化に閉じる。発行しないと、0 円の来店だけ取り戻せない
+    String orderId = confirmedOrder(null, "0円無帰属");
+
+    ResponseEntity<JsonNode> completed = complete(orderId, 0);
+
+    assertThat(completed.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(completed.getBody().path("receipt_token").asString()).isNotBlank();
+    assertThat(tokenOf(orderId).getPlannedPoints()).isZero();
+  }
+
+  @Test
+  @DisplayName("会員へ帰属した完了ではトークンが発行されないこと")
+  void completionThatReachesAMemberIssuesNoReceiptToken() {
+    String memberCode = registerMember("attributed");
+    String customerId = createCustomer("会員帰属");
+    linkMember(customerId, memberCode);
+    String orderId = confirmedOrder(customerId, "会員帰属");
+
+    ResponseEntity<JsonNode> completed = complete(orderId, TOTAL_FEE);
+
+    assertThat(completed.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(completed.getBody().has("receipt_token")).as("会員へ帰属した完了は生値を返さないこと").isFalse();
+    assertThat(tokensOf(orderId)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("完了後に関連を解除しても、その受注へ遡ってトークンは発行されないこと")
+  void releasingTheLinkAfterCompletionIssuesNoTokenRetroactively() {
+    // 帰属は完了の瞬間に確定した不変の事実で、以後の関連の変化は過去の受注を書き換えない（ADR 0009）。
+    // 遡及発行があると、既に会員の履歴に載っている来店を別人が申領しに来られる
+    String memberCode = registerMember("retro");
+    String customerId = createCustomer("遡及なし");
+    linkMember(customerId, memberCode);
+    String orderId = confirmedOrder(customerId, "遡及なし");
+    assertThat(complete(orderId, TOTAL_FEE).getStatusCode())
+        .as("前提: 会員へ帰属する完了ができること")
+        .isEqualTo(HttpStatus.OK);
+
+    ResponseEntity<Void> unlinked =
+        rest.exchange(
+            "/store/customers/" + customerId + "/member-link",
+            HttpMethod.DELETE,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            Void.class);
+    assertThat(unlinked.getStatusCode().is2xxSuccessful()).as("前提: 関連を解除できること").isTrue();
+
+    assertThat(tokensOf(orderId)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("生値がデータベースのどの文字列列にも残らず、トークン行はダイジェストだけを持つこと")
+  void theRawTokenIsNotPersistedAnywhere() {
+    String remarks = "生値非永続-" + nonce;
+    String orderId = confirmedOrder(null, remarks);
+    String raw = complete(orderId, TOTAL_FEE).getBody().path("receipt_token").asString();
+    assertThat(raw).as("前提: 生値が完了応答に現れること").isNotBlank();
+
+    // 走査が実際に値を見つけられることを、確かに保存されている値で先に確かめる（不在の断言が
+    // 「探し方が悪くて見つからないだけ」に化けないため）
+    assertThat(columnsHoldingValue(remarks)).as("走査が保存済みの値を見つけること").contains("t_orders.remarks");
+
+    // トークン行そのものが生値を持たないこと（列名を先読みせず、行の全値を見る）
+    Map<String, Object> row =
+        jdbcTemplate.queryForMap(
+            "select * from t_order_receipt_tokens where order_id = ?", orderId);
+    assertThat(row.values())
+        .as("トークン行のどの列も生値を持たないこと")
+        .noneMatch(value -> raw.equals(String.valueOf(value)));
+    assertThat(row.get("token_digest")).as("照合の材料はダイジェストであること").isNotNull().isNotEqualTo(raw);
+
+    // 応答の経路（受注・台帳・監査）へ写し取られていないことを、全テーブルの文字列列に当たって確かめる
+    assertThat(columnsHoldingValue(raw)).as("生値を持つ列").isEmpty();
+  }
+
+  /** public スキーマの全文字列列を走査し、与えた値をそのまま持つ列を返す。 */
+  private List<String> columnsHoldingValue(String value) {
+    List<Map<String, Object>> columns =
+        jdbcTemplate.queryForList(
+            """
+            select c.table_name, c.column_name
+            from information_schema.columns c
+              join information_schema.tables t
+                on t.table_schema = c.table_schema and t.table_name = c.table_name
+            where c.table_schema = 'public'
+              and t.table_type = 'BASE TABLE'
+              and c.data_type in ('character varying', 'text', 'character')
+            """);
+    assertThat(columns).as("走査対象の文字列列が見つかること").isNotEmpty();
+    return columns.stream()
+        .filter(
+            column ->
+                jdbcTemplate.queryForObject(
+                        "select count(*) from public.\"%s\" where \"%s\" = ?"
+                            .formatted(column.get("table_name"), column.get("column_name")),
+                        Integer.class,
+                        value)
+                    > 0)
+        .map(column -> column.get("table_name") + "." + column.get("column_name"))
+        .toList();
+  }
+
+  // ==================== トークンの読み出し ====================
+
+  private OrderReceiptToken tokenOf(String orderId) {
+    List<OrderReceiptToken> found = tokensOf(orderId);
+    assertThat(found).as("受注 %s のトークンが 1 件だけ発行されること", orderId).hasSize(1);
+    return found.get(0);
+  }
+
+  private List<OrderReceiptToken> tokensOf(String orderId) {
+    return orderReceiptTokenRepository.findAll().stream()
+        .filter(row -> orderId.equals(row.getOrderId()))
+        .toList();
+  }
+
+  // ==================== 受注の用意 ====================
+
+  private String confirmedOrder(String customerId, String label) {
+    String castId = createCast(label);
+    String orderId = createOrder(castId, customerId, label);
+    assertThat(updateStatus(orderId, castId, "CONFIRMED")).as("前提: 受注を確定できること").isTrue();
+    return orderId;
+  }
+
+  private String createOrder(String castId, String customerId, String remarks) {
+    String body =
+        "{\"receptionist_id\": "
+            + SEED_RECEPTIONIST_ID
+            + ", \"business_date\": \""
+            + LocalDate.now()
+            + "\", \"cast_id\": \""
+            + castId
+            + "\""
+            + (customerId == null ? "" : ", \"customer_id\": \"" + customerId + "\"")
+            + ", \"remarks\": \""
+            + remarks
+            + "\"}";
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/store/orders", new HttpEntity<>(body, storeHeaders(STORE_A)), JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful()).as("前提: 受注作成が成功すること").isTrue();
+    return created.getBody().path("id").asString();
+  }
+
+  private boolean updateStatus(String orderId, String castId, String status) {
+    String body =
+        "{\"receptionist_id\": "
+            + SEED_RECEPTIONIST_ID
+            + ", \"cast_id\": \""
+            + castId
+            + "\", \"status\": \""
+            + status
+            + "\"}";
+    return rest.exchange(
+            "/store/orders/" + orderId,
+            HttpMethod.PUT,
+            new HttpEntity<>(body, storeHeaders(STORE_A)),
+            JsonNode.class)
+        .getStatusCode()
+        .is2xxSuccessful();
+  }
+
+  private String createCast(String name) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/store/casts",
+            new HttpEntity<>("{\"name\": \"" + name + "-" + nonce + "\"}", storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful()).as("前提: キャスト作成が成功すること").isTrue();
+    return created.getBody().path("id").asString();
+  }
+
+  private String createCustomer(String name) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/store/customers",
+            new HttpEntity<>("{\"name\": \"" + name + "-" + nonce + "\"}", storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful()).as("前提: 顧客作成が成功すること").isTrue();
+    return created.getBody().path("id").asString();
+  }
+
+  private ResponseEntity<JsonNode> complete(String orderId, int totalFee) {
+    return rest.exchange(
+        "/store/orders/" + orderId + "/completion",
+        HttpMethod.POST,
+        new HttpEntity<>("{\"total_fee\": " + totalFee + "}", storeHeaders(STORE_A)),
+        JsonNode.class);
+  }
+
+  private ResponseEntity<JsonNode> get(String orderId) {
+    return rest.exchange(
+        "/store/orders/" + orderId,
+        HttpMethod.GET,
+        new HttpEntity<>(storeHeaders(STORE_A)),
+        JsonNode.class);
+  }
+
+  // ==================== 会員・関連 ====================
+
+  private String registerMember(String prefix) {
+    String email = prefix + "-receipt-token-it-" + nonce + "-" + System.nanoTime() + "@kizuna.test";
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/platform/members",
+            new HttpEntity<>(
+                "{\"email\": \""
+                    + email
+                    + "\", \"password\": \""
+                    + PASSWORD
+                    + "\", \"display_name\": \"伝票トークン検証会員\"}",
+                headers),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).as("前提: 会員登録が成功すること").isEqualTo(HttpStatus.CREATED);
+    return res.getBody().path("member_code").asString();
+  }
+
+  private void linkMember(String customerId, String memberCode) {
+    ResponseEntity<JsonNode> linked =
+        rest.exchange(
+            "/store/customers/" + customerId + "/member-link",
+            HttpMethod.POST,
+            new HttpEntity<>("{\"member_code\": \"" + memberCode + "\"}", storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(linked.getStatusCode()).as("前提: 会員の紐づけが成功すること").isEqualTo(HttpStatus.OK);
+  }
+}

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderMapper.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderMapper.java
@@ -15,6 +15,8 @@ public interface OrderMapper {
   // ==================== View(projection) -> Response ====================
 
   /** 読み側 projection をレスポンスDTOに変換します。 */
+  // 伝票トークンの生値は保存されず読み側にも存在しない。完了処理だけが応答へ載せる
+  @Mapping(target = "receiptToken", ignore = true)
   OrderResponse toResponse(OrderView view);
 
   /** 平台横断一覧の projection をレスポンスDTOに変換します（集合作用域）。 */

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderResponse.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderResponse.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @Builder
@@ -44,4 +45,11 @@ public class OrderResponse {
   private String requesterMemberCode; // 申請した会員（店舗が起こした受注では null）
   private String locationAddress;
   private String locationBuilding;
+
+  /**
+   * 発行された伝票トークンの生値。会員へ帰属しなかった完了の<b>応答にだけ</b>現れ、他の読み口では常に null。
+   *
+   * <p>保存されるのはダイジェストだけなので、この応答を取り逃すと生値は二度と手に入らない。診断出力へ滲ませないため {@code toString()} からも外す。
+   */
+  @ToString.Exclude private String receiptToken;
 }

--- a/backend/src/main/java/com/kizuna/order/application/OrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderService.java
@@ -19,9 +19,12 @@ import com.kizuna.order.domain.IllegalOrderStateTransitionException;
 import com.kizuna.order.domain.Order;
 import com.kizuna.order.domain.OrderAttribution;
 import com.kizuna.order.domain.OrderAttributionRepository;
+import com.kizuna.order.domain.OrderReceiptToken;
+import com.kizuna.order.domain.OrderReceiptTokenRepository;
 import com.kizuna.order.domain.OrderRepository;
 import com.kizuna.order.domain.OrderStatus;
 import com.kizuna.order.domain.OrderView;
+import com.kizuna.order.infrastructure.ReceiptTokenGenerator;
 import com.kizuna.point.application.PointLedgerService;
 import com.kizuna.shared.exception.DbConstraint;
 import com.kizuna.shared.exception.NotFoundException;
@@ -61,6 +64,8 @@ public class OrderService {
 
   private final OrderRepository orderRepository;
   private final OrderAttributionRepository orderAttributionRepository;
+  private final OrderReceiptTokenRepository orderReceiptTokenRepository;
+  private final ReceiptTokenGenerator receiptTokenGenerator;
   private final CustomerRepository customerRepository;
   private final CustomerMemberLinkRepository customerMemberLinkRepository;
   private final NominatableCastLookup nominatableCast;
@@ -295,6 +300,9 @@ public class OrderService {
    *
    * <p>会員に達した完了は、記帳と同一トランザクションで受注帰属記録（根拠 COMPLETION）を残す。会員の来店履歴はこの記録だけから読むため、
    * ここで記録が生まれない受注はその会員から永久に見えない。
+   *
+   * <p>会員に達しなかった完了（顧客の有無は問わない）は、代わりに伝票トークンを発行して生値を応答で一度だけ返す。 事後帰属の証明はこのトークンの所持だけであり（ADR
+   * 0008）、この応答を逃した客に v1 の救済経路は無い。
    */
   @StoreScoped
   @Transactional
@@ -326,6 +334,7 @@ public class OrderService {
     }
 
     int granted = 0;
+    String receiptToken = null;
     if (memberId != null) {
       Long actorId = resolveActorId(actorEmail);
       // 単位の制約と残高の充足は台帳側が判定する（利用の入口が増えても規則が分かれないため）。
@@ -340,11 +349,35 @@ public class OrderService {
       // 関連時点の値がそのまま帰属時点の値であり、会員行が消えた後も誰の来店だったかを読めるようにする。
       orderAttributionRepository.save(
           OrderAttribution.onCompletion(id, memberId, link.getMemberCode(), OffsetDateTime.now()));
+    } else {
+      receiptToken = issueReceiptToken(id, request.getTotalFee());
     }
 
     order.completeWith(request.getTotalFee(), usePoints, granted);
     orderRepository.save(order);
-    return toResponse(id);
+    OrderResponse response = toResponse(id);
+    // 生値がこの応答の外へ出る経路は無い（保存されるのはダイジェストだけ）。会員へ帰属した完了では null。
+    response.setReceiptToken(receiptToken);
+    return response;
+  }
+
+  /**
+   * 会員へ帰属しなかった完了に伝票トークンを発行し、生値を返す。顧客の有無は問わない — 顧客に着いていても関連の無い受注は 会員から見えず、事後帰属の対象になる。
+   *
+   * <p>付与予定額はこの時点の付与規則で確定して持つ。申領時点の設定を読むと、同じ会計が申領の早い遅いで別のポイントになる。 0
+   * 円完了にも予定額0で発行する（申領の効果は来店の可視化に閉じる）。
+   *
+   * <p>保存するのはダイジェストだけで、生値はここから返る応答にしか現れない。
+   */
+  private String issueReceiptToken(String orderId, int totalFee) {
+    ReceiptTokenGenerator.GeneratedToken generated = receiptTokenGenerator.generate();
+    orderReceiptTokenRepository.save(
+        OrderReceiptToken.issueFor(
+            orderId,
+            generated.digest(),
+            pointLedgerService.previewGrant(totalFee),
+            OffsetDateTime.now()));
+    return generated.raw();
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/order/domain/InvalidOrderReceiptTokenException.java
+++ b/backend/src/main/java/com/kizuna/order/domain/InvalidOrderReceiptTokenException.java
@@ -1,0 +1,11 @@
+package com.kizuna.order.domain;
+
+import com.kizuna.shared.exception.ServiceException;
+
+/** 伝票トークンの不変条件に違反したことを表すドメイン例外。ServiceException 継承により HTTP 400 で応答される。 */
+public class InvalidOrderReceiptTokenException extends ServiceException {
+
+  public InvalidOrderReceiptTokenException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/com/kizuna/order/domain/OrderReceiptToken.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderReceiptToken.java
@@ -1,0 +1,103 @@
+package com.kizuna.order.domain;
+
+import com.kizuna.shared.persistence.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 完了時に会員へ帰属しなかった受注へ発行する、事後帰属のためのワンタイムの伝票トークン。所持そのものが証明となるため、 受注 ID のように列挙できる値では代替できない（受注 ID
+ * は時刻順で辿れて秘密ではない）。
+ *
+ * <p>この行が持つのは<b>ダイジェストだけ</b>で、生値は発行の応答で一度返るきり残らない。照合はダイジェストで行うため、
+ * バックアップや診断経路が未申領のクレデンシャルの漏えい経路にならない。
+ *
+ * <p>{@code plannedPoints} は完了時点の付与規則で確定した固定値。申領時点の設定は読まない — 同じ会計が申領の早い遅いで 別のポイントになることを許さないためで、0
+ * 円完了にも 0 として発行する（申領の効果は来店の可視化に閉じる）。
+ *
+ * <p>帰属記録（{@link OrderAttribution}）と同じく platform 帰属で、店舗行分離機構には載せない — 申領するのは店舗文脈を
+ * 持たない会員本人であり、店舗で絞ると照合そのものが成立しない。
+ *
+ * <p>不変条件（構築時に検証、違反は 400 系ドメイン例外 {@link InvalidOrderReceiptTokenException}）: 受注 ID・ダイジェスト・発行時刻が必須で、
+ * 付与予定額は非負、構築直後は必ず ISSUED。
+ */
+@Entity
+@Table(name = "t_order_receipt_tokens")
+@Getter
+@NoArgsConstructor
+public class OrderReceiptToken extends BaseEntity {
+
+  /** 申領期限（発行から）。予約の先読み上限（90 日）と対称の固定値。 */
+  public static final Duration VALIDITY = Duration.ofDays(90);
+
+  @Column(name = "order_id", nullable = false, updatable = false, length = 64)
+  private String orderId;
+
+  /** 生値の鍵付きハッシュ。生値そのものはどこにも永続化しない。 */
+  @Column(name = "token_digest", nullable = false, updatable = false, unique = true, length = 64)
+  private String tokenDigest;
+
+  /** 完了時点の付与規則で確定した付与予定額。申領時に記帳する額であり、以後の設定変更に影響されない。 */
+  @Column(name = "planned_points", nullable = false, updatable = false)
+  private int plannedPoints;
+
+  @Column(name = "issued_at", nullable = false, updatable = false)
+  private OffsetDateTime issuedAt;
+
+  @Column(name = "expires_at", nullable = false, updatable = false)
+  private OffsetDateTime expiresAt;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false, length = 20)
+  private OrderReceiptTokenStatus status;
+
+  private OrderReceiptToken(
+      String orderId, String tokenDigest, int plannedPoints, OffsetDateTime issuedAt) {
+    if (orderId == null || orderId.isBlank()) {
+      throw new InvalidOrderReceiptTokenException("受注 ID は必須です");
+    }
+    if (tokenDigest == null || tokenDigest.isBlank()) {
+      throw new InvalidOrderReceiptTokenException("トークンのダイジェストは必須です");
+    }
+    if (plannedPoints < 0) {
+      throw new InvalidOrderReceiptTokenException("付与予定額は 0 以上です");
+    }
+    if (issuedAt == null) {
+      throw new InvalidOrderReceiptTokenException("発行の日時は必須です");
+    }
+    this.orderId = orderId;
+    this.tokenDigest = tokenDigest;
+    this.plannedPoints = plannedPoints;
+    this.issuedAt = issuedAt;
+    this.expiresAt = issuedAt.plus(VALIDITY);
+    this.status = OrderReceiptTokenStatus.ISSUED;
+  }
+
+  /** 完了時の発行。申領期限は発行時刻から数える。 */
+  public static OrderReceiptToken issueFor(
+      String orderId, String tokenDigest, int plannedPoints, OffsetDateTime issuedAt) {
+    return new OrderReceiptToken(orderId, tokenDigest, plannedPoints, issuedAt);
+  }
+
+  /** 生値もダイジェストも載せない。診断出力がクレデンシャルの漏えい経路にならないようにする。 */
+  @Override
+  public String toString() {
+    return "OrderReceiptToken(id="
+        + getId()
+        + ", orderId="
+        + orderId
+        + ", plannedPoints="
+        + plannedPoints
+        + ", expiresAt="
+        + expiresAt
+        + ", status="
+        + status
+        + ")";
+  }
+}

--- a/backend/src/main/java/com/kizuna/order/domain/OrderReceiptTokenRepository.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderReceiptTokenRepository.java
@@ -1,0 +1,5 @@
+package com.kizuna.order.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderReceiptTokenRepository extends JpaRepository<OrderReceiptToken, Long> {}

--- a/backend/src/main/java/com/kizuna/order/domain/OrderReceiptTokenStatus.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderReceiptTokenStatus.java
@@ -1,0 +1,9 @@
+package com.kizuna.order.domain;
+
+/** 伝票トークンの状態。申領の成立はこの遷移そのものが表し、前提状態の消滅が申領の再送を遮断する。 */
+public enum OrderReceiptTokenStatus {
+  /** 発行済み・未申領。期限内であれば事後帰属に使える。 */
+  ISSUED,
+  /** 申領済み。同じトークンで二度目の帰属は成立しない。 */
+  CLAIMED
+}

--- a/backend/src/main/java/com/kizuna/order/infrastructure/ReceiptTokenGenerator.java
+++ b/backend/src/main/java/com/kizuna/order/infrastructure/ReceiptTokenGenerator.java
@@ -1,0 +1,75 @@
+package com.kizuna.order.infrastructure;
+
+import com.kizuna.shared.config.AppProperties;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.stereotype.Component;
+
+/**
+ * 伝票トークンの生値の生成と、保存・照合に使う鍵付きダイジェストの算出。
+ *
+ * <p>生値は暗号学的擬似乱数 32 バイト。推測・列挙できないことが所持を証明と認める根拠そのものであり、 桁数を削ると帰属の成立要件そのものが緩む。
+ *
+ * <p>ダイジェストが鍵付き（HMAC）なのは、データベースだけを手に入れた者が候補を総当たりしても未申領のトークンへ 到達できないようにするため。鍵はアプリケーションの対称秘密（{@code
+ * app.jwt.secret}）から用途ラベル付きで 派生させる — 用途ごとに独立した鍵になり、この鍵で JWT を、JWT の鍵でトークンを偽造することはできない。 秘密が 32
+ * バイト以上であることは JWT 側の鍵組み立てが起動時に検証しており、満たさない秘密ではそもそも起動しない。
+ *
+ * <p><b>運用上の帰結</b>: {@code APP_JWT_SECRET} を交換すると既存のダイジェストは二度と一致せず、未申領の伝票トークンは
+ * すべて申領不能になる。配り直す口も人手で申領を通す口も無いため、秘密の交換は 未申領分を捨てる決定と同義になる。
+ */
+@Component
+public class ReceiptTokenGenerator {
+
+  private static final String ALGORITHM = "HmacSHA256";
+
+  /** 鍵の用途ラベル。別用途の鍵と衝突させないための定数で、変えると既存のダイジェストが一致しなくなる。 */
+  private static final String KEY_PURPOSE = "kizuna:order-receipt-token-digest:v1";
+
+  private static final int TOKEN_BYTES = 32;
+
+  private final SecretKey digestKey;
+
+  private final SecureRandom random = new SecureRandom();
+
+  public ReceiptTokenGenerator(AppProperties appProperties) {
+    this.digestKey =
+        new SecretKeySpec(
+            hmac(
+                new SecretKeySpec(
+                    appProperties.getJwtSecret().getBytes(StandardCharsets.UTF_8), ALGORITHM),
+                KEY_PURPOSE),
+            ALGORITHM);
+  }
+
+  /** 発行 1 回分の生値とそのダイジェスト。生値は呼出側が応答へ載せるためだけに存在し、保存してはならない。 */
+  public record GeneratedToken(String raw, String digest) {}
+
+  /** 新しい伝票トークンを生成する。同じ生値が二度出ることは実質的に無い。 */
+  public GeneratedToken generate() {
+    byte[] bytes = new byte[TOKEN_BYTES];
+    random.nextBytes(bytes);
+    String raw = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    return new GeneratedToken(raw, digest(raw));
+  }
+
+  /** 提示された生値のダイジェスト。保存された値との照合はこの写像を通して行う（生値の比較は存在しない）。 */
+  public String digest(String raw) {
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(hmac(digestKey, raw));
+  }
+
+  private static byte[] hmac(SecretKey key, String message) {
+    try {
+      Mac mac = Mac.getInstance(ALGORITHM);
+      mac.init(key);
+      return mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
+    } catch (GeneralSecurityException e) {
+      // HmacSHA256 は JCA の必須アルゴリズムで、鍵も自前で組み立てている。ここへ来るのは実装欠陥。
+      throw new IllegalStateException("伝票トークンのダイジェストを算出できません", e);
+    }
+  }
+}

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -47,6 +47,9 @@ databaseChangeLog:
   - include:
       file: releases/v0.16.0/master.yaml
       relativeToChangelogFile: true
+  - include:
+      file: releases/v0.17.0/master.yaml
+      relativeToChangelogFile: true
   # reconcile/ は版に属さない恒久的な写像取り直しで、必ず全 release の後に置く（毎回実行されるため、
   # ロールの改名など release 側の移行より先に走ると、移行前の状態を見て齟齬と判定してしまう）。
   # 新しい release の include は必ずこの include より前に足すこと。

--- a/backend/src/main/resources/db/changelog/releases/v0.17.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.17.0/master.yaml
@@ -1,0 +1,5 @@
+# v0.17.0 = 伝票トークン（事後帰属の所持証明）。platform 層のみ。
+databaseChangeLog:
+  - include:
+      file: platform/01-order-receipt-token.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.17.0/platform/01-order-receipt-token.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.17.0/platform/01-order-receipt-token.yaml
@@ -1,0 +1,103 @@
+databaseChangeLog:
+  - changeSet:
+      id: platform-v01700-001-order-receipt-token
+      author: kanghouchao
+      # 完了時に会員へ帰属しなかった受注へ発行するワンタイムの伝票トークン。所持そのものが事後帰属の証明に
+      # なるため、受注 ID のように列挙できる値では代替できない。
+      # 保存するのは鍵付きハッシュ（token_digest）だけで、生値は完了応答で一度返るきりどこにも残らない —
+      # バックアップや診断経路が未申領クレデンシャルの漏えい経路にならないようにする。
+      # planned_points は完了時点の付与規則で確定した固定値で、申領時点の設定は読まない（同じ会計が申領の
+      # 早い遅いで別のポイントになることを許さない）。0 円完了にも 0 で発行する。
+      # 帰属記録（t_order_attributions）と同じく platform 帰属とし店舗行分離機構には載せない — 申領するのは
+      # 店舗文脈を持たない会員本人であり、店舗で絞ると照合そのものが成立しない。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - createTable:
+            tableName: t_order_receipt_tokens
+            remarks: 事後帰属のためのワンタイム伝票トークン（保存はダイジェストのみ）
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_t_order_receipt_tokens
+              - column:
+                  name: order_id
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+                  remarks: トークンが指す受注
+              - column:
+                  name: token_digest
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uq_t_order_receipt_tokens_digest
+                  remarks: 生値の鍵付きハッシュ（照合はこの値で行う。生値は保存しない）
+              - column:
+                  name: planned_points
+                  type: INT
+                  constraints:
+                    nullable: false
+                  remarks: 完了時点の付与規則で確定した付与予定額（申領時に記帳する固定値）
+              - column:
+                  name: issued_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints:
+                    nullable: false
+                  remarks: 発行の日時
+              - column:
+                  name: expires_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints:
+                    nullable: false
+                  remarks: 申領期限（発行から 90 日）
+              - column:
+                  name: status
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+                  remarks: 状態（ISSUED=発行済み・未申領 / CLAIMED=申領済み）
+              - column:
+                  name: created_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン
+        # 受注へは CASCADE。帰属記録と同じ判断で、削除できる店舗は準備中に限られ完了受注を持たないため、
+        # 実履歴が消える経路は無い。
+        - addForeignKeyConstraint:
+            constraintName: fk_t_order_receipt_tokens_order
+            baseTableName: t_order_receipt_tokens
+            baseColumnNames: order_id
+            referencedTableName: t_orders
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - createIndex:
+            indexName: idx_t_order_receipt_tokens_order
+            tableName: t_order_receipt_tokens
+            columns:
+              - column:
+                  name: order_id
+      rollback:
+        - dropTable:
+            tableName: t_order_receipt_tokens

--- a/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
@@ -39,10 +39,14 @@ import com.kizuna.order.domain.OrderAttributionRepository;
 import com.kizuna.order.domain.OrderAttributionSource;
 import com.kizuna.order.domain.OrderAttributionStatus;
 import com.kizuna.order.domain.OrderPatch;
+import com.kizuna.order.domain.OrderReceiptToken;
+import com.kizuna.order.domain.OrderReceiptTokenRepository;
+import com.kizuna.order.domain.OrderReceiptTokenStatus;
 import com.kizuna.order.domain.OrderRepository;
 import com.kizuna.order.domain.OrderStatus;
 import com.kizuna.order.domain.OrderView;
 import com.kizuna.order.domain.ReceptionRoute;
+import com.kizuna.order.infrastructure.ReceiptTokenGenerator;
 import com.kizuna.point.application.PointLedgerService;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
@@ -84,6 +88,8 @@ class OrderServiceTest {
   @Mock CustomerRepository customerRepository;
   @Mock CustomerMemberLinkRepository customerMemberLinkRepository;
   @Mock OrderAttributionRepository orderAttributionRepository;
+  @Mock OrderReceiptTokenRepository orderReceiptTokenRepository;
+  @Mock ReceiptTokenGenerator receiptTokenGenerator;
   @Mock NominatableCastLookup nominatableCast;
   @Mock ConfirmedShiftLookupService confirmedShiftLookupService;
   @Mock PointLedgerService pointLedgerService;
@@ -1416,13 +1422,16 @@ class OrderServiceTest {
     Order order = Order.builder().status(OrderStatus.CONFIRMED).castId("cast-1").build();
     order.setStoreId(STORE_ID);
     when(orderRepository.findById("o1")).thenReturn(Optional.of(order));
+    stubReceiptTokenIssuance();
     stubReservationRequestUpdateResponse();
 
     service.complete("o1", completion(12000, null), "staff@kizuna.test");
 
     assertThat(order.getStatus()).isEqualTo(OrderStatus.COMPLETED);
     assertThat(order.getAutoGrantPoints()).isZero();
-    verifyNoInteractions(pointLedgerService);
+    // 台帳へは何も積まない（付与予定額の算定で規則は読むが、書き込みは起きない）
+    verify(pointLedgerService, never()).grantForOrder(anyLong(), any(), any(), anyInt(), any());
+    verify(pointLedgerService, never()).useForOrder(anyLong(), any(), any(), anyInt(), any());
     // 顧客が未設定なら押さえる行も引く紐づけも無い
     verify(customerRepository, never()).findByIdForUpdate(any());
     verify(customerMemberLinkRepository, never()).findByCustomerIdAndStatus(any(), any());
@@ -1470,6 +1479,7 @@ class OrderServiceTest {
     when(orderRepository.findById("o1")).thenReturn(Optional.of(order));
     when(customerMemberLinkRepository.findByCustomerIdAndStatus("cust-1", LinkStatus.ACTIVE))
         .thenReturn(Optional.empty());
+    stubReceiptTokenIssuance();
     stubReservationRequestUpdateResponse();
 
     service.complete("o1", completion(12000, null), "staff@kizuna.test");
@@ -1491,19 +1501,107 @@ class OrderServiceTest {
             .build();
     order.setStoreId(STORE_ID);
     when(orderRepository.findById("o1")).thenReturn(Optional.of(order));
+    stubReceiptTokenIssuance();
     stubReservationRequestUpdateResponse();
 
     service.complete("o1", completion(12000, null), "staff@kizuna.test");
 
     assertThat(order.getStatus()).isEqualTo(OrderStatus.COMPLETED);
     verifyNoInteractions(orderAttributionRepository);
-    verifyNoInteractions(pointLedgerService);
+    verify(pointLedgerService, never()).grantForOrder(anyLong(), any(), any(), anyInt(), any());
   }
 
   private OrderAttribution savedAttribution() {
     ArgumentCaptor<OrderAttribution> captor = ArgumentCaptor.forClass(OrderAttribution.class);
     verify(orderAttributionRepository).save(captor.capture());
     return captor.getValue();
+  }
+
+  // ==================== 伝票トークンの発行 ====================
+
+  private static final String RAW_TOKEN = "raw-receipt-token";
+  private static final String TOKEN_DIGEST = "digest-of-the-raw-receipt-token";
+
+  /** 発行される生値とダイジェスト。乱数と鍵派生そのものは {@code ReceiptTokenGeneratorTest} が固定する。 */
+  private void stubReceiptTokenIssuance() {
+    lenient()
+        .when(receiptTokenGenerator.generate())
+        .thenReturn(new ReceiptTokenGenerator.GeneratedToken(RAW_TOKEN, TOKEN_DIGEST));
+  }
+
+  private OrderReceiptToken savedReceiptToken() {
+    ArgumentCaptor<OrderReceiptToken> captor = ArgumentCaptor.forClass(OrderReceiptToken.class);
+    verify(orderReceiptTokenRepository).save(captor.capture());
+    return captor.getValue();
+  }
+
+  @Test
+  void completeOfAnOrderThatReachedNoMemberIssuesAReceiptToken() {
+    // 事後帰属の証明は所持だけ（受注 ID は列挙できるので証明にならない）。ここで発行しないと、
+    // 会員と分からないまま完了した来店を本人が取り戻す経路が無い
+    Order order = confirmedOrderWithCustomer();
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(order));
+    when(customerMemberLinkRepository.findByCustomerIdAndStatus("cust-1", LinkStatus.ACTIVE))
+        .thenReturn(Optional.empty());
+    when(pointLedgerService.previewGrant(12000)).thenReturn(120);
+    stubReceiptTokenIssuance();
+    stubReservationRequestUpdateResponse();
+
+    OrderResponse response = service.complete("o1", completion(12000, null), "staff@kizuna.test");
+
+    OrderReceiptToken token = savedReceiptToken();
+    assertThat(token.getOrderId()).isEqualTo("o1");
+    // 保存するのはダイジェストだけ。生値はこの応答にしか現れない
+    assertThat(token.getTokenDigest()).isEqualTo(TOKEN_DIGEST);
+    assertThat(token.getStatus()).isEqualTo(OrderReceiptTokenStatus.ISSUED);
+    assertThat(token.getExpiresAt()).isEqualTo(token.getIssuedAt().plusDays(90));
+    assertThat(response.getReceiptToken()).isEqualTo(RAW_TOKEN);
+  }
+
+  @Test
+  void completeFreezesThePlannedPointsAtTheCompletionTimeRule() {
+    // 申領時点の設定を読むと、同じ会計が申領の早い遅いで別のポイントになる
+    Order order = Order.builder().status(OrderStatus.CONFIRMED).castId("cast-1").build();
+    order.setStoreId(STORE_ID);
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(order));
+    when(pointLedgerService.previewGrant(12000)).thenReturn(120);
+    stubReceiptTokenIssuance();
+    stubReservationRequestUpdateResponse();
+
+    service.complete("o1", completion(12000, null), "staff@kizuna.test");
+
+    assertThat(savedReceiptToken().getPlannedPoints()).isEqualTo(120);
+  }
+
+  @Test
+  void completeOfAZeroFeeOrderStillIssuesAReceiptToken() {
+    // 付与が 0 でも来店の事実は取り戻せなければならない（申領の効果は来店の可視化に閉じる）
+    Order order = Order.builder().status(OrderStatus.CONFIRMED).castId("cast-1").build();
+    order.setStoreId(STORE_ID);
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(order));
+    when(pointLedgerService.previewGrant(0)).thenReturn(0);
+    stubReceiptTokenIssuance();
+    stubReservationRequestUpdateResponse();
+
+    OrderResponse response = service.complete("o1", completion(0, null), "staff@kizuna.test");
+
+    assertThat(savedReceiptToken().getPlannedPoints()).isZero();
+    assertThat(response.getReceiptToken()).isEqualTo(RAW_TOKEN);
+  }
+
+  @Test
+  void completeOfAMemberOrderIssuesNoReceiptToken() {
+    // 会員へ帰属した完了に事後帰属の余地は無い。発行すると、その受注を別の会員が申領しに来る口を開ける
+    Order order = confirmedOrderWithCustomer();
+    when(orderRepository.findById("o1")).thenReturn(Optional.of(order));
+    stubActiveLink(MEMBER_ID);
+    stubActor();
+    stubReservationRequestUpdateResponse();
+
+    OrderResponse response = service.complete("o1", completion(12000, null), "staff@kizuna.test");
+
+    verifyNoInteractions(orderReceiptTokenRepository, receiptTokenGenerator);
+    assertThat(response.getReceiptToken()).isNull();
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/order/domain/OrderReceiptTokenTest.java
+++ b/backend/src/test/java/com/kizuna/order/domain/OrderReceiptTokenTest.java
@@ -1,0 +1,76 @@
+package com.kizuna.order.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OrderReceiptTokenTest {
+
+  private static final OffsetDateTime ISSUED_AT = OffsetDateTime.parse("2026-08-12T19:00:00Z");
+
+  private static final String DIGEST = "ZGlnZXN0LW9mLXRoZS1yYXctdG9rZW4";
+
+  @Test
+  @DisplayName("発行されたトークンは未申領で、申領期限を発行から 90 日後に持つこと")
+  void issuedTokenExpiresNinetyDaysAfterIssuance() {
+    OrderReceiptToken token = OrderReceiptToken.issueFor("o1", DIGEST, 120, ISSUED_AT);
+
+    assertThat(token.getOrderId()).isEqualTo("o1");
+    assertThat(token.getTokenDigest()).isEqualTo(DIGEST);
+    assertThat(token.getPlannedPoints()).isEqualTo(120);
+    assertThat(token.getIssuedAt()).isEqualTo(ISSUED_AT);
+    assertThat(token.getExpiresAt()).isEqualTo(ISSUED_AT.plusDays(90));
+    assertThat(token.getStatus()).isEqualTo(OrderReceiptTokenStatus.ISSUED);
+  }
+
+  @Test
+  @DisplayName("0 円完了の無帰属受注にも付与予定額 0 で発行できること")
+  void zeroPlannedPointsIsIssuable() {
+    // 申領の効果は来店の可視化に閉じる。付与が 0 でも発行しないと、その来店を取り戻す経路が無い
+    assertThat(OrderReceiptToken.issueFor("o1", DIGEST, 0, ISSUED_AT).getPlannedPoints()).isZero();
+  }
+
+  @Test
+  @DisplayName("受注 ID の無いトークンは発行できないこと")
+  void missingOrderIdIsRejected() {
+    assertThatThrownBy(() -> OrderReceiptToken.issueFor(" ", DIGEST, 120, ISSUED_AT))
+        .isInstanceOf(InvalidOrderReceiptTokenException.class)
+        .hasMessageContaining("受注 ID");
+  }
+
+  @Test
+  @DisplayName("ダイジェストの無いトークンは発行できないこと（照合の術が無くなる）")
+  void missingDigestIsRejected() {
+    assertThatThrownBy(() -> OrderReceiptToken.issueFor("o1", " ", 120, ISSUED_AT))
+        .isInstanceOf(InvalidOrderReceiptTokenException.class)
+        .hasMessageContaining("ダイジェスト");
+  }
+
+  @Test
+  @DisplayName("負の付与予定額は発行できないこと")
+  void negativePlannedPointsIsRejected() {
+    assertThatThrownBy(() -> OrderReceiptToken.issueFor("o1", DIGEST, -1, ISSUED_AT))
+        .isInstanceOf(InvalidOrderReceiptTokenException.class)
+        .hasMessageContaining("付与予定額");
+  }
+
+  @Test
+  @DisplayName("発行時刻の無いトークンは発行できないこと（期限を数える起点が無くなる）")
+  void missingIssuedAtIsRejected() {
+    assertThatThrownBy(() -> OrderReceiptToken.issueFor("o1", DIGEST, 120, null))
+        .isInstanceOf(InvalidOrderReceiptTokenException.class)
+        .hasMessageContaining("発行の日時");
+  }
+
+  @Test
+  @DisplayName("診断出力にダイジェストが載らないこと")
+  void toStringOmitsTheDigest() {
+    // 生値は元より持たないが、ダイジェストも照合の鍵そのもの。ログへ流れると保存を絞った意味が消える
+    assertThat(OrderReceiptToken.issueFor("o1", DIGEST, 120, ISSUED_AT).toString())
+        .doesNotContain(DIGEST)
+        .contains("o1");
+  }
+}

--- a/backend/src/test/java/com/kizuna/order/infrastructure/ReceiptTokenGeneratorTest.java
+++ b/backend/src/test/java/com/kizuna/order/infrastructure/ReceiptTokenGeneratorTest.java
@@ -1,0 +1,92 @@
+package com.kizuna.order.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kizuna.order.infrastructure.ReceiptTokenGenerator.GeneratedToken;
+import com.kizuna.shared.config.AppProperties;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.IntStream;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ReceiptTokenGeneratorTest {
+
+  private static final String SECRET = "receipt-token-test-secret-0123456789";
+
+  private static ReceiptTokenGenerator generatorWithSecret(String secret) {
+    AppProperties properties = new AppProperties();
+    properties.getJwt().setSecret(secret);
+    return new ReceiptTokenGenerator(properties);
+  }
+
+  @Test
+  @DisplayName("生値は 256 ビットの乱数で、生成のたびに異なること")
+  void rawTokensCarryFullEntropyAndNeverRepeat() {
+    // 推測・列挙できないことが所持を証明と認める根拠そのもの。桁を削ると帰属の成立要件が緩む
+    ReceiptTokenGenerator generator = generatorWithSecret(SECRET);
+
+    Set<String> raws = new HashSet<>();
+    IntStream.range(0, 100).forEach(i -> raws.add(generator.generate().raw()));
+
+    assertThat(raws).hasSize(100);
+    assertThat(Base64.getUrlDecoder().decode(raws.iterator().next())).hasSize(32);
+  }
+
+  @Test
+  @DisplayName("保存される値が生値そのものではないこと")
+  void theStoredDigestIsNotTheRawToken() {
+    GeneratedToken generated = generatorWithSecret(SECRET).generate();
+
+    assertThat(generated.digest()).isNotEqualTo(generated.raw()).doesNotContain(generated.raw());
+    assertThat(Base64.getUrlDecoder().decode(generated.digest())).hasSize(32);
+  }
+
+  @Test
+  @DisplayName("発行のダイジェストが、同じ生値を後から照合したときと一致すること")
+  void theIssuedDigestMatchesTheDigestOfThePresentedRawToken() {
+    // 申領はダイジェストで照合する。再現しなければ、正しいトークンを持つ本人が誰も申領できない
+    ReceiptTokenGenerator generator = generatorWithSecret(SECRET);
+    GeneratedToken generated = generator.generate();
+
+    assertThat(generator.digest(generated.raw())).isEqualTo(generated.digest());
+    // 鍵が同じなら別のインスタンスでも一致する（起動をまたいで照合できる条件）
+    assertThat(generatorWithSecret(SECRET).digest(generated.raw())).isEqualTo(generated.digest());
+  }
+
+  @Test
+  @DisplayName("鍵が違えば同じ生値でも別のダイジェストになること（鍵付きハッシュであること）")
+  void theDigestIsKeyed() {
+    // 鍵無しのハッシュなら、データベースだけを手に入れた者が候補を総当たりで照合できてしまう
+    GeneratedToken generated = generatorWithSecret(SECRET).generate();
+
+    assertThat(generatorWithSecret("another-secret-0123456789abcdef01").digest(generated.raw()))
+        .isNotEqualTo(generated.digest());
+  }
+
+  @Test
+  @DisplayName("ダイジェストが秘密そのものの HMAC ではないこと（用途ごとに独立した鍵から導かれること）")
+  void theDigestKeyIsDerivedForItsOwnPurpose() {
+    // 秘密をそのまま鍵に使うと、同じ鍵で JWT と伝票トークンの両方が作れる状態になる
+    GeneratedToken generated = generatorWithSecret(SECRET).generate();
+
+    assertThat(generated.digest()).isNotEqualTo(hmacWithRawSecret(SECRET, generated.raw()));
+  }
+
+  private static String hmacWithRawSecret(String secret, String message) {
+    try {
+      Mac mac = Mac.getInstance("HmacSHA256");
+      mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+      return Base64.getUrlEncoder()
+          .withoutPadding()
+          .encodeToString(mac.doFinal(message.getBytes(StandardCharsets.UTF_8)));
+    } catch (GeneralSecurityException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/frontend/src/_pages/store-orders/__tests__/OrderCompletionModal.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrderCompletionModal.test.tsx
@@ -316,7 +316,7 @@ describe('OrderCompletionModal', () => {
     // 客が読み取って行き着くのは申領画面。トークンだけを載せると、読み取っても開く先が無い
     expect(screen.getByTestId('qr')).toHaveAttribute(
       'data-value',
-      'http://kizuna.test/member/receipts/raw-receipt-token'
+      'http://kizuna.test/member/receipts#raw-receipt-token'
     );
     expect(onCompleted).toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();

--- a/frontend/src/_pages/store-orders/__tests__/OrderCompletionModal.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrderCompletionModal.test.tsx
@@ -14,6 +14,13 @@ jest.mock('@/shared/notify', () => ({
   notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
 }));
 
+// QR は描画された画像からは中身を読めない。運ぶ値そのものを断言できるよう、値を属性へ出す差し替えにする
+jest.mock('qrcode.react', () => ({
+  QRCodeSVG: ({ value, ...props }: { value: string; 'aria-label': string; role: string }) => (
+    <span data-testid="qr" data-value={value} aria-label={props['aria-label']} role={props.role} />
+  ),
+}));
+
 const mockedComplete = orderApi.complete as jest.Mock;
 const mockedPreview = orderApi.completionPreview as jest.Mock;
 
@@ -294,6 +301,101 @@ describe('OrderCompletionModal', () => {
     expect(await screen.findByText('会員紐づけ済み')).toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
+
+  it('伝票トークンが返ったら閉じずに QR を出す', async () => {
+    // 生値は完了応答にしか現れない。ここで閉じると、客が後から来店を取り戻す手段ごと消える
+    const onClose = jest.fn();
+    const onCompleted = jest.fn();
+    mockedPreview.mockResolvedValue({ member_linked: false, usage_unit: 100, grant_points: 50 });
+    mockedComplete.mockResolvedValue({ ...confirmedOrder, receipt_token: 'raw-receipt-token' });
+    renderModal(onCompleted, onClose);
+
+    await completeWith('8000');
+
+    expect(await screen.findByLabelText('伝票QR')).toBeInTheDocument();
+    // 客が読み取って行き着くのは申領画面。トークンだけを載せると、読み取っても開く先が無い
+    expect(screen.getByTestId('qr')).toHaveAttribute(
+      'data-value',
+      'http://kizuna.test/member/receipts/raw-receipt-token'
+    );
+    expect(onCompleted).toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    // 会計の欄は役目を終えている。QR と入れ替える
+    expect(screen.queryByLabelText('会計金額')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('QR を出している間は Escape で閉じない', async () => {
+    // 生値はこの応答にしか無い。誤って閉じると客が来店を取り戻す手段ごと消えるので、
+    // 閉じるのは明示のボタンだけにする
+    const onClose = jest.fn();
+    mockedPreview.mockResolvedValue({ member_linked: false, usage_unit: 100, grant_points: 50 });
+    mockedComplete.mockResolvedValue({ ...confirmedOrder, receipt_token: 'raw-receipt-token' });
+    renderModal(jest.fn(), onClose);
+
+    await completeWith('8000');
+    await screen.findByLabelText('伝票QR');
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('伝票QR')).toBeInTheDocument();
+  });
+
+  it('会計の入力中は Escape で閉じる', async () => {
+    // 閉じない扱いは QR を出している間だけ。入力中まで塞ぐと、開いただけのモーダルから出られない
+    const onClose = jest.fn();
+    renderModal(jest.fn(), onClose);
+    await screen.findByLabelText('会計金額');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('伝票トークンが返らない完了では QR を出さずに閉じる', async () => {
+    // 会員へ帰属した完了に事後帰属の余地は無い
+    const onClose = jest.fn();
+    renderModal(jest.fn(), onClose);
+
+    await completeWith('8000');
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(screen.queryByLabelText('伝票QR')).not.toBeInTheDocument();
+  });
+
+  it('別の受注へ切り替えたら、前の受注の QR を持ち越さない', async () => {
+    // 発行済みのトークンは受注 1 件に結びついている。持ち越すと、別の来店の QR を客に読ませる
+    const otherOrder: Order = { ...confirmedOrder, id: 'o2', customer_name: '鈴木花子' };
+
+    await reopenAfterIssuing(otherOrder);
+
+    expect(await screen.findByLabelText('会計金額')).toBeInTheDocument();
+    expect(screen.queryByLabelText('伝票QR')).not.toBeInTheDocument();
+  });
+
+  it('同じ受注を開き直しても、前に発行した QR は出さない', async () => {
+    // 生値は発行の応答にしか現れない。閉じた後に出し直せると、「今だけ」と書いた画面が嘘になる
+    await reopenAfterIssuing({ ...confirmedOrder });
+
+    expect(await screen.findByLabelText('会計金額')).toBeInTheDocument();
+    expect(screen.queryByLabelText('伝票QR')).not.toBeInTheDocument();
+  });
+
+  /** 受注 o1 を完了して QR を出し、いったん閉じてから指定の受注で開き直す。 */
+  const reopenAfterIssuing = async (reopened: Order) => {
+    mockedPreview.mockResolvedValue({ member_linked: false, usage_unit: 100, grant_points: 50 });
+    mockedComplete.mockResolvedValue({ ...confirmedOrder, receipt_token: 'raw-receipt-token' });
+    const { rerender } = render(
+      <OrderCompletionModal order={confirmedOrder} onClose={jest.fn()} onCompleted={jest.fn()} />
+    );
+    await completeWith('8000');
+    await screen.findByLabelText('伝票QR');
+
+    rerender(<OrderCompletionModal order={null} onClose={jest.fn()} onCompleted={jest.fn()} />);
+    rerender(<OrderCompletionModal order={reopened} onClose={jest.fn()} onCompleted={jest.fn()} />);
+  };
 
   it('送信中はキャンセルも完了もどちらも押せない', async () => {
     // 台帳へ記帳されたか分からないまま閉じられると、一覧が古いまま残る

--- a/frontend/src/_pages/store-orders/__tests__/receiptClaimUrl.test.ts
+++ b/frontend/src/_pages/store-orders/__tests__/receiptClaimUrl.test.ts
@@ -1,25 +1,29 @@
 import { receiptClaimUrl } from '../lib/receiptClaimUrl';
 
 describe('receiptClaimUrl', () => {
-  it('平台ドメインの申領画面を指し、トークンをパスに置く', () => {
+  it('平台ドメインの申領画面を指し、トークンをフラグメントに置く', () => {
     // 会員ポータルは平台ドメイン側。店舗コンソールのドメインで組み立てると、店舗ドメインで
     // 配信された瞬間に客の QR が行き先を失う
     expect(receiptClaimUrl('raw-receipt-token')).toBe(
-      'http://kizuna.test/member/receipts/raw-receipt-token'
+      'http://kizuna.test/member/receipts#raw-receipt-token'
     );
   });
 
-  it('トークンを問い合わせ文字列に載せない', () => {
-    // 所持そのものが証明になる値なので、Referer やアクセスログへ素通りする位置には置かない
-    expect(receiptClaimUrl('raw-receipt-token')).not.toContain('?');
+  it('サーバへ送られる部分にトークンを載せない', () => {
+    // パスも問い合わせ文字列もリクエストターゲットとして送られ、アクセスログへ 90 日有効の
+    // 生値が残る。読み取られるたびにログへクレデンシャルを書くことになる
+    const [requestTarget] = receiptClaimUrl('raw-receipt-token').split('#');
+
+    expect(requestTarget).toBe('http://kizuna.test/member/receipts');
+    expect(requestTarget).not.toContain('raw-receipt-token');
   });
 
   it('末尾にスラッシュを付けない', () => {
     // 付けると 308 で落とされる URL を客の手元に配ることになる
-    expect(receiptClaimUrl('raw-receipt-token').endsWith('/')).toBe(false);
+    expect(receiptClaimUrl('raw-receipt-token').split('#')[0].endsWith('/')).toBe(false);
   });
 
   it('URL で意味を持つ文字を含むトークンも安全に載せる', () => {
-    expect(receiptClaimUrl('a/b?c#d')).toBe('http://kizuna.test/member/receipts/a%2Fb%3Fc%23d');
+    expect(receiptClaimUrl('a/b?c#d')).toBe('http://kizuna.test/member/receipts#a%2Fb%3Fc%23d');
   });
 });

--- a/frontend/src/_pages/store-orders/__tests__/receiptClaimUrl.test.ts
+++ b/frontend/src/_pages/store-orders/__tests__/receiptClaimUrl.test.ts
@@ -1,0 +1,25 @@
+import { receiptClaimUrl } from '../lib/receiptClaimUrl';
+
+describe('receiptClaimUrl', () => {
+  it('平台ドメインの申領画面を指し、トークンをパスに置く', () => {
+    // 会員ポータルは平台ドメイン側。店舗コンソールのドメインで組み立てると、店舗ドメインで
+    // 配信された瞬間に客の QR が行き先を失う
+    expect(receiptClaimUrl('raw-receipt-token')).toBe(
+      'http://kizuna.test/member/receipts/raw-receipt-token'
+    );
+  });
+
+  it('トークンを問い合わせ文字列に載せない', () => {
+    // 所持そのものが証明になる値なので、Referer やアクセスログへ素通りする位置には置かない
+    expect(receiptClaimUrl('raw-receipt-token')).not.toContain('?');
+  });
+
+  it('末尾にスラッシュを付けない', () => {
+    // 付けると 308 で落とされる URL を客の手元に配ることになる
+    expect(receiptClaimUrl('raw-receipt-token').endsWith('/')).toBe(false);
+  });
+
+  it('URL で意味を持つ文字を含むトークンも安全に載せる', () => {
+    expect(receiptClaimUrl('a/b?c#d')).toBe('http://kizuna.test/member/receipts/a%2Fb%3Fc%23d');
+  });
+});

--- a/frontend/src/_pages/store-orders/lib/receiptClaimUrl.ts
+++ b/frontend/src/_pages/store-orders/lib/receiptClaimUrl.ts
@@ -6,11 +6,14 @@ import { getPlatformDomain } from '@/shared/lib';
  * 会員ポータルは平台ドメイン側にあるので、店舗コンソールが配信されているドメインではなく
  * 平台ドメインへ組み立てる（店舗サイトから会員ポータルへ渡す導線と同じ流儀）。
  *
- * トークンはパスに置く。問い合わせ文字列に載せると Referer や履歴・アクセスログへ素通りするため、
- * 所持そのものが証明になる値は経路に残さない。末尾のスラッシュは付けない — 付けると 308 で
- * 落とされた URL を客の手元に配ることになる。
+ * トークンはフラグメントに置く。パスも問い合わせ文字列もリクエストターゲットとして送られ、
+ * リバースプロキシとアプリのアクセスログに 90 日有効の生値がそのまま残る — 読み取られるたびに
+ * ログへクレデンシャルを書くことになる。フラグメントはサーバへ送られないので、申領画面が
+ * ブラウザ側で読み取って申領要求の本体に載せる形にできる。
+ *
+ * 末尾のスラッシュは付けない — 付けると 308 で落とされた URL を客の手元に配ることになる。
  */
 export function receiptClaimUrl(token: string): string {
   const { protocol } = window.location;
-  return `${protocol}//${getPlatformDomain()}/member/receipts/${encodeURIComponent(token)}`;
+  return `${protocol}//${getPlatformDomain()}/member/receipts#${encodeURIComponent(token)}`;
 }

--- a/frontend/src/_pages/store-orders/lib/receiptClaimUrl.ts
+++ b/frontend/src/_pages/store-orders/lib/receiptClaimUrl.ts
@@ -1,0 +1,16 @@
+import { getPlatformDomain } from '@/shared/lib';
+
+/**
+ * 伝票トークンの申領 URL（QR が運ぶ値）。
+ *
+ * 会員ポータルは平台ドメイン側にあるので、店舗コンソールが配信されているドメインではなく
+ * 平台ドメインへ組み立てる（店舗サイトから会員ポータルへ渡す導線と同じ流儀）。
+ *
+ * トークンはパスに置く。問い合わせ文字列に載せると Referer や履歴・アクセスログへ素通りするため、
+ * 所持そのものが証明になる値は経路に残さない。末尾のスラッシュは付けない — 付けると 308 で
+ * 落とされた URL を客の手元に配ることになる。
+ */
+export function receiptClaimUrl(token: string): string {
+  const { protocol } = window.location;
+  return `${protocol}//${getPlatformDomain()}/member/receipts/${encodeURIComponent(token)}`;
+}

--- a/frontend/src/_pages/store-orders/ui/OrderCompletionModal.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderCompletionModal.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { QRCodeSVG } from 'qrcode.react';
 import { notify } from '@/shared/notify';
 import { Order, OrderCompletionPreview, orderApi } from '@/entities/order';
 import { getApiErrorMessage, integerRule, useResource } from '@/shared/lib';
 import { UNLINKED_NOTE, customerLabel } from '../lib/customerLabel';
+import { receiptClaimUrl } from '../lib/receiptClaimUrl';
 import {
   Button,
   Dialog,
@@ -50,6 +52,12 @@ interface OrderCompletionFormValues {
 interface PreviewSnapshot {
   orderId: string;
   body: OrderCompletionPreview;
+}
+
+/** 発行された伝票トークンと、その発行元の受注（見込みと同じ理由で、値だけでは別の受注のものと見分けられない）。 */
+interface IssuedReceiptToken {
+  orderId: string;
+  token: string;
 }
 
 interface OrderCompletionModalProps {
@@ -106,11 +114,18 @@ export function OrderCompletionModal({ order, onClose, onCompleted }: OrderCompl
   // 前の値を出したままにする。
   const preview = snapshot !== null && snapshot.orderId === orderId ? snapshot.body : null;
 
+  // 発行された伝票トークン。会員へ帰属しなかった完了でだけ返るので、これが在る間は QR を出したまま
+  // 閉じずに待つ（生値はこの応答にしか現れず、閉じると二度と出せない）。
+  const [issued, setIssued] = useState<IssuedReceiptToken | null>(null);
+  const receiptToken = issued !== null && issued.orderId === orderId ? issued.token : null;
+
   useEffect(() => {
     if (!order) return;
     reset({ total_fee: NaN, use_points: NaN });
     // 確定値も欄と一緒に戻す。同じ受注を開き直したとき、空の欄のまま前回の金額で付与予定が出る
     setCommitted(null);
+    // 発行済みの QR も一緒に戻す。「今だけ表示できる」と書いた画面が、開き直しで前の QR を出し直さない
+    setIssued(null);
   }, [order, reset]);
 
   const submit = async (values: OrderCompletionFormValues) => {
@@ -119,7 +134,7 @@ export function OrderCompletionModal({ order, onClose, onCompleted }: OrderCompl
     // 送信可否は入力ではなく今の見込みで決める。
     const usePoints = preview?.member_linked === true ? values.use_points : NaN;
     try {
-      await orderApi.complete(order.id, {
+      const completed = await orderApi.complete(order.id, {
         total_fee: values.total_fee,
         // 0 はサーバ側の @Min(1) に撥ねられる。利用しない完了では項目ごと送らない
         // （undefined は JSON 化の段でキーごと消える）。
@@ -127,7 +142,12 @@ export function OrderCompletionModal({ order, onClose, onCompleted }: OrderCompl
       });
       notify.success('オーダーを完了しました');
       onCompleted();
-      onClose();
+      // 会員へ帰属した完了はトークンを持たないので、これまでどおり閉じる。
+      if (completed.receipt_token) {
+        setIssued({ orderId, token: completed.receipt_token });
+      } else {
+        onClose();
+      }
     } catch (error) {
       // 残高不足・単位違反・非会員の利用は、サーバが対処できる文言を返す。汎用文言に潰さない。
       notify.error(getApiErrorMessage(error, 'オーダーの完了に失敗しました'));
@@ -138,8 +158,10 @@ export function OrderCompletionModal({ order, onClose, onCompleted }: OrderCompl
     <Dialog
       open={order !== null}
       onOpenChange={next => {
-        // 送信中に閉じると、台帳へ記帳されたかどうか分からないまま古い一覧が残る
-        if (!next && !isSubmitting) onClose();
+        // 送信中に閉じると、台帳へ記帳されたかどうか分からないまま古い一覧が残る。
+        // QR を出している間も同じく閉じない — 生値はこの応答にしか無く、ESC や背景押下で
+        // 誤って閉じると客が来店を取り戻す手段ごと消える。閉じるのは明示のボタンだけにする。
+        if (!next && !isSubmitting && receiptToken === null) onClose();
       }}
     >
       <DialogContent
@@ -148,137 +170,165 @@ export function OrderCompletionModal({ order, onClose, onCompleted }: OrderCompl
         className="gap-0 rounded-[10px] p-0 sm:max-w-md"
       >
         <div className="border-b px-6 py-4">
-          <DialogTitle>完了処理</DialogTitle>
+          <DialogTitle>{receiptToken !== null ? '伝票QRコード' : '完了処理'}</DialogTitle>
           <p className="mt-1 text-sm text-muted-foreground">
             {order?.business_date ?? '-'} / {customerText(order)}
           </p>
         </div>
-        <Form {...form}>
-          {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+        {receiptToken !== null ? (
+          <div className="px-6 py-5">
+            <div className="flex flex-col items-center gap-4">
+              <div className="rounded-xl border bg-card p-4">
+                <QRCodeSVG
+                  value={receiptClaimUrl(receiptToken)}
+                  size={192}
+                  aria-label="伝票QR"
+                  role="img"
+                />
+              </div>
+              {/* 生値はこの応答にしか現れない。閉じた後に出し直す経路が無いことを先に伝える */}
+              <p className="text-sm text-foreground">
+                この QR は今だけ表示できます。閉じると再表示できません。
+              </p>
+              <p className="text-sm text-muted-foreground">
+                お客様が読み取ると、この来店をご自身のポイントと履歴に取り込めます（完了から 90
+                日以内）。
+              </p>
+            </div>
+            <div className="mt-4 flex justify-end gap-3 border-t pt-4">
+              <Button type="button" onClick={onClose}>
+                閉じる
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Form {...form}>
+            {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
               我々の文言は永久に描かれない。required と min={0} は下の規則が引き継ぐ */}
-          <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5" noValidate>
-            <FormField
-              control={control}
-              name="total_fee"
-              rules={{
-                required: TOTAL_FEE_REQUIRED,
-                min: { value: 0, message: '会計金額は 0 以上です' },
-                validate: {
-                  // 空欄は NaN であって null でも空文字でもないため required は素通りする
-                  notEmpty: value => !Number.isNaN(value) || TOTAL_FEE_REQUIRED,
-                  // noValidate は type="number" の暗黙の step=1 も止める。これが無いと
-                  // 1.5 が Integer の totalFee へ届く
-                  integer: integerRule('会計金額'),
-                },
-              }}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>会計金額</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="number"
-                      required
-                      min={0}
-                      {...field}
-                      // register の valueAsNumber と同じ写像。Number() は空欄を 0 にしてしまい、
-                      // 「未入力」を表す NaN が失われる。
-                      value={Number.isNaN(field.value) ? '' : field.value}
-                      onChange={event => field.onChange(event.target.valueAsNumber)}
-                      onBlur={event => {
-                        field.onBlur();
-                        const fee = event.target.valueAsNumber;
-                        setCommitted({ orderId, fee: Number.isNaN(fee) ? 0 : fee });
-                      }}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            {/* 見込みが読めなくても送信は塞がない。単位も残高も会員資格もサーバ側が再検証する */}
-            {previewLoading ? (
-              <p className="text-sm text-muted-foreground">読み込み中...</p>
-            ) : previewFailure !== null ? (
-              <RegionError
-                message="ポイントの見込みを取得できませんでした"
-                onRetry={() => void reloadPreview()}
-              />
-            ) : (
-              preview !== null && (
-                <div className="space-y-1 text-sm text-foreground">
-                  <p>{preview.member_linked ? '会員紐づけ済み' : '未紐づけ'}</p>
-                  {preview.point_balance !== undefined && (
-                    <p>残高: {preview.point_balance} ポイント</p>
-                  )}
-                  {/* 非会員の受注には付与も利用も無い。予定を出すと、完了しても増えないポイントを約束することになる */}
-                  {preview.member_linked && (
-                    <>
-                      <p>付与予定: {preview.grant_points} ポイント</p>
-                      <p className="text-muted-foreground">
-                        利用は {preview.usage_unit} ポイント単位で指定できます
-                      </p>
-                    </>
-                  )}
-                </div>
-              )
-            )}
-            {/* 非会員の受注にはポイントそのものが存在しないので、欄を出さない。同じ受注で金額を
-                取り直している最中は直前の見込みのまま出したままにする（消えると打ちかけの値が
-                視界から外れる） */}
-            {preview !== null && preview.member_linked && (
+            <form onSubmit={handleSubmit(submit)} className="space-y-4 px-6 py-5" noValidate>
               <FormField
                 control={control}
-                name="use_points"
+                name="total_fee"
                 rules={{
-                  min: { value: 0, message: '利用ポイントは 0 以上です' },
+                  required: TOTAL_FEE_REQUIRED,
+                  min: { value: 0, message: '会計金額は 0 以上です' },
                   validate: {
-                    integer: integerRule('利用ポイント'),
-                    // 空欄（NaN）は「利用なし」であって違反ではない。どの規則も素通りさせる
-                    unit: value =>
-                      Number.isNaN(value) ||
-                      value % preview.usage_unit === 0 ||
-                      `利用ポイントは ${preview.usage_unit} ポイント単位で指定してください`,
-                    withinBalance: value =>
-                      Number.isNaN(value) ||
-                      preview.point_balance === undefined ||
-                      value <= preview.point_balance ||
-                      `残高を超えています（残高: ${preview.point_balance}）`,
-                    // 請求より大きい割引に相当する利用は台帳へ積ませない。同額までは全額のポイント払い。
-                    // 金額が未入力（NaN）なら会計金額側の規則が名乗るので、ここでは重ねて名乗らない
-                    withinTotalFee: (value, values) =>
-                      Number.isNaN(value) ||
-                      Number.isNaN(values.total_fee) ||
-                      value <= values.total_fee ||
-                      `会計金額を超えています（会計金額: ${values.total_fee}）`,
+                    // 空欄は NaN であって null でも空文字でもないため required は素通りする
+                    notEmpty: value => !Number.isNaN(value) || TOTAL_FEE_REQUIRED,
+                    // noValidate は type="number" の暗黙の step=1 も止める。これが無いと
+                    // 1.5 が Integer の totalFee へ届く
+                    integer: integerRule('会計金額'),
                   },
                 }}
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>利用ポイント</FormLabel>
+                    <FormLabel>会計金額</FormLabel>
                     <FormControl>
                       <Input
                         type="number"
+                        required
                         min={0}
                         {...field}
+                        // register の valueAsNumber と同じ写像。Number() は空欄を 0 にしてしまい、
+                        // 「未入力」を表す NaN が失われる。
                         value={Number.isNaN(field.value) ? '' : field.value}
                         onChange={event => field.onChange(event.target.valueAsNumber)}
+                        onBlur={event => {
+                          field.onBlur();
+                          const fee = event.target.valueAsNumber;
+                          setCommitted({ orderId, fee: Number.isNaN(fee) ? 0 : fee });
+                        }}
                       />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
               />
-            )}
-            <div className="flex justify-end gap-3 border-t pt-4">
-              <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
-                キャンセル
-              </Button>
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? '処理中...' : '完了する'}
-              </Button>
-            </div>
-          </form>
-        </Form>
+              {/* 見込みが読めなくても送信は塞がない。単位も残高も会員資格もサーバ側が再検証する */}
+              {previewLoading ? (
+                <p className="text-sm text-muted-foreground">読み込み中...</p>
+              ) : previewFailure !== null ? (
+                <RegionError
+                  message="ポイントの見込みを取得できませんでした"
+                  onRetry={() => void reloadPreview()}
+                />
+              ) : (
+                preview !== null && (
+                  <div className="space-y-1 text-sm text-foreground">
+                    <p>{preview.member_linked ? '会員紐づけ済み' : '未紐づけ'}</p>
+                    {preview.point_balance !== undefined && (
+                      <p>残高: {preview.point_balance} ポイント</p>
+                    )}
+                    {/* 非会員の受注には付与も利用も無い。予定を出すと、完了しても増えないポイントを約束することになる */}
+                    {preview.member_linked && (
+                      <>
+                        <p>付与予定: {preview.grant_points} ポイント</p>
+                        <p className="text-muted-foreground">
+                          利用は {preview.usage_unit} ポイント単位で指定できます
+                        </p>
+                      </>
+                    )}
+                  </div>
+                )
+              )}
+              {/* 非会員の受注にはポイントそのものが存在しないので、欄を出さない。同じ受注で金額を
+                取り直している最中は直前の見込みのまま出したままにする（消えると打ちかけの値が
+                視界から外れる） */}
+              {preview !== null && preview.member_linked && (
+                <FormField
+                  control={control}
+                  name="use_points"
+                  rules={{
+                    min: { value: 0, message: '利用ポイントは 0 以上です' },
+                    validate: {
+                      integer: integerRule('利用ポイント'),
+                      // 空欄（NaN）は「利用なし」であって違反ではない。どの規則も素通りさせる
+                      unit: value =>
+                        Number.isNaN(value) ||
+                        value % preview.usage_unit === 0 ||
+                        `利用ポイントは ${preview.usage_unit} ポイント単位で指定してください`,
+                      withinBalance: value =>
+                        Number.isNaN(value) ||
+                        preview.point_balance === undefined ||
+                        value <= preview.point_balance ||
+                        `残高を超えています（残高: ${preview.point_balance}）`,
+                      // 請求より大きい割引に相当する利用は台帳へ積ませない。同額までは全額のポイント払い。
+                      // 金額が未入力（NaN）なら会計金額側の規則が名乗るので、ここでは重ねて名乗らない
+                      withinTotalFee: (value, values) =>
+                        Number.isNaN(value) ||
+                        Number.isNaN(values.total_fee) ||
+                        value <= values.total_fee ||
+                        `会計金額を超えています（会計金額: ${values.total_fee}）`,
+                    },
+                  }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>利用ポイント</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          min={0}
+                          {...field}
+                          value={Number.isNaN(field.value) ? '' : field.value}
+                          onChange={event => field.onChange(event.target.valueAsNumber)}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+              <div className="flex justify-end gap-3 border-t pt-4">
+                <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
+                  キャンセル
+                </Button>
+                <Button type="submit" disabled={isSubmitting}>
+                  {isSubmitting ? '処理中...' : '完了する'}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/entities/order/model/types.ts
+++ b/frontend/src/entities/order/model/types.ts
@@ -65,6 +65,11 @@ export interface Order {
    */
   contact_name?: string;
   contact_phone_number?: string;
+  /**
+   * 伝票トークンの生値。会員へ帰属しなかった完了の応答にだけ現れる（他の読み口では応答から消える）。
+   * サーバはダイジェストしか保存しないので、この応答を逃すと二度と取得できない。
+   */
+  receipt_token?: string;
 }
 
 export interface OrderReceptionist {


### PR DESCRIPTION
## 概要

完了時に会員へ帰属しなかった受注へワンタイムの伝票トークンを発行し、店舗コンソールの完了画面が申領 QR として提示する。保存は鍵付きハッシュ（ダイジェスト）だけで、生値は完了応答に一度だけ現れる。

Closes #652

## 変更内容

- **backend**
  - `t_order_receipt_tokens`（v0.17.0・platform 帰属）と `OrderReceiptToken` / `OrderReceiptTokenStatus` / `OrderReceiptTokenRepository` / `InvalidOrderReceiptTokenException`。
  - `ReceiptTokenGenerator`（`SecureRandom` 32 バイト＋用途ラベル付きで派生した鍵での HMAC-SHA256）。
  - `OrderService.complete` の会員未達枝で発行し、`OrderResponse.receiptToken` に生値を載せる（他の読み口では応答から消える）。
- **frontend**
  - 完了モーダルが、トークンを受け取ったら閉じずに QR へ差し替わる。QR が運ぶのは申領 URL。
  - `receiptClaimUrl`（`_pages/store-orders/lib`）と `Order.receipt_token`。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（unit 946 + backend unit、integrationTest は新規 `OrderReceiptTokenIT` 6 件込みで全緑）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全 14 feature・24 シナリオ全通過。本 PR が触る受注完了のシナリオは元から存在しないため、退行の有無を見るための全量実行）
- [x] ローカルで code-review 実施済み（Standards / Spec の 2 軸。指摘の消化は「備考」に記載）

**テストが赤になれることの実測**（緑だけでは通ったことにならないため）:

- ダイジェストの代わりに生値を保存させる → `OrderReceiptTokenIT.theRawTokenIsNotPersistedAnywhere` が落ちる。走査自体が空振りでないことは、保存済みの値（`t_orders.remarks`）を見つける正の対照を同じテストに入れて担保。
- QR の URL 化と閉じるガードを外す → 対応する Jest 2 本が落ちる。
- 開き直しの後片付け（`setIssued(null)`）を外す → 「同じ受注を開き直しても前の QR を出さない」が落ちる。

### 視覚確認（UI 変更時）

実ブラウザ（Chrome・ダークモード・店舗コンソール）で確認済み。顧客に着いていない確定受注を 9800 円で完了 →

- toast「オーダーを完了しました」と一覧の「完了」への更新は起きたうえで、**モーダルは閉じず「伝票QRコード」へ差し替わる**。
- **Escape でも背景押下でも閉じない**（閉じるのは「閉じる」ボタンだけ）。
- DB 実データ: `planned_points=98`・`status=ISSUED`・`expires_at - issued_at = 90 日`・列に残るのはダイジェストのみ。

## 決定ログ

- **ダイジェストの鍵は `app.jwt.secret` から用途ラベル付きで派生**（`HMAC(secret, "kizuna:order-receipt-token-digest:v1")` を鍵にして生値を HMAC）。専用の環境変数を新設する案を見送ったのは、`application.yml` と compose 4 本に波及したうえ、宣言漏れが起動失敗になるため。用途ラベルで鍵は独立するので、この鍵で JWT を、JWT の鍵でトークンを偽造することはできない。**代償は「`APP_JWT_SECRET` の交換＝未申領トークンを捨てる決定」になること**で、クラスの javadoc に明記した。
- **QR が運ぶのは申領 URL**（`{protocol}//{平台ドメイン}/member/receipts#{token}`）。**当初はトークンの生値を載せていたが、レビューで覆した** — 申領画面（#653）が着地するまでは生値 QR も同じく機能しない（読み取っても開く先が無い）ので「404 を避ける」利得が無く、一方でこの画面自身の文言「読み取るとポイントと履歴に取り込めます」が果たせない。ペイロードはこの票で決まり、#653 は画面を作る側になる。ドメインの組み立ては `_sections/Header.tsx`（会員ポータルへの導線）の先例に倣う。
- **トークンはフラグメントに置く**（当初はパスに置いていたが Codex の指摘で修正）。パスも問い合わせ文字列もリクエストターゲットとして送られるため、リバースプロキシとアプリのアクセスログに 90 日有効の生値が残る — QR が読み取られるたびにクレデンシャルをログへ書くことになる。フラグメントはサーバへ送られないので、申領画面がブラウザ側で読み取って申領要求の本体に載せられる。**#653 への含意**: 申領画面は `location.hash` から読み、未ログイン時のログイン往復でフラグメントを持ち越す必要がある（`sessionStorage` か復帰 URL への再付与）。末尾スラッシュは付けない（付けると 308 で落とされる URL を客に配ることになる）。
- **生値は `OrderResponse` の可空フィールドで返す**（完了専用の DTO へ包まない）。`default-property-inclusion: non_null` なので他の読み口では**キーごと消える**。診断経路へ滲ませないため `@ToString.Exclude` を付けた。
- **`order_id` に部分一意索引は張らない**。本票に重複発行の経路が無く、無効化後の再発行（#654）が「生きた行 2 本」を要りうるため、その判断はその票に残す。効かせている制約は `token_digest` の一意だけ。
- **付与予定額は完了時点の付与規則で確定して持つ**。申領時点の設定を読むと、同じ会計が申領の早い遅いで別のポイントになる。0 円完了にも 0 で発行する（申領の効果は来店の可視化に閉じる）。
- **トークン行は帰属記録（ADR 0006 と同じ判定）と同じく platform 帰属**とし、店舗行分離機構には載せない — 申領するのは店舗文脈を持たない会員本人で、店舗で絞ると照合そのものが成立しない。

## 備考 / レビュー観点

- **⚠️ 合流順の制約（判断をお願いしたい点）**: 申領画面 `/member/receipts` は #653 の範囲でまだ存在しない。この PR だけが入った状態で店員が QR を客へ提示すると、読み取った客は 404 に着く。**票の分割（#652 発行 → #653 申領）どおりに進めた結果であり、どちらのペイロードを選んでも #653 までこの機能は動かない**（生値を載せても読み取り先が無い）が、「何も起きない」と「404 が出る」の差はある。#653 と揃えて合流するか、この PR を先に入れるかは合流の判断に委ねる。Codex の同旨の指摘（P1・2 件目）はこの理由で未対応のままにしてある。
- **副次的な挙動の変更**: 会員へ帰属しない完了でも付与規則を読むようになったため、int で表せない付与になる異常な会計金額が 200 から 400 に変わる。事前計算（`completionPreview`）が同じ入力で既にそう振る舞っており、見込みと確定の食い違いが 1 つ減る方向。
- **受け入れ基準「付与予定額はその後の設定変更に影響されない」は半分だけ機械で固定されている**。現状 `plannedPoints` の読み手が居らず反証不能なため、`@Column(updatable=false)` と再計算経路の不在で保つに留めた（統合テストで global な `SystemConfig` を書き換えると、同じ DB を共有する他テストを汚す）。真の固定は #653 の申領で入る。
- **`ReceiptTokenGenerator.digest(String)` は本番の呼び手がまだ無い**（#653 の照合で使う）。消すと「保存された値が照合可能な鍵である」ことを示すテストごと消え、ダイジェスト列が検証不能になるため残した。
- **見送った指摘 2 件**（どちらも判断案件）: ①`{orderId, value}` の陳腐化ガードが 3 箇所になった（`useOrderScopedState` 相当の抽出）— 既存 2 箇所の書き換えを伴い本票の射程を超える。②QR ブロックが `MemberHomePage` と重複 — `shared/ui` は vendored shadcn 層で、3 行の枠を 2 用例で上げるのは早いと判断。
- **`APP_JWT_SECRET` の運用**: 上記のとおり交換は未申領トークンを無効化する。ここが受け入れられないなら専用の秘密へ切り出す判断になるので、レビューで見てほしい。
