### PR TITLE
fix: nanoid を 3.3.18 へ更新し size=0 の無限ループ脆弱性を解消する

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9457,9 +9457,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## 概要

Dependabot alert #124（high）で報告された nanoid の脆弱性 GHSA-2v37-7h3g-55p8 を解消する。`frontend/package-lock.json` の nanoid 解決先を 3.3.16 → 3.3.18 へ進めるだけの lockfile 変更。

## 変更内容

- `frontend/package-lock.json` の `node_modules/nanoid` を 3.3.16 → 3.3.18（version / resolved / integrity の 3 行のみ）

nanoid は postcss の推移依存で、postcss 側の依存範囲は `^3.3.16`。修正版 3.3.17 以降もこの範囲に収まるため、`package.json` の変更も overrides の追加も不要。`npm update nanoid --package-lock-only` で解決先だけを進めた。

## 検証

- [x] `task lint service=frontend` exit 0 / `task lint service=backend` exit 0
- [x] `task test service=frontend` exit 0（116 suites / 966 tests passed）
- [x] `task build service=frontend` exit 0 / `task build service=backend` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全 24 シナリオ、24 passed / 4.5m）
- [x] ローカルで code-review 実施済み — 対象が lockfile 1 ブロックのため diff 全文を目視確認

追加の実証:

- `docker build --no-cache-filter deps --target deps` で deps ステージを強制再構築し、`npm ci` が新 lockfile で成功すること（added 877 packages）と integrity ハッシュが有効であることを確認
- 構築されたイメージ内の `node_modules/nanoid/package.json` が 3.3.18 であることを確認
- `npm audit --package-lock-only` の指摘から nanoid が消えたことを確認

## 決定ログ

- **3.3.17（Dependabot が示す最小修正版）ではなく 3.3.18 を採用**: `^3.3.16` の範囲内で最新。3.3.17 に固定すると次の patch で再度 alert が立つだけで、範囲内最新に揃えるほうが lockfile の意味に合う。
- **`overrides` への追加は見送り**: postcss の依存範囲が既に修正版を許容しているため、override は不要な固定を生むだけ。既存の `overrides` は next 配下の postcss / sharp に限定されており、そこへ nanoid を足す理由がない。
- **差分の広がりを許さない方針**: `npm update` は npm のバージョン差で lockfile 全体を再解決することがあるため、実行後に `git diff --stat` で nanoid 1 ブロックのみであることを確認した。広い差分になっていた場合は lockfile を戻して 3 フィールドを手書きする予定だった。

## 備考 / レビュー観点

- `npm audit` には別途 brace-expansion（high）が残るが、これは Dependabot 側で 4 件とも `auto_dismissed`（到達不能と判定）になっており、本 PR のスコープ外。open な alert は #124 の nanoid 1 件のみ。
- `e2e/package-lock.json` には nanoid が含まれないことを確認済み（同根の取りこぼし防止）。
