### PR TITLE
feat: 帰属記録の無効化とトークン再発行（店舗コンソール・理由必須・ポイント無波及）

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/order/OrderAttributionInvalidationIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/OrderAttributionInvalidationIT.java
@@ -1,0 +1,545 @@
+package com.kizuna.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kizuna.member.domain.Member;
+import com.kizuna.member.domain.MemberRepository;
+import com.kizuna.order.domain.OrderAttribution;
+import com.kizuna.order.domain.OrderAttributionRepository;
+import com.kizuna.order.domain.OrderAttributionSource;
+import com.kizuna.order.domain.OrderAttributionStatus;
+import com.kizuna.order.domain.OrderReceiptToken;
+import com.kizuna.order.domain.OrderReceiptTokenRepository;
+import com.kizuna.shared.CrossStoreTestSupport;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * 誤帰属の訂正（無効化と伝票トークンの再発行）を本物の PostgreSQL で検証する統合テスト。
+ *
+ * <p>固定するのは 4 つ。①無効化が理由・実行者・時刻を<b>行として残す</b>こと（列の書き込みが実際に往復すること）。
+ * ②無効化された来店が会員の履歴から消える一方でポイント台帳は動かないこと — 清算は手動調整であり、訂正は機械の級聯にしない（ADR 0009）。
+ * ③再発行された伝票の申領期限が<b>再発行時点</b>から 90 日で数え直されること（同 ADR の意図的な例外）。 ④再発行された伝票で正しい本人が申領でき、根拠 RECEIPT_TOKEN
+ * の帰属が成立すること。
+ *
+ * <p>シード設定は「100 円ごとに 1 ポイント付与、利用は 100 ポイント単位」。
+ */
+class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
+
+  private static final String PASSWORD = "password1234";
+
+  /** v0.5.0 の山田次郎シード（STORE_STAFF・授権店舗 = 店舗1）。店舗A の受付担当として使用。 */
+  private static final long SEED_RECEPTIONIST_ID = 3L;
+
+  private static final int TOTAL_FEE = 12000;
+
+  /** シード設定（100 円ごとに 1 ポイント）を {@link #TOTAL_FEE} に当てた付与額。 */
+  private static final int EXPECTED_POINTS = 120;
+
+  private static final String REASON = "別人の来店として取り違えたため";
+
+  @Autowired private OrderAttributionRepository orderAttributionRepository;
+  @Autowired private OrderReceiptTokenRepository orderReceiptTokenRepository;
+  @Autowired private MemberRepository memberRepository;
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  private final long nonce = System.nanoTime();
+
+  @Test
+  @DisplayName("無効化は理由・実行者・時刻を行に残し、帰属そのものの記録は書き換えないこと")
+  void invalidationPersistsTheReasonActorAndTime() {
+    RegisteredMember wrongMember = registerAndLogin("wrong");
+    String orderId = completedOrderAttributedTo(wrongMember, "誤帰属担当-" + nonce);
+
+    ResponseEntity<JsonNode> invalidated = invalidate(orderId, REASON);
+
+    assertThat(invalidated.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(invalidated.getBody().path("attributed").asBoolean()).isFalse();
+
+    // 実データを読む。@Column の書き込み可否を取り違えると、行は INVALIDATED になりつつ理由だけ NULL になり、
+    // 集約を往復させないテストは緑のままになる
+    Map<String, Object> row =
+        jdbcTemplate.queryForMap(
+            "select status, invalidated_reason, invalidated_by, invalidated_at"
+                + " from t_order_attributions where order_id = ?",
+            orderId);
+    assertThat(row.get("status")).isEqualTo(OrderAttributionStatus.INVALIDATED.name());
+    assertThat(row.get("invalidated_reason")).isEqualTo(REASON);
+    assertThat(row.get("invalidated_by")).isEqualTo(seedStaffId());
+    assertThat(row.get("invalidated_at")).isNotNull();
+
+    // 誰の来店として記録されていたかは訂正後も辿れること（監査の対象そのもの）
+    OrderAttribution attribution = attributionOf(orderId);
+    assertThat(attribution.getMemberCode()).isEqualTo(wrongMember.memberCode());
+    assertThat(attribution.getSource()).isEqualTo(OrderAttributionSource.COMPLETION);
+  }
+
+  @Test
+  @DisplayName("無効化で来店は会員の履歴から消え、ポイント台帳は動かないこと（清算は手動調整）")
+  void invalidationHidesTheVisitButLeavesTheLedgerUntouched() {
+    RegisteredMember wrongMember = registerAndLogin("ledger");
+    String castName = "台帳無波及担当-" + nonce;
+    String orderId = completedOrderAttributedTo(wrongMember, castName);
+
+    assertThat(castNamesInVisitsOf(wrongMember)).as("前提: 無効化の前は来店として見えること").contains(castName);
+    assertThat(balanceOf(wrongMember)).as("前提: 付与が台帳へ入っていること").isEqualTo(EXPECTED_POINTS);
+
+    assertThat(invalidate(orderId, REASON).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    assertThat(castNamesInVisitsOf(wrongMember)).as("無効化された来店は履歴から消えること").doesNotContain(castName);
+    // 誤って付与されたポイントは残る。取り消すなら理由の残る手動調整で行う（ADR 0009）
+    assertThat(balanceOf(wrongMember)).as("台帳は動かないこと").isEqualTo(EXPECTED_POINTS);
+    assertThat(ledgerRowsFor(orderId)).as("台帳へ打ち消しの仕訳も積まないこと").isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("理由の無い無効化は撥ねられ、帰属記録が有効なまま残ること")
+  void invalidationWithoutAReasonIsRejected() {
+    RegisteredMember wrongMember = registerAndLogin("noreason");
+    String orderId = completedOrderAttributedTo(wrongMember, "理由なし担当-" + nonce);
+
+    assertThat(invalidate(orderId, " ").getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+    assertThat(attributionOf(orderId).getStatus()).isEqualTo(OrderAttributionStatus.ACTIVE);
+  }
+
+  @Test
+  @DisplayName("再発行の申領期限は原期限を引き継がず、再発行から 90 日で数え直されること")
+  void reissuedTokenRestartsTheNinetyDayWindow() {
+    // 完了時に会員へ達しなかった受注から始める。誤帰属が申領で成立した形なので、この受注には原期限を持つ
+    // 伝票が実在し、「原期限を引き継ぐ」実装と「数え直す」実装を見分けられる（完了時帰属の受注には
+    // 引き継ぐ元の期限がそもそも無く、どちらの実装でも同じ値になってしまう）
+    RegisteredMember wrongMember = registerAndLogin("window");
+    Issued original = completedOrderWithToken("期限再計算担当-" + nonce);
+    assertThat(claim(wrongMember, original.token()).getStatusCode())
+        .as("前提: 誤った本人が申領できること")
+        .isEqualTo(HttpStatus.OK);
+    assertThat(invalidate(original.orderId(), REASON).getStatusCode())
+        .as("前提: 無効化できること")
+        .isEqualTo(HttpStatus.OK);
+
+    // 原期限を「もうすぐ切れる」側へ倒す。引き継ぐ実装ならここで倒した値がそのまま新しい伝票の期限になる
+    OffsetDateTime shortenedExpiry = OffsetDateTime.now().plusDays(3);
+    jdbcTemplate.update(
+        "update t_order_receipt_tokens set expires_at = ? where order_id = ?",
+        shortenedExpiry,
+        original.orderId());
+
+    ResponseEntity<JsonNode> reissued = reissue(original.orderId());
+
+    assertThat(reissued.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(reissued.getBody().path("receipt_token").asString()).isNotBlank();
+    OrderReceiptToken token =
+        orderReceiptTokenRepository.findByOrderIdOrderByIdDesc(original.orderId()).get(0);
+    assertThat(token.getIssuedAt()).isAfter(OffsetDateTime.now().minusMinutes(5));
+    assertThat(ChronoUnit.DAYS.between(token.getIssuedAt(), token.getExpiresAt()))
+        .isEqualTo(OrderReceiptToken.VALIDITY.toDays());
+    assertThat(token.getExpiresAt()).as("誤帰属の期間に食い潰された原期限を引き継がないこと").isAfter(shortenedExpiry);
+  }
+
+  @Test
+  @DisplayName("再発行の付与予定額は完了時に確定した額を引き継ぎ、受注の付与実績（非会員完了では 0）を読まないこと")
+  void reissueCarriesForwardThePlannedPointsFixedAtCompletion() {
+    RegisteredMember wrongMember = registerAndLogin("planned");
+    RegisteredMember rightMember = registerAndLogin("plannedowner");
+    Issued original = completedOrderWithToken("予定額引継担当-" + nonce);
+    // 発行時の確定額を現行規則では出得ない値へ倒す。会計金額から計算し直す実装ならここで倒した値が消える
+    int fixedPoints = 7;
+    jdbcTemplate.update(
+        "update t_order_receipt_tokens set planned_points = ? where order_id = ?",
+        fixedPoints,
+        original.orderId());
+    assertThat(claim(wrongMember, original.token()).getStatusCode())
+        .as("前提: 誤った本人が申領できること")
+        .isEqualTo(HttpStatus.OK);
+    assertThat(invalidate(original.orderId(), REASON).getStatusCode())
+        .as("前提: 無効化できること")
+        .isEqualTo(HttpStatus.OK);
+
+    String raw = reissue(original.orderId()).getBody().path("receipt_token").asString();
+
+    assertThat(claim(rightMember, raw).getBody().path("granted_points").asInt())
+        .isEqualTo(fixedPoints);
+    assertThat(balanceOf(rightMember)).isEqualTo(fixedPoints);
+  }
+
+  @Test
+  @DisplayName("再発行された伝票で正しい本人が申領でき、根拠 RECEIPT_TOKEN の帰属が成立すること")
+  void theRightMemberReclaimsTheVisitWithTheReissuedToken() {
+    RegisteredMember wrongMember = registerAndLogin("thief");
+    RegisteredMember rightMember = registerAndLogin("owner");
+    String castName = "取り戻し担当-" + nonce;
+    String orderId = completedOrderAttributedTo(wrongMember, castName);
+    assertThat(invalidate(orderId, REASON).getStatusCode())
+        .as("前提: 無効化できること")
+        .isEqualTo(HttpStatus.OK);
+
+    String raw = reissue(orderId).getBody().path("receipt_token").asString();
+    ResponseEntity<JsonNode> claimed = claim(rightMember, raw);
+
+    assertThat(claimed.getStatusCode()).isEqualTo(HttpStatus.OK);
+    // 付与予定額は完了時点で確定した額を引き継ぐ（訂正の早い遅いで同じ会計が別のポイントにならない）
+    assertThat(claimed.getBody().path("granted_points").asInt()).isEqualTo(EXPECTED_POINTS);
+
+    List<OrderAttribution> rows = attributionsOf(orderId);
+    assertThat(rows).as("無効化した記録は残り、新しい帰属が別の行として生まれること").hasSize(2);
+    OrderAttribution active =
+        rows.stream()
+            .filter(row -> row.getStatus() == OrderAttributionStatus.ACTIVE)
+            .findFirst()
+            .orElseThrow();
+    assertThat(active.getSource()).isEqualTo(OrderAttributionSource.RECEIPT_TOKEN);
+    assertThat(active.getMemberCode()).isEqualTo(rightMember.memberCode());
+
+    assertThat(castNamesInVisitsOf(rightMember)).as("正しい本人の履歴に現れること").contains(castName);
+    assertThat(balanceOf(rightMember)).isEqualTo(EXPECTED_POINTS);
+    assertThat(castNamesInVisitsOf(wrongMember))
+        .as("誤って帰属していた側からは消えたままであること")
+        .doesNotContain(castName);
+    // 誤帰属の付与は残ったまま。清算は手動調整で行うため、同じ受注に付与が 2 本立つ
+    assertThat(ledgerRowsFor(orderId)).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("有効な帰属のある受注・帰属したことのない受注へは再発行できないこと")
+  void reissueIsRefusedUnlessTheOrderWasInvalidated() {
+    RegisteredMember member = registerAndLogin("guard");
+    String attributedOrder = completedOrderAttributedTo(member, "帰属中担当-" + nonce);
+    assertThat(reissue(attributedOrder).getStatusCode())
+        .as("先に無効化していない受注へは発行しないこと")
+        .isEqualTo(HttpStatus.BAD_REQUEST);
+
+    // 完了時に会員へ達しなかった受注は、そもそも完了の応答で伝票を受け取っている。訂正の経路を発行の経路にしない
+    String neverAttributed = completedOrderWithoutMember("無帰属担当-" + nonce);
+    assertThat(reissue(neverAttributed).getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("申領できる伝票が既にある受注へは再発行できないこと（生きた伝票が 2 本並ばない）")
+  void reissueIsRefusedWhileAClaimableTokenExists() {
+    RegisteredMember wrongMember = registerAndLogin("double");
+    String orderId = completedOrderAttributedTo(wrongMember, "二重発行担当-" + nonce);
+    assertThat(invalidate(orderId, REASON).getStatusCode())
+        .as("前提: 無効化できること")
+        .isEqualTo(HttpStatus.OK);
+    assertThat(reissue(orderId).getStatusCode()).as("前提: 1 度目の再発行ができること").isEqualTo(HttpStatus.OK);
+
+    assertThat(reissue(orderId).getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+    assertThat(tokenCountFor(orderId)).as("生きた伝票は 1 本だけであること").isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("他店舗の受注の帰属は読めず、無効化も再発行もできないこと")
+  void otherStoreCannotReachTheAttribution() {
+    RegisteredMember member = registerAndLogin("cross");
+    String castName = "他店舗担当-" + nonce;
+    String orderId = completedOrderAttributedTo(member, castName);
+
+    assertThat(
+            rest.exchange(
+                    "/store/orders/" + orderId + "/attribution",
+                    HttpMethod.GET,
+                    new HttpEntity<>(storeHeaders(STORE_A)),
+                    JsonNode.class)
+                .getBody()
+                .path("member_code")
+                .asString())
+        .as("正向対照: 自店舗では会員コードまで読めること")
+        .isEqualTo(member.memberCode());
+
+    ResponseEntity<JsonNode> leaked =
+        rest.exchange(
+            "/store/orders/" + orderId + "/attribution",
+            HttpMethod.GET,
+            new HttpEntity<>(storeHeaders(STORE_B)),
+            JsonNode.class);
+    assertThat(leaked.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(leaked.getBody().toString())
+        .as("他店舗の応答が会員コードを運ばないこと")
+        .doesNotContain(member.memberCode());
+
+    ResponseEntity<JsonNode> foreignInvalidation =
+        rest.exchange(
+            "/store/orders/" + orderId + "/attribution/invalidation",
+            HttpMethod.POST,
+            new HttpEntity<>("{\"reason\": \"" + REASON + "\"}", storeHeaders(STORE_B)),
+            JsonNode.class);
+    assertThat(foreignInvalidation.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    ResponseEntity<JsonNode> foreignReissue =
+        rest.exchange(
+            "/store/orders/" + orderId + "/receipt-token",
+            HttpMethod.POST,
+            new HttpEntity<>(storeHeaders(STORE_B)),
+            JsonNode.class);
+    assertThat(foreignReissue.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+
+    assertThat(attributionOf(orderId).getStatus()).isEqualTo(OrderAttributionStatus.ACTIVE);
+    assertThat(castNamesInVisitsOf(member)).contains(castName);
+  }
+
+  // ==================== 訂正の操作 ====================
+
+  private ResponseEntity<JsonNode> invalidate(String orderId, String reason) {
+    return rest.exchange(
+        "/store/orders/" + orderId + "/attribution/invalidation",
+        HttpMethod.POST,
+        new HttpEntity<>("{\"reason\": \"" + reason + "\"}", storeHeaders(STORE_A)),
+        JsonNode.class);
+  }
+
+  private ResponseEntity<JsonNode> reissue(String orderId) {
+    return rest.exchange(
+        "/store/orders/" + orderId + "/receipt-token",
+        HttpMethod.POST,
+        new HttpEntity<>(storeHeaders(STORE_A)),
+        JsonNode.class);
+  }
+
+  private ResponseEntity<JsonNode> claim(RegisteredMember member, String rawToken) {
+    return rest.exchange(
+        "/platform/me/receipts/claim",
+        HttpMethod.POST,
+        new HttpEntity<>("{\"token\": \"" + rawToken + "\"}", bearer(member.token())),
+        JsonNode.class);
+  }
+
+  // ==================== 会員側の読み口 ====================
+
+  private List<String> castNamesInVisitsOf(RegisteredMember member) {
+    ResponseEntity<JsonNode> response =
+        rest.exchange(
+            "/platform/me/visits",
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(member.token())),
+            JsonNode.class);
+    assertThat(response.getStatusCode()).as("前提: 来店履歴が読めること").isEqualTo(HttpStatus.OK);
+    List<String> castNames = new ArrayList<>();
+    for (JsonNode visit : response.getBody().path("content")) {
+      castNames.add(visit.path("cast_name").asString());
+    }
+    return castNames;
+  }
+
+  private long balanceOf(RegisteredMember member) {
+    ResponseEntity<JsonNode> response =
+        rest.exchange(
+            "/platform/me/points/balance",
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(member.token())),
+            JsonNode.class);
+    assertThat(response.getStatusCode()).as("前提: 残高が読めること").isEqualTo(HttpStatus.OK);
+    return response.getBody().path("balance").asLong();
+  }
+
+  // ==================== 実データの読み出し ====================
+
+  private OrderAttribution attributionOf(String orderId) {
+    List<OrderAttribution> found = attributionsOf(orderId);
+    assertThat(found).as("受注 %s の帰属記録が 1 件だけであること", orderId).hasSize(1);
+    return found.get(0);
+  }
+
+  private List<OrderAttribution> attributionsOf(String orderId) {
+    return orderAttributionRepository.findAll().stream()
+        .filter(row -> orderId.equals(row.getOrderId()))
+        .toList();
+  }
+
+  private int ledgerRowsFor(String orderId) {
+    return jdbcTemplate.queryForObject(
+        "select count(*) from t_point_entries where order_id = ?", Integer.class, orderId);
+  }
+
+  private int tokenCountFor(String orderId) {
+    return jdbcTemplate.queryForObject(
+        "select count(*) from t_order_receipt_tokens where order_id = ?", Integer.class, orderId);
+  }
+
+  private long seedStaffId() {
+    return jdbcTemplate.queryForObject(
+        "select id from t_users where email = ?", Long.class, "yamada.jiro@kizuna.test");
+  }
+
+  // ==================== 受注の用意 ====================
+
+  /** 会員へ帰属した完了を 1 件作る（顧客 → 有効な関連 → 会員の一本道を通す）。 */
+  private String completedOrderAttributedTo(RegisteredMember member, String castName) {
+    String customerId = createCustomer(castName);
+    linkMember(customerId, member.memberCode());
+    String orderId = confirmedOrder(customerId, castName);
+    assertThat(complete(orderId).getStatusCode()).as("前提: 受注を完了できること").isEqualTo(HttpStatus.OK);
+    assertThat(attributionOf(orderId).getSource()).isEqualTo(OrderAttributionSource.COMPLETION);
+    return orderId;
+  }
+
+  /** 会員へ帰属しない完了を 1 件作る（完了の応答が伝票を運ぶ枝）。 */
+  private String completedOrderWithoutMember(String castName) {
+    String orderId = confirmedOrder(null, castName);
+    assertThat(complete(orderId).getStatusCode()).as("前提: 受注を完了できること").isEqualTo(HttpStatus.OK);
+    return orderId;
+  }
+
+  /** 発行された伝票トークンとその受注。 */
+  private record Issued(String orderId, String token) {}
+
+  /** 会員へ帰属しない完了を 1 件作り、発行された生値を受け取る。 */
+  private Issued completedOrderWithToken(String castName) {
+    String orderId = confirmedOrder(null, castName);
+    ResponseEntity<JsonNode> completed = complete(orderId);
+    assertThat(completed.getStatusCode()).as("前提: 受注を完了できること").isEqualTo(HttpStatus.OK);
+    String raw = completed.getBody().path("receipt_token").asString();
+    assertThat(raw).as("前提: 完了応答が伝票トークンを運ぶこと").isNotBlank();
+    return new Issued(orderId, raw);
+  }
+
+  private String confirmedOrder(String customerId, String castName) {
+    String castId = createCast(castName);
+    String orderId = createOrder(castId, customerId, castName);
+    assertThat(updateStatus(orderId, castId, "CONFIRMED")).as("前提: 受注を確定できること").isTrue();
+    return orderId;
+  }
+
+  private ResponseEntity<JsonNode> complete(String orderId) {
+    return rest.exchange(
+        "/store/orders/" + orderId + "/completion",
+        HttpMethod.POST,
+        new HttpEntity<>("{\"total_fee\": " + TOTAL_FEE + "}", storeHeaders(STORE_A)),
+        JsonNode.class);
+  }
+
+  private String createOrder(String castId, String customerId, String remarks) {
+    String body =
+        "{\"receptionist_id\": "
+            + SEED_RECEPTIONIST_ID
+            + ", \"business_date\": \""
+            + LocalDate.now()
+            + "\", \"cast_id\": \""
+            + castId
+            + "\", \"pax\": 2"
+            + (customerId == null ? "" : ", \"customer_id\": \"" + customerId + "\"")
+            + ", \"remarks\": \""
+            + remarks
+            + "\"}";
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/store/orders", new HttpEntity<>(body, storeHeaders(STORE_A)), JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful()).as("前提: 受注作成が成功すること").isTrue();
+    return created.getBody().path("id").asString();
+  }
+
+  private boolean updateStatus(String orderId, String castId, String status) {
+    String body =
+        "{\"receptionist_id\": "
+            + SEED_RECEPTIONIST_ID
+            + ", \"cast_id\": \""
+            + castId
+            + "\", \"status\": \""
+            + status
+            + "\"}";
+    return rest.exchange(
+            "/store/orders/" + orderId,
+            HttpMethod.PUT,
+            new HttpEntity<>(body, storeHeaders(STORE_A)),
+            JsonNode.class)
+        .getStatusCode()
+        .is2xxSuccessful();
+  }
+
+  private String createCast(String name) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/store/casts",
+            new HttpEntity<>("{\"name\": \"" + name + "\"}", storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful()).as("前提: キャスト作成が成功すること").isTrue();
+    return created.getBody().path("id").asString();
+  }
+
+  private String createCustomer(String name) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/store/customers",
+            new HttpEntity<>("{\"name\": \"" + name + "\"}", storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful()).as("前提: 顧客作成が成功すること").isTrue();
+    return created.getBody().path("id").asString();
+  }
+
+  private void linkMember(String customerId, String memberCode) {
+    ResponseEntity<JsonNode> linked =
+        rest.exchange(
+            "/store/customers/" + customerId + "/member-link",
+            HttpMethod.POST,
+            new HttpEntity<>("{\"member_code\": \"" + memberCode + "\"}", storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(linked.getStatusCode()).as("前提: 会員の紐づけが成功すること").isEqualTo(HttpStatus.OK);
+  }
+
+  // ==================== 会員 ====================
+
+  /** 訂正の前後を会員側の読み口で確かめるための本人確認材料。 */
+  private record RegisteredMember(long id, String memberCode, String token) {}
+
+  /**
+   * 会員を 1 人作ってログインまで済ませる。
+   *
+   * <p>{@code prefix} は同じテスト内での呼び分け。email の local 部は 64 文字までなので、区別に要る分より長い接頭辞を 足さない（超えると登録が 400
+   * になり、前提の失敗として現れる）。
+   */
+  private RegisteredMember registerAndLogin(String prefix) {
+    String email = prefix + "-attr-inv-" + nonce + "@kizuna.test";
+    ResponseEntity<JsonNode> registration =
+        rest.postForEntity(
+            "/platform/members",
+            new HttpEntity<>(
+                "{\"email\": \""
+                    + email
+                    + "\", \"password\": \""
+                    + PASSWORD
+                    + "\", \"display_name\": \"帰属訂正検証会員\"}",
+                jsonHeaders()),
+            JsonNode.class);
+    assertThat(registration.getStatusCode()).as("前提: 会員登録が成功すること").isEqualTo(HttpStatus.CREATED);
+    String memberCode = registration.getBody().path("member_code").asString();
+    long registeredId =
+        memberRepository.findByMemberCode(memberCode).map(Member::getId).orElseThrow();
+
+    ResponseEntity<JsonNode> login =
+        rest.postForEntity(
+            "/platform/login",
+            new HttpEntity<>(
+                "{\"email\": \"" + email + "\", \"password\": \"" + PASSWORD + "\"}",
+                jsonHeaders()),
+            JsonNode.class);
+    assertThat(login.getStatusCode()).as("前提: 会員としてログインできること").isEqualTo(HttpStatus.OK);
+    return new RegisteredMember(registeredId, memberCode, login.getBody().path("token").asString());
+  }
+
+  private static HttpHeaders jsonHeaders() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+
+  private static HttpHeaders bearer(String bearerToken) {
+    HttpHeaders headers = jsonHeaders();
+    headers.setBearerAuth(bearerToken);
+    return headers;
+  }
+}

--- a/backend/src/integrationTest/java/com/kizuna/order/OrderAttributionInvalidationIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/OrderAttributionInvalidationIT.java
@@ -17,6 +17,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -242,6 +247,50 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
     assertThat(reissue(orderId).getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
 
     assertThat(tokenCountFor(orderId)).as("生きた伝票は 1 本だけであること").isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("並行する再発行は一方だけが成立し、申領できる伝票が 2 本並ばないこと")
+  void concurrentReissuesLeaveOnlyOneClaimableToken() throws Exception {
+    // 「申領できる伝票が無い」を確かめてから発行するまでが直列化されないと、両者が同じ「無い」を観測して
+    // 2 本とも発行される。そうなると後から申領した側は帰属記録の部分一意違反（500 系）で落ち、#653 が
+    // 意図して作った「申領できない伝票はすべて同形のエラー」が壊れる
+    RegisteredMember wrongMember = registerAndLogin("race");
+    String orderId = completedOrderAttributedTo(wrongMember, "並行再発行担当-" + nonce);
+    assertThat(invalidate(orderId, REASON).getStatusCode())
+        .as("前提: 無効化できること")
+        .isEqualTo(HttpStatus.OK);
+
+    CountDownLatch ready = new CountDownLatch(2);
+    CountDownLatch go = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    try {
+      List<Future<ResponseEntity<JsonNode>>> races = new ArrayList<>();
+      for (int i = 0; i < 2; i++) {
+        races.add(
+            pool.submit(
+                () -> {
+                  ready.countDown();
+                  go.await(10, TimeUnit.SECONDS);
+                  return reissue(orderId);
+                }));
+      }
+      assertThat(ready.await(10, TimeUnit.SECONDS)).as("前提: 2 つの再発行が同時に構えること").isTrue();
+      go.countDown();
+
+      List<ResponseEntity<JsonNode>> responses = new ArrayList<>();
+      for (Future<ResponseEntity<JsonNode>> race : races) {
+        responses.add(race.get(30, TimeUnit.SECONDS));
+      }
+      assertThat(responses)
+          .filteredOn(response -> response.getStatusCode() == HttpStatus.OK)
+          .as("成立するのは一方だけ")
+          .hasSize(1);
+    } finally {
+      pool.shutdownNow();
+    }
+
+    assertThat(tokenCountFor(orderId)).as("発行された伝票は 1 本だけであること").isEqualTo(1);
   }
 
   @Test

--- a/backend/src/integrationTest/java/com/kizuna/order/OrderAttributionInvalidationIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/OrderAttributionInvalidationIT.java
@@ -124,6 +124,43 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
   }
 
   @Test
+  @DisplayName("画面が見ていた記録と現に有効な記録がずれた無効化は 409 で差し戻され、正しい帰属が残ること")
+  void invalidationOfAStaleTargetIsRefused() {
+    // 画面を開いたまま別の操作者が訂正を一巡させると、有効な記録は「正しい本人の新しい帰属」に入れ替わる。
+    // 受注から対象を導く実装だと、古い理由がその新しい帰属へ当たって取り戻したばかりの来店を消す
+    RegisteredMember wrongMember = registerAndLogin("stale");
+    RegisteredMember rightMember = registerAndLogin("staleowner");
+    String castName = "取り違え上書き担当-" + nonce;
+    Issued original = completedOrderWithToken(castName);
+    assertThat(claim(wrongMember, original.token()).getStatusCode())
+        .as("前提: 誤った本人が申領できること")
+        .isEqualTo(HttpStatus.OK);
+    Long staleTarget = activeAttributionIdOf(original.orderId());
+
+    // 別の操作者が一巡させる
+    assertThat(invalidate(original.orderId(), staleTarget, REASON).getStatusCode())
+        .as("前提: 一巡目の無効化ができること")
+        .isEqualTo(HttpStatus.OK);
+    String raw = reissue(original.orderId()).getBody().path("receipt_token").asString();
+    assertThat(claim(rightMember, raw).getStatusCode())
+        .as("前提: 正しい本人が取り戻せること")
+        .isEqualTo(HttpStatus.OK);
+
+    // 開いたままだった画面が、古い記録を指したまま送信する
+    ResponseEntity<JsonNode> stale = invalidate(original.orderId(), staleTarget, "古い理由");
+
+    assertThat(stale.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(castNamesInVisitsOf(rightMember)).as("正しい本人の来店が消えないこと").contains(castName);
+    OrderAttribution active =
+        attributionsOf(original.orderId()).stream()
+            .filter(row -> row.getStatus() == OrderAttributionStatus.ACTIVE)
+            .findFirst()
+            .orElseThrow();
+    assertThat(active.getMemberCode()).isEqualTo(rightMember.memberCode());
+    assertThat(active.getInvalidatedReason()).as("誤った監査記録も残さないこと").isNull();
+  }
+
+  @Test
   @DisplayName("再発行の申領期限は原期限を引き継がず、再発行から 90 日で数え直されること")
   void reissuedTokenRestartsTheNinetyDayWindow() {
     // 完了時に会員へ達しなかった受注から始める。誤帰属が申領で成立した形なので、この受注には原期限を持つ
@@ -344,12 +381,31 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
 
   // ==================== 訂正の操作 ====================
 
+  /** 現に有効な帰属記録を対象に無効化する（画面が読み口で得た ID を添える経路と同じ形）。 */
   private ResponseEntity<JsonNode> invalidate(String orderId, String reason) {
+    return invalidate(orderId, activeAttributionIdOf(orderId), reason);
+  }
+
+  private ResponseEntity<JsonNode> invalidate(String orderId, Long attributionId, String reason) {
     return rest.exchange(
         "/store/orders/" + orderId + "/attribution/invalidation",
         HttpMethod.POST,
-        new HttpEntity<>("{\"reason\": \"" + reason + "\"}", storeHeaders(STORE_A)),
+        new HttpEntity<>(
+            "{\"attribution_id\": " + attributionId + ", \"reason\": \"" + reason + "\"}",
+            storeHeaders(STORE_A)),
         JsonNode.class);
+  }
+
+  /** 読み口が返す現況の ID。画面はこれを持って無効化を要求する。 */
+  private Long activeAttributionIdOf(String orderId) {
+    ResponseEntity<JsonNode> current =
+        rest.exchange(
+            "/store/orders/" + orderId + "/attribution",
+            HttpMethod.GET,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(current.getStatusCode()).as("前提: 帰属の現況が読めること").isEqualTo(HttpStatus.OK);
+    return current.getBody().path("id").asLong();
   }
 
   private ResponseEntity<JsonNode> reissue(String orderId) {

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderAttributionInvalidationRequest.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderAttributionInvalidationRequest.java
@@ -1,18 +1,25 @@
 package com.kizuna.order.api.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 /**
- * 帰属記録の無効化。受け取るのは理由だけで、無効化の対象は受注 1 件に対して高々 1 件の有効な帰属記録に定まる。
+ * 帰属記録の無効化。対象の記録と、その訂正の理由を受け取る。
  *
  * <p>理由は必須。無効化は帰属記録に対する唯一の訂正操作であり、後から「なぜ他人の来店が消えたのか」を辿れる根拠はここにしか残らない。
  *
  * <p>上限は列長（500）と揃える。契約側で撥ねないと、超過が 400 ではなく DB のエラーになる。
+ *
+ * <p>対象の帰属記録は受注 ID から導かず、画面が見ていた記録を {@code attributionId} で名指す。導くと、画面を開いたまま別の操作者が 訂正一巡（無効化 → 再発行 →
+ * 正しい本人の申領）を終えた場合に、古い理由が<b>新しく成立した正しい帰属</b>へ当たり、 取り戻したばかりの来店を消してしまう。
  */
 @Data
 public class OrderAttributionInvalidationRequest {
+
+  @NotNull(message = "無効化する帰属記録の指定は必須です")
+  private Long attributionId;
 
   @NotBlank(message = "無効化の理由は必須です")
   @Size(max = 500, message = "無効化の理由は 500 文字以内で入力してください")

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderAttributionInvalidationRequest.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderAttributionInvalidationRequest.java
@@ -1,0 +1,20 @@
+package com.kizuna.order.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * 帰属記録の無効化。受け取るのは理由だけで、無効化の対象は受注 1 件に対して高々 1 件の有効な帰属記録に定まる。
+ *
+ * <p>理由は必須。無効化は帰属記録に対する唯一の訂正操作であり、後から「なぜ他人の来店が消えたのか」を辿れる根拠はここにしか残らない。
+ *
+ * <p>上限は列長（500）と揃える。契約側で撥ねないと、超過が 400 ではなく DB のエラーになる。
+ */
+@Data
+public class OrderAttributionInvalidationRequest {
+
+  @NotBlank(message = "無効化の理由は必須です")
+  @Size(max = 500, message = "無効化の理由は 500 文字以内で入力してください")
+  private String reason;
+}

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderAttributionResponse.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderAttributionResponse.java
@@ -1,0 +1,28 @@
+package com.kizuna.order.api.dto;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 店舗が見る受注 1 件の帰属の現況（JSON キーは snake_case）。
+ *
+ * <p>返すのは直近の帰属記録 1 件だけで、区間の履歴一覧にはしない。帰属記録は「誰の来店か」の現況を判じるためのもので、 訂正が稀な人手操作である以上、店舗が読むのは常に最新の 1 件になる。
+ *
+ * <p>会員側の情報は<b>会員コードだけ</b>を返す。表示名・メールはプラットフォーム側プロフィールであり店舗へ渡らない（ADR 0008 の一本道と同じ紀律）。
+ *
+ * <p>{@code attributed} を独立した真偽値で持つのは、{@code non_null} 包含設定では記録の無い受注から他の項目がキーごと消えるため。
+ * 「帰属していない」と「読めなかった」を画面が取り違えないようにする。
+ *
+ * @param attributed 現にこの受注が会員へ帰属しているか（有効な帰属記録があるか）
+ * @param memberCode 直近の帰属記録の会員コード。記録が 1 件も無ければ欠落する
+ * @param source 成立の機構（COMPLETION / RECEIPT_TOKEN）。記録が無ければ欠落する
+ * @param attributedAt 帰属が確定した日時。記録が無ければ欠落する
+ * @param invalidatedReason 直近の記録が無効化済みならその理由。有効な記録・記録なしでは欠落する
+ * @param invalidatedAt 無効化した日時。同上
+ */
+public record OrderAttributionResponse(
+    boolean attributed,
+    String memberCode,
+    String source,
+    OffsetDateTime attributedAt,
+    String invalidatedReason,
+    OffsetDateTime invalidatedAt) {}

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderAttributionResponse.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderAttributionResponse.java
@@ -12,6 +12,7 @@ import java.time.OffsetDateTime;
  * <p>{@code attributed} を独立した真偽値で持つのは、{@code non_null} 包含設定では記録の無い受注から他の項目がキーごと消えるため。
  * 「帰属していない」と「読めなかった」を画面が取り違えないようにする。
  *
+ * @param id 直近の帰属記録の ID。無効化はこの値で「画面が見ていた記録」を名指す。記録が 1 件も無ければ欠落する
  * @param attributed 現にこの受注が会員へ帰属しているか（有効な帰属記録があるか）
  * @param memberCode 直近の帰属記録の会員コード。記録が 1 件も無ければ欠落する
  * @param source 成立の機構（COMPLETION / RECEIPT_TOKEN）。記録が無ければ欠落する
@@ -20,6 +21,7 @@ import java.time.OffsetDateTime;
  * @param invalidatedAt 無効化した日時。同上
  */
 public record OrderAttributionResponse(
+    Long id,
     boolean attributed,
     String memberCode,
     String source,

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderReceiptTokenResponse.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderReceiptTokenResponse.java
@@ -1,0 +1,12 @@
+package com.kizuna.order.api.dto;
+
+/**
+ * 伝票トークンの再発行の結果（JSON キーは snake_case）。
+ *
+ * <p>返すのは生値だけ。受注そのものは再発行で変わらないため、完了の応答のように受注の表現へ載せない。
+ *
+ * <p>保存されるのはダイジェストだけなので、この応答を取り逃すと生値は二度と手に入らない。診断出力へ滲ませないよう、 この型を持ち回す側もログへ落とさないこと。
+ *
+ * @param receiptToken 発行された伝票トークンの生値
+ */
+public record OrderReceiptTokenResponse(String receiptToken) {}

--- a/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
+++ b/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
@@ -1,13 +1,17 @@
 package com.kizuna.order.api.store;
 
+import com.kizuna.order.api.dto.OrderAttributionInvalidationRequest;
+import com.kizuna.order.api.dto.OrderAttributionResponse;
 import com.kizuna.order.api.dto.OrderCastCandidateResponse;
 import com.kizuna.order.api.dto.OrderCompletionPreviewResponse;
 import com.kizuna.order.api.dto.OrderCompletionRequest;
 import com.kizuna.order.api.dto.OrderCreateRequest;
+import com.kizuna.order.api.dto.OrderReceiptTokenResponse;
 import com.kizuna.order.api.dto.OrderReceptionistResponse;
 import com.kizuna.order.api.dto.OrderResponse;
 import com.kizuna.order.api.dto.OrderUpdateRequest;
 import com.kizuna.order.api.dto.ReservationRequestUpdateRequest;
+import com.kizuna.order.application.OrderAttributionService;
 import com.kizuna.order.application.OrderService;
 import com.kizuna.shared.exception.DbConstraint;
 import com.kizuna.shared.exception.IntegrityViolations;
@@ -38,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
   private final OrderService orderService;
+  private final OrderAttributionService orderAttributionService;
 
   @GetMapping
   @PreAuthorize("hasAuthority('PERM_ORDER_MANAGE')")
@@ -134,6 +139,38 @@ public class OrderController {
       @Valid @RequestBody OrderCompletionRequest request,
       Principal principal) {
     return ResponseEntity.ok(orderService.complete(id, request, principal.getName()));
+  }
+
+  /** 受注 1 件の帰属の現況（会員コード・成立の機構・無効化の理由）。無効化と再発行のどちらを提示するかはこの読み口で決まる。 */
+  @GetMapping("/{id}/attribution")
+  @PreAuthorize("hasAuthority('PERM_ORDER_MANAGE')")
+  public ResponseEntity<OrderAttributionResponse> attribution(@PathVariable String id) {
+    return ResponseEntity.ok(orderAttributionService.get(id));
+  }
+
+  /**
+   * 帰属記録を理由付きで無効化する（誤帰属の訂正）。帰属記録に対する唯一の訂正操作で、行は削除しない。
+   *
+   * <p>ポイント台帳へは波及しない。誤って付与されたポイントの清算は理由の残る手動調整で行う。
+   */
+  @PostMapping("/{id}/attribution/invalidation")
+  @PreAuthorize("hasAuthority('PERM_ORDER_MANAGE')")
+  public ResponseEntity<OrderAttributionResponse> invalidateAttribution(
+      @PathVariable String id,
+      @Valid @RequestBody OrderAttributionInvalidationRequest request,
+      Principal principal) {
+    return ResponseEntity.ok(orderAttributionService.invalidate(id, request, principal.getName()));
+  }
+
+  /**
+   * 無効化された受注へ伝票トークンを再発行する。正しい本人が所持証明で来店を取り戻すための唯一の経路。
+   *
+   * <p>申領期限は再発行から 90 日で数え直す。生値はこの応答にしか現れない。
+   */
+  @PostMapping("/{id}/receipt-token")
+  @PreAuthorize("hasAuthority('PERM_ORDER_MANAGE')")
+  public ResponseEntity<OrderReceiptTokenResponse> reissueReceiptToken(@PathVariable String id) {
+    return ResponseEntity.ok(orderAttributionService.reissueReceiptToken(id));
   }
 
   /** 完了処理の事前計算（会計金額に対する付与見込みと、会員なら残高）。 */

--- a/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
+++ b/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
@@ -145,7 +145,7 @@ public class OrderController {
   @GetMapping("/{id}/attribution")
   @PreAuthorize("hasAuthority('PERM_ORDER_MANAGE')")
   public ResponseEntity<OrderAttributionResponse> attribution(@PathVariable String id) {
-    return ResponseEntity.ok(orderAttributionService.get(id));
+    return ResponseEntity.ok(orderAttributionService.currentAttribution(id));
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/order/application/OrderAttributionService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderAttributionService.java
@@ -50,7 +50,7 @@ public class OrderAttributionService {
   /** 受注 1 件の帰属の現況。無効化・再発行のどちらを提示するかを店舗側の画面が判じるための読み口。 */
   @StoreScoped
   @Transactional(readOnly = true)
-  public OrderAttributionResponse get(String orderId) {
+  public OrderAttributionResponse currentAttribution(String orderId) {
     requireScopedOrder(orderId);
     return toResponse(latestAttribution(orderId).orElse(null));
   }
@@ -134,7 +134,7 @@ public class OrderAttributionService {
 
   /** 直近の帰属記録。無効化で行を消さないため複数行を持ちうるが、有効な行は部分一意索引により高々 1 件で、あればそれが直近になる。 */
   private Optional<OrderAttribution> latestAttribution(String orderId) {
-    return orderAttributionRepository.findByOrderIdOrderByIdDesc(orderId).stream().findFirst();
+    return orderAttributionRepository.findFirstByOrderIdOrderByIdDesc(orderId);
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/order/application/OrderAttributionService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderAttributionService.java
@@ -1,0 +1,165 @@
+package com.kizuna.order.application;
+
+import com.kizuna.order.api.dto.OrderAttributionInvalidationRequest;
+import com.kizuna.order.api.dto.OrderAttributionResponse;
+import com.kizuna.order.api.dto.OrderReceiptTokenResponse;
+import com.kizuna.order.domain.Order;
+import com.kizuna.order.domain.OrderAttribution;
+import com.kizuna.order.domain.OrderAttributionRepository;
+import com.kizuna.order.domain.OrderAttributionStatus;
+import com.kizuna.order.domain.OrderReceiptToken;
+import com.kizuna.order.domain.OrderReceiptTokenRepository;
+import com.kizuna.order.domain.OrderRepository;
+import com.kizuna.order.domain.OrderStatus;
+import com.kizuna.order.infrastructure.ReceiptTokenGenerator;
+import com.kizuna.shared.exception.NotFoundException;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.StaleSessionException;
+import com.kizuna.shared.storescope.StoreScoped;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 誤帰属の訂正（店舗コンソール）。帰属記録の無効化と、その受注に対する伝票トークンの再発行を受け持つ。
+ *
+ * <p>台帳へは<b>一切触らない</b>。無効化はポイントへ自動波及せず、清算は理由の残る手動調整で行う（ADR 0009）。 依存に {@code PointLedgerService}
+ * を持たないことがその宣言でもある。
+ *
+ * <p>帰属記録も伝票トークンも platform 帰属で店舗行分離機構に載らないため、店舗の境界を決めるのは受注だけである。 どの操作も先に {@link
+ * OrderRepository#findScopedById} で受注を引き、引けなければそこで終える。
+ *
+ * <p>完了（{@link OrderService#complete}）が受け持つのは帰属の<b>成立</b>で、こちらは成立済みの記録の訂正にあたる。
+ * 台帳への記帳を伴うかどうかで責務が分かれる。
+ */
+@Service
+@RequiredArgsConstructor
+public class OrderAttributionService {
+
+  private final OrderRepository orderRepository;
+  private final OrderAttributionRepository orderAttributionRepository;
+  private final OrderReceiptTokenRepository orderReceiptTokenRepository;
+  private final ReceiptTokenGenerator receiptTokenGenerator;
+  private final PlatformUserRepository platformUserRepository;
+
+  /** 受注 1 件の帰属の現況。無効化・再発行のどちらを提示するかを店舗側の画面が判じるための読み口。 */
+  @StoreScoped
+  @Transactional(readOnly = true)
+  public OrderAttributionResponse get(String orderId) {
+    requireScopedOrder(orderId);
+    return toResponse(latestAttribution(orderId).orElse(null));
+  }
+
+  /**
+   * 帰属記録を理由付きで無効化する（誤帰属の訂正）。
+   *
+   * <p>対象は現に有効な帰属記録 1 件。無効化された受注は「会員へ帰属しない状態」へ戻り、伝票トークンの再発行による 事後帰属の対象に復帰する。
+   *
+   * <p>誤って付与されたポイントはここでは動かない。無効化で台帳を機械的に巻き戻すと、誤りの上に誤りを重ねる危険が 誤りを残す危険を上回る（ADR 0009）。
+   */
+  @StoreScoped
+  @Transactional
+  public OrderAttributionResponse invalidate(
+      String orderId, OrderAttributionInvalidationRequest request, String actorEmail) {
+    requireScopedOrder(orderId);
+    OrderAttribution attribution =
+        latestAttribution(orderId)
+            .filter(row -> row.getStatus() == OrderAttributionStatus.ACTIVE)
+            .orElseThrow(() -> new ServiceException("この受注は会員へ帰属していません"));
+
+    attribution.invalidate(request.getReason(), resolveActorId(actorEmail), OffsetDateTime.now());
+    return toResponse(orderAttributionRepository.save(attribution));
+  }
+
+  /**
+   * 無効化された受注へ伝票トークンを再発行し、生値を返す。正しい本人はこの QR の所持証明で来店を取り戻せる。
+   *
+   * <p>申領期限は<b>再発行から</b> 90 日で数え直す（ADR 0009 の意図的な例外）。誤帰属の期間が本人の申領窓を食い潰したまま
+   * 原期限を残すと、訂正が形骸化するため。期限の起点は {@link OrderReceiptToken#issueFor} が受け取る発行時刻そのものになる。
+   *
+   * <p>付与予定額は<b>完了時点で確定した額</b>を引き継ぐ。ここで会計金額から計算し直すと、同じ会計が訂正の早い遅い（＝その間の
+   * 付与設定の変更）で別のポイントになる。引き継ぎ元は、この受注に伝票トークンの履歴があればその直近の予定額（完了時に非会員として
+   * 発行された額）、無ければ完了時に実際に付与された額（会員へ帰属した完了ではトークンが発行されないため、確定額はこちらにしか無い）。
+   *
+   * <p>申領できるトークンが既にある受注へは発行しない。生きたトークンが 2 本並ぶと、後から申領した側は帰属記録の部分一意違反で 落ち、申領の応答が同形でなくなる（{@code
+   * MemberReceiptClaimService} の収束は同一トークンの並行申領しか担わない）。
+   * 有効な帰属記録がある間はトークンが生きていることは無いので、無効化の側にトークンを止める処理は要らない。
+   */
+  @StoreScoped
+  @Transactional
+  public OrderReceiptTokenResponse reissueReceiptToken(String orderId) {
+    Order order = requireScopedOrder(orderId);
+    if (order.getStatus() != OrderStatus.COMPLETED) {
+      throw new ServiceException("完了していない受注に伝票は発行できません");
+    }
+    List<OrderAttribution> attributions =
+        orderAttributionRepository.findByOrderIdOrderByIdDesc(orderId);
+    if (attributions.isEmpty()) {
+      throw new ServiceException("この受注は会員へ帰属したことがありません。伝票の再発行は無効化された帰属の訂正にだけ使えます");
+    }
+    if (attributions.stream().anyMatch(row -> row.getStatus() == OrderAttributionStatus.ACTIVE)) {
+      throw new ServiceException("この受注は会員へ帰属しています。先に帰属を無効化してください");
+    }
+
+    OffsetDateTime now = OffsetDateTime.now();
+    List<OrderReceiptToken> tokens =
+        orderReceiptTokenRepository.findByOrderIdOrderByIdDesc(orderId);
+    if (tokens.stream().anyMatch(token -> token.isClaimableAt(now))) {
+      throw new ServiceException("この受注には申領できる伝票が既にあります");
+    }
+
+    int plannedPoints =
+        tokens.isEmpty() ? order.getAutoGrantPoints() : tokens.get(0).getPlannedPoints();
+    ReceiptTokenGenerator.GeneratedToken generated = receiptTokenGenerator.generate();
+    orderReceiptTokenRepository.save(
+        OrderReceiptToken.issueFor(orderId, generated.digest(), plannedPoints, now));
+    return new OrderReceiptTokenResponse(generated.raw());
+  }
+
+  /**
+   * 現店舗の受注。帰属記録・伝票トークンはどちらも受注 ID でしか辿れないため、店舗の所有はここでだけ決まる。
+   *
+   * <p>引けない受注は他店舗のものか存在しないかを区別せず 404 にする（区別すると受注 ID の存在が漏れる）。
+   */
+  private Order requireScopedOrder(String orderId) {
+    return orderRepository
+        .findScopedById(orderId)
+        .orElseThrow(() -> new NotFoundException("注文が見つかりません: " + orderId));
+  }
+
+  /** 直近の帰属記録。無効化で行を消さないため複数行を持ちうるが、有効な行は部分一意索引により高々 1 件で、あればそれが直近になる。 */
+  private Optional<OrderAttribution> latestAttribution(String orderId) {
+    return orderAttributionRepository.findByOrderIdOrderByIdDesc(orderId).stream().findFirst();
+  }
+
+  /**
+   * JWT は user-id claim を持たないため、実行者は認証主体の email から解決する。
+   *
+   * <p>解決できない認証主体は黙って null にせず失敗させる — 無効化の実行者は訂正の根拠の一部であり、失効した認証セッションによる 操作を実行者不明のまま通すと記録が監査に耐えない。
+   */
+  private Long resolveActorId(String actorEmail) {
+    return platformUserRepository
+        .findByEmail(actorEmail)
+        .map(PlatformUser::getId)
+        .orElseThrow(() -> new StaleSessionException("認証セッションの主体が存在しません"));
+  }
+
+  /** 会員側の情報は会員コードだけを写す。表示名・メールはプラットフォーム側プロフィールで、店舗へは渡らない。 */
+  private static OrderAttributionResponse toResponse(OrderAttribution attribution) {
+    if (attribution == null) {
+      return new OrderAttributionResponse(false, null, null, null, null, null);
+    }
+    return new OrderAttributionResponse(
+        attribution.getStatus() == OrderAttributionStatus.ACTIVE,
+        attribution.getMemberCode(),
+        attribution.getSource().name(),
+        attribution.getAttributedAt(),
+        attribution.getInvalidatedReason(),
+        attribution.getInvalidatedAt());
+  }
+}

--- a/backend/src/main/java/com/kizuna/order/application/OrderAttributionService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderAttributionService.java
@@ -93,7 +93,12 @@ public class OrderAttributionService {
   @StoreScoped
   @Transactional
   public OrderReceiptTokenResponse reissueReceiptToken(String orderId) {
-    Order order = requireScopedOrder(orderId);
+    // 「申領できる伝票がまだ無い」を確かめてから発行するまでの間、受注を押さえて並行する再発行と直列化する。
+    // 押さえないと両者が同じ「無い」を観測して 2 本とも発行され、下の門が素通りする。
+    Order order =
+        orderRepository
+            .findScopedByIdForUpdate(orderId)
+            .orElseThrow(() -> new NotFoundException("注文が見つかりません: " + orderId));
     if (order.getStatus() != OrderStatus.COMPLETED) {
       throw new ServiceException("完了していない受注に伝票は発行できません");
     }

--- a/backend/src/main/java/com/kizuna/order/application/OrderAttributionService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderAttributionService.java
@@ -12,6 +12,7 @@ import com.kizuna.order.domain.OrderReceiptTokenRepository;
 import com.kizuna.order.domain.OrderRepository;
 import com.kizuna.order.domain.OrderStatus;
 import com.kizuna.order.infrastructure.ReceiptTokenGenerator;
+import com.kizuna.shared.exception.ConflictException;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.exception.StaleSessionException;
@@ -61,6 +62,10 @@ public class OrderAttributionService {
    * <p>対象は現に有効な帰属記録 1 件。無効化された受注は「会員へ帰属しない状態」へ戻り、伝票トークンの再発行による 事後帰属の対象に復帰する。
    *
    * <p>誤って付与されたポイントはここでは動かない。無効化で台帳を機械的に巻き戻すと、誤りの上に誤りを重ねる危険が 誤りを残す危険を上回る（ADR 0009）。
+   *
+   * <p>対象は受注から導かず、要求が名指した記録と現に有効な記録の一致を確かめる。画面を開いたまま別の操作者が訂正を一巡 （無効化 → 再発行 →
+   * 正しい本人の申領）させると、受注から導く実装では古い理由が<b>新しく成立した正しい帰属</b>へ当たり、 取り戻したばかりの来店を消したうえに誤った監査記録を残す。ずれていれば書かずに
+   * 409 で差し戻す。
    */
   @StoreScoped
   @Transactional
@@ -71,6 +76,9 @@ public class OrderAttributionService {
         latestAttribution(orderId)
             .filter(row -> row.getStatus() == OrderAttributionStatus.ACTIVE)
             .orElseThrow(() -> new ServiceException("この受注は会員へ帰属していません"));
+    if (!attribution.getId().equals(request.getAttributionId())) {
+      throw new ConflictException("この受注の帰属は別の操作で変わりました。最新の状態を確認してからやり直してください");
+    }
 
     attribution.invalidate(request.getReason(), resolveActorId(actorEmail), OffsetDateTime.now());
     return toResponse(orderAttributionRepository.save(attribution));
@@ -157,9 +165,10 @@ public class OrderAttributionService {
   /** 会員側の情報は会員コードだけを写す。表示名・メールはプラットフォーム側プロフィールで、店舗へは渡らない。 */
   private static OrderAttributionResponse toResponse(OrderAttribution attribution) {
     if (attribution == null) {
-      return new OrderAttributionResponse(false, null, null, null, null, null);
+      return new OrderAttributionResponse(null, false, null, null, null, null, null);
     }
     return new OrderAttributionResponse(
+        attribution.getId(),
         attribution.getStatus() == OrderAttributionStatus.ACTIVE,
         attribution.getMemberCode(),
         attribution.getSource().name(),

--- a/backend/src/main/java/com/kizuna/order/domain/OrderAttribution.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderAttribution.java
@@ -53,6 +53,12 @@ public class OrderAttribution extends BaseEntity {
   @Column(name = "invalidated_reason", length = 500)
   private String invalidatedReason;
 
+  /**
+   * 無効化を実行した操作者。書き込み時は必須だが、読み出しでは欠落しうる — 操作者の削除で FK が SET NULL になるためで、会員参照（{@code
+   * memberId}）と同じ紀律である。
+   *
+   * <p>非対称なのは意図で、「実行者不明のまま訂正を通す」ことと「訂正の後に操作者の口座が消える」ことは別の事象にあたる。前者は失効した認証セッションによる操作を記録に残せなくするので拒む。
+   */
   @Column(name = "invalidated_by")
   private Long invalidatedBy;
 

--- a/backend/src/main/java/com/kizuna/order/domain/OrderAttribution.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderAttribution.java
@@ -49,6 +49,16 @@ public class OrderAttribution extends BaseEntity {
   @Column(name = "status", nullable = false, length = 20)
   private OrderAttributionStatus status;
 
+  /** 無効化の理由。訂正の根拠そのものなので無効化では必須で、有効な記録では null。 */
+  @Column(name = "invalidated_reason", length = 500)
+  private String invalidatedReason;
+
+  @Column(name = "invalidated_by")
+  private Long invalidatedBy;
+
+  @Column(name = "invalidated_at")
+  private OffsetDateTime invalidatedAt;
+
   private OrderAttribution(
       String orderId,
       Long memberId,
@@ -91,6 +101,34 @@ public class OrderAttribution extends BaseEntity {
       String orderId, Long memberId, String memberCode, OffsetDateTime attributedAt) {
     return new OrderAttribution(
         orderId, memberId, memberCode, OrderAttributionSource.RECEIPT_TOKEN, attributedAt);
+  }
+
+  /**
+   * 誤帰属を訂正する。帰属記録に対する唯一の訂正操作で、行は削除せず状態だけを倒し、理由・実行者・時刻を残す。
+   *
+   * <p>帰属そのものの記録（会員・根拠・帰属時刻）は書き換えない。訂正の対象は「誰の来店だったことにしていたか」であり、 それを消してしまうと監査に必要な事実が残らない。
+   *
+   * <p>ポイント台帳へは波及しない — 清算は理由の残る手動調整で行う（ADR 0009）。訂正を機械の級聯にすると、誤りの上に 誤りを重ねる危険が誤りを残す危険を上回る。
+   *
+   * <p>二度目の無効化は受け付けない。通せば初回の理由と実行者が上書きされ、最初の訂正の根拠が失われる。
+   */
+  public void invalidate(String reason, Long actorId, OffsetDateTime at) {
+    if (status != OrderAttributionStatus.ACTIVE) {
+      throw new InvalidOrderAttributionException("この帰属記録は既に無効化されています");
+    }
+    if (reason == null || reason.isBlank()) {
+      throw new InvalidOrderAttributionException("無効化の理由は必須です");
+    }
+    if (actorId == null) {
+      throw new InvalidOrderAttributionException("無効化の実行者は必須です");
+    }
+    if (at == null) {
+      throw new InvalidOrderAttributionException("無効化の日時は必須です");
+    }
+    this.status = OrderAttributionStatus.INVALIDATED;
+    this.invalidatedReason = reason;
+    this.invalidatedBy = actorId;
+    this.invalidatedAt = at;
   }
 
   @Override

--- a/backend/src/main/java/com/kizuna/order/domain/OrderAttributionRepository.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderAttributionRepository.java
@@ -2,6 +2,7 @@ package com.kizuna.order.domain;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,6 +16,14 @@ public interface OrderAttributionRepository extends JpaRepository<OrderAttributi
    * <p>この読み口は店舗行分離機構に載らない（帰属記録は platform 帰属）。店舗の所有は受注を先に引いて確かめること。
    */
   List<OrderAttribution> findByOrderIdOrderByIdDesc(String orderId);
+
+  /**
+   * 受注の直近の帰属記録 1 件。有効な行があれば必ずこれになる（無効化は過去の行にしか起こらないため）。
+   *
+   * <p>現況だけが要る経路は履歴を丸ごと読まずにこちらを使う。{@link #findByOrderIdOrderByIdDesc} は「1 件でもあるか」と「有効な行があるか」を
+   * 同時に判じる再発行の門でだけ要る。
+   */
+  Optional<OrderAttribution> findFirstByOrderIdOrderByIdDesc(String orderId);
 
   // 会員本人の来店一覧。帰属記録が正本で、表示に要る属性は受注へ join して導出する（ADR 0003 と同じ扱い。
   // 帰属記録は台帳と同じく platform 帰属なので同 ADR が名指す店舗作用域エンティティそのものではない）。店舗は

--- a/backend/src/main/java/com/kizuna/order/domain/OrderAttributionRepository.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderAttributionRepository.java
@@ -9,6 +9,13 @@ import org.springframework.data.repository.query.Param;
 
 public interface OrderAttributionRepository extends JpaRepository<OrderAttribution, Long> {
 
+  /**
+   * 受注の帰属記録を新しい順に。無効化で行を消さないため 1 受注が複数行を持ちうるが、有効な行は部分一意索引により高々 1 件。
+   *
+   * <p>この読み口は店舗行分離機構に載らない（帰属記録は platform 帰属）。店舗の所有は受注を先に引いて確かめること。
+   */
+  List<OrderAttribution> findByOrderIdOrderByIdDesc(String orderId);
+
   // 会員本人の来店一覧。帰属記録が正本で、表示に要る属性は受注へ join して導出する（ADR 0003 と同じ扱い。
   // 帰属記録は台帳と同じく platform 帰属なので同 ADR が名指す店舗作用域エンティティそのものではない）。店舗は
   // 内部結合でよい — 完了受注を持つ店舗は削除ガードが明示的に拒むため、来店の店舗が欠けることはない。

--- a/backend/src/main/java/com/kizuna/order/domain/OrderReceiptTokenRepository.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderReceiptTokenRepository.java
@@ -1,6 +1,7 @@
 package com.kizuna.order.domain;
 
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -15,4 +16,14 @@ public interface OrderReceiptTokenRepository extends JpaRepository<OrderReceiptT
    */
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   Optional<OrderReceiptToken> findByTokenDigest(String tokenDigest);
+
+  /**
+   * 受注に対して発行された伝票トークンを新しい順に。再発行があるため 1 受注が複数行を持ちうる。
+   *
+   * <p>「申領できる行が既にあるか」の判定は取得した行に {@link OrderReceiptToken#isClaimableAt} を当てて行う —
+   * 状態と期限を問い合わせ側で書き下すと、 申領できるかの定義が二箇所に分かれる。
+   *
+   * <p>この読み口は店舗行分離機構に載らない（伝票トークンは platform 帰属）。店舗の所有は受注を先に引いて確かめること。
+   */
+  List<OrderReceiptToken> findByOrderIdOrderByIdDesc(String orderId);
 }

--- a/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
@@ -1,5 +1,6 @@
 package com.kizuna.order.domain;
 
+import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -9,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -75,6 +77,20 @@ public interface OrderRepository
    */
   @Query("select o from com.kizuna.order.domain.Order o where o.id = :id")
   Optional<Order> findScopedById(@Param("id") String id);
+
+  /**
+   * 現店舗の受注 1 件を、その受注に紐づく行を書き換える間だけ押さえて引く。
+   *
+   * <p>伝票トークンの再発行は「申領できる伝票がまだ無い」を確かめてから 1 本発行する。トークン表の一意制約はダイジェストにしか 掛からないため、ロックが無いと並行する 2
+   * つの再発行が同じ「無い」を観測して両方成功し、申領できる伝票が 2 本並ぶ。 そうなると後から申領した側は帰属記録の部分一意違反（500 系）で落ち、申領の応答が同形でなくなる。
+   *
+   * <p>押さえるのが受注なのは、帰属記録も伝票トークンも受注 ID でしか辿れず、まだ存在しない行はロックできないため。 受注は両者の親であり、この操作の直列化の単位になる。
+   *
+   * <p>申領（{@code MemberReceiptClaimService}）が押さえるのはトークン行だけで、こちらは受注行だけなので待ちが環にならない。
+   */
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select o from com.kizuna.order.domain.Order o where o.id = :id")
+  Optional<Order> findScopedByIdForUpdate(@Param("id") String id);
 
   // 未確定の申請の抽出条件。先頭と続きの問い合わせが同じ条件を共有する（片方だけ直すと、続きの取得が
   // 先頭の取得と違う母集合を辿り、到達できない申請を生む）。

--- a/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
@@ -64,6 +64,18 @@ public interface OrderRepository
   @Query(VIEW_SELECT + " where o.id = :id")
   Optional<OrderView> findViewById(@Param("id") String id);
 
+  /**
+   * 現店舗の受注 1 件を集約として引く。
+   *
+   * <p>JPQL で書くのは {@code storeFilter} を効かせるため。Order は StoreScopedEntity だが、Hibernate のフィルタは {@code
+   * EntityManager.find} には掛からず、派生の {@code findById} はそこへ落ちる。複数店舗を授権された操作者は現店舗の文脈のまま 他店舗の受注 ID
+   * を指せるので、店舗を跨がない読み書きはこの形で引く。
+   *
+   * <p>受注に紐づく帰属記録・伝票トークンは platform 帰属で店舗行分離機構に載らない。それらを受注 ID で引く操作は、 先にこの読み口で店舗の所有を確かめてから行う。
+   */
+  @Query("select o from com.kizuna.order.domain.Order o where o.id = :id")
+  Optional<Order> findScopedById(@Param("id") String id);
+
   // 未確定の申請の抽出条件。先頭と続きの問い合わせが同じ条件を共有する（片方だけ直すと、続きの取得が
   // 先頭の取得と違う母集合を辿り、到達できない申請を生む）。
   String PENDING_REQUEST_WHERE =

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -50,6 +50,9 @@ databaseChangeLog:
   - include:
       file: releases/v0.17.0/master.yaml
       relativeToChangelogFile: true
+  - include:
+      file: releases/v0.18.0/master.yaml
+      relativeToChangelogFile: true
   # reconcile/ は版に属さない恒久的な写像取り直しで、必ず全 release の後に置く（毎回実行されるため、
   # ロールの改名など release 側の移行より先に走ると、移行前の状態を見て齟齬と判定してしまう）。
   # 新しい release の include は必ずこの include より前に足すこと。

--- a/backend/src/main/resources/db/changelog/releases/v0.18.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.18.0/master.yaml
@@ -1,0 +1,5 @@
+# v0.18.0 = 帰属記録の無効化（誤帰属の訂正）。platform 層のみ。
+databaseChangeLog:
+  - include:
+      file: platform/01-order-attribution-invalidation.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.18.0/platform/01-order-attribution-invalidation.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.18.0/platform/01-order-attribution-invalidation.yaml
@@ -1,0 +1,48 @@
+databaseChangeLog:
+  - changeSet:
+      id: platform-v01800-001-order-attribution-invalidation
+      author: kanghouchao
+      # 誤帰属の訂正。帰属記録の唯一の訂正操作は理由付きの無効化で、行は削除せず status を
+      # INVALIDATED へ倒したうえで、理由・実行者・時刻をこの 3 列に残す。
+      # 理由を必須にするのは記録側ではなく操作側の契約なので列は可空 — ACTIVE の行は当然 NULL で、
+      # NOT NULL にすると既存の有効な帰属記録を表現できない。
+      # 無効化はポイント台帳へ自動波及しない（清算は手動調整）ため、この移行は台帳側の列を一切触らない。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - addColumn:
+            tableName: t_order_attributions
+            columns:
+              - column:
+                  name: invalidated_reason
+                  type: VARCHAR(500)
+                  remarks: 無効化の理由（無効化時は必須。有効な帰属記録では NULL）
+              - column:
+                  name: invalidated_by
+                  type: BIGINT
+                  remarks: 無効化を実行した操作者。操作者の削除後も記録は残るため SET NULL
+              - column:
+                  name: invalidated_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  remarks: 無効化した日時
+        - addForeignKeyConstraint:
+            constraintName: fk_t_order_attributions_invalidated_by
+            baseTableName: t_order_attributions
+            baseColumnNames: invalidated_by
+            referencedTableName: t_users
+            referencedColumnNames: id
+            onDelete: SET NULL
+      rollback:
+        - dropForeignKeyConstraint:
+            constraintName: fk_t_order_attributions_invalidated_by
+            baseTableName: t_order_attributions
+        - dropColumn:
+            tableName: t_order_attributions
+            columns:
+              - column:
+                  name: invalidated_reason
+              - column:
+                  name: invalidated_by
+              - column:
+                  name: invalidated_at

--- a/backend/src/test/java/com/kizuna/order/api/store/OrderControllerTest.java
+++ b/backend/src/test/java/com/kizuna/order/api/store/OrderControllerTest.java
@@ -14,8 +14,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.kizuna.order.api.dto.OrderAttributionResponse;
 import com.kizuna.order.api.dto.OrderCompletionPreviewResponse;
 import com.kizuna.order.api.dto.OrderResponse;
+import com.kizuna.order.application.OrderAttributionService;
 import com.kizuna.order.application.OrderService;
 import com.kizuna.settings.application.SystemConfigService;
 import com.kizuna.shared.storescope.StoreContext;
@@ -56,6 +58,7 @@ class OrderControllerTest {
   @Autowired private MockMvc mockMvc;
 
   @MockitoBean private OrderService orderService;
+  @MockitoBean private OrderAttributionService orderAttributionService;
 
   // MaintenanceModeInterceptor / StoreExistenceInterceptor は HandlerInterceptor として
   // @WebMvcTest に自動で取り込まれるため、その依存もモックで満たす必要がある。
@@ -298,6 +301,57 @@ class OrderControllerTest {
     mockMvc.perform(storePost("/store/orders/o1/confirmation")).andExpect(status().isConflict());
 
     verify(orderService, times(1)).confirm(any(), any());
+  }
+
+  @Test
+  @DisplayName("受注管理権限が無ければ帰属の閲覧・無効化・伝票の再発行が拒否されること")
+  @WithMockUser(authorities = "PERM_CUSTOMER_MANAGE")
+  void attributionCorrectionIsRejectedWithoutOrderManage() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+
+    mockMvc.perform(storeGet("/store/orders/o1/attribution")).andExpect(status().isForbidden());
+    mockMvc
+        .perform(storePost("/store/orders/o1/attribution/invalidation", "{\"reason\": \"取り違え\"}"))
+        .andExpect(status().isForbidden());
+    mockMvc.perform(storePost("/store/orders/o1/receipt-token")).andExpect(status().isForbidden());
+    verifyNoInteractions(orderAttributionService);
+  }
+
+  @Test
+  @DisplayName("理由の無い無効化は撥ねられ、サービスへ届かないこと")
+  @WithMockUser(authorities = "PERM_ORDER_MANAGE")
+  void invalidationWithoutAReasonIsRejected() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+
+    mockMvc
+        .perform(storePost("/store/orders/o1/attribution/invalidation", "{\"reason\": \" \"}"))
+        .andExpect(status().isBadRequest());
+    mockMvc
+        .perform(storePost("/store/orders/o1/attribution/invalidation", "{}"))
+        .andExpect(status().isBadRequest());
+    verifyNoInteractions(orderAttributionService);
+  }
+
+  @Test
+  @DisplayName("列長を超える理由は 400 で撥ねられること（DB のエラーにしない）")
+  @WithMockUser(authorities = "PERM_ORDER_MANAGE")
+  void invalidationWithAnOverlongReasonIsRejected() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+    String body = "{\"reason\": \"" + "あ".repeat(501) + "\"}";
+
+    mockMvc
+        .perform(storePost("/store/orders/o1/attribution/invalidation", body))
+        .andExpect(status().isBadRequest());
+
+    // 正向対照: 上限ちょうどは通る
+    when(orderAttributionService.invalidate(any(), any(), any()))
+        .thenReturn(new OrderAttributionResponse(false, null, null, null, null, null));
+    mockMvc
+        .perform(
+            storePost(
+                "/store/orders/o1/attribution/invalidation",
+                "{\"reason\": \"" + "あ".repeat(500) + "\"}"))
+        .andExpect(status().isOk());
   }
 
   /** 制約名を持つ整合性違反。全域ハンドラの一意違反判定（SQLSTATE 23505）も通る形にする。 */

--- a/backend/src/test/java/com/kizuna/order/api/store/OrderControllerTest.java
+++ b/backend/src/test/java/com/kizuna/order/api/store/OrderControllerTest.java
@@ -311,7 +311,10 @@ class OrderControllerTest {
 
     mockMvc.perform(storeGet("/store/orders/o1/attribution")).andExpect(status().isForbidden());
     mockMvc
-        .perform(storePost("/store/orders/o1/attribution/invalidation", "{\"reason\": \"取り違え\"}"))
+        .perform(
+            storePost(
+                "/store/orders/o1/attribution/invalidation",
+                "{\"attribution_id\": 1, \"reason\": \"取り違え\"}"))
         .andExpect(status().isForbidden());
     mockMvc.perform(storePost("/store/orders/o1/receipt-token")).andExpect(status().isForbidden());
     verifyNoInteractions(orderAttributionService);
@@ -324,10 +327,26 @@ class OrderControllerTest {
     when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
 
     mockMvc
-        .perform(storePost("/store/orders/o1/attribution/invalidation", "{\"reason\": \" \"}"))
+        .perform(
+            storePost(
+                "/store/orders/o1/attribution/invalidation",
+                "{\"attribution_id\": 1, \"reason\": \" \"}"))
         .andExpect(status().isBadRequest());
     mockMvc
         .perform(storePost("/store/orders/o1/attribution/invalidation", "{}"))
+        .andExpect(status().isBadRequest());
+    verifyNoInteractions(orderAttributionService);
+  }
+
+  @Test
+  @DisplayName("対象の帰属記録を名指さない無効化は撥ねられ、サービスへ届かないこと")
+  @WithMockUser(authorities = "PERM_ORDER_MANAGE")
+  void invalidationWithoutATargetIsRejected() throws Exception {
+    // 受注から対象を導く形へ戻ると、画面が見ていた記録と別の記録を消しうる
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+
+    mockMvc
+        .perform(storePost("/store/orders/o1/attribution/invalidation", "{\"reason\": \"取り違え\"}"))
         .andExpect(status().isBadRequest());
     verifyNoInteractions(orderAttributionService);
   }
@@ -337,7 +356,7 @@ class OrderControllerTest {
   @WithMockUser(authorities = "PERM_ORDER_MANAGE")
   void invalidationWithAnOverlongReasonIsRejected() throws Exception {
     when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
-    String body = "{\"reason\": \"" + "あ".repeat(501) + "\"}";
+    String body = "{\"attribution_id\": 1, \"reason\": \"" + "あ".repeat(501) + "\"}";
 
     mockMvc
         .perform(storePost("/store/orders/o1/attribution/invalidation", body))
@@ -345,12 +364,12 @@ class OrderControllerTest {
 
     // 正向対照: 上限ちょうどは通る
     when(orderAttributionService.invalidate(any(), any(), any()))
-        .thenReturn(new OrderAttributionResponse(false, null, null, null, null, null));
+        .thenReturn(new OrderAttributionResponse(null, false, null, null, null, null, null));
     mockMvc
         .perform(
             storePost(
                 "/store/orders/o1/attribution/invalidation",
-                "{\"reason\": \"" + "あ".repeat(500) + "\"}"))
+                "{\"attribution_id\": 1, \"reason\": \"" + "あ".repeat(500) + "\"}"))
         .andExpect(status().isOk());
   }
 

--- a/backend/src/test/java/com/kizuna/order/application/OrderAttributionServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderAttributionServiceTest.java
@@ -87,7 +87,7 @@ class OrderAttributionServiceTest {
     givenOrder(OrderStatus.COMPLETED);
     givenAttributions(activeAttribution());
 
-    OrderAttributionResponse response = service.get(ORDER_ID);
+    OrderAttributionResponse response = service.currentAttribution(ORDER_ID);
 
     assertThat(response.attributed()).isTrue();
     assertThat(response.memberCode()).isEqualTo(MEMBER_CODE);
@@ -103,7 +103,7 @@ class OrderAttributionServiceTest {
     invalidated.invalidate(REASON, ACTOR_ID, OffsetDateTime.now());
     givenAttributions(invalidated);
 
-    OrderAttributionResponse response = service.get(ORDER_ID);
+    OrderAttributionResponse response = service.currentAttribution(ORDER_ID);
 
     assertThat(response.attributed()).isFalse();
     // 誰の来店として記録されていたかは訂正後も読めなければならない（訂正の妥当性を店舗が確かめる材料）
@@ -118,7 +118,7 @@ class OrderAttributionServiceTest {
     givenOrder(OrderStatus.COMPLETED);
     givenAttributions();
 
-    OrderAttributionResponse response = service.get(ORDER_ID);
+    OrderAttributionResponse response = service.currentAttribution(ORDER_ID);
 
     assertThat(response.attributed()).isFalse();
     assertThat(response.memberCode()).isNull();
@@ -130,7 +130,8 @@ class OrderAttributionServiceTest {
   void getRejectsAnOrderOutsideTheStore() {
     Mockito.when(orderRepository.findScopedById(ORDER_ID)).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> service.get(ORDER_ID)).isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(() -> service.currentAttribution(ORDER_ID))
+        .isInstanceOf(NotFoundException.class);
     // 帰属記録は platform 帰属で店舗行分離機構に載らない。受注を引けない時点で終えないと他店舗の会員コードが漏れる
     Mockito.verifyNoInteractions(orderAttributionRepository);
   }
@@ -356,8 +357,12 @@ class OrderAttributionServiceTest {
   }
 
   private void givenAttributions(OrderAttribution... rows) {
-    Mockito.when(orderAttributionRepository.findByOrderIdOrderByIdDesc(ORDER_ID))
+    Mockito.lenient()
+        .when(orderAttributionRepository.findByOrderIdOrderByIdDesc(ORDER_ID))
         .thenReturn(List.of(rows));
+    Mockito.lenient()
+        .when(orderAttributionRepository.findFirstByOrderIdOrderByIdDesc(ORDER_ID))
+        .thenReturn(rows.length == 0 ? Optional.empty() : Optional.of(rows[0]));
   }
 
   private void givenTokens(OrderReceiptToken... rows) {

--- a/backend/src/test/java/com/kizuna/order/application/OrderAttributionServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderAttributionServiceTest.java
@@ -15,6 +15,7 @@ import com.kizuna.order.domain.OrderReceiptTokenRepository;
 import com.kizuna.order.domain.OrderRepository;
 import com.kizuna.order.domain.OrderStatus;
 import com.kizuna.order.infrastructure.ReceiptTokenGenerator;
+import com.kizuna.shared.exception.ConflictException;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.exception.StaleSessionException;
@@ -49,6 +50,7 @@ class OrderAttributionServiceTest {
   private static final String REASON = "別人の来店を取り違えたため";
   private static final int COMPLETION_GRANT = 98;
   private static final int TOKEN_PLANNED_POINTS = 120;
+  private static final long ATTRIBUTION_ID = 501L;
 
   @Mock private OrderRepository orderRepository;
   @Mock private OrderAttributionRepository orderAttributionRepository;
@@ -177,6 +179,24 @@ class OrderAttributionServiceTest {
     assertThatThrownBy(() -> service.invalidate(ORDER_ID, request(REASON), ACTOR_EMAIL))
         .isInstanceOf(ServiceException.class);
     assertThat(invalidated.getInvalidatedReason()).isEqualTo("初回の理由");
+  }
+
+  @Test
+  @DisplayName("画面が見ていた記録と現に有効な記録がずれていれば、書かずに 409 で差し戻すこと")
+  void invalidateRejectsAStaleTarget() {
+    // 画面を開いたまま別の操作者が訂正を一巡させると、有効な記録は「正しい本人の新しい帰属」に入れ替わる。
+    // 受注から対象を導く実装だと、古い理由がその新しい帰属へ当たって取り戻したばかりの来店を消す
+    givenOrder(OrderStatus.COMPLETED);
+    OrderAttribution current = activeAttribution();
+    current.setId(ATTRIBUTION_ID + 1);
+    givenAttributions(current);
+
+    assertThatThrownBy(
+            () -> service.invalidate(ORDER_ID, request(ATTRIBUTION_ID, REASON), ACTOR_EMAIL))
+        .isInstanceOf(ConflictException.class);
+
+    assertThat(current.getStatus()).isEqualTo(OrderAttributionStatus.ACTIVE);
+    Mockito.verify(orderAttributionRepository, Mockito.never()).save(Mockito.any());
   }
 
   @Test
@@ -356,7 +376,12 @@ class OrderAttributionServiceTest {
   // ==================== 用意 ====================
 
   private static OrderAttributionInvalidationRequest request(String reason) {
+    return request(ATTRIBUTION_ID, reason);
+  }
+
+  private static OrderAttributionInvalidationRequest request(Long attributionId, String reason) {
     OrderAttributionInvalidationRequest request = new OrderAttributionInvalidationRequest();
+    request.setAttributionId(attributionId);
     request.setReason(reason);
     return request;
   }
@@ -391,8 +416,11 @@ class OrderAttributionServiceTest {
   }
 
   private static OrderAttribution activeAttribution() {
-    return OrderAttribution.onCompletion(
-        ORDER_ID, MEMBER_ID, MEMBER_CODE, OffsetDateTime.parse("2026-08-10T19:00:00Z"));
+    OrderAttribution attribution =
+        OrderAttribution.onCompletion(
+            ORDER_ID, MEMBER_ID, MEMBER_CODE, OffsetDateTime.parse("2026-08-10T19:00:00Z"));
+    attribution.setId(ATTRIBUTION_ID);
+    return attribution;
   }
 
   private static OrderAttribution invalidatedAttribution() {

--- a/backend/src/test/java/com/kizuna/order/application/OrderAttributionServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderAttributionServiceTest.java
@@ -1,0 +1,378 @@
+package com.kizuna.order.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.kizuna.order.api.dto.OrderAttributionInvalidationRequest;
+import com.kizuna.order.api.dto.OrderAttributionResponse;
+import com.kizuna.order.api.dto.OrderReceiptTokenResponse;
+import com.kizuna.order.domain.Order;
+import com.kizuna.order.domain.OrderAttribution;
+import com.kizuna.order.domain.OrderAttributionRepository;
+import com.kizuna.order.domain.OrderAttributionStatus;
+import com.kizuna.order.domain.OrderReceiptToken;
+import com.kizuna.order.domain.OrderReceiptTokenRepository;
+import com.kizuna.order.domain.OrderRepository;
+import com.kizuna.order.domain.OrderStatus;
+import com.kizuna.order.infrastructure.ReceiptTokenGenerator;
+import com.kizuna.shared.exception.NotFoundException;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.StaleSessionException;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import com.kizuna.user.domain.StoreScopeType;
+import com.kizuna.user.domain.UserType;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OrderAttributionServiceTest {
+
+  private static final String ORDER_ID = "o1";
+  private static final String ACTOR_EMAIL = "staff@kizuna.test";
+  private static final long ACTOR_ID = 42L;
+  private static final long MEMBER_ID = 7L;
+  private static final String MEMBER_CODE = "123456789012";
+  private static final String REASON = "別人の来店を取り違えたため";
+  private static final int COMPLETION_GRANT = 98;
+  private static final int TOKEN_PLANNED_POINTS = 120;
+
+  @Mock private OrderRepository orderRepository;
+  @Mock private OrderAttributionRepository orderAttributionRepository;
+  @Mock private OrderReceiptTokenRepository orderReceiptTokenRepository;
+  @Mock private ReceiptTokenGenerator receiptTokenGenerator;
+  @Mock private PlatformUserRepository platformUserRepository;
+
+  @InjectMocks private OrderAttributionService service;
+
+  @Captor private ArgumentCaptor<OrderReceiptToken> savedToken;
+
+  @BeforeEach
+  void resolveActor() {
+    PlatformUser actor =
+        PlatformUser.builder()
+            .email(ACTOR_EMAIL)
+            .password("encoded")
+            .displayName("店舗 太郎")
+            .enabled(true)
+            .userType(UserType.STAFF)
+            .storeScopeType(StoreScopeType.SPECIFIC_STORES)
+            .storeIds(Set.of(1L))
+            .roleIds(Set.of(1L))
+            .build();
+    actor.setId(ACTOR_ID);
+    Mockito.lenient()
+        .when(platformUserRepository.findByEmail(ACTOR_EMAIL))
+        .thenReturn(Optional.of(actor));
+  }
+
+  // ==================== 現況の読み出し ====================
+
+  @Test
+  @DisplayName("有効な帰属のある受注は帰属済みとして会員コードと成立の機構を返すこと")
+  void getReportsTheActiveAttribution() {
+    givenOrder(OrderStatus.COMPLETED);
+    givenAttributions(activeAttribution());
+
+    OrderAttributionResponse response = service.get(ORDER_ID);
+
+    assertThat(response.attributed()).isTrue();
+    assertThat(response.memberCode()).isEqualTo(MEMBER_CODE);
+    assertThat(response.source()).isEqualTo("COMPLETION");
+    assertThat(response.invalidatedReason()).isNull();
+  }
+
+  @Test
+  @DisplayName("無効化済みの受注は未帰属として、直近の記録の理由を添えて返すこと")
+  void getReportsTheInvalidatedAttribution() {
+    givenOrder(OrderStatus.COMPLETED);
+    OrderAttribution invalidated = activeAttribution();
+    invalidated.invalidate(REASON, ACTOR_ID, OffsetDateTime.now());
+    givenAttributions(invalidated);
+
+    OrderAttributionResponse response = service.get(ORDER_ID);
+
+    assertThat(response.attributed()).isFalse();
+    // 誰の来店として記録されていたかは訂正後も読めなければならない（訂正の妥当性を店舗が確かめる材料）
+    assertThat(response.memberCode()).isEqualTo(MEMBER_CODE);
+    assertThat(response.invalidatedReason()).isEqualTo(REASON);
+    assertThat(response.invalidatedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("帰属記録の無い受注は未帰属として、会員側の項目を持たずに返すこと")
+  void getReportsNoAttribution() {
+    givenOrder(OrderStatus.COMPLETED);
+    givenAttributions();
+
+    OrderAttributionResponse response = service.get(ORDER_ID);
+
+    assertThat(response.attributed()).isFalse();
+    assertThat(response.memberCode()).isNull();
+    assertThat(response.source()).isNull();
+  }
+
+  @Test
+  @DisplayName("他店舗の受注（storeFilter で引けない）は帰属記録に触れる前に 404 になること")
+  void getRejectsAnOrderOutsideTheStore() {
+    Mockito.when(orderRepository.findScopedById(ORDER_ID)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.get(ORDER_ID)).isInstanceOf(NotFoundException.class);
+    // 帰属記録は platform 帰属で店舗行分離機構に載らない。受注を引けない時点で終えないと他店舗の会員コードが漏れる
+    Mockito.verifyNoInteractions(orderAttributionRepository);
+  }
+
+  // ==================== 無効化 ====================
+
+  @Test
+  @DisplayName("無効化は理由・実行者・時刻を記録し、記録は残したまま未帰属へ戻すこと")
+  void invalidateRecordsTheReasonAndActor() {
+    givenOrder(OrderStatus.COMPLETED);
+    OrderAttribution attribution = activeAttribution();
+    givenAttributions(attribution);
+    Mockito.when(orderAttributionRepository.save(attribution)).thenReturn(attribution);
+
+    OrderAttributionResponse response = service.invalidate(ORDER_ID, request(REASON), ACTOR_EMAIL);
+
+    assertThat(attribution.getStatus()).isEqualTo(OrderAttributionStatus.INVALIDATED);
+    assertThat(attribution.getInvalidatedReason()).isEqualTo(REASON);
+    assertThat(attribution.getInvalidatedBy()).isEqualTo(ACTOR_ID);
+    assertThat(attribution.getInvalidatedAt()).isNotNull();
+    assertThat(response.attributed()).isFalse();
+  }
+
+  @Test
+  @DisplayName("帰属していない受注の無効化は拒まれること")
+  void invalidateRejectsAnUnattributedOrder() {
+    givenOrder(OrderStatus.COMPLETED);
+    givenAttributions();
+
+    assertThatThrownBy(() -> service.invalidate(ORDER_ID, request(REASON), ACTOR_EMAIL))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("会員へ帰属していません");
+  }
+
+  @Test
+  @DisplayName("無効化済みの帰属は二度目の無効化を受け付けないこと")
+  void invalidateRejectsAnAlreadyInvalidatedAttribution() {
+    givenOrder(OrderStatus.COMPLETED);
+    OrderAttribution invalidated = activeAttribution();
+    invalidated.invalidate("初回の理由", ACTOR_ID, OffsetDateTime.now());
+    givenAttributions(invalidated);
+
+    assertThatThrownBy(() -> service.invalidate(ORDER_ID, request(REASON), ACTOR_EMAIL))
+        .isInstanceOf(ServiceException.class);
+    assertThat(invalidated.getInvalidatedReason()).isEqualTo("初回の理由");
+  }
+
+  @Test
+  @DisplayName("失効した認証セッションの無効化は実行者不明のまま通らないこと")
+  void invalidateRejectsAnUnresolvableActor() {
+    givenOrder(OrderStatus.COMPLETED);
+    givenAttributions(activeAttribution());
+    Mockito.when(platformUserRepository.findByEmail(ACTOR_EMAIL)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.invalidate(ORDER_ID, request(REASON), ACTOR_EMAIL))
+        .isInstanceOf(StaleSessionException.class);
+  }
+
+  @Test
+  @DisplayName("他店舗の受注の無効化は帰属記録に触れる前に 404 になること")
+  void invalidateRejectsAnOrderOutsideTheStore() {
+    Mockito.when(orderRepository.findScopedById(ORDER_ID)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.invalidate(ORDER_ID, request(REASON), ACTOR_EMAIL))
+        .isInstanceOf(NotFoundException.class);
+    Mockito.verifyNoInteractions(orderAttributionRepository);
+  }
+
+  // ==================== 再発行 ====================
+
+  @Test
+  @DisplayName("無効化された受注へ再発行でき、期限は再発行から 90 日で数え直されること")
+  void reissueRestartsTheClaimWindow() {
+    givenOrder(OrderStatus.COMPLETED);
+    givenAttributions(invalidatedAttribution());
+    givenTokens();
+    Mockito.when(receiptTokenGenerator.generate())
+        .thenReturn(new ReceiptTokenGenerator.GeneratedToken("raw", "digest"));
+
+    OrderReceiptTokenResponse response = service.reissueReceiptToken(ORDER_ID);
+
+    assertThat(response.receiptToken()).isEqualTo("raw");
+    Mockito.verify(orderReceiptTokenRepository).save(savedToken.capture());
+    OrderReceiptToken token = savedToken.getValue();
+    // 誤帰属の期間が本人の申領窓を食い潰したまま原期限を残すと、訂正が形骸化する（ADR 0009 の意図的な例外）
+    assertThat(token.getExpiresAt())
+        .isEqualTo(token.getIssuedAt().plus(OrderReceiptToken.VALIDITY));
+    assertThat(token.getIssuedAt()).isAfter(OffsetDateTime.now().minusMinutes(1));
+    // 保存されるのはダイジェストだけで、生値は応答にしか現れない
+    assertThat(token.getTokenDigest()).isEqualTo("digest");
+  }
+
+  @Test
+  @DisplayName("完了時に会員へ帰属した受注の再発行では、完了時に付与された額を予定額として引き継ぐこと")
+  void reissueCarriesForwardTheGrantFixedAtCompletion() {
+    givenOrder(OrderStatus.COMPLETED);
+    givenAttributions(invalidatedAttribution());
+    // 完了時に会員へ帰属した受注には伝票トークンが発行されないため、確定額は受注の付与実績にしか無い
+    givenTokens();
+    Mockito.when(receiptTokenGenerator.generate())
+        .thenReturn(new ReceiptTokenGenerator.GeneratedToken("raw", "digest"));
+
+    service.reissueReceiptToken(ORDER_ID);
+
+    Mockito.verify(orderReceiptTokenRepository).save(savedToken.capture());
+    assertThat(savedToken.getValue().getPlannedPoints()).isEqualTo(COMPLETION_GRANT);
+  }
+
+  @Test
+  @DisplayName("申領済みの伝票がある受注の再発行では、その伝票の予定額を引き継ぐこと（受注の付与実績は 0 のため）")
+  void reissueCarriesForwardThePriorTokensPlannedPoints() {
+    givenOrder(OrderStatus.COMPLETED);
+    givenAttributions(invalidatedAttribution());
+    OrderReceiptToken claimed =
+        OrderReceiptToken.issueFor(
+            ORDER_ID, "old-digest", TOKEN_PLANNED_POINTS, OffsetDateTime.now());
+    claimed.claim(OffsetDateTime.now());
+    givenTokens(claimed);
+    Mockito.when(receiptTokenGenerator.generate())
+        .thenReturn(new ReceiptTokenGenerator.GeneratedToken("raw", "digest"));
+
+    service.reissueReceiptToken(ORDER_ID);
+
+    Mockito.verify(orderReceiptTokenRepository).save(savedToken.capture());
+    // 受注側の付与実績（非会員完了なので 0）を読むと、正しい本人が取り戻せるポイントが消える
+    assertThat(savedToken.getValue().getPlannedPoints()).isEqualTo(TOKEN_PLANNED_POINTS);
+  }
+
+  @Test
+  @DisplayName("有効な帰属のある受注へは再発行しないこと（先に無効化が要る）")
+  void reissueRejectsAnAttributedOrder() {
+    givenOrder(OrderStatus.COMPLETED);
+    givenAttributions(activeAttribution());
+
+    assertThatThrownBy(() -> service.reissueReceiptToken(ORDER_ID))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("先に帰属を無効化");
+    Mockito.verify(orderReceiptTokenRepository, Mockito.never()).save(Mockito.any());
+  }
+
+  @Test
+  @DisplayName("会員へ帰属したことのない受注へは再発行しないこと（訂正の経路であって発行の経路ではない）")
+  void reissueRejectsAnOrderThatWasNeverAttributed() {
+    givenOrder(OrderStatus.COMPLETED);
+    givenAttributions();
+
+    assertThatThrownBy(() -> service.reissueReceiptToken(ORDER_ID))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("帰属したことがありません");
+    Mockito.verify(orderReceiptTokenRepository, Mockito.never()).save(Mockito.any());
+  }
+
+  @Test
+  @DisplayName("完了していない受注へは再発行しないこと")
+  void reissueRejectsAnIncompleteOrder() {
+    givenOrder(OrderStatus.CONFIRMED);
+
+    assertThatThrownBy(() -> service.reissueReceiptToken(ORDER_ID))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("完了していない");
+  }
+
+  @Test
+  @DisplayName("申領できる伝票が既にある受注へは再発行しないこと（生きた伝票が 2 本並ぶと申領の応答が同形でなくなる）")
+  void reissueRejectsWhenAClaimableTokenAlreadyExists() {
+    givenOrder(OrderStatus.COMPLETED);
+    givenAttributions(invalidatedAttribution());
+    givenTokens(
+        OrderReceiptToken.issueFor(
+            ORDER_ID, "live-digest", TOKEN_PLANNED_POINTS, OffsetDateTime.now()));
+
+    assertThatThrownBy(() -> service.reissueReceiptToken(ORDER_ID))
+        .isInstanceOf(ServiceException.class)
+        .hasMessageContaining("申領できる伝票が既にあります");
+    Mockito.verify(orderReceiptTokenRepository, Mockito.never()).save(Mockito.any());
+  }
+
+  @Test
+  @DisplayName("期限切れの伝票は再発行を妨げないこと（申領できない伝票に窓を塞がせない）")
+  void reissueIgnoresAnExpiredToken() {
+    givenOrder(OrderStatus.COMPLETED);
+    givenAttributions(invalidatedAttribution());
+    givenTokens(
+        OrderReceiptToken.issueFor(
+            ORDER_ID,
+            "expired-digest",
+            TOKEN_PLANNED_POINTS,
+            OffsetDateTime.now().minus(OrderReceiptToken.VALIDITY).minusDays(1)));
+    Mockito.when(receiptTokenGenerator.generate())
+        .thenReturn(new ReceiptTokenGenerator.GeneratedToken("raw", "digest"));
+
+    assertThat(service.reissueReceiptToken(ORDER_ID).receiptToken()).isEqualTo("raw");
+  }
+
+  @Test
+  @DisplayName("他店舗の受注の再発行は帰属記録に触れる前に 404 になること")
+  void reissueRejectsAnOrderOutsideTheStore() {
+    Mockito.when(orderRepository.findScopedById(ORDER_ID)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.reissueReceiptToken(ORDER_ID))
+        .isInstanceOf(NotFoundException.class);
+    Mockito.verifyNoInteractions(orderAttributionRepository, orderReceiptTokenRepository);
+  }
+
+  // ==================== 用意 ====================
+
+  private static OrderAttributionInvalidationRequest request(String reason) {
+    OrderAttributionInvalidationRequest request = new OrderAttributionInvalidationRequest();
+    request.setReason(reason);
+    return request;
+  }
+
+  private void givenOrder(OrderStatus status) {
+    Order order =
+        Order.builder()
+            .businessDate(LocalDate.parse("2026-08-10"))
+            .status(status)
+            .autoGrantPoints(COMPLETION_GRANT)
+            .build();
+    order.setId(ORDER_ID);
+    order.setStoreId(1L);
+    Mockito.when(orderRepository.findScopedById(ORDER_ID)).thenReturn(Optional.of(order));
+  }
+
+  private void givenAttributions(OrderAttribution... rows) {
+    Mockito.when(orderAttributionRepository.findByOrderIdOrderByIdDesc(ORDER_ID))
+        .thenReturn(List.of(rows));
+  }
+
+  private void givenTokens(OrderReceiptToken... rows) {
+    Mockito.when(orderReceiptTokenRepository.findByOrderIdOrderByIdDesc(ORDER_ID))
+        .thenReturn(List.of(rows));
+  }
+
+  private static OrderAttribution activeAttribution() {
+    return OrderAttribution.onCompletion(
+        ORDER_ID, MEMBER_ID, MEMBER_CODE, OffsetDateTime.parse("2026-08-10T19:00:00Z"));
+  }
+
+  private static OrderAttribution invalidatedAttribution() {
+    OrderAttribution attribution = activeAttribution();
+    attribution.invalidate(REASON, ACTOR_ID, OffsetDateTime.parse("2026-08-12T10:00:00Z"));
+    return attribution;
+  }
+}

--- a/backend/src/test/java/com/kizuna/order/application/OrderAttributionServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderAttributionServiceTest.java
@@ -327,9 +327,26 @@ class OrderAttributionServiceTest {
   }
 
   @Test
+  @DisplayName("再発行は受注を押さえてから門を判じること（並行する再発行が同じ「伝票が無い」を観測しないため）")
+  void reissueLocksTheOrderBeforeCheckingItsGuards() {
+    givenOrder(OrderStatus.COMPLETED);
+    givenAttributions(invalidatedAttribution());
+    givenTokens();
+    Mockito.when(receiptTokenGenerator.generate())
+        .thenReturn(new ReceiptTokenGenerator.GeneratedToken("raw", "digest"));
+
+    service.reissueReceiptToken(ORDER_ID);
+
+    // 実際の競合は統合テストが踏む。ここが固定するのは「ロックを取る読み口を通っている」配線そのもので、
+    // 素の読み口へ差し替わると門が check-then-act に戻る
+    Mockito.verify(orderRepository).findScopedByIdForUpdate(ORDER_ID);
+    Mockito.verify(orderRepository, Mockito.never()).findScopedById(ORDER_ID);
+  }
+
+  @Test
   @DisplayName("他店舗の受注の再発行は帰属記録に触れる前に 404 になること")
   void reissueRejectsAnOrderOutsideTheStore() {
-    Mockito.when(orderRepository.findScopedById(ORDER_ID)).thenReturn(Optional.empty());
+    Mockito.when(orderRepository.findScopedByIdForUpdate(ORDER_ID)).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> service.reissueReceiptToken(ORDER_ID))
         .isInstanceOf(NotFoundException.class);
@@ -353,7 +370,10 @@ class OrderAttributionServiceTest {
             .build();
     order.setId(ORDER_ID);
     order.setStoreId(1L);
-    Mockito.when(orderRepository.findScopedById(ORDER_ID)).thenReturn(Optional.of(order));
+    Mockito.lenient().when(orderRepository.findScopedById(ORDER_ID)).thenReturn(Optional.of(order));
+    Mockito.lenient()
+        .when(orderRepository.findScopedByIdForUpdate(ORDER_ID))
+        .thenReturn(Optional.of(order));
   }
 
   private void givenAttributions(OrderAttribution... rows) {

--- a/backend/src/test/java/com/kizuna/order/domain/OrderAttributionTest.java
+++ b/backend/src/test/java/com/kizuna/order/domain/OrderAttributionTest.java
@@ -11,6 +11,8 @@ class OrderAttributionTest {
 
   private static final OffsetDateTime ATTRIBUTED_AT = OffsetDateTime.parse("2026-08-12T19:00:00Z");
 
+  private static final OffsetDateTime INVALIDATED_AT = OffsetDateTime.parse("2026-08-20T10:00:00Z");
+
   @Test
   @DisplayName("完了時の帰属は根拠 COMPLETION の有効な記録になり、会員コードを帰属時点のまま持つこと")
   void onCompletionIsAnActiveCompletionRecord() {
@@ -69,5 +71,61 @@ class OrderAttributionTest {
     assertThatThrownBy(() -> OrderAttribution.onCompletion("o1", 7L, "123456789012", null))
         .isInstanceOf(InvalidOrderAttributionException.class)
         .hasMessageContaining("帰属の日時");
+  }
+
+  @Test
+  @DisplayName("無効化は理由・実行者・時刻を残し、帰属そのものの記録は書き換えないこと")
+  void invalidateRecordsTheReasonActorAndTime() {
+    OrderAttribution attribution =
+        OrderAttribution.onCompletion("o1", 7L, "123456789012", ATTRIBUTED_AT);
+
+    attribution.invalidate("別人の来店を取り違えたため", 42L, INVALIDATED_AT);
+
+    assertThat(attribution.getStatus()).isEqualTo(OrderAttributionStatus.INVALIDATED);
+    assertThat(attribution.getInvalidatedReason()).isEqualTo("別人の来店を取り違えたため");
+    assertThat(attribution.getInvalidatedBy()).isEqualTo(42L);
+    assertThat(attribution.getInvalidatedAt()).isEqualTo(INVALIDATED_AT);
+    // 誰の来店として記録されていたかは訂正後も読めなければならない（監査の対象そのもの）
+    assertThat(attribution.getMemberId()).isEqualTo(7L);
+    assertThat(attribution.getMemberCode()).isEqualTo("123456789012");
+    assertThat(attribution.getSource()).isEqualTo(OrderAttributionSource.COMPLETION);
+    assertThat(attribution.getAttributedAt()).isEqualTo(ATTRIBUTED_AT);
+  }
+
+  @Test
+  @DisplayName("理由の無い無効化は拒まれること（訂正の根拠が残らない）")
+  void invalidateWithoutReasonIsRejected() {
+    OrderAttribution attribution =
+        OrderAttribution.onCompletion("o1", 7L, "123456789012", ATTRIBUTED_AT);
+
+    assertThatThrownBy(() -> attribution.invalidate(" ", 42L, INVALIDATED_AT))
+        .isInstanceOf(InvalidOrderAttributionException.class)
+        .hasMessageContaining("無効化の理由");
+    assertThat(attribution.getStatus()).isEqualTo(OrderAttributionStatus.ACTIVE);
+  }
+
+  @Test
+  @DisplayName("実行者の無い無効化は拒まれること")
+  void invalidateWithoutActorIsRejected() {
+    OrderAttribution attribution =
+        OrderAttribution.onCompletion("o1", 7L, "123456789012", ATTRIBUTED_AT);
+
+    assertThatThrownBy(() -> attribution.invalidate("取り違え", null, INVALIDATED_AT))
+        .isInstanceOf(InvalidOrderAttributionException.class)
+        .hasMessageContaining("無効化の実行者");
+  }
+
+  @Test
+  @DisplayName("無効化済みの記録は二度目の無効化を受け付けないこと（初回の理由と実行者が上書きされる）")
+  void invalidatingTwiceIsRejected() {
+    OrderAttribution attribution =
+        OrderAttribution.onCompletion("o1", 7L, "123456789012", ATTRIBUTED_AT);
+    attribution.invalidate("初回の理由", 42L, INVALIDATED_AT);
+
+    assertThatThrownBy(() -> attribution.invalidate("二度目の理由", 43L, INVALIDATED_AT.plusDays(1)))
+        .isInstanceOf(InvalidOrderAttributionException.class)
+        .hasMessageContaining("既に無効化");
+    assertThat(attribution.getInvalidatedReason()).isEqualTo("初回の理由");
+    assertThat(attribution.getInvalidatedBy()).isEqualTo(42L);
   }
 }

--- a/frontend/src/_pages/store-orders/__tests__/OrderAttributionModal.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrderAttributionModal.test.tsx
@@ -1,0 +1,183 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { notify } from '@/shared/notify';
+import { OrderAttributionModal } from '../ui/OrderAttributionModal';
+import { Order, OrderAttribution, orderApi } from '@/entities/order';
+
+jest.mock('@/entities/order', () => ({
+  orderApi: {
+    attribution: jest.fn(),
+    invalidateAttribution: jest.fn(),
+    reissueReceiptToken: jest.fn(),
+  },
+}));
+
+jest.mock('@/shared/notify', () => ({
+  notify: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
+}));
+
+// QR は描画された画像からは中身を読めない。運ぶ値そのものを断言できるよう、値を属性へ出す差し替えにする
+jest.mock('qrcode.react', () => ({
+  QRCodeSVG: ({ value, ...props }: { value: string; 'aria-label': string; role: string }) => (
+    <span data-testid="qr" data-value={value} aria-label={props['aria-label']} role={props.role} />
+  ),
+}));
+
+const mockedAttribution = orderApi.attribution as jest.Mock;
+const mockedInvalidate = orderApi.invalidateAttribution as jest.Mock;
+const mockedReissue = orderApi.reissueReceiptToken as jest.Mock;
+
+const completedOrder: Order = {
+  id: 'o1',
+  status: 'COMPLETED',
+  business_date: '2026-08-10',
+  customer_name: '山田太郎',
+};
+
+const attributed: OrderAttribution = {
+  attributed: true,
+  member_code: '123456789012',
+  source: 'COMPLETION',
+  attributed_at: '2026-08-10T19:00:00Z',
+};
+
+const invalidated: OrderAttribution = {
+  attributed: false,
+  member_code: '123456789012',
+  source: 'COMPLETION',
+  attributed_at: '2026-08-10T19:00:00Z',
+  invalidated_reason: '別人の来店を取り違えたため',
+  invalidated_at: '2026-08-12T10:00:00Z',
+};
+
+const renderModal = (onClose = jest.fn()) =>
+  render(<OrderAttributionModal order={completedOrder} onClose={onClose} />);
+
+describe('OrderAttributionModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAttribution.mockResolvedValue(attributed);
+  });
+
+  it('閉じている間は帰属の現況を取りに行かない', () => {
+    // 一覧に常時 mount されているので、開くまで取りに行くと訂正しない画面が毎回読む
+    render(<OrderAttributionModal order={null} onClose={jest.fn()} />);
+
+    expect(mockedAttribution).not.toHaveBeenCalled();
+  });
+
+  it('帰属している受注では会員コードと成立の機構を出し、理由を添えて無効化できる', async () => {
+    mockedInvalidate.mockResolvedValue(invalidated);
+    renderModal();
+
+    expect(await screen.findByText('123456789012')).toBeInTheDocument();
+    expect(screen.getByText(/完了時の会員紐づけ/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('無効化の理由'), {
+      target: { value: '別人の来店を取り違えたため' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '無効化する' }));
+
+    await waitFor(() =>
+      expect(mockedInvalidate).toHaveBeenCalledWith('o1', { reason: '別人の来店を取り違えたため' })
+    );
+    expect(notify.success).toHaveBeenCalledWith('帰属を無効化しました');
+  });
+
+  it('理由が空のまま無効化しようとしても要求を飛ばさない', async () => {
+    renderModal();
+    await screen.findByLabelText('無効化の理由');
+
+    fireEvent.click(screen.getByRole('button', { name: '無効化する' }));
+
+    // 理由はこの訂正の唯一の根拠。空のまま往復させると、サーバの 400 を待つ間に押し直せてしまう
+    expect(await screen.findByText('無効化の理由を入力してください')).toBeInTheDocument();
+    expect(mockedInvalidate).not.toHaveBeenCalled();
+  });
+
+  it('台帳へ波及しないことを無効化の前に画面が名乗る', async () => {
+    // 事後に気づくと、誤って付与されたポイントが残ったまま訂正が済んだと見なされる
+    renderModal();
+
+    expect(await screen.findByText(/付与済みのポイントは戻りません/)).toBeInTheDocument();
+  });
+
+  it('無効化に成功すると、取り直さずに再発行の導線へ切り替わる', async () => {
+    mockedInvalidate.mockResolvedValue(invalidated);
+    renderModal();
+
+    fireEvent.change(await screen.findByLabelText('無効化の理由'), {
+      target: { value: '取り違え' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '無効化する' }));
+
+    expect(await screen.findByRole('button', { name: '伝票QRを再発行' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('無効化の理由')).not.toBeInTheDocument();
+    // 応答が訂正後の現況を持つので、読み込み表示を挟んで取り直さない
+    expect(mockedAttribution).toHaveBeenCalledTimes(1);
+  });
+
+  it('再発行した伝票の生値を QR が運ぶ', async () => {
+    mockedAttribution.mockResolvedValue(invalidated);
+    mockedReissue.mockResolvedValue({ receipt_token: 'raw-token-value' });
+    renderModal();
+
+    fireEvent.click(await screen.findByRole('button', { name: '伝票QRを再発行' }));
+
+    const qr = await screen.findByTestId('qr');
+    // 生値そのものへ退行しても描画は変わらないため、QR が運ぶ値を断言する
+    expect(qr).toHaveAttribute('data-value', expect.stringContaining('raw-token-value'));
+    expect(qr.getAttribute('data-value')).toContain('/member/receipts#');
+  });
+
+  it('QR を出している間は明示のボタン以外で閉じない', async () => {
+    mockedAttribution.mockResolvedValue(invalidated);
+    mockedReissue.mockResolvedValue({ receipt_token: 'raw-token-value' });
+    const onClose = jest.fn();
+    renderModal(onClose);
+
+    fireEvent.click(await screen.findByRole('button', { name: '伝票QRを再発行' }));
+    await screen.findByTestId('qr');
+
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    // 生値はこの応答にしか無い。誤って閉じると客が来店を取り戻す手段ごと消える
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('帰属したことのない受注では再発行の導線を出さない', async () => {
+    mockedAttribution.mockResolvedValue({ attributed: false });
+    renderModal();
+
+    expect(await screen.findByText(/訂正の対象ではありません/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '伝票QRを再発行' })).not.toBeInTheDocument();
+  });
+
+  it('現況を読めなかったときは領域が失敗を名乗り、訂正の導線を出さない', async () => {
+    // 読めなかった現況を「未帰属」で描くと、他人の来店が残っているのに再発行を勧めることになる
+    mockedAttribution.mockRejectedValue(new Error('boom'));
+    renderModal();
+
+    expect(await screen.findByText('帰属の状況を取得できませんでした')).toBeInTheDocument();
+    expect(screen.queryByLabelText('無効化の理由')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '伝票QRを再発行' })).not.toBeInTheDocument();
+  });
+
+  it('無効化の失敗はサーバの文言をそのまま知らせ、入力を残す', async () => {
+    mockedInvalidate.mockRejectedValue({
+      response: { data: { message: 'この受注は会員へ帰属していません' } },
+    });
+    renderModal();
+
+    fireEvent.change(await screen.findByLabelText('無効化の理由'), {
+      target: { value: '取り違え' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '無効化する' }));
+
+    await waitFor(() =>
+      expect(notify.error).toHaveBeenCalledWith('この受注は会員へ帰属していません')
+    );
+    expect(screen.getByLabelText('無効化の理由')).toHaveValue('取り違え');
+  });
+});

--- a/frontend/src/_pages/store-orders/__tests__/OrderAttributionModal.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrderAttributionModal.test.tsx
@@ -94,11 +94,25 @@ describe('OrderAttributionModal', () => {
     expect(mockedInvalidate).not.toHaveBeenCalled();
   });
 
-  it('台帳へ波及しないことを無効化の前に画面が名乗る', async () => {
+  it('台帳へ波及しないことと、清算の手段を無効化の前に画面が名乗る', async () => {
     // 事後に気づくと、誤って付与されたポイントが残ったまま訂正が済んだと見なされる
     renderModal();
 
     expect(await screen.findByText(/付与済みのポイントは戻りません/)).toBeInTheDocument();
+    // 完了時の紐づけで成立した帰属は顧客に会員が紐づいているので、その画面の調整が届く
+    expect(screen.getByText(/顧客の画面でポイント調整/)).toBeInTheDocument();
+  });
+
+  it('伝票QR申領で成立した帰属では、届かない清算手段を案内しない', async () => {
+    // 申領は店舗台帳に会員の紐づけを作らない。店舗側のポイント調整は顧客に紐づく会員しか対象に
+    // 取れないため、顧客画面を案内すると実行できない操作を指示することになる
+    mockedAttribution.mockResolvedValue({ ...attributed, source: 'RECEIPT_TOKEN' });
+    renderModal();
+
+    expect(
+      await screen.findByText(/店舗からポイントを戻す操作は現在ありません/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/顧客の画面でポイント調整/)).not.toBeInTheDocument();
   });
 
   it('無効化に成功すると、取り直さずに再発行の導線へ切り替わる', async () => {

--- a/frontend/src/_pages/store-orders/__tests__/OrderAttributionModal.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrderAttributionModal.test.tsx
@@ -100,26 +100,20 @@ describe('OrderAttributionModal', () => {
     expect(mockedInvalidate).not.toHaveBeenCalled();
   });
 
-  it('台帳へ波及しないことと、清算の手段を無効化の前に画面が名乗る', async () => {
-    // 事後に気づくと、誤って付与されたポイントが残ったまま訂正が済んだと見なされる
-    renderModal();
+  it.each(['COMPLETION', 'RECEIPT_TOKEN'] as const)(
+    '清算の宛先は帰属の会員だと述べ、顧客画面の調整を宛先として案内しない（%s）',
+    async source => {
+      // 調整の口は「その顧客に現在紐づく会員」を対象に取る一方、清算すべき相手はこの帰属記録が
+      // 持つ会員（不変）。ずれた状態で案内どおり操作すると無関係な会員から引かれるため、成立の
+      // 機構によらず特定の画面を宛先として案内しない
+      mockedAttribution.mockResolvedValue({ ...attributed, source });
+      renderModal();
 
-    expect(await screen.findByText(/付与済みのポイントは戻りません/)).toBeInTheDocument();
-    // 完了時の紐づけで成立した帰属は顧客に会員が紐づいているので、その画面の調整が届く
-    expect(screen.getByText(/顧客の画面でポイント調整/)).toBeInTheDocument();
-  });
-
-  it('伝票QR申領で成立した帰属では、届かない清算手段を案内しない', async () => {
-    // 申領は店舗台帳に会員の紐づけを作らない。店舗側のポイント調整は顧客に紐づく会員しか対象に
-    // 取れないため、顧客画面を案内すると実行できない操作を指示することになる
-    mockedAttribution.mockResolvedValue({ ...attributed, source: 'RECEIPT_TOKEN' });
-    renderModal();
-
-    expect(
-      await screen.findByText(/店舗からポイントを戻す操作は現在ありません/)
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/顧客の画面でポイント調整/)).not.toBeInTheDocument();
-  });
+      expect(await screen.findByText(/付与済みのポイントは戻りません/)).toBeInTheDocument();
+      expect(screen.getByText(/上の会員コードの台帳に対して行う/)).toBeInTheDocument();
+      expect(screen.getByText(/この会員に届きません/)).toBeInTheDocument();
+    }
+  );
 
   it('無効化に成功すると、取り直さずに再発行の導線へ切り替わる', async () => {
     mockedInvalidate.mockResolvedValue(invalidated);

--- a/frontend/src/_pages/store-orders/__tests__/OrderAttributionModal.test.tsx
+++ b/frontend/src/_pages/store-orders/__tests__/OrderAttributionModal.test.tsx
@@ -34,6 +34,7 @@ const completedOrder: Order = {
 };
 
 const attributed: OrderAttribution = {
+  id: 501,
   attributed: true,
   member_code: '123456789012',
   source: 'COMPLETION',
@@ -41,6 +42,7 @@ const attributed: OrderAttribution = {
 };
 
 const invalidated: OrderAttribution = {
+  id: 501,
   attributed: false,
   member_code: '123456789012',
   source: 'COMPLETION',
@@ -78,7 +80,11 @@ describe('OrderAttributionModal', () => {
     fireEvent.click(screen.getByRole('button', { name: '無効化する' }));
 
     await waitFor(() =>
-      expect(mockedInvalidate).toHaveBeenCalledWith('o1', { reason: '別人の来店を取り違えたため' })
+      expect(mockedInvalidate).toHaveBeenCalledWith('o1', {
+        // 受注から導かせず、画面が読み口で得た記録そのものを名指す
+        attribution_id: 501,
+        reason: '別人の来店を取り違えたため',
+      })
     );
     expect(notify.success).toHaveBeenCalledWith('帰属を無効化しました');
   });

--- a/frontend/src/_pages/store-orders/lib/customerLabel.ts
+++ b/frontend/src/_pages/store-orders/lib/customerLabel.ts
@@ -24,3 +24,18 @@ export function customerLabel(order: Order): OrderCustomerLabel | null {
   const reported = order.contact_name || order.contact_phone_number;
   return reported ? { name: reported, unlinked: true } : null;
 }
+
+/**
+ * 取り消せない操作のモーダルが見出しに出す呼び名。相手が誰か分からないまま会計を確定したり
+ * 帰属を無効化したりさせないため、顧客未設定の受注も録入された連絡先で呼ぶ。
+ *
+ * 見出しの行はすでに全体が注記の体裁なので、注記（{@link UNLINKED_NOTE}）だけを分けて装飾せず
+ * 1 本の文字列に畳む。
+ */
+export function customerHeadingText(order: Order | null): string {
+  const label = order === null ? null : customerLabel(order);
+  if (label === null) {
+    return 'お客様名なし';
+  }
+  return label.unlinked ? `${label.name}${UNLINKED_NOTE}` : label.name;
+}

--- a/frontend/src/_pages/store-orders/ui/OrderAttributionModal.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderAttributionModal.tsx
@@ -122,9 +122,14 @@ export function OrderAttributionModal({ order, onClose }: OrderAttributionModalP
   }, [order, reset]);
 
   const invalidate = async (values: InvalidationFormValues) => {
-    if (!order?.id) return;
+    // 対象は画面が読み口で得た記録そのものを名指す。受注から導く形へ戻すと、開いたまま別の操作者が
+    // 訂正を一巡させた場合に、この理由が新しく成立した正しい帰属へ当たって来店を消す
+    if (!order?.id || attribution?.id === undefined) return;
     try {
-      const updated = await orderApi.invalidateAttribution(order.id, { reason: values.reason });
+      const updated = await orderApi.invalidateAttribution(order.id, {
+        attribution_id: attribution.id,
+        reason: values.reason,
+      });
       notify.success('帰属を無効化しました');
       // 応答が訂正後の現況を持つので、取り直さず差し替える（読み込み表示で一瞬消えない）
       setSnapshot({ orderId, body: updated });

--- a/frontend/src/_pages/store-orders/ui/OrderAttributionModal.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderAttributionModal.tsx
@@ -32,6 +32,20 @@ const SOURCE_LABELS: Record<OrderAttributionSource, string> = {
   RECEIPT_TOKEN: '伝票QRの申領',
 };
 
+/**
+ * 無効化の前に出す清算の注意書き。台帳へ波及しないことは共通だが、清算の手段は成立の機構で変わる。
+ *
+ * 伝票QRの申領で成立した帰属は店舗台帳に会員の紐づけを作らない（申領は受注 1 件の事実だけを証明し、
+ * 店舗と会員の継続的な関係を作らない）。店舗側のポイント調整は顧客に紐づく会員だけを対象に取るため、
+ * この経路で付いたポイントには届かない。届かない操作を案内しないよう、機構ごとに言い分ける。
+ */
+const SETTLEMENT_NOTES: Record<OrderAttributionSource, string> = {
+  COMPLETION:
+    '無効化しても付与済みのポイントは戻りません。清算が必要な場合は、その顧客の画面でポイント調整を行ってください。',
+  RECEIPT_TOKEN:
+    '無効化しても付与済みのポイントは戻りません。この来店は伝票QRの申領で帰属したため店舗台帳に会員の紐づけが無く、店舗からポイントを戻す操作は現在ありません。',
+};
+
 interface InvalidationFormValues {
   reason: string;
 }
@@ -235,7 +249,9 @@ export function OrderAttributionModal({ order, onClose }: OrderAttributionModalP
                     {/* 台帳へ波及しないことは操作の前に知らせる。事後に気づくと、誤付与が残ったまま
                         訂正が済んだと見なされる */}
                     <p className="text-sm text-muted-foreground">
-                      無効化しても付与済みのポイントは戻りません。清算が必要な場合は顧客画面のポイント調整で行ってください。
+                      {attribution.source
+                        ? SETTLEMENT_NOTES[attribution.source]
+                        : '無効化しても付与済みのポイントは戻りません。'}
                     </p>
                     <div className="flex justify-end gap-3 border-t pt-4">
                       <Button type="button" variant="outline" onClick={onClose} disabled={isBusy}>

--- a/frontend/src/_pages/store-orders/ui/OrderAttributionModal.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderAttributionModal.tsx
@@ -2,12 +2,11 @@
 
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { QRCodeSVG } from 'qrcode.react';
 import { notify } from '@/shared/notify';
-import { Order, OrderAttribution, orderApi } from '@/entities/order';
+import { Order, OrderAttribution, OrderAttributionSource, orderApi } from '@/entities/order';
 import { getApiErrorMessage, useResource } from '@/shared/lib';
-import { UNLINKED_NOTE, customerLabel } from '../lib/customerLabel';
-import { receiptClaimUrl } from '../lib/receiptClaimUrl';
+import { customerHeadingText } from '../lib/customerLabel';
+import { ReceiptTokenPanel } from './ReceiptTokenPanel';
 import {
   Badge,
   Button,
@@ -28,7 +27,7 @@ import {
 const REASON_MAX_LENGTH = 500;
 
 /** 成立の機構の日本語表示。値そのものは事実の記録で、挙動は分けない。 */
-const SOURCE_LABELS: Record<string, string> = {
+const SOURCE_LABELS: Record<OrderAttributionSource, string> = {
   COMPLETION: '完了時の会員紐づけ',
   RECEIPT_TOKEN: '伝票QRの申領',
 };
@@ -156,35 +155,15 @@ export function OrderAttributionModal({ order, onClose }: OrderAttributionModalP
         <div className="border-b px-6 py-4">
           <DialogTitle>{receiptToken !== null ? '伝票QRコード' : '会員帰属の訂正'}</DialogTitle>
           <p className="mt-1 text-sm text-muted-foreground">
-            {order?.business_date ?? '-'} / {customerText(order)}
+            {order?.business_date ?? '-'} / {customerHeadingText(order)}
           </p>
         </div>
         {receiptToken !== null ? (
-          <div className="px-6 py-5">
-            <div className="flex flex-col items-center gap-4">
-              <div className="rounded-xl border bg-card p-4">
-                <QRCodeSVG
-                  value={receiptClaimUrl(receiptToken)}
-                  size={192}
-                  aria-label="伝票QR"
-                  role="img"
-                />
-              </div>
-              {/* 生値はこの応答にしか現れない。閉じた後に出し直す経路が無いことを先に伝える */}
-              <p className="text-sm text-foreground">
-                この QR は今だけ表示できます。閉じると再表示できません。
-              </p>
-              <p className="text-sm text-muted-foreground">
-                正しいお客様が読み取ると、この来店をご自身のポイントと履歴に取り込めます（再発行から
-                90 日以内）。
-              </p>
-            </div>
-            <div className="mt-4 flex justify-end gap-3 border-t pt-4">
-              <Button type="button" onClick={onClose}>
-                閉じる
-              </Button>
-            </div>
-          </div>
+          <ReceiptTokenPanel
+            token={receiptToken}
+            claimNote="正しいお客様が読み取ると、この来店をご自身のポイントと履歴に取り込めます（再発行から 90 日以内）。"
+            onClose={onClose}
+          />
         ) : isLoading ? (
           <p className="px-6 py-8 text-center text-sm text-muted-foreground">読み込み中...</p>
         ) : failure !== null ? (
@@ -210,7 +189,7 @@ export function OrderAttributionModal({ order, onClose }: OrderAttributionModalP
                       <span>{attribution.member_code}</span>
                     </div>
                     <p className="text-muted-foreground">
-                      {SOURCE_LABELS[attribution.source ?? ''] ?? attribution.source} /{' '}
+                      {attribution.source ? SOURCE_LABELS[attribution.source] : '-'} /{' '}
                       {formatDateTime(attribution.attributed_at)}
                     </p>
                   </>
@@ -297,16 +276,4 @@ export function OrderAttributionModal({ order, onClose }: OrderAttributionModalP
       </DialogContent>
     </Dialog>
   );
-}
-
-/**
- * 見出しに出す顧客の呼び名。訂正の相手が誰か分からないまま無効化させないため、顧客未設定の受注も
- * 録入された連絡先で呼ぶ。見出しの行はすでに全体が注記の体裁なので、注記だけを分けて装飾しない。
- */
-function customerText(order: Order | null): string {
-  const label = order === null ? null : customerLabel(order);
-  if (label === null) {
-    return 'お客様名なし';
-  }
-  return label.unlinked ? `${label.name}${UNLINKED_NOTE}` : label.name;
 }

--- a/frontend/src/_pages/store-orders/ui/OrderAttributionModal.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderAttributionModal.tsx
@@ -1,0 +1,312 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { QRCodeSVG } from 'qrcode.react';
+import { notify } from '@/shared/notify';
+import { Order, OrderAttribution, orderApi } from '@/entities/order';
+import { getApiErrorMessage, useResource } from '@/shared/lib';
+import { UNLINKED_NOTE, customerLabel } from '../lib/customerLabel';
+import { receiptClaimUrl } from '../lib/receiptClaimUrl';
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  RegionError,
+  Textarea,
+} from '@/shared/ui';
+
+/** 理由の上限。帰属記録側の @Size(max = 500) と同値。 */
+const REASON_MAX_LENGTH = 500;
+
+/** 成立の機構の日本語表示。値そのものは事実の記録で、挙動は分けない。 */
+const SOURCE_LABELS: Record<string, string> = {
+  COMPLETION: '完了時の会員紐づけ',
+  RECEIPT_TOKEN: '伝票QRの申領',
+};
+
+interface InvalidationFormValues {
+  reason: string;
+}
+
+/**
+ * 取得した帰属の現況と、その取得元の受注。取得フックは取り直しの間も前の値を保つため、
+ * 値だけでは別の受注の現況と見分けられない。
+ */
+interface AttributionSnapshot {
+  orderId: string;
+  body: OrderAttribution;
+}
+
+/** 再発行された伝票トークンと、その発行元の受注（現況と同じ理由で、値だけでは別の受注のものと見分けられない）。 */
+interface ReissuedReceiptToken {
+  orderId: string;
+  token: string;
+}
+
+interface OrderAttributionModalProps {
+  /** 訂正の対象。null なら閉じている。 */
+  order: Order | null;
+  onClose: () => void;
+}
+
+function formatDateTime(value?: string): string {
+  return value ? new Date(value).toLocaleString('ja-JP') : '-';
+}
+
+/**
+ * 誤帰属の訂正モーダル（帰属記録の無効化と、伝票QRの再発行）。
+ *
+ * 無効化は帰属記録に対する唯一の訂正操作で、行は削除されず理由・実行者・時刻が残る。
+ * ポイント台帳へは波及しないため、誤って付与されたポイントの清算は顧客側のポイント調整で
+ * 別途行う必要がある — その旨は取り消せない操作の手前で画面が名乗る。
+ *
+ * 無効化された受注は「会員へ帰属しない状態」へ戻り、正しい本人は再発行された QR の所持証明で
+ * 来店を取り戻せる。申領期限は再発行から 90 日で数え直される。
+ */
+export function OrderAttributionModal({ order, onClose }: OrderAttributionModalProps) {
+  const form = useForm<InvalidationFormValues>({ defaultValues: { reason: '' } });
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { isSubmitting },
+  } = form;
+
+  const orderId = order?.id ?? '';
+  // 閉じている間は取りに行かない（開いた時点で取り直す）
+  const {
+    data: snapshot,
+    setData: setSnapshot,
+    isLoading,
+    failure,
+    reload,
+  } = useResource<AttributionSnapshot>(
+    order === null ? null : async () => ({ orderId, body: await orderApi.attribution(orderId) }),
+    [orderId]
+  );
+  // 別の受注へ切り替わった瞬間は現況を持たない状態から始める（レンダー期の判定なので、前の受注の
+  // 帰属で無効化・再発行の可否を決めるフレームが 1 つも無い）。
+  const attribution = snapshot !== null && snapshot.orderId === orderId ? snapshot.body : null;
+
+  const [reissued, setReissued] = useState<ReissuedReceiptToken | null>(null);
+  const receiptToken = reissued !== null && reissued.orderId === orderId ? reissued.token : null;
+  const [isReissuing, setIsReissuing] = useState(false);
+
+  useEffect(() => {
+    if (!order) return;
+    reset({ reason: '' });
+    // 発行済みの QR も一緒に戻す。「今だけ表示できる」と書いた画面が、開き直しで前の QR を出し直さない
+    setReissued(null);
+  }, [order, reset]);
+
+  const invalidate = async (values: InvalidationFormValues) => {
+    if (!order?.id) return;
+    try {
+      const updated = await orderApi.invalidateAttribution(order.id, { reason: values.reason });
+      notify.success('帰属を無効化しました');
+      // 応答が訂正後の現況を持つので、取り直さず差し替える（読み込み表示で一瞬消えない）
+      setSnapshot({ orderId, body: updated });
+      reset({ reason: '' });
+    } catch (error) {
+      // 帰属していない・既に無効化済みは、サーバが対処できる文言を返す。汎用文言に潰さない。
+      notify.error(getApiErrorMessage(error, '帰属の無効化に失敗しました'));
+    }
+  };
+
+  const reissue = async () => {
+    if (!order?.id) return;
+    try {
+      setIsReissuing(true);
+      const issued = await orderApi.reissueReceiptToken(order.id);
+      notify.success('伝票QRを再発行しました');
+      setReissued({ orderId, token: issued.receipt_token });
+    } catch (error) {
+      notify.error(getApiErrorMessage(error, '伝票QRの再発行に失敗しました'));
+    } finally {
+      setIsReissuing(false);
+    }
+  };
+
+  const isBusy = isSubmitting || isReissuing;
+
+  return (
+    <Dialog
+      open={order !== null}
+      onOpenChange={next => {
+        // 送信中に閉じると、訂正が成立したかどうか分からないまま古い現況が残る。
+        // QR を出している間も同じく閉じない — 生値はこの応答にしか無く、ESC や背景押下で
+        // 誤って閉じると客が来店を取り戻す手段ごと消える。閉じるのは明示のボタンだけにする。
+        if (!next && !isBusy && receiptToken === null) onClose();
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        aria-describedby={undefined}
+        className="gap-0 rounded-[10px] p-0 sm:max-w-md"
+      >
+        <div className="border-b px-6 py-4">
+          <DialogTitle>{receiptToken !== null ? '伝票QRコード' : '会員帰属の訂正'}</DialogTitle>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {order?.business_date ?? '-'} / {customerText(order)}
+          </p>
+        </div>
+        {receiptToken !== null ? (
+          <div className="px-6 py-5">
+            <div className="flex flex-col items-center gap-4">
+              <div className="rounded-xl border bg-card p-4">
+                <QRCodeSVG
+                  value={receiptClaimUrl(receiptToken)}
+                  size={192}
+                  aria-label="伝票QR"
+                  role="img"
+                />
+              </div>
+              {/* 生値はこの応答にしか現れない。閉じた後に出し直す経路が無いことを先に伝える */}
+              <p className="text-sm text-foreground">
+                この QR は今だけ表示できます。閉じると再表示できません。
+              </p>
+              <p className="text-sm text-muted-foreground">
+                正しいお客様が読み取ると、この来店をご自身のポイントと履歴に取り込めます（再発行から
+                90 日以内）。
+              </p>
+            </div>
+            <div className="mt-4 flex justify-end gap-3 border-t pt-4">
+              <Button type="button" onClick={onClose}>
+                閉じる
+              </Button>
+            </div>
+          </div>
+        ) : isLoading ? (
+          <p className="px-6 py-8 text-center text-sm text-muted-foreground">読み込み中...</p>
+        ) : failure !== null ? (
+          // 読めなかった現況を「未帰属」で描くと、他人の来店が残っているのに再発行を勧めることになる
+          <RegionError
+            message="帰属の状況を取得できませんでした"
+            onRetry={() => void reload()}
+            className="justify-center px-6 py-8"
+          />
+        ) : (
+          attribution !== null && (
+            <div className="space-y-4 px-6 py-5">
+              <div className="space-y-1 text-sm text-foreground">
+                {attribution.attributed ? (
+                  <>
+                    <div className="flex items-center gap-2">
+                      <Badge
+                        variant="outline"
+                        className="border-transparent bg-success/10 text-success-strong"
+                      >
+                        帰属済み
+                      </Badge>
+                      <span>{attribution.member_code}</span>
+                    </div>
+                    <p className="text-muted-foreground">
+                      {SOURCE_LABELS[attribution.source ?? ''] ?? attribution.source} /{' '}
+                      {formatDateTime(attribution.attributed_at)}
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <p className="text-muted-foreground">この来店は会員へ帰属していません。</p>
+                    {attribution.member_code && (
+                      <p className="text-muted-foreground">
+                        {attribution.member_code} への帰属を
+                        {formatDateTime(attribution.invalidated_at)}に無効化（
+                        {attribution.invalidated_reason}）
+                      </p>
+                    )}
+                  </>
+                )}
+              </div>
+
+              {attribution.attributed ? (
+                <Form {...form}>
+                  {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、
+                      我々の文言は永久に描かれない。required は下の規則が引き継ぐ */}
+                  <form onSubmit={handleSubmit(invalidate)} className="space-y-4" noValidate>
+                    <FormField
+                      control={control}
+                      name="reason"
+                      rules={{
+                        required: '無効化の理由を入力してください',
+                        maxLength: {
+                          value: REASON_MAX_LENGTH,
+                          message: `理由は${REASON_MAX_LENGTH}文字以内で入力してください`,
+                        },
+                      }}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>無効化の理由</FormLabel>
+                          <FormControl>
+                            <Textarea rows={3} required maxLength={REASON_MAX_LENGTH} {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    {/* 台帳へ波及しないことは操作の前に知らせる。事後に気づくと、誤付与が残ったまま
+                        訂正が済んだと見なされる */}
+                    <p className="text-sm text-muted-foreground">
+                      無効化しても付与済みのポイントは戻りません。清算が必要な場合は顧客画面のポイント調整で行ってください。
+                    </p>
+                    <div className="flex justify-end gap-3 border-t pt-4">
+                      <Button type="button" variant="outline" onClick={onClose} disabled={isBusy}>
+                        キャンセル
+                      </Button>
+                      <Button type="submit" disabled={isBusy}>
+                        {isSubmitting ? '処理中...' : '無効化する'}
+                      </Button>
+                    </div>
+                  </form>
+                </Form>
+              ) : (
+                <>
+                  {attribution.member_code ? (
+                    <p className="text-sm text-muted-foreground">
+                      伝票QRを再発行すると、正しいお客様が読み取ってこの来店を取り戻せます。
+                    </p>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      この受注は会員へ帰属したことがないため、訂正の対象ではありません。
+                    </p>
+                  )}
+                  <div className="flex justify-end gap-3 border-t pt-4">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isBusy}>
+                      閉じる
+                    </Button>
+                    {attribution.member_code && (
+                      <Button type="button" onClick={() => void reissue()} disabled={isBusy}>
+                        {isReissuing ? '発行中...' : '伝票QRを再発行'}
+                      </Button>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          )
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * 見出しに出す顧客の呼び名。訂正の相手が誰か分からないまま無効化させないため、顧客未設定の受注も
+ * 録入された連絡先で呼ぶ。見出しの行はすでに全体が注記の体裁なので、注記だけを分けて装飾しない。
+ */
+function customerText(order: Order | null): string {
+  const label = order === null ? null : customerLabel(order);
+  if (label === null) {
+    return 'お客様名なし';
+  }
+  return label.unlinked ? `${label.name}${UNLINKED_NOTE}` : label.name;
+}

--- a/frontend/src/_pages/store-orders/ui/OrderAttributionModal.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderAttributionModal.tsx
@@ -33,18 +33,19 @@ const SOURCE_LABELS: Record<OrderAttributionSource, string> = {
 };
 
 /**
- * 無効化の前に出す清算の注意書き。台帳へ波及しないことは共通だが、清算の手段は成立の機構で変わる。
+ * 無効化の前に出す清算の注意書き。
  *
- * 伝票QRの申領で成立した帰属は店舗台帳に会員の紐づけを作らない（申領は受注 1 件の事実だけを証明し、
- * 店舗と会員の継続的な関係を作らない）。店舗側のポイント調整は顧客に紐づく会員だけを対象に取るため、
- * この経路で付いたポイントには届かない。届かない操作を案内しないよう、機構ごとに言い分ける。
+ * 清算の宛先は<b>この帰属記録が持つ会員</b>（不変）である一方、店舗コンソールのポイント調整は
+ * 「その顧客に<b>現在</b>紐づく会員」を対象に取る。両者は一致するとは限らない — 申領で成立した帰属は
+ * そもそも紐づけを作らず、完了時の帰属でも紐づけはあとから解除・変更されうる。ずれている状態で
+ * 案内どおりに操作すると、撥ねられるか、<b>無関係な会員から引かれる</b>。
+ *
+ * よって特定の画面を宛先として案内しない。宛先は上に表示している会員コードであることと、
+ * 顧客画面の調整が届くとは限らないことだけを述べる。機構ごとに文言を出し分ける形は採らない —
+ * 「どの場合に届くか」は紐づけの現況しだいで、成立の機構からは判らないため。
  */
-const SETTLEMENT_NOTES: Record<OrderAttributionSource, string> = {
-  COMPLETION:
-    '無効化しても付与済みのポイントは戻りません。清算が必要な場合は、その顧客の画面でポイント調整を行ってください。',
-  RECEIPT_TOKEN:
-    '無効化しても付与済みのポイントは戻りません。この来店は伝票QRの申領で帰属したため店舗台帳に会員の紐づけが無く、店舗からポイントを戻す操作は現在ありません。',
-};
+const SETTLEMENT_NOTE =
+  '無効化しても付与済みのポイントは戻りません。清算は上の会員コードの台帳に対して行う必要があります。顧客画面のポイント調整はその顧客に現在紐づく会員を対象に取るため、紐づけが無い・変わっている場合はこの会員に届きません。';
 
 interface InvalidationFormValues {
   reason: string;
@@ -253,11 +254,7 @@ export function OrderAttributionModal({ order, onClose }: OrderAttributionModalP
                     />
                     {/* 台帳へ波及しないことは操作の前に知らせる。事後に気づくと、誤付与が残ったまま
                         訂正が済んだと見なされる */}
-                    <p className="text-sm text-muted-foreground">
-                      {attribution.source
-                        ? SETTLEMENT_NOTES[attribution.source]
-                        : '無効化しても付与済みのポイントは戻りません。'}
-                    </p>
+                    <p className="text-sm text-muted-foreground">{SETTLEMENT_NOTE}</p>
                     <div className="flex justify-end gap-3 border-t pt-4">
                       <Button type="button" variant="outline" onClick={onClose} disabled={isBusy}>
                         キャンセル

--- a/frontend/src/_pages/store-orders/ui/OrderCompletionModal.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrderCompletionModal.tsx
@@ -2,12 +2,11 @@
 
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { QRCodeSVG } from 'qrcode.react';
 import { notify } from '@/shared/notify';
 import { Order, OrderCompletionPreview, orderApi } from '@/entities/order';
 import { getApiErrorMessage, integerRule, useResource } from '@/shared/lib';
-import { UNLINKED_NOTE, customerLabel } from '../lib/customerLabel';
-import { receiptClaimUrl } from '../lib/receiptClaimUrl';
+import { customerHeadingText } from '../lib/customerLabel';
+import { ReceiptTokenPanel } from './ReceiptTokenPanel';
 import {
   Button,
   Dialog,
@@ -25,18 +24,6 @@ import {
 
 /** 空欄と 0 は別物なので、未入力の文言は 1 箇所に持って両方の規則から指す。 */
 const TOTAL_FEE_REQUIRED = '会計金額を入力してください';
-
-/**
- * 見出しに出す顧客の呼び名。会計の相手が誰か分からないまま完了させないため、顧客未設定の受注も
- * 録入された連絡先で呼ぶ。見出しの行はすでに全体が注記の体裁なので、注記だけを分けて装飾しない。
- */
-function customerText(order: Order | null): string {
-  const label = order === null ? null : customerLabel(order);
-  if (label === null) {
-    return 'お客様名なし';
-  }
-  return label.unlinked ? `${label.name}${UNLINKED_NOTE}` : label.name;
-}
 
 interface OrderCompletionFormValues {
   /** 空欄は NaN。「未入力」と 0 円の会計を取り違えないため、valueAsNumber の写像をそのまま持つ。 */
@@ -172,35 +159,15 @@ export function OrderCompletionModal({ order, onClose, onCompleted }: OrderCompl
         <div className="border-b px-6 py-4">
           <DialogTitle>{receiptToken !== null ? '伝票QRコード' : '完了処理'}</DialogTitle>
           <p className="mt-1 text-sm text-muted-foreground">
-            {order?.business_date ?? '-'} / {customerText(order)}
+            {order?.business_date ?? '-'} / {customerHeadingText(order)}
           </p>
         </div>
         {receiptToken !== null ? (
-          <div className="px-6 py-5">
-            <div className="flex flex-col items-center gap-4">
-              <div className="rounded-xl border bg-card p-4">
-                <QRCodeSVG
-                  value={receiptClaimUrl(receiptToken)}
-                  size={192}
-                  aria-label="伝票QR"
-                  role="img"
-                />
-              </div>
-              {/* 生値はこの応答にしか現れない。閉じた後に出し直す経路が無いことを先に伝える */}
-              <p className="text-sm text-foreground">
-                この QR は今だけ表示できます。閉じると再表示できません。
-              </p>
-              <p className="text-sm text-muted-foreground">
-                お客様が読み取ると、この来店をご自身のポイントと履歴に取り込めます（完了から 90
-                日以内）。
-              </p>
-            </div>
-            <div className="mt-4 flex justify-end gap-3 border-t pt-4">
-              <Button type="button" onClick={onClose}>
-                閉じる
-              </Button>
-            </div>
-          </div>
+          <ReceiptTokenPanel
+            token={receiptToken}
+            claimNote="お客様が読み取ると、この来店をご自身のポイントと履歴に取り込めます（完了から 90 日以内）。"
+            onClose={onClose}
+          />
         ) : (
           <Form {...form}>
             {/* noValidate: 未達の原生制約が生きている限りブラウザが submit の手前で止め、

--- a/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
+++ b/frontend/src/_pages/store-orders/ui/OrdersPage.tsx
@@ -3,11 +3,12 @@
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
-import { CircleCheckIcon, PlusIcon, SquarePenIcon } from 'lucide-react';
+import { CircleCheckIcon, PlusIcon, SquarePenIcon, UserRoundCogIcon } from 'lucide-react';
 import { ORDER_STATUS_LABELS, Order, OrderStatus, orderApi } from '@/entities/order';
 import { storePath, useListPage } from '@/shared/lib';
 import { ListPage } from '@/widgets/list-page';
 import { UNLINKED_NOTE, customerLabel } from '../lib/customerLabel';
+import { OrderAttributionModal } from './OrderAttributionModal';
 import { OrderCompletionModal } from './OrderCompletionModal';
 import { ReservationRequestInbox } from './ReservationRequestInbox';
 import {
@@ -62,6 +63,7 @@ export default function OrderListPage() {
   const params = useParams();
   const storeId = params.storeId as string;
   const [completing, setCompleting] = useState<Order | null>(null);
+  const [correcting, setCorrecting] = useState<Order | null>(null);
   const list = useListPage(
     // created_at は一意でない可能性があるため、offset ページングの境界を確定させる
     // 一意な副キーを添える（sort=prop1,prop2,direction は Spring Data の複数キー形式）
@@ -171,6 +173,19 @@ export default function OrderListPage() {
                         完了
                       </Button>
                     )}
+                    {/* 誤帰属の訂正は完了した受注にしか起こらない（帰属が生まれるのは完了と事後申領の
+                        瞬間だけ）。現に帰属しているかは一覧の読み口が持たないので、開いた先で名乗る */}
+                    {order.status === 'COMPLETED' && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setCorrecting(order)}
+                      >
+                        <UserRoundCogIcon aria-hidden="true" />
+                        会員帰属
+                      </Button>
+                    )}
                     <Button
                       render={<Link href={storePath(storeId, `/orders/${order.id}/edit`)} />}
                       variant="ghost"
@@ -192,6 +207,8 @@ export default function OrderListPage() {
         // 持たないため、現在のページをそのまま取り直す。
         onCompleted={list.reload}
       />
+      {/* 訂正は受注の状態も会計欄も変えないため、一覧の取り直しは要らない */}
+      <OrderAttributionModal order={correcting} onClose={() => setCorrecting(null)} />
     </div>
   );
 }

--- a/frontend/src/_pages/store-orders/ui/ReceiptTokenPanel.tsx
+++ b/frontend/src/_pages/store-orders/ui/ReceiptTokenPanel.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { QRCodeSVG } from 'qrcode.react';
+import { receiptClaimUrl } from '../lib/receiptClaimUrl';
+import { Button } from '@/shared/ui';
+
+interface ReceiptTokenPanelProps {
+  /** 発行された伝票トークンの生値。保存されるのはダイジェストだけなので、この値は応答にしか現れない。 */
+  token: string;
+  /** 誰がいつまでに読み取れるかの一文。発行の文脈（完了時 / 訂正の再発行）で違うので呼出側が持つ。 */
+  claimNote: string;
+  onClose: () => void;
+}
+
+/**
+ * 発行された伝票 QR を出す一画面。完了時の発行と訂正の再発行が同じ表示を共有する。
+ *
+ * 生値はこの表示にしか現れず、閉じた後に出し直す経路が無い。だから「今だけ表示できる」ことを
+ * 先に伝え、閉じる手段を明示のボタンだけに絞る — 呼出側の Dialog は QR を出している間
+ * ESC と背景押下で閉じないようにしておくこと（この区画だけでは塞げない）。
+ */
+export function ReceiptTokenPanel({ token, claimNote, onClose }: ReceiptTokenPanelProps) {
+  return (
+    <div className="px-6 py-5">
+      <div className="flex flex-col items-center gap-4">
+        <div className="rounded-xl border bg-card p-4">
+          <QRCodeSVG value={receiptClaimUrl(token)} size={192} aria-label="伝票QR" role="img" />
+        </div>
+        {/* 生値はこの応答にしか現れない。閉じた後に出し直す経路が無いことを先に伝える */}
+        <p className="text-sm text-foreground">
+          この QR は今だけ表示できます。閉じると再表示できません。
+        </p>
+        <p className="text-sm text-muted-foreground">{claimNote}</p>
+      </div>
+      <div className="mt-4 flex justify-end gap-3 border-t pt-4">
+        <Button type="button" onClick={onClose}>
+          閉じる
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/entities/order/__tests__/order-api.test.ts
+++ b/frontend/src/entities/order/__tests__/order-api.test.ts
@@ -75,6 +75,28 @@ describe('orderApi', () => {
   it('decline は謝絶の子リソースを POST する', async () => {
     expect(await orderApi.decline('o1')).toEqual({ ok: true, url: '/store/orders/o1/decline' });
   });
+  it('attribution は受注の帰属の現況を GET する', async () => {
+    expect(await orderApi.attribution('o1')).toEqual({
+      ok: true,
+      url: '/store/orders/o1/attribution',
+    });
+  });
+  it('invalidateAttribution は理由を添えて無効化の子リソースを POST する', async () => {
+    // 理由はこの訂正の唯一の根拠。省略できる形にすると、後から誰の来店が消えたのか辿れなくなる
+    expect(await orderApi.invalidateAttribution('o1', { reason: '取り違え' })).toEqual({
+      ok: true,
+      url: '/store/orders/o1/attribution/invalidation',
+    });
+    expect(apiClient.post).toHaveBeenCalledWith('/store/orders/o1/attribution/invalidation', {
+      reason: '取り違え',
+    });
+  });
+  it('reissueReceiptToken は伝票トークンの子リソースを POST する', async () => {
+    expect(await orderApi.reissueReceiptToken('o1')).toEqual({
+      ok: true,
+      url: '/store/orders/o1/receipt-token',
+    });
+  });
 });
 
 describe('memberOrderApi', () => {

--- a/frontend/src/entities/order/__tests__/order-api.test.ts
+++ b/frontend/src/entities/order/__tests__/order-api.test.ts
@@ -83,11 +83,14 @@ describe('orderApi', () => {
   });
   it('invalidateAttribution は理由を添えて無効化の子リソースを POST する', async () => {
     // 理由はこの訂正の唯一の根拠。省略できる形にすると、後から誰の来店が消えたのか辿れなくなる
-    expect(await orderApi.invalidateAttribution('o1', { reason: '取り違え' })).toEqual({
+    expect(
+      await orderApi.invalidateAttribution('o1', { attribution_id: 501, reason: '取り違え' })
+    ).toEqual({
       ok: true,
       url: '/store/orders/o1/attribution/invalidation',
     });
     expect(apiClient.post).toHaveBeenCalledWith('/store/orders/o1/attribution/invalidation', {
+      attribution_id: 501,
       reason: '取り違え',
     });
   });

--- a/frontend/src/entities/order/api/order.ts
+++ b/frontend/src/entities/order/api/order.ts
@@ -13,10 +13,13 @@ import {
   MemberReceiptClaim,
   MemberVisit,
   Order,
+  OrderAttribution,
+  OrderAttributionInvalidationRequest,
   OrderCastCandidate,
   OrderCompletionPreview,
   OrderCompletionRequest,
   OrderCreateRequest,
+  OrderReceiptTokenIssue,
   OrderReceptionist,
   ReservationRequestUpdateRequest,
 } from '../model/types';
@@ -91,6 +94,32 @@ export const orderApi = {
     const response = await apiClient.get(`/store/orders/${id}/completion-preview`, {
       params: { total_fee: totalFee },
     });
+    return response.data;
+  },
+  /** 受注 1 件の帰属の現況。無効化と再発行のどちらを提示するかはこの読み口で決まる。 */
+  attribution: async (id: string): Promise<OrderAttribution> => {
+    const response = await apiClient.get(`/store/orders/${id}/attribution`);
+    return response.data;
+  },
+  /**
+   * 帰属記録を理由付きで無効化する（誤帰属の訂正）。行は削除されず、理由・実行者・時刻が記録に残る。
+   *
+   * ポイント台帳へは波及しない。誤って付与されたポイントの清算は手動のポイント調整で行う。
+   */
+  invalidateAttribution: async (
+    id: string,
+    data: OrderAttributionInvalidationRequest
+  ): Promise<OrderAttribution> => {
+    const response = await apiClient.post(`/store/orders/${id}/attribution/invalidation`, data);
+    return response.data;
+  },
+  /**
+   * 無効化された受注へ伝票トークンを再発行する。申領期限は再発行から 90 日で数え直される。
+   *
+   * 生値はこの応答にしか現れない（保存されるのはダイジェストだけ）。
+   */
+  reissueReceiptToken: async (id: string): Promise<OrderReceiptTokenIssue> => {
+    const response = await apiClient.post(`/store/orders/${id}/receipt-token`);
     return response.data;
   },
 };

--- a/frontend/src/entities/order/model/types.ts
+++ b/frontend/src/entities/order/model/types.ts
@@ -164,6 +164,8 @@ export type OrderAttributionSource = 'COMPLETION' | 'RECEIPT_TOKEN';
  * attributed 以外は Java 側が可空のため、記録の無い受注ではキーごと消える。
  */
 export interface OrderAttribution {
+  /** 直近の帰属記録の ID。無効化はこの値で対象を名指す。記録が 1 件も無ければ応答から消える。 */
+  id?: number;
   /** Java 側が primitive の boolean のため、キーは必ず応答に含まれる。 */
   attributed: boolean;
   member_code?: string;
@@ -175,7 +177,10 @@ export interface OrderAttribution {
 }
 
 // 帰属記録の無効化（POST /store/orders/{id}/attribution/invalidation）。理由は必須（500 文字以内）。
+// 対象は受注から導かず、画面が読み口で得た帰属記録の ID を名指す（開いたまま別の操作者が訂正を
+// 一巡させると、有効な記録が別人の新しい帰属に入れ替わっているため）。
 export interface OrderAttributionInvalidationRequest {
+  attribution_id: number;
   reason: string;
 }
 

--- a/frontend/src/entities/order/model/types.ts
+++ b/frontend/src/entities/order/model/types.ts
@@ -154,6 +154,36 @@ export interface OrderCompletionPreview {
   grant_points: number;
 }
 
+// 受注の帰属の成立機構。COMPLETION=完了時の関連解決 / RECEIPT_TOKEN=伝票トークンの事後申領。
+export type OrderAttributionSource = 'COMPLETION' | 'RECEIPT_TOKEN';
+
+/**
+ * 受注 1 件の帰属の現況（GET /store/orders/{id}/attribution）。
+ *
+ * 返るのは直近の記録 1 件で、会員側の情報は会員コードだけ（表示名・メールは店舗へ渡らない）。
+ * attributed 以外は Java 側が可空のため、記録の無い受注ではキーごと消える。
+ */
+export interface OrderAttribution {
+  /** Java 側が primitive の boolean のため、キーは必ず応答に含まれる。 */
+  attributed: boolean;
+  member_code?: string;
+  source?: OrderAttributionSource;
+  attributed_at?: string;
+  /** 直近の記録が無効化済みならその理由。 */
+  invalidated_reason?: string;
+  invalidated_at?: string;
+}
+
+// 帰属記録の無効化（POST /store/orders/{id}/attribution/invalidation）。理由は必須（500 文字以内）。
+export interface OrderAttributionInvalidationRequest {
+  reason: string;
+}
+
+// 再発行された伝票トークン（POST /store/orders/{id}/receipt-token）。生値はこの応答にしか現れない。
+export interface OrderReceiptTokenIssue {
+  receipt_token: string;
+}
+
 // 会員本人の予約1件（GET /platform/me/orders）。店舗の顧客台帳の項目は含まない。
 export interface MemberOrder {
   id?: string;


### PR DESCRIPTION
## 概要

誤帰属の訂正経路を店舗コンソールへ足す。帰属記録を**理由付きで無効化**でき、無効化された受注へ**伝票トークンを再発行**して正しい本人が来店を取り戻せるようにした（ADR 0009）。無効化はポイント台帳へ自動波及しない。

Closes #654

## 変更内容

- **v0.18.0**: `t_order_attributions` へ `invalidated_reason` / `invalidated_by`（FK → `t_users`, SET NULL）/ `invalidated_at` を追加。行は削除せず `status` を `INVALIDATED` へ倒す形は既存のまま（`ACTIVE` 部分一意索引が無効化と同時に枠を空ける）。
- **`OrderAttribution.invalidate(reason, actorId, at)`**: 理由・実行者・時刻が必須、二度目の無効化は拒否（初回の根拠が上書きされるため）。帰属そのものの記録（会員・根拠・帰属時刻）は書き換えない。
- **`OrderAttributionService`（新設）**: 訂正の 3 ユースケース。`PointLedgerService` を依存に持たないことが「台帳へ波及しない」の宣言でもある。
- **店舗側 3 端点**（すべて `PERM_ORDER_MANAGE`）:
  - `GET /store/orders/{id}/attribution` — 帰属の現況（会員コード・成立の機構・無効化の理由）
  - `POST /store/orders/{id}/attribution/invalidation` — 理由必須（`@NotBlank` + `@Size(max=500)` = 列長）。対象は受注から導かず、読み口が返した帰属記録の ID を名指す（ずれていれば 409）
  - `POST /store/orders/{id}/receipt-token` — 再発行。申領期限は再発行から 90 日で数え直す
- **`OrderRepository#findScopedById`（新設）**: JPQL で引く `storeFilter` の効く読み口。
- **フロント**: 完了行から開く `OrderAttributionModal`。現況の表示 → 理由付き無効化 → 再発行 → QR 表示（完了時の発行と同じ閉じるガード）。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task test-unit` / `task test-integration` それぞれ exit 0。統合 322 件）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（既存シナリオ 24 件 passed。本 PR はシナリオを追加していない — 理由は下の備考）
- [x] ローカルで code-review 実施済み（Standards / Spec の 2 軸）。指摘は `b66d4bf1` で対応済み（QR 表示区画の共有化・表示写像の型付け・現況取得の 1 行化・改名）。codex の指摘は `bb27dc59` / `e1e9dea9` で対応。うち 2 件は #669 へ切り出し（下記）

### 視覚確認（UI 変更時）

`task build` → `task up` → 店舗コンソール（`kizuna.test/store/1/orders`）で実機確認済み。API で「会員へ帰属した完了受注」を 1 件用意したうえで:

1. 完了行にだけ「会員帰属」が出る（未確定行には出ない）
2. モーダルが `帰属済み` バッジ＋会員コード `547579256544`、`完了時の会員紐づけ / 2026/8/13 17:29:09` を表示
3. 理由が空のまま送信 → 欄の傍に「無効化の理由を入力してください」、**要求は飛ばない**
4. 理由付きで無効化 → 取り直さずその場で再発行の導線へ切り替わり、「誰への帰属をいつ・なぜ無効化したか」を表示
5. 再発行 → QR 表示。**ESC を押しても閉じない**（明示のボタンのみ）

DB の実データも確認: 帰属記録は `INVALIDATED` ＋理由＋実行者 `3`、新トークンは `planned_points=120` ・有効 90 日、`t_point_entries` は `ORDER_GRANT` 1 本のまま（打ち消しの仕訳は積まれない）。

## 決定ログ

**再発行は「訂正の経路」であって「発行の経路」ではない。** 門は 4 つ — ①完了済み ②帰属記録が 1 件以上ある ③有効な帰属が無い ④申領できる伝票が無い。②を落として「未帰属の完了受注なら誰でも」に広げる案は見送った。完了時に会員へ達しなかった受注は完了の応答で既に伝票を受け取っており、チケットと ADR が言う「無効化された受注は…事後帰属の対象に復帰する」を素直に読むとこちらになる。

**④が要る理由**は生きた伝票を 2 本並ばせないため。並ぶと後から申領した側が帰属記録の部分一意違反（500 系）で落ち、#653 が意図して作った「申領できない伝票はすべて同形のエラー」が壊れる（`MemberReceiptClaimService` の行ロックは同一トークンの並行申領しか担わない）。判定は取得した行に `isClaimableAt` を当てる形にした — 状態と期限を問い合わせ側へ書き下すと「申領できる」の定義が二箇所に分かれる。

**`OrderReceiptTokenStatus` に `REVOKED` は足さない**案を採った。有効な帰属がある間は伝票が生きていることが構造上あり得ないので、無効化の側にトークンを止める処理が要らない。`(order_id) WHERE status='ISSUED'` の部分一意索引も張らない — 期限切れの `ISSUED` 行が残るため、張ると期限切れ後の再発行が死ぬ。

**再発行の付与予定額は「完了時点で確定した額」の引き継ぎで、参照の順序が意味を持つ。** ①直近の伝票トークンの `planned_points` ②無ければ `order.auto_grant_points`。逆順にすると「非会員完了 → 誤った本人が申領 → 訂正」の系で予定額が 0 に潰れる（その受注の付与実績は 0 だから）。会計金額から計算し直す案は、訂正の早い遅い＝その間の付与設定の変更で同じ会計が別のポイントになるので採らない。

**店舗の境界を決めるのは受注だけ。** 帰属記録も伝票トークンも platform 帰属で店舗行分離機構に載らないため、受注 ID で引く操作は先に受注の所有を確かめるしかない。ここで `orderRepository.findById` は使えない — Hibernate のフィルタは `EntityManager.find` に掛からず、派生の `findById` はそこへ落ちる（先例の記述は `CustomerRepository#findByIdForUpdate` の javadoc）。JPQL の `findScopedById` を新設して 3 メソッドすべての入口に置いた。

**画面の分岐は「読めなかった」を「未帰属」に潰さない。** 現況の取得に失敗したら領域自身が失敗を名乗り、訂正の導線を出さない（DESIGN.md の clause ①）。未帰属で描くと、他人の来店が残っているのに再発行を勧めることになる。

## 備考 / レビュー観点

- **`OrderService.complete` / `get` の `findById` は触っていない。** 同じ「フィルタが掛からない」性質を持つが、複数店舗を授権された操作者が現店舗の文脈のまま他店舗の受注 ID を指した場合にだけ開く既存の隙で、本 PR がそれを悪化させてはいない。横展開するなら別 issue で受注モジュール全体を一度に見るのが筋だと考え、射程外にした。**別の判断があればそちらに従います。**
- **誤って付与されたポイントは残る。** ADR 0009 のとおり清算は手動調整で行う。結果として同じ受注に `ORDER_GRANT` が 2 本立つ（誤帰属の分＋正しい本人の分）— 台帳側に受注単位の一意制約は無く、`idempotency_key` は `ORDER_GRANT` では NULL なので制約違反にはならない。画面は無効化の**手前**でこの旨を名乗る。
- **⚠️ 伝票トークンの直列化と応答喪失からの復旧は #669 へ切り出しました。** 評審で挙がった「申領と再発行が互いに排他でない」「発行応答を取り逃すと 90 日復旧できない」の 2 件は、機序まで確認したうえで妥当と判断しています。ただし解くには申領側のロック規約（#653 で確定・テストで固定）の変更か、「生きた伝票は 1 本」という不変量そのものの見直しかという設計判断が要り、#654（誤帰属の訂正）の射程を超えます。#669 に症状・機序・検討した 3 方向と受け入れ基準を記載しました。**該当の評審スレッドは追跡のため未解決のまま残しています。**
- **⚠️ 誤帰属で付いたポイントを店舗が安全に清算する経路がありません → #670 で追跡。** 清算の宛先は帰属記録が持つ会員（不変）ですが、店舗の調整口は「その顧客に**現在**紐づく会員」を対象に取ります。食い違う経路が 3 つ — ①申領で成立した帰属（関連も顧客行も作らない）②関連が解除済み（撥ねられる）③**関連が別会員へ張り替え済み（無関係な会員から引かれる）**。本 PR では危険な案内を消すところまで（特定画面を宛先として案内せず、宛先は表示中の会員コードだと述べる）。以下は最初の確認記録です — codex の指摘を追って確認した事実 — 店舗側の調整口は `/store/customers/{customerId}/point-adjustments` だけで、`CustomerPointService#adjust` は ACTIVE な関連の無い顧客を拒む。一方で申領は店舗台帳に関連を作らず（ADR 0008 の「申領は台帳へ一切波及しない」）、顧客未設定の受注には顧客 ID そのものが無い。よってこの経路で誤って付いたポイントは、店舗の操作では戻せません。本 PR では**実行できない操作を案内しないこと**に留め（注意書きを成立の機構ごとに言い分ける）、会員を直接対象に取る調整経路の新設は見送っています — ADR 0009 が「清算しきれない場合の扱い…は本 ADR では定めず、運用の実例に基づいて別途裁定する」としており、#654 の射程外の設計判断になるためです。**別票を起こすかどうかの裁定をお願いします。**
- **`OrderAttribution` の新しい 3 列に `updatable = false` を付けていない**のは意図的。既存フィールドは全部それを持つので写経しやすいが、付けると Hibernate が UPDATE から黙って落とし「行は `INVALIDATED` なのに理由が NULL」になる。集約を往復させない単体テストでは捕まらないため、IT で `jdbcTemplate` の実データ断言を置いた（`OrderAttributionInvalidationIT#invalidationPersistsTheReasonActorAndTime`）。手本は `CustomerMemberLink.releasedBy/releasedAt`。
- **「期限が再発行から 90 日」の赤は完了時帰属の系では作れない**（引き継ぐ元の期限が無く、正しい実装と誤った実装が同じ値になる）。そのため IT は「非会員完了 → 誤った本人が申領 → 無効化」の系を組み、旧トークンの `expires_at` を近い日付へ倒してから再発行して見分けている。
- **フロント側の権限ゲートは足していない。** この 3 端点は `OrderController` の他の全端点と同じ `ORDER_MANAGE` を使うので、画面側で同じ権限をもう一度判定しても空振りの fail-closed にしかならない。強制はサーバの `@PreAuthorize` で、権限なしの 403 は `OrderControllerTest#attributionCorrectionIsRejectedWithoutOrderManage` が固定している。受け入れ基準の「UI があり権限でゲートされる」を UI 層での判定と読むなら、`MemberLinkSection` の `hasPermission(readTokenClaims(), …)` 方式へ寄せられます — **裁定をお願いします**。
- **受け入れ基準の「端到端」は統合テストで満たした**（`OrderAttributionInvalidationIT#theRightMemberReclaimsTheVisitWithTheReissuedToken` が店舗コンソール HTTP → 会員申領 HTTP を通しで踏む）。Playwright のシナリオは足していない — `e2e/features/` には #652 / #653 の時点で伝票・申領のシナリオが 1 件も無く、本 PR だけ先行して足すと申領系の e2e 資産がここだけ孤立するため。必要なら別 issue で 3 票分まとめて起こすのが筋だと考えています。
- **新設した読み口 `GET /store/orders/{id}/attribution` はチケットの「作るもの」に無い追加 API 面。** モーダルが「無効化」と「再発行」のどちらを出すかを判じる材料が他に無いため足した。
- **再発行トークンの付与予定額はチケットにも ADR 0009 にも定めが無い。** 上の決定ログのとおり「完了時点で確定した額の引き継ぎ」を採ったが、**未裁定の判断**である点を明示しておきます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
