### PR TITLE
feat: 重複した顧客行を統合できるようにする (#672)

### DIFF
--- a/backend/docs/modulith/module-customer.adoc
+++ b/backend/docs/modulith/module-customer.adoc
@@ -10,13 +10,15 @@
 _Repositories_
 
 * `c.k.c.domain.CustomerMemberLinkRepository`
+* `c.k.c.domain.CustomerMergeRepository`
 * `c.k.c.domain.CustomerRepository`
 |Bean references
 |* `c.k.m.application.MemberLookupService` (in Member)
 * `c.k.u.domain.PlatformUserRepository` (in User)
-* `c.k.p.application.PointLedgerService` (in Point)
 * `c.k.s.storescope.StoreContext` (in Shared)
+* `c.k.p.application.PointLedgerService` (in Point)
 |Aggregate roots
 |* `c.k.c.domain.Customer`
 * `c.k.c.domain.CustomerMemberLink`
+* `c.k.c.domain.CustomerMerge`
 |===

--- a/backend/src/integrationTest/java/com/kizuna/customer/CustomerMergeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/CustomerMergeIT.java
@@ -125,6 +125,30 @@ class CustomerMergeIT extends CrossStoreTestSupport {
     assertThat(mergedIntoOf(b)).isEqualTo(c);
   }
 
+  @Test
+  @DisplayName("付替えと圧平が行の版を上げること（並行して読まれていた行の書き戻しが静かに勝たない）")
+  void advancesTheVersionOfEveryRowItRewrites() {
+    String a = createCustomer("版A-" + nonce);
+    String b = createCustomer("版B-" + nonce);
+    String c = createCustomer("版C-" + nonce);
+    String orderId = orderFor(b, "版受注");
+    assertThat(merge(STORE_A, b, a).getStatusCode())
+        .as("前提: A を B へ統合できること")
+        .isEqualTo(HttpStatus.OK);
+    long tombstoneVersionBefore = versionOfCustomer(a);
+    long orderVersionBefore = versionOfOrder(orderId);
+
+    assertThat(merge(STORE_A, c, b).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    // 版を上げないと、統合の前に読まれていた行を後から保存する経路が、自分が読んだ時点の値
+    // （墓標 A なら統合先 B、受注なら顧客 B）を他の項目と一緒に書き戻せてしまう。楽観ロックの
+    // 述語が成立するため競合として現れず、圧平と付替えだけが静かに取り消される。
+    // 外形（並行する 2 つの要求のどちらが勝つか）の固定は後続の並行テストの範囲で、
+    // ここではその競合が検出可能になる前提だけを決定的に押さえる。
+    assertThat(versionOfCustomer(a)).as("圧平した墓標の版").isGreaterThan(tombstoneVersionBefore);
+    assertThat(versionOfOrder(orderId)).as("付け替えた受注の版").isGreaterThan(orderVersionBefore);
+  }
+
   // ==================== 統合履歴 ====================
 
   @Test
@@ -309,6 +333,14 @@ class CustomerMergeIT extends CrossStoreTestSupport {
 
   private String customerOf(String orderId) {
     return orderRepository.findById(orderId).map(Order::getCustomerId).orElseThrow();
+  }
+
+  private long versionOfCustomer(String customerId) {
+    return customer(customerId).getVersion();
+  }
+
+  private long versionOfOrder(String orderId) {
+    return orderRepository.findById(orderId).map(Order::getVersion).orElseThrow();
   }
 
   private OrderStatus statusOf(String orderId) {

--- a/backend/src/integrationTest/java/com/kizuna/customer/CustomerMergeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/CustomerMergeIT.java
@@ -1,0 +1,504 @@
+package com.kizuna.customer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kizuna.customer.domain.Customer;
+import com.kizuna.customer.domain.CustomerMemberLinkRepository;
+import com.kizuna.customer.domain.CustomerMerge;
+import com.kizuna.customer.domain.CustomerMergeRepository;
+import com.kizuna.customer.domain.CustomerRepository;
+import com.kizuna.customer.domain.LinkStatus;
+import com.kizuna.order.domain.Order;
+import com.kizuna.order.domain.OrderRepository;
+import com.kizuna.order.domain.OrderStatus;
+import com.kizuna.shared.CrossStoreTestSupport;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * 顧客統合を本物の PostgreSQL で検証する統合テスト。
+ *
+ * <p>固定するのは ADR 0010 の骨格 — 存続行へ受注（全状態）と関連（ACTIVE・RELEASED の全区間）が移り、被統合行は削除されずに
+ * 統合先参照を持つ墓標として残り、連鎖統合では既存の墓標も新しい統合先へ付け替わる（解決は常に一跳）。統合履歴に誰が・いつ・何を移したかが残り、 取り消す端点は存在しない。
+ *
+ * <p>統合がポイント台帳・会員の来店履歴に波及しないことは、件数ではなく応答の**内容**を統合の前後で突き合わせて見る。
+ * 不一致が無いことは正しさの証明ではないが、内容の同一は構造的な不波及（仕訳も帰属記録も顧客を参照しない）が 実際に成り立っていることの観測になる。
+ *
+ * <p>統合は店長権限（{@code CUSTOMER_MERGE}）を要するため、基底クラスの店員トークン（山田次郎）ではなく {@link
+ * #managerHeaders(long)}（田中花子・店舗{1,2} 授権）で叩く。店員では 403 になることも併せて見る。
+ *
+ * <p>墓標を電話照合・一覧から外すこと、旧 ID を渡された解決を統合先へ届けることは後続の作業の範囲で、本テストは扱わない。
+ * 応答に出ない事実（統合先参照・統合履歴・付替え後の受注の顧客）は、行を直接読んで固定する。
+ */
+class CustomerMergeIT extends CrossStoreTestSupport {
+
+  private static final String PASSWORD = "password1234";
+
+  /** v0.5.0 の山田次郎シード（STORE_STAFF・授権店舗 = 店舗1）。受注の受付担当として使用。 */
+  private static final long SEED_RECEPTIONIST_ID = 3L;
+
+  private static final String MANAGER_EMAIL = "tanaka.hanako@kizuna.test";
+
+  private static final int TOTAL_FEE = 12000;
+
+  @Autowired private CustomerRepository customerRepository;
+  @Autowired private CustomerMemberLinkRepository customerMemberLinkRepository;
+  @Autowired private CustomerMergeRepository customerMergeRepository;
+  @Autowired private OrderRepository orderRepository;
+  @Autowired private PlatformUserRepository platformUserRepository;
+
+  private final long nonce = System.nanoTime();
+
+  // ==================== 付替え ====================
+
+  @Test
+  @DisplayName("被統合行の受注が状態を問わず存続行に着き、被統合行は墓標として残ること")
+  void movesOrdersOfEveryStatusAndLeavesATombstone() {
+    String surviving = createCustomer("存続-" + nonce);
+    String merged = createCustomer("被統合-" + nonce);
+    String created = orderFor(merged, "予約中");
+    String confirmed = confirmedOrderFor(merged, "確定");
+    String completed = completedOrderFor(merged, "完了");
+    String cancelled = cancelledOrderFor(merged, "取消");
+
+    ResponseEntity<JsonNode> response = merge(STORE_A, surviving, merged);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().path("surviving_customer_id").asString()).isEqualTo(surviving);
+    assertThat(response.getBody().path("moved_order_count").asInt()).isEqualTo(4);
+    // 状態は付替えの条件に入らない。売上も履歴も欠けないこと。
+    assertThat(statusOf(created)).isEqualTo(OrderStatus.CREATED);
+    assertThat(statusOf(confirmed)).isEqualTo(OrderStatus.CONFIRMED);
+    assertThat(statusOf(completed)).isEqualTo(OrderStatus.COMPLETED);
+    assertThat(statusOf(cancelled)).isEqualTo(OrderStatus.CANCELLED);
+    assertThat(List.of(created, confirmed, completed, cancelled))
+        .allSatisfy(orderId -> assertThat(customerOf(orderId)).isEqualTo(surviving));
+    // 行は削除されず、統合先を指す墓標として残る
+    assertThat(mergedIntoOf(merged)).isEqualTo(surviving);
+    assertThat(mergedIntoOf(surviving)).as("存続行は生きたまま").isNull();
+  }
+
+  @Test
+  @DisplayName("被統合行の関連が ACTIVE・RELEASED の全区間ごと存続行へ移ること")
+  void movesEveryLinkIntervalIncludingReleasedOnes() {
+    String surviving = createCustomer("関連存続-" + nonce);
+    String merged = createCustomer("関連被統合-" + nonce);
+    link(merged, registerMember("merge-link-old"));
+    unlink(merged);
+    link(merged, registerMember("merge-link-new"));
+
+    ResponseEntity<JsonNode> response = merge(STORE_A, surviving, merged);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().path("moved_link_count").asInt()).isEqualTo(2);
+    // 解除済みの区間も移らなければ「過去に誰と紐づいていたか」の履歴が統合で切れる
+    assertThat(customerMemberLinkRepository.findHistory(merged)).isEmpty();
+    assertThat(customerMemberLinkRepository.findHistory(surviving)).hasSize(2);
+    assertThat(customerMemberLinkRepository.findByCustomerIdAndStatus(surviving, LinkStatus.ACTIVE))
+        .as("有効な区間は存続行の側で有効なまま")
+        .isPresent();
+  }
+
+  @Test
+  @DisplayName("連鎖統合で既存の墓標も新しい統合先へ付け替わり、旧 ID の解決が一跳で届くこと")
+  void flattensChainsSoResolutionIsAlwaysOneHop() {
+    String a = createCustomer("連鎖A-" + nonce);
+    String b = createCustomer("連鎖B-" + nonce);
+    String c = createCustomer("連鎖C-" + nonce);
+
+    assertThat(merge(STORE_A, b, a).getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(merge(STORE_A, c, b).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    assertThat(mergedIntoOf(a)).as("A→B→C の後、A は直接 C を指す").isEqualTo(c);
+    assertThat(mergedIntoOf(b)).isEqualTo(c);
+  }
+
+  // ==================== 統合履歴 ====================
+
+  @Test
+  @DisplayName("統合履歴に実行者・実行時刻・存続行・被統合行・移した件数が残り、取り消す端点が存在しないこと")
+  void recordsWhoMovedWhatAndOffersNoUndo() {
+    String surviving = createCustomer("履歴存続-" + nonce);
+    String merged = createCustomer("履歴被統合-" + nonce);
+    orderFor(merged, "履歴受注1");
+    orderFor(merged, "履歴受注2");
+    link(merged, registerMember("merge-history"));
+
+    assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    List<CustomerMerge> history = customerMergeRepository.findByMergedCustomerId(merged);
+    assertThat(history).hasSize(1);
+    CustomerMerge recorded = history.get(0);
+    assertThat(recorded.getSurvivingCustomerId()).isEqualTo(surviving);
+    assertThat(recorded.getMergedBy()).isEqualTo(managerId());
+    assertThat(recorded.getMergedAt()).isNotNull();
+    assertThat(recorded.getStoreId()).isEqualTo(STORE_A);
+    assertThat(recorded.getMovedOrderCount()).isEqualTo(2);
+    assertThat(recorded.getMovedLinkCount()).isEqualTo(1);
+
+    // 統合に undo は無い。誤統合の修復は履歴を根拠とする人手作業である（ADR 0010）。
+    // 「取り消せない」は応答符号の字面ではなく、取消を試みた後も墓標と履歴が動かないことで見る
+    // （端点が無いときの符号は全域ハンドラの分類次第で変わりうるが、この不変量は変わらない）。
+    ResponseEntity<JsonNode> undoAttempt =
+        rest.exchange(
+            mergePath(surviving),
+            HttpMethod.DELETE,
+            new HttpEntity<>(managerHeaders(STORE_A)),
+            JsonNode.class);
+
+    assertThat(undoAttempt.getStatusCode().is2xxSuccessful()).isFalse();
+    assertThat(mergedIntoOf(merged)).as("取消の試みで墓標が生き返らないこと").isEqualTo(surviving);
+    assertThat(customerMergeRepository.findByMergedCustomerId(merged)).hasSize(1);
+  }
+
+  // ==================== 拒否 ====================
+
+  @Test
+  @DisplayName("自分自身への統合は撥ねられること")
+  void rejectsMergingACustomerIntoItself() {
+    String customerId = createCustomer("自己統合-" + nonce);
+
+    assertThat(merge(STORE_A, customerId, customerId).getStatusCode())
+        .isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("墓標を存続行に指定した統合と、墓標をもう一度統合する要求はいずれも 409 になること")
+  void rejectsMergesThatWouldBreakTheOneHopInvariant() {
+    String surviving = createCustomer("再統合存続-" + nonce);
+    String merged = createCustomer("再統合被統合-" + nonce);
+    String another = createCustomer("再統合別-" + nonce);
+    assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    // 墓標を存続行にすると、そこへ着けた参照の解決が二跳になる
+    assertThat(merge(STORE_A, merged, another).getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    // 応答喪失後の再送。前提状態が「生きている行 → 墓標」へ遷移済みなので二度目は通らない
+    assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+  }
+
+  @Test
+  @DisplayName("他店舗の顧客を指定した統合は存続行・被統合行のいずれでも 404 になり、存在の有無が漏れないこと")
+  void hidesForeignStoreCustomersBehindNotFound() {
+    String inStoreA = createCustomer("越境自店-" + nonce);
+    String inStoreB = createCustomerAt(STORE_B, "越境他店-" + nonce);
+
+    // 田中花子は両店舗に授権されるためヘッダは通り、越境は storeFilter による 404 として現れる
+    assertThat(merge(STORE_A, inStoreA, inStoreB).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(merge(STORE_A, inStoreB, inStoreA).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(mergedIntoOf(inStoreA)).isNull();
+    assertThat(mergedIntoOf(inStoreB)).isNull();
+  }
+
+  @Test
+  @DisplayName("両行が ACTIVE 関連を持つ統合は撥ねられ、先に関連を解除することが応答から判ること")
+  void rejectsMergeWhenBothRowsAreClaimedByAMember() {
+    String surviving = createCustomer("両認領存続-" + nonce);
+    String merged = createCustomer("両認領被統合-" + nonce);
+    link(surviving, registerMember("merge-claim-1"));
+    link(merged, registerMember("merge-claim-2"));
+
+    ResponseEntity<JsonNode> response = merge(STORE_A, surviving, merged);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(response.getBody().path("error").asString()).contains("先に関連を解除");
+    assertThat(mergedIntoOf(merged)).as("撥ねた統合は何も動かさない").isNull();
+  }
+
+  @Test
+  @DisplayName("統合の実行は店長権限を要し、スタッフ権限では 403 になること")
+  void requiresTheManagerOnlyMergePermission() {
+    String surviving = createCustomer("権限存続-" + nonce);
+    String merged = createCustomer("権限被統合-" + nonce);
+
+    ResponseEntity<JsonNode> asStaff =
+        rest.exchange(
+            mergePath(surviving),
+            HttpMethod.POST,
+            new HttpEntity<>(mergeBody(merged), storeHeaders(STORE_A)),
+            JsonNode.class);
+
+    assertThat(asStaff.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    assertThat(mergedIntoOf(merged)).isNull();
+  }
+
+  @Test
+  @DisplayName("統合に関与した行は存続行・被統合行とも削除できず、案内の読める応答になること")
+  void keepsBothMergedRowsUndeletable() {
+    String surviving = createCustomer("削除存続-" + nonce);
+    String merged = createCustomer("削除被統合-" + nonce);
+    assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    ResponseEntity<JsonNode> deleteSurviving = deleteCustomer(surviving);
+    ResponseEntity<JsonNode> deleteMerged = deleteCustomer(merged);
+
+    assertThat(deleteSurviving.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(deleteSurviving.getBody().path("error").asString()).contains("統合");
+    assertThat(deleteMerged.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(deleteMerged.getBody().path("error").asString()).contains("統合");
+    assertThat(customerRepository.findById(surviving)).isPresent();
+    assertThat(customerRepository.findById(merged)).isPresent();
+  }
+
+  // ==================== 不波及 ====================
+
+  @Test
+  @DisplayName("統合の前後で、会員のポイント残高・明細行の内容・来店履歴の行の内容が同一であること")
+  void leavesTheMembersLedgerAndVisitHistoryUntouched() {
+    RegisteredMember member = registerAndLoginMember("merge-untouched");
+    String surviving = createCustomer("不波及存続-" + nonce);
+    String merged = createCustomer("不波及被統合-" + nonce);
+    link(merged, member.memberCode());
+    completedOrderFor(merged, "不波及来店");
+
+    JsonNode balanceBefore = memberGet("/platform/me/points/balance", member).getBody();
+    JsonNode entriesBefore = memberGet("/platform/me/points/entries", member).getBody();
+    JsonNode visitsBefore = memberGet("/platform/me/visits", member).getBody();
+    assertThat(balanceBefore.path("balance").asInt()).as("前提: 来店でポイントが積まれること").isPositive();
+    assertThat(entriesBefore.path("content")).as("前提: 明細が 1 行以上あること").isNotEmpty();
+    assertThat(visitsBefore.path("content")).as("前提: 来店が 1 行以上あること").isNotEmpty();
+
+    assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    // 仕訳も帰属記録も受注と会員を参照し、顧客を参照しない（ADR 0006 / 0009）。件数ではなく内容が同一であること。
+    assertThat(memberGet("/platform/me/points/balance", member).getBody()).isEqualTo(balanceBefore);
+    assertThat(memberGet("/platform/me/points/entries", member).getBody()).isEqualTo(entriesBefore);
+    assertThat(memberGet("/platform/me/visits", member).getBody()).isEqualTo(visitsBefore);
+  }
+
+  // ==================== 統合の呼び出し ====================
+
+  private static String mergePath(String survivingCustomerId) {
+    return "/store/customers/" + survivingCustomerId + "/merges";
+  }
+
+  private static String mergeBody(String mergedCustomerId) {
+    return "{\"merged_customer_id\": \"" + mergedCustomerId + "\"}";
+  }
+
+  private ResponseEntity<JsonNode> merge(
+      long storeId, String survivingCustomerId, String mergedCustomerId) {
+    return rest.exchange(
+        mergePath(survivingCustomerId),
+        HttpMethod.POST,
+        new HttpEntity<>(mergeBody(mergedCustomerId), managerHeaders(storeId)),
+        JsonNode.class);
+  }
+
+  // ==================== 行の直読（応答に出ない事実） ====================
+
+  /** 統合先参照。生きている行では null なので、Optional の写像で畳まずに行そのものを取り出して読む。 */
+  private String mergedIntoOf(String customerId) {
+    return customer(customerId).getMergedIntoId();
+  }
+
+  private Customer customer(String customerId) {
+    return customerRepository.findById(customerId).orElseThrow();
+  }
+
+  private String customerOf(String orderId) {
+    return orderRepository.findById(orderId).map(Order::getCustomerId).orElseThrow();
+  }
+
+  private OrderStatus statusOf(String orderId) {
+    return orderRepository.findById(orderId).map(Order::getStatus).orElseThrow();
+  }
+
+  private Long managerId() {
+    return platformUserRepository.findByEmail(MANAGER_EMAIL).map(PlatformUser::getId).orElseThrow();
+  }
+
+  // ==================== 顧客・受注・関連の用意 ====================
+
+  private String createCustomer(String name) {
+    return createCustomerAt(STORE_A, name);
+  }
+
+  private String createCustomerAt(long storeId, String name) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/store/customers",
+            new HttpEntity<>("{\"name\": \"" + name + "\"}", managerHeaders(storeId)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful())
+        .as("前提: store %d での顧客作成が成功すること", storeId)
+        .isTrue();
+    return created.getBody().path("id").asString();
+  }
+
+  private ResponseEntity<JsonNode> deleteCustomer(String customerId) {
+    return rest.exchange(
+        "/store/customers/" + customerId,
+        HttpMethod.DELETE,
+        new HttpEntity<>(managerHeaders(STORE_A)),
+        JsonNode.class);
+  }
+
+  /** 予約中（CREATED）の受注を 1 件作る。 */
+  private String orderFor(String customerId, String label) {
+    String castId = createCast(label + "-" + nonce);
+    String body =
+        "{\"receptionist_id\": "
+            + SEED_RECEPTIONIST_ID
+            + ", \"business_date\": \""
+            + LocalDate.now()
+            + "\", \"cast_id\": \""
+            + castId
+            + "\", \"pax\": 2, \"customer_id\": \""
+            + customerId
+            + "\", \"remarks\": \""
+            + label
+            + "\"}";
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/store/orders", new HttpEntity<>(body, managerHeaders(STORE_A)), JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful()).as("前提: 受注作成が成功すること").isTrue();
+    return created.getBody().path("id").asString();
+  }
+
+  private String confirmedOrderFor(String customerId, String label) {
+    String orderId = orderFor(customerId, label);
+    assertThat(updateStatus(orderId, "CONFIRMED")).as("前提: 受注を確定できること").isTrue();
+    return orderId;
+  }
+
+  private String completedOrderFor(String customerId, String label) {
+    String orderId = confirmedOrderFor(customerId, label);
+    assertThat(
+            rest.exchange(
+                    "/store/orders/" + orderId + "/completion",
+                    HttpMethod.POST,
+                    new HttpEntity<>("{\"total_fee\": " + TOTAL_FEE + "}", managerHeaders(STORE_A)),
+                    JsonNode.class)
+                .getStatusCode())
+        .as("前提: 受注を完了できること")
+        .isEqualTo(HttpStatus.OK);
+    return orderId;
+  }
+
+  private String cancelledOrderFor(String customerId, String label) {
+    String orderId = orderFor(customerId, label);
+    assertThat(updateStatus(orderId, "CANCELLED")).as("前提: 受注を取消できること").isTrue();
+    return orderId;
+  }
+
+  private boolean updateStatus(String orderId, String status) {
+    String castId = orderRepository.findById(orderId).map(Order::getCastId).orElseThrow();
+    String body =
+        "{\"receptionist_id\": "
+            + SEED_RECEPTIONIST_ID
+            + ", \"cast_id\": \""
+            + castId
+            + "\", \"status\": \""
+            + status
+            + "\"}";
+    return rest.exchange(
+            "/store/orders/" + orderId,
+            HttpMethod.PUT,
+            new HttpEntity<>(body, managerHeaders(STORE_A)),
+            JsonNode.class)
+        .getStatusCode()
+        .is2xxSuccessful();
+  }
+
+  private String createCast(String name) {
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/store/casts",
+            new HttpEntity<>("{\"name\": \"" + name + "\"}", managerHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(created.getStatusCode().is2xxSuccessful()).as("前提: キャスト作成が成功すること").isTrue();
+    return created.getBody().path("id").asString();
+  }
+
+  private void link(String customerId, String memberCode) {
+    ResponseEntity<JsonNode> linked =
+        rest.exchange(
+            "/store/customers/" + customerId + "/member-link",
+            HttpMethod.POST,
+            new HttpEntity<>("{\"member_code\": \"" + memberCode + "\"}", managerHeaders(STORE_A)),
+            JsonNode.class);
+    assertThat(linked.getStatusCode()).as("前提: 会員の紐づけが成功すること").isEqualTo(HttpStatus.OK);
+  }
+
+  private void unlink(String customerId) {
+    assertThat(
+            rest.exchange(
+                    "/store/customers/" + customerId + "/member-link",
+                    HttpMethod.DELETE,
+                    new HttpEntity<>(managerHeaders(STORE_A)),
+                    JsonNode.class)
+                .getStatusCode())
+        .as("前提: 会員の紐づけを解除できること")
+        .isEqualTo(HttpStatus.OK);
+  }
+
+  // ==================== 会員 ====================
+
+  /** 会員本人として読むための材料。 */
+  private record RegisteredMember(String memberCode, String token) {}
+
+  private String registerMember(String prefix) {
+    return registerMemberAs(uniqueEmail(prefix)).memberCode();
+  }
+
+  private RegisteredMember registerAndLoginMember(String prefix) {
+    String email = uniqueEmail(prefix);
+    String memberCode = registerMemberAs(email).memberCode();
+    ResponseEntity<JsonNode> login =
+        rest.postForEntity(
+            "/platform/login",
+            new HttpEntity<>(
+                "{\"email\": \"" + email + "\", \"password\": \"" + PASSWORD + "\"}",
+                jsonHeaders()),
+            JsonNode.class);
+    assertThat(login.getStatusCode()).as("前提: 会員としてログインできること").isEqualTo(HttpStatus.OK);
+    return new RegisteredMember(memberCode, login.getBody().path("token").asString());
+  }
+
+  private RegisteredMember registerMemberAs(String email) {
+    ResponseEntity<JsonNode> registered =
+        rest.postForEntity(
+            "/platform/members",
+            new HttpEntity<>(
+                "{\"email\": \""
+                    + email
+                    + "\", \"password\": \""
+                    + PASSWORD
+                    + "\", \"display_name\": \"統合検証会員\"}",
+                jsonHeaders()),
+            JsonNode.class);
+    assertThat(registered.getStatusCode()).as("前提: 会員登録が成功すること").isEqualTo(HttpStatus.CREATED);
+    return new RegisteredMember(registered.getBody().path("member_code").asString(), null);
+  }
+
+  private ResponseEntity<JsonNode> memberGet(String path, RegisteredMember member) {
+    HttpHeaders headers = jsonHeaders();
+    headers.setBearerAuth(member.token());
+    ResponseEntity<JsonNode> response =
+        rest.exchange(path, HttpMethod.GET, new HttpEntity<>(headers), JsonNode.class);
+    assertThat(response.getStatusCode()).as("前提: %s を本人として読めること", path).isEqualTo(HttpStatus.OK);
+    return response;
+  }
+
+  private String uniqueEmail(String prefix) {
+    return prefix + "-merge-it-" + nonce + "-" + System.nanoTime() + "@kizuna.test";
+  }
+
+  private static HttpHeaders jsonHeaders() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+}

--- a/backend/src/integrationTest/java/com/kizuna/store/StoreDeletionCascadeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/store/StoreDeletionCascadeIT.java
@@ -185,6 +185,64 @@ class StoreDeletionCascadeIT {
     assertThat(countStore(storeId)).as("拒否された店舗は残存すること").isEqualTo(1L);
   }
 
+  @Test
+  @DisplayName("顧客統合を行った準備中の店舗も削除でき、墓標と統合履歴が CASCADE 消去されること")
+  void storeWithCustomerMergeCanStillBeDeleted() {
+    Store store = freshStore("統合済み検証店舗", "merge-store-delete-it");
+    long storeId = store.getId();
+    // 統合が残す形（存続行・統合先を指す墓標・両行を指す統合履歴）を直挿する。ここで見たいのは
+    // サービス層ではなく外部キーの働き — 顧客への参照は RESTRICT なので、店舗削除の CASCADE が
+    // 統合履歴より先に顧客へ届くと、削除が違反で止まりうるのではないかという疑いを潰す。
+    String surviving = "merge-cascade-surviving-" + UUID.randomUUID();
+    String merged = "merge-cascade-merged-" + UUID.randomUUID();
+    insertCustomer(storeId, surviving, null);
+    insertCustomer(storeId, merged, surviving);
+    insertCustomerMerge(storeId, surviving, merged);
+
+    // 前提: 削除前は墓標と統合履歴が実在する（空振りで緑にならないことを固定）。
+    assertThat(countCustomers(storeId)).as("削除前は顧客が 2 件あること").isEqualTo(2L);
+    assertThat(countCustomerMerges(storeId)).as("削除前は統合履歴が 1 件あること").isEqualTo(1L);
+
+    ResponseEntity<JsonNode> res = deleteStore(storeId);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    assertThat(countCustomers(storeId)).as("顧客は店舗と共に消えること").isZero();
+    assertThat(countCustomerMerges(storeId)).as("統合履歴も店舗と共に消えること").isZero();
+    assertThat(countStore(storeId)).isZero();
+  }
+
+  private void insertCustomer(long storeId, String customerId, String mergedIntoId) {
+    jdbcTemplate.update(
+        "INSERT INTO t_customers (id, store_id, name, merged_into_id, created_at, updated_at,"
+            + " version) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)",
+        customerId,
+        storeId,
+        "統合カスケード検証顧客",
+        mergedIntoId);
+  }
+
+  private void insertCustomerMerge(long storeId, String survivingId, String mergedId) {
+    jdbcTemplate.update(
+        "INSERT INTO t_customer_merges (id, store_id, surviving_customer_id, merged_customer_id,"
+            + " merged_at, moved_order_count, moved_link_count, created_at, updated_at, version)"
+            + " VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,"
+            + " 0)",
+        "merge-cascade-it-" + UUID.randomUUID(),
+        storeId,
+        survivingId,
+        mergedId);
+  }
+
+  private long countCustomers(long storeId) {
+    return jdbcTemplate.queryForObject(
+        "SELECT count(*) FROM t_customers WHERE store_id = ?", Long.class, storeId);
+  }
+
+  private long countCustomerMerges(long storeId) {
+    return jdbcTemplate.queryForObject(
+        "SELECT count(*) FROM t_customer_merges WHERE store_id = ?", Long.class, storeId);
+  }
+
   /** 台帳の持ち主となる会員を公開端点から用意し、その id を返す。 */
   private long registerMember() {
     HttpHeaders headers = new HttpHeaders();

--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -883,7 +883,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
   }
 
   @Test
-  @DisplayName("権限目録は STAFF_MANAGE 保持者に 17 件の code+console を返すこと")
+  @DisplayName("権限目録は STAFF_MANAGE 保持者に 18 件の code+console を返すこと")
   void permissionCatalogIsExposedToStaffManage() {
     String hq = platformToken(SEED_EMAIL, PASSWORD);
 
@@ -892,7 +892,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
             "/platform/permissions", HttpMethod.GET, new HttpEntity<>(bearer(hq)), JsonNode.class);
 
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(res.getBody()).hasSize(17);
+    assertThat(res.getBody()).hasSize(18);
     assertThat(res.getBody().toString()).contains("ORDER_MANAGE").contains("PLATFORM");
   }
 

--- a/backend/src/main/java/com/kizuna/customer/api/dto/CustomerMapper.java
+++ b/backend/src/main/java/com/kizuna/customer/api/dto/CustomerMapper.java
@@ -16,6 +16,8 @@ public interface CustomerMapper {
   @Mapping(target = "landmark", ignore = true)
   // rank は DB デフォルト（'SILVER'）と同義。エンティティに列をマッピングしたため明示的に補完する
   @Mapping(target = "rank", source = "rank", defaultValue = "SILVER")
+  // 起こしたばかりの行は定義上まだ生きている。統合先参照は統合だけが立てる。
+  @Mapping(target = "mergedIntoId", ignore = true)
   Customer toEntity(CustomerCreateRequest request);
 
   /** 更新リクエストをドメインの部分更新コマンドに変換します。null フィールドは「変更しない」。 */

--- a/backend/src/main/java/com/kizuna/customer/api/dto/CustomerMergeRequest.java
+++ b/backend/src/main/java/com/kizuna/customer/api/dto/CustomerMergeRequest.java
@@ -1,0 +1,18 @@
+package com.kizuna.customer.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * 顧客統合の要求。受け取るのは被統合行の ID だけで、存続行はパスが名指す。
+ *
+ * <p>どのフィールドを残すかは受け取らない。フィールド値の自動合併を持たないのが ADR 0010 の裁定で、存続行へ移したい値は 人が見て転記する。
+ */
+@Data
+public class CustomerMergeRequest {
+
+  @NotBlank(message = "被統合の顧客 ID は必須です")
+  @Size(max = 64, message = "被統合の顧客 ID は64文字以内です")
+  private String mergedCustomerId;
+}

--- a/backend/src/main/java/com/kizuna/customer/api/dto/CustomerMergeResponse.java
+++ b/backend/src/main/java/com/kizuna/customer/api/dto/CustomerMergeResponse.java
@@ -1,0 +1,9 @@
+package com.kizuna.customer.api.dto;
+
+/**
+ * 実行された顧客統合の応答。JSON キーは Jackson 設定により snake_case（surviving_customer_id）。
+ *
+ * <p>件数は統合が実際に移した数で、統合履歴に残る値と同一である。
+ */
+public record CustomerMergeResponse(
+    String survivingCustomerId, int movedOrderCount, int movedLinkCount) {}

--- a/backend/src/main/java/com/kizuna/customer/api/store/CustomerMergeController.java
+++ b/backend/src/main/java/com/kizuna/customer/api/store/CustomerMergeController.java
@@ -1,0 +1,38 @@
+package com.kizuna.customer.api.store;
+
+import com.kizuna.customer.api.dto.CustomerMergeRequest;
+import com.kizuna.customer.api.dto.CustomerMergeResponse;
+import com.kizuna.customer.application.CustomerMergeService;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 顧客統合の実行。パスが名指すのが存続行で、本文が被統合行を指す。
+ *
+ * <p>統合を取り消す端点は無い。誤統合の修復は統合履歴を根拠とする人手作業である（ADR 0010）。
+ */
+@RestController
+@RequestMapping("/store/customers/{customerId}/merges")
+@RequiredArgsConstructor
+public class CustomerMergeController {
+
+  private final CustomerMergeService customerMergeService;
+
+  @PostMapping
+  @PreAuthorize("hasAuthority('PERM_CUSTOMER_MERGE')")
+  public ResponseEntity<CustomerMergeResponse> merge(
+      @PathVariable String customerId,
+      @Valid @RequestBody CustomerMergeRequest request,
+      Principal principal) {
+    return ResponseEntity.ok(
+        customerMergeService.merge(customerId, request.getMergedCustomerId(), principal.getName()));
+  }
+}

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerMergeService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerMergeService.java
@@ -38,6 +38,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CustomerMergeService {
 
+  /** 両行が認領されているときの案内。事前判定と、それをすり抜けた競合が部分一意索引に当たる場合とで同じ文言を返す。 */
+  private static final String RELEASE_THE_LINK_FIRST = "両方の顧客に会員が紐づいています。先に関連を解除してから統合してください";
+
   private final CustomerRepository customerRepository;
   private final CustomerMemberLinkRepository customerMemberLinkRepository;
   private final CustomerMergeRepository customerMergeRepository;
@@ -75,7 +78,7 @@ public class CustomerMergeService {
     if (hasActiveLink(survivingCustomerId) && hasActiveLink(mergedCustomerId)) {
       // 部分一意索引により両者は必ず別会員を指す。二人の本人がそれぞれ認領している行なので、
       // 台帳級の「同一人物か」の判断と一緒に片付けさせない（ADR 0010）。
-      throw new ConflictException("両方の顧客に会員が紐づいています。先に関連を解除してから統合してください");
+      throw new ConflictException(RELEASE_THE_LINK_FIRST);
     }
 
     Long storeId = storeContext.getStoreId();
@@ -136,7 +139,7 @@ public class CustomerMergeService {
           ex,
           Map.of(
               DbConstraint.UQ_T_CUSTOMER_MEMBER_LINKS_ACTIVE_CUSTOMER,
-              () -> new ConflictException("両方の顧客に会員が紐づいています。先に関連を解除してから統合してください")));
+              () -> new ConflictException(RELEASE_THE_LINK_FIRST)));
     }
   }
 

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerMergeService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerMergeService.java
@@ -1,0 +1,150 @@
+package com.kizuna.customer.application;
+
+import com.kizuna.customer.api.dto.CustomerMergeResponse;
+import com.kizuna.customer.domain.Customer;
+import com.kizuna.customer.domain.CustomerMemberLinkRepository;
+import com.kizuna.customer.domain.CustomerMerge;
+import com.kizuna.customer.domain.CustomerMergeRepository;
+import com.kizuna.customer.domain.CustomerRepository;
+import com.kizuna.customer.domain.LinkStatus;
+import com.kizuna.shared.exception.ConflictException;
+import com.kizuna.shared.exception.DbConstraint;
+import com.kizuna.shared.exception.IntegrityViolations;
+import com.kizuna.shared.exception.NotFoundException;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.exception.StaleSessionException;
+import com.kizuna.shared.storescope.StoreContext;
+import com.kizuna.shared.storescope.StoreScoped;
+import com.kizuna.user.domain.PlatformUserRepository;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 同一店舗内で重複した顧客行を一つへまとめるユースケース。形は付替え＋墓標＋統合履歴で、行は削除しない（ADR 0010）。
+ *
+ * <p>存続行へ被統合行の受注（全状態）と関連（ACTIVE・RELEASED の全区間）を付け替え、被統合行は統合先参照を持つ墓標として残す。 連鎖統合は圧平する — B を C
+ * へ統合するとき、B を指していた既存の墓標もすべて C へ付け替え、旧 ID の解決が常に一跳で届くようにする。
+ *
+ * <p>統合はポイント台帳・受注帰属記録・会員の来店履歴に一切波及しない。これは偶然ではなく構造的である — 仕訳も帰属記録も受注と会員を 参照し、顧客を参照しないため（ADR 0006 /
+ * 0009）、受注の顧客参照を書き換えてもそれらの行は読まれも書かれもしない。
+ *
+ * <p>統合に取消（undo）は無い。誤統合の修復は統合履歴を根拠とする人手作業であり、この操作が店長権限（{@code CUSTOMER_MERGE}）に限られるのはそのためである。
+ */
+@Service
+@RequiredArgsConstructor
+public class CustomerMergeService {
+
+  private final CustomerRepository customerRepository;
+  private final CustomerMemberLinkRepository customerMemberLinkRepository;
+  private final CustomerMergeRepository customerMergeRepository;
+  private final PlatformUserRepository platformUserRepository;
+  private final StoreContext storeContext;
+
+  /**
+   * 統合を実行する。
+   *
+   * <p>顧客参照を書く他の経路（{@link CustomerReferenceResolver}）は通さない。あちらは「既にある行を指す参照の書き込み先」を解決する口で、
+   * 墓標を渡されれば統合先へ 向け直す。統合が対象にするのは名指された 2 行そのもので、別の行へ向け直してよい操作ではない（解除 {@code
+   * CustomerMemberLinkService#unlink} と同じ理由）。
+   *
+   * @param survivingCustomerId 統合後に台帳へ残る行
+   * @param mergedCustomerId 墓標になる行
+   */
+  @StoreScoped
+  @Transactional
+  public CustomerMergeResponse merge(
+      String survivingCustomerId, String mergedCustomerId, String actorEmail) {
+    if (survivingCustomerId.equals(mergedCustomerId)) {
+      throw new ServiceException("同じ顧客を統合することはできません");
+    }
+    Long actorId = resolveActorId(actorEmail);
+    Customer merged = lockBothInIdOrder(survivingCustomerId, mergedCustomerId);
+
+    // 可否は実行の瞬間に判定し直す。確認画面を開いた時点の判定は、その後の統合で古くなりうる。
+    // 判定は押さえた実体の状態からではなく別問い合わせで行う（CustomerRepository#isMerged の契約）。
+    if (customerRepository.isMerged(survivingCustomerId)) {
+      throw new ConflictException("統合先の顧客は既に統合済みです。統合先の顧客を指定してください");
+    }
+    if (customerRepository.isMerged(mergedCustomerId)) {
+      throw new ConflictException("この顧客は既に統合済みです");
+    }
+    if (hasActiveLink(survivingCustomerId) && hasActiveLink(mergedCustomerId)) {
+      // 部分一意索引により両者は必ず別会員を指す。二人の本人がそれぞれ認領している行なので、
+      // 台帳級の「同一人物か」の判断と一緒に片付けさせない（ADR 0010）。
+      throw new ConflictException("両方の顧客に会員が紐づいています。先に関連を解除してから統合してください");
+    }
+
+    Long storeId = storeContext.getStoreId();
+    int movedOrderCount =
+        customerMergeRepository.repointOrders(survivingCustomerId, mergedCustomerId, storeId);
+    int movedLinkCount = repointLinks(survivingCustomerId, mergedCustomerId, storeId);
+    customerRepository.flattenMergedInto(survivingCustomerId, mergedCustomerId, storeId);
+
+    merged.mergeInto(survivingCustomerId);
+    customerRepository.save(merged);
+    customerMergeRepository.save(
+        CustomerMerge.record(
+            survivingCustomerId,
+            mergedCustomerId,
+            actorId,
+            OffsetDateTime.now(),
+            movedOrderCount,
+            movedLinkCount));
+
+    return new CustomerMergeResponse(survivingCustomerId, movedOrderCount, movedLinkCount);
+  }
+
+  /**
+   * 2 行を顧客 ID の昇順で悲観排他ロックし、被統合行の実体を返す。取得できない顧客は他店舗の顧客も含めて 404 で、存在の有無は漏れない。
+   *
+   * <p>昇順に固定するのは、同じ 2 行を逆向きに統合しようとする要求どうしがデッドロックしないため。統合は台帳の加算ロットを触らないので、 既存のロック順序（顧客行 → 関連 →
+   * 台帳の加算ロット）と待ちが環にならない。
+   */
+  private Customer lockBothInIdOrder(String survivingCustomerId, String mergedCustomerId) {
+    boolean survivingFirst = survivingCustomerId.compareTo(mergedCustomerId) < 0;
+    Customer first = lockCustomer(survivingFirst ? survivingCustomerId : mergedCustomerId);
+    Customer second = lockCustomer(survivingFirst ? mergedCustomerId : survivingCustomerId);
+    return survivingFirst ? second : first;
+  }
+
+  private Customer lockCustomer(String customerId) {
+    return customerRepository
+        .findByIdForUpdate(customerId)
+        .orElseThrow(() -> new NotFoundException("顧客が見つかりません"));
+  }
+
+  private boolean hasActiveLink(String customerId) {
+    return customerMemberLinkRepository.existsByCustomerIdAndStatus(customerId, LinkStatus.ACTIVE);
+  }
+
+  /**
+   * 関連を存続行へ付け替える。
+   *
+   * <p>両行の ACTIVE 関連は上で撥ねているが、部分一意索引 {@code uq_t_customer_member_links_active_customer}
+   * が最終防波堤として残る。事前判定をすり抜けた競合はここで違反として現れるので、汎用の一意違反文言ではなく 次の一手の読める案内へ写す。
+   */
+  private int repointLinks(String survivingCustomerId, String mergedCustomerId, Long storeId) {
+    try {
+      return customerMemberLinkRepository.repointCustomer(
+          survivingCustomerId, mergedCustomerId, storeId);
+    } catch (DataIntegrityViolationException ex) {
+      throw IntegrityViolations.translate(
+          ex,
+          Map.of(
+              DbConstraint.UQ_T_CUSTOMER_MEMBER_LINKS_ACTIVE_CUSTOMER,
+              () -> new ConflictException("両方の顧客に会員が紐づいています。先に関連を解除してから統合してください")));
+    }
+  }
+
+  /** JWT は user-id claim を持たないため、実行者は認証主体の email から解決する。 */
+  private Long resolveActorId(String actorEmail) {
+    return platformUserRepository
+        .findByEmail(actorEmail)
+        .orElseThrow(() -> new StaleSessionException("認証セッションの主体が存在しません"))
+        .getId();
+  }
+}

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
@@ -19,6 +19,7 @@ import jakarta.persistence.criteria.Predicate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -147,15 +148,14 @@ public class CustomerService {
       // 墓標からの自己参照にも指されており、どれが先に違反として現れるかは DB の検査順に依るので 3 本とも
       // 同じ案内へ写す。写像を持たない他の整合性違反（受注が残っている等）は translate が元の例外を返し、
       // 従来どおり大きく失敗する。
+      Supplier<RuntimeException> undeletable =
+          () -> new ConflictException(MERGED_CUSTOMER_UNDELETABLE);
       throw IntegrityViolations.translate(
           ex,
           Map.of(
-              DbConstraint.FK_T_CUSTOMER_MERGES_SURVIVING,
-              () -> new ConflictException(MERGED_CUSTOMER_UNDELETABLE),
-              DbConstraint.FK_T_CUSTOMER_MERGES_MERGED,
-              () -> new ConflictException(MERGED_CUSTOMER_UNDELETABLE),
-              DbConstraint.FK_T_CUSTOMERS_MERGED_INTO,
-              () -> new ConflictException(MERGED_CUSTOMER_UNDELETABLE)));
+              DbConstraint.FK_T_CUSTOMER_MERGES_SURVIVING, undeletable,
+              DbConstraint.FK_T_CUSTOMER_MERGES_MERGED, undeletable,
+              DbConstraint.FK_T_CUSTOMERS_MERGED_INTO, undeletable));
     }
   }
 

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
@@ -7,8 +7,12 @@ import com.kizuna.customer.api.dto.CustomerUpdateRequest;
 import com.kizuna.customer.domain.Customer;
 import com.kizuna.customer.domain.CustomerMemberLink;
 import com.kizuna.customer.domain.CustomerMemberLinkRepository;
+import com.kizuna.customer.domain.CustomerMergeRepository;
 import com.kizuna.customer.domain.CustomerRepository;
 import com.kizuna.customer.domain.LinkStatus;
+import com.kizuna.shared.exception.ConflictException;
+import com.kizuna.shared.exception.DbConstraint;
+import com.kizuna.shared.exception.IntegrityViolations;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.storescope.StoreScoped;
 import jakarta.persistence.criteria.Predicate;
@@ -17,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -31,8 +36,12 @@ public class CustomerService {
   /** LIKE パターンのエスケープ規則。派生クエリが内部で使うものと同一で、手書きの cb.like にも同じ規則を適用する。 */
   private static final EscapeCharacter LIKE_ESCAPE = EscapeCharacter.DEFAULT;
 
+  private static final String MERGED_CUSTOMER_UNDELETABLE =
+      "統合に関与した顧客は削除できません。統合履歴と旧 ID の解決の根拠になります";
+
   private final CustomerRepository customerRepository;
   private final CustomerMemberLinkRepository customerMemberLinkRepository;
+  private final CustomerMergeRepository customerMergeRepository;
   private final CustomerMapper customerMapper;
 
   @StoreScoped
@@ -115,13 +124,39 @@ public class CustomerService {
         customerMapper.toResponse(customerRepository.save(customer)), activeMemberCodeOf(id));
   }
 
+  /**
+   * 顧客を削除する。統合に関与した行は存続行・被統合行のいずれも削除できない — 統合履歴が誤統合の唯一の修復根拠であり、旧 ID の解決も
+   * 墓標が残っていて初めて届くため、誤削除で消えるほうが重い（ADR 0010）。
+   */
   @StoreScoped
   @Transactional
   public void delete(String id) {
     if (!customerRepository.existsById(id)) {
       throw new NotFoundException("顧客が見つかりません");
     }
-    customerRepository.deleteById(id);
+    if (customerMergeRepository.existsInvolving(id)) {
+      throw new ConflictException(MERGED_CUSTOMER_UNDELETABLE);
+    }
+    try {
+      customerRepository.deleteById(id);
+      // DELETE を今この場へ流す。トランザクション境界の commit まで遅れると、外部キー違反が
+      // この catch を素通りして全域ハンドラの兜底（500）へ落ちる。
+      customerRepository.flush();
+    } catch (DataIntegrityViolationException ex) {
+      // 事前判定と削除の間に統合が確定した競合の最終防波堤。統合に関与した行は履歴の 2 本と、存続行なら
+      // 墓標からの自己参照にも指されており、どれが先に違反として現れるかは DB の検査順に依るので 3 本とも
+      // 同じ案内へ写す。写像を持たない他の整合性違反（受注が残っている等）は translate が元の例外を返し、
+      // 従来どおり大きく失敗する。
+      throw IntegrityViolations.translate(
+          ex,
+          Map.of(
+              DbConstraint.FK_T_CUSTOMER_MERGES_SURVIVING,
+              () -> new ConflictException(MERGED_CUSTOMER_UNDELETABLE),
+              DbConstraint.FK_T_CUSTOMER_MERGES_MERGED,
+              () -> new ConflictException(MERGED_CUSTOMER_UNDELETABLE),
+              DbConstraint.FK_T_CUSTOMERS_MERGED_INTO,
+              () -> new ConflictException(MERGED_CUSTOMER_UNDELETABLE)));
+    }
   }
 
   private String activeMemberCodeOf(String customerId) {

--- a/backend/src/main/java/com/kizuna/customer/domain/Customer.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/Customer.java
@@ -59,6 +59,25 @@ public class Customer extends StoreScopedEntity {
   @Column(name = "ng_content")
   private String ngContent;
 
+  /**
+   * 統合先の顧客。NULL がこの行は生きていることを意味し、値があればこの行は墓標でその値が統合先である（ADR 0010）。
+   *
+   * <p>{@code updatable = false} を付けてはならない。連鎖統合の圧平は「被統合行を指している既存の墓標」の指す先を
+   * 書き換えるので、不変列として写像すると圧平が静かに効かなくなる。
+   */
+  @Column(name = "merged_into_id")
+  private String mergedIntoId;
+
+  /**
+   * 統合の被統合行としてこの行を墓標にする。行は削除せず、以後は統合先への道標としてだけ残る。
+   *
+   * <p>既に墓標の行を再び統合できないのは呼出側（{@code CustomerMergeService}）が実行の瞬間に判定する。
+   * その判定は押さえた行の状態からではなく別問い合わせで行うため、ここでは 自分自身の状態を見ない。
+   */
+  public void mergeInto(String survivingCustomerId) {
+    this.mergedIntoId = survivingCustomerId;
+  }
+
   /** 部分更新コマンドを適用する。null のフィールドは変更しない。 */
   public void apply(CustomerPatch patch) {
     if (patch.name() != null) {

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerMemberLinkRepository.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerMemberLinkRepository.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -19,6 +20,29 @@ public interface CustomerMemberLinkRepository extends JpaRepository<CustomerMemb
       Collection<String> customerIds, LinkStatus status);
 
   boolean existsByMemberIdAndStatus(Long memberId, LinkStatus status);
+
+  boolean existsByCustomerIdAndStatus(String customerId, LinkStatus status);
+
+  /**
+   * 統合の付替えで、被統合行の関連を存続行へ移す。状態では絞らない — 解除済み（RELEASED）の区間も移さなければ「過去に誰と紐づいていたか」の 履歴が統合で切れる。
+   *
+   * <p>顧客参照は行ごと不変の写像（{@code updatable = false}）なので、実体の setter を開かずにここで書く。通常の経路から書き換えられる形にすると、
+   * 区間史の顧客が統合以外の理由で動きうることになる。
+   *
+   * <p>WHERE 句に店舗を明示するのは、Hibernate の {@code @Filter} が HQL の一括 UPDATE には掛からないため。
+   *
+   * @return 移した関連の件数（統合履歴にそのまま残す）
+   */
+  @Modifying
+  @Query(
+      """
+      update com.kizuna.customer.domain.CustomerMemberLink l set l.customerId = :survivingId
+      where l.customerId = :mergedId and l.storeId = :storeId
+      """)
+  int repointCustomer(
+      @Param("survivingId") String survivingId,
+      @Param("mergedId") String mergedId,
+      @Param("storeId") Long storeId);
 
   // 会員起点の照会。店舗文脈を持たない経路（会員本人）から呼ばれるため storeFilter は働かず、
   // 引数の storeId が唯一の店舗境界になる。ACTIVE 行は部分一意索引により店舗ごとに 1 件以下。

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerMerge.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerMerge.java
@@ -1,0 +1,87 @@
+package com.kizuna.customer.domain;
+
+import com.kizuna.shared.persistence.StoreScopedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Filter;
+
+/**
+ * 顧客統合が 1 回実行された事実。統合に取消（undo）は無く、誤統合の修復は「誰が・いつ・どの行をどの行へ・何を移したか」を
+ * 根拠とする人手作業になるため、この記録がその根拠そのものである（ADR 0010）。
+ *
+ * <p>移した件数は統合時の一括 UPDATE が報告した件数をそのまま持つ。後から存続行を数え直す形にすると、統合後に積まれた受注・関連まで 数えてしまい、何が移ったのかの根拠にならない。
+ *
+ * <p>全フィールドが確定した事実で、書き換える操作を持たない。実行者だけは利用者の削除で欠落しうる（FK が SET NULL）—
+ * 表示名が引けなくなっても行ごと消さないためで、関連（{@link CustomerMemberLink}）の実行者と同じ紀律である。
+ */
+@Entity
+@Table(name = "t_customer_merges")
+@Filter(name = "storeFilter", condition = "store_id = :storeId")
+@Filter(name = "storeSetFilter", condition = "store_id in (:storeIds)")
+@Getter
+@NoArgsConstructor
+public class CustomerMerge extends StoreScopedEntity {
+
+  @Column(name = "surviving_customer_id", nullable = false, updatable = false, length = 64)
+  private String survivingCustomerId;
+
+  @Column(name = "merged_customer_id", nullable = false, updatable = false, length = 64)
+  private String mergedCustomerId;
+
+  @Column(name = "merged_by", updatable = false)
+  private Long mergedBy;
+
+  @Column(name = "merged_at", nullable = false, updatable = false)
+  private OffsetDateTime mergedAt;
+
+  @Column(name = "moved_order_count", nullable = false, updatable = false)
+  private int movedOrderCount;
+
+  @Column(name = "moved_link_count", nullable = false, updatable = false)
+  private int movedLinkCount;
+
+  private CustomerMerge(
+      String survivingCustomerId,
+      String mergedCustomerId,
+      Long mergedBy,
+      OffsetDateTime mergedAt,
+      int movedOrderCount,
+      int movedLinkCount) {
+    this.survivingCustomerId = survivingCustomerId;
+    this.mergedCustomerId = mergedCustomerId;
+    this.mergedBy = mergedBy;
+    this.mergedAt = mergedAt;
+    this.movedOrderCount = movedOrderCount;
+    this.movedLinkCount = movedLinkCount;
+  }
+
+  /**
+   * 実行された統合を記録する。値はすべて統合の実行そのものが決めたもので、要求から直接来るものは無い（実行者は認証主体から、件数は 一括 UPDATE
+   * の結果から）。欠落は要求誤りではなく実装欠陥なので、NOT NULL 列による大きな失敗に委ねて構築時の検証は置かない。
+   */
+  public static CustomerMerge record(
+      String survivingCustomerId,
+      String mergedCustomerId,
+      Long mergedBy,
+      OffsetDateTime mergedAt,
+      int movedOrderCount,
+      int movedLinkCount) {
+    return new CustomerMerge(
+        survivingCustomerId, mergedCustomerId, mergedBy, mergedAt, movedOrderCount, movedLinkCount);
+  }
+
+  @Override
+  public String toString() {
+    return "CustomerMerge(id="
+        + getId()
+        + ", survivingCustomerId="
+        + survivingCustomerId
+        + ", mergedCustomerId="
+        + mergedCustomerId
+        + ")";
+  }
+}

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerMergeRepository.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerMergeRepository.java
@@ -1,0 +1,45 @@
+package com.kizuna.customer.domain;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CustomerMergeRepository extends JpaRepository<CustomerMerge, String> {
+
+  /**
+   * 統合の付替えで、被統合行に着いていた受注を存続行へ移す。状態（予約中・確定・完了・取消）では絞らない — 移らなかった受注は台帳から辿れない受注になる。
+   *
+   * <p>受注は order モジュールの集約だが、付替えの主体は統合そのものなのでこの操作は customer 側に置く。型として order へ依存すると order →
+   * customer（受注録入が顧客参照を解決する既存の依存）と環になるため、参照は HQL の中だけに閉じる — 読み取りの JOIN が {@code
+   * OrderRepository.VIEW_SELECT}（customer を参照）や {@code
+   * CustomerMemberLinkRepository#findHistory}（user を参照）で既に取っている形と同じで、綴りの誤りは起動時の HQL 検証で大きく失敗する。
+   *
+   * <p>WHERE 句に店舗を明示するのは、Hibernate の {@code @Filter} が HQL の一括 UPDATE には掛からないため。フィルタ任せにすると
+   * 店舗境界がこの文から消える。
+   *
+   * @return 移した受注の件数（統合履歴にそのまま残す）
+   */
+  @Modifying
+  @Query(
+      """
+      update com.kizuna.order.domain.Order o set o.customerId = :survivingId
+      where o.customerId = :mergedId and o.storeId = :storeId
+      """)
+  int repointOrders(
+      @Param("survivingId") String survivingId,
+      @Param("mergedId") String mergedId,
+      @Param("storeId") Long storeId);
+
+  /** その顧客が統合に関与しているか（存続行として受けた統合・自分が被統合となった統合のいずれも）。 */
+  @Query(
+      """
+      select count(m) > 0 from com.kizuna.customer.domain.CustomerMerge m
+      where m.survivingCustomerId = :customerId or m.mergedCustomerId = :customerId
+      """)
+  boolean existsInvolving(@Param("customerId") String customerId);
+
+  /** ある行が被統合となった統合。統合履歴を両方向で読むうちの片側で、もう一方は存続行として受けた統合。 */
+  List<CustomerMerge> findByMergedCustomerId(String mergedCustomerId);
+}

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerMergeRepository.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerMergeRepository.java
@@ -19,12 +19,16 @@ public interface CustomerMergeRepository extends JpaRepository<CustomerMerge, St
    * <p>WHERE 句に店舗を明示するのは、Hibernate の {@code @Filter} が HQL の一括 UPDATE には掛からないため。フィルタ任せにすると
    * 店舗境界がこの文から消える。
    *
+   * <p>{@code versioned} を付けるのは、受注の顧客参照が可変列であり、この文が版を上げないと並行する受注更新の
+   * 書き戻しが付替えを静かに取り消すため。付替えの前に読まれた受注は、自分が読んだ時点の顧客（墓標）を他の項目と 一緒に flush する — 版が据え置きなら楽観ロックの述語が成立し、その 1
+   * 件だけ墓標に着いたまま残る。 版を上げれば敗者は 409 になり、やり直せば正しい存続行に着く。
+   *
    * @return 移した受注の件数（統合履歴にそのまま残す）
    */
   @Modifying
   @Query(
       """
-      update com.kizuna.order.domain.Order o set o.customerId = :survivingId
+      update versioned com.kizuna.order.domain.Order o set o.customerId = :survivingId
       where o.customerId = :mergedId and o.storeId = :storeId
       """)
   int repointOrders(

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
@@ -76,12 +76,16 @@ public interface CustomerRepository
    *
    * <p>WHERE 句に店舗を明示するのは、Hibernate の {@code @Filter} が HQL の一括 UPDATE には掛からないため。
    *
+   * <p>{@code versioned} を付けるのは、統合先参照が可変列であり、この文が版を上げないと並行する顧客更新の 書き戻しが圧平を静かに取り消すため。墓標 A を読んだ更新の途中で
+   * B→C の統合が A を C へ付け替えると、 更新側は自分が読んだ時点の値（B）を他の項目と一緒に flush する — 版が据え置きなら楽観ロックの述語が 成立してしまい、A→B→C
+   * の連鎖が復活して「解決は常に一跳」が破れる。版を上げれば敗者は 409 になる。
+   *
    * @return 付け替えた墓標の件数
    */
   @Modifying
   @Query(
       """
-      update com.kizuna.customer.domain.Customer c set c.mergedIntoId = :survivingId
+      update versioned com.kizuna.customer.domain.Customer c set c.mergedIntoId = :survivingId
       where c.mergedIntoId = :mergedId and c.storeId = :storeId
       """)
   int flattenMergedInto(

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -54,4 +55,37 @@ public interface CustomerRepository
    * 0009）。
    */
   List<Customer> findByPhoneNumberAndStoreId(String phoneNumber, Long storeId);
+
+  /**
+   * その顧客が既に墓標（統合済み）かどうか。
+   *
+   * <p>押さえた行の実体からではなく別問い合わせで判定する。悲観排他ロックは既に永続化文脈に載っている実体の状態を更新しないため、
+   * ロック後に実体のフィールドを読むと第一次キャッシュの古い値を見る（{@link #findByIdForUpdate} の契約）。集計の投影は 実体を経由しないので、押さえた直後の DB
+   * の値をそのまま返す。
+   */
+  @Query(
+      """
+      select count(c) > 0 from com.kizuna.customer.domain.Customer c
+      where c.id = :id and c.mergedIntoId is not null
+      """)
+  boolean isMerged(@Param("id") String id);
+
+  /**
+   * 連鎖統合の圧平。被統合行を指していた既存の墓標を、新しい統合先へ付け替える。A→B の後で B→C を統合すると A は直接 C を指し、旧 ID の解決は常に一跳で届く（ADR
+   * 0010）。
+   *
+   * <p>WHERE 句に店舗を明示するのは、Hibernate の {@code @Filter} が HQL の一括 UPDATE には掛からないため。
+   *
+   * @return 付け替えた墓標の件数
+   */
+  @Modifying
+  @Query(
+      """
+      update com.kizuna.customer.domain.Customer c set c.mergedIntoId = :survivingId
+      where c.mergedIntoId = :mergedId and c.storeId = :storeId
+      """)
+  int flattenMergedInto(
+      @Param("survivingId") String survivingId,
+      @Param("mergedId") String mergedId,
+      @Param("storeId") Long storeId);
 }

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderMapper.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderMapper.java
@@ -65,5 +65,7 @@ public interface OrderMapper {
   @Mapping(target = "rank", constant = "SILVER")
   @Mapping(target = "lineId", ignore = true)
   @Mapping(target = "usageAreas", ignore = true)
+  // 起こしたばかりの行は定義上まだ生きている。統合先参照は統合だけが立てる。
+  @Mapping(target = "mergedIntoId", ignore = true)
   Customer toCustomer(OrderCreateRequest request);
 }

--- a/backend/src/main/java/com/kizuna/shared/exception/DbConstraint.java
+++ b/backend/src/main/java/com/kizuna/shared/exception/DbConstraint.java
@@ -32,7 +32,19 @@ public enum DbConstraint {
   UQ_T_POINT_ENTRIES_IDEMPOTENCY_KEY("uq_t_point_entries_idempotency_key"),
 
   /** t_customer_member_links の「店舗ごと会員 1 人につき有効な関連は高々 1 本」の部分一意索引。 */
-  UQ_T_CUSTOMER_MEMBER_LINKS_ACTIVE_MEMBER("uq_t_customer_member_links_active_member");
+  UQ_T_CUSTOMER_MEMBER_LINKS_ACTIVE_MEMBER("uq_t_customer_member_links_active_member"),
+
+  /** t_customer_member_links の「顧客 1 行につき有効な関連は高々 1 本」の部分一意索引。 */
+  UQ_T_CUSTOMER_MEMBER_LINKS_ACTIVE_CUSTOMER("uq_t_customer_member_links_active_customer"),
+
+  /** t_customer_merges → t_customers（存続行）の FK（RESTRICT）。 */
+  FK_T_CUSTOMER_MERGES_SURVIVING("fk_t_customer_merges_surviving"),
+
+  /** t_customer_merges → t_customers（被統合行）の FK（RESTRICT）。 */
+  FK_T_CUSTOMER_MERGES_MERGED("fk_t_customer_merges_merged"),
+
+  /** t_customers.merged_into_id の自己参照 FK（RESTRICT）。墓標の指す先が消えると旧 ID の解決が切れる。 */
+  FK_T_CUSTOMERS_MERGED_INTO("fk_t_customers_merged_into");
 
   private final String sqlName;
 

--- a/backend/src/main/java/com/kizuna/user/domain/PermissionCode.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PermissionCode.java
@@ -47,10 +47,9 @@ public enum PermissionCode {
   CUSTOMER_MANAGE(Console.STORE, SystemRole.STORE_MANAGER, SystemRole.STORE_STAFF),
 
   /**
-   * 重複した顧客行の統合の実行と、統合履歴・重複候補の閲覧（CustomerMergeController）。取り返しのつかない台帳級の操作のため店長限定。
+   * 重複した顧客行の統合の実行（CustomerMergeController）。取り返しのつかない台帳級の操作のため店長限定。
    *
-   * <p>統合には取消（undo）が無く、誤統合の修復は統合履歴を根拠とする人手作業になる（ADR 0010）。履歴そのものが機微情報であり、
-   * 候補提示は統合画面の一部で単独の価値を持たないため、実行・履歴閲覧・候補提示のいずれもこの一つの権限で守る。
+   * <p>統合には取消（undo）が無く、誤統合の修復は統合履歴を根拠とする人手作業になる（ADR 0010）。
    */
   CUSTOMER_MERGE(Console.STORE, SystemRole.STORE_MANAGER),
 

--- a/backend/src/main/java/com/kizuna/user/domain/PermissionCode.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PermissionCode.java
@@ -47,6 +47,14 @@ public enum PermissionCode {
   CUSTOMER_MANAGE(Console.STORE, SystemRole.STORE_MANAGER, SystemRole.STORE_STAFF),
 
   /**
+   * 重複した顧客行の統合の実行と、統合履歴・重複候補の閲覧（CustomerMergeController）。取り返しのつかない台帳級の操作のため店長限定。
+   *
+   * <p>統合には取消（undo）が無く、誤統合の修復は統合履歴を根拠とする人手作業になる（ADR 0010）。履歴そのものが機微情報であり、
+   * 候補提示は統合画面の一部で単独の価値を持たないため、実行・履歴閲覧・候補提示のいずれもこの一つの権限で守る。
+   */
+  CUSTOMER_MERGE(Console.STORE, SystemRole.STORE_MANAGER),
+
+  /**
    * 会員ポイントの手動調整と、誤帰属の訂正（帰属記録の無効化と、その台帳訂正）。準金銭的な確定系操作のため店長限定。
    *
    * <p>無効化までこの権限に含めるのは、不可逆なその操作だけを店員に許すと、二段目の台帳訂正を実行できない者が訂正を 始められ、やり残しが人を跨いで残るためである（ADR 0012）。

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -59,6 +59,9 @@ databaseChangeLog:
   - include:
       file: releases/v0.20.0/master.yaml
       relativeToChangelogFile: true
+  - include:
+      file: releases/v0.21.0/master.yaml
+      relativeToChangelogFile: true
   # reconcile/ は版に属さない恒久的な写像取り直しで、必ず全 release の後に置く（毎回実行されるため、
   # ロールの改名など release 側の移行より先に走ると、移行前の状態を見て齟齬と判定してしまう）。
   # 新しい release の include は必ずこの include より前に足すこと。

--- a/backend/src/main/resources/db/changelog/releases/v0.21.0/master.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.21.0/master.yaml
@@ -1,0 +1,5 @@
+# v0.21.0 = 顧客統合（統合先参照の列と統合履歴。ADR 0010）。store 層のみ。
+databaseChangeLog:
+  - include:
+      file: store/01-customer-merge.yaml
+      relativeToChangelogFile: true

--- a/backend/src/main/resources/db/changelog/releases/v0.21.0/store/01-customer-merge.yaml
+++ b/backend/src/main/resources/db/changelog/releases/v0.21.0/store/01-customer-merge.yaml
@@ -1,0 +1,179 @@
+databaseChangeLog:
+  - changeSet:
+      id: store-v02100-001-customer-merged-into
+      author: kanghouchao
+      # 統合先参照。NULL が「生きている行」で、値があればその行は墓標であり値が統合先を指す（ADR 0010）。
+      # 自己参照の外部キーは RESTRICT — 墓標の指す先が消えると旧 ID の解決が切れるため、統合先の削除は
+      # DB が止める。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - addColumn:
+            tableName: t_customers
+            columns:
+              - column:
+                  name: merged_into_id
+                  type: VARCHAR(64)
+                  remarks: 統合先の顧客。NULL は生きている行で、値があれば墓標
+        - addForeignKeyConstraint:
+            constraintName: fk_t_customers_merged_into
+            baseTableName: t_customers
+            baseColumnNames: merged_into_id
+            referencedTableName: t_customers
+            referencedColumnNames: id
+            onDelete: RESTRICT
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: t_customers
+            constraintName: fk_t_customers_merged_into
+        - dropColumn:
+            tableName: t_customers
+            columnName: merged_into_id
+
+  - changeSet:
+      id: store-v02100-002-customer-merged-into-index
+      author: kanghouchao
+      # 連鎖統合の圧平は「被統合行を指している墓標」を一括で書き換える。PostgreSQL は参照側の外部キー列に
+      # 索引を作らないので、無いと統合のたびに台帳を全走査する。値を持つのは墓標だけなので部分索引にする。
+      # Liquibase OSS の createIndex は述語を持たないため素の SQL。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - sql:
+            sql: >-
+              CREATE INDEX idx_t_customers_merged_into
+              ON t_customers (merged_into_id)
+              WHERE merged_into_id IS NOT NULL
+      rollback:
+        - dropIndex:
+            indexName: idx_t_customers_merged_into
+            tableName: t_customers
+
+  - changeSet:
+      id: store-v02100-003-customer-merge-history
+      author: kanghouchao
+      # 統合履歴。統合に取消（undo）は無く、誤統合の修復は「誰が・いつ・どの行をどの行へ・何を移したか」を
+      # 根拠とする人手作業になる（ADR 0010）。移した件数は統合時の一括 UPDATE の結果をそのまま残す
+      # （後から数え直すと、統合後に積まれた受注・関連まで数えてしまい根拠にならない）。
+      #
+      # 顧客への外部キーは両方とも RESTRICT。結果として統合に関与した行は存続行・被統合行とも削除できなく
+      # なるが、修復の根拠と旧 ID の解決が誤削除で消えるほうが重い。実行者は削除されても履歴が残るよう
+      # SET NULL（表示名の欠落で行ごと消さない）。
+      preConditions:
+        - dbms:
+            type: postgresql
+      changes:
+        - createTable:
+            tableName: t_customer_merges
+            remarks: 顧客統合の履歴
+            columns:
+              - column:
+                  name: id
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_t_customer_merges
+              - column:
+                  name: store_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: surviving_customer_id
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+                  remarks: 統合後に台帳へ残る行
+              - column:
+                  name: merged_customer_id
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+                  remarks: 墓標になった行
+              - column:
+                  name: merged_by
+                  type: BIGINT
+                  remarks: 統合の実行者。利用者削除後も履歴を残すため SET NULL
+              - column:
+                  name: merged_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints:
+                    nullable: false
+                  remarks: 統合の実行時刻
+              - column:
+                  name: moved_order_count
+                  type: INTEGER
+                  constraints:
+                    nullable: false
+                  remarks: 存続行へ付け替えた受注の件数
+              - column:
+                  name: moved_link_count
+                  type: INTEGER
+                  constraints:
+                    nullable: false
+                  remarks: 存続行へ付け替えた関連の件数（ACTIVE・RELEASED の全区間）
+              - column:
+                  name: created_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: version
+                  type: BIGINT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+                  remarks: 楽観ロック用バージョン
+        - addForeignKeyConstraint:
+            constraintName: fk_t_customer_merges_store
+            baseTableName: t_customer_merges
+            baseColumnNames: store_id
+            referencedTableName: t_stores
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            constraintName: fk_t_customer_merges_surviving
+            baseTableName: t_customer_merges
+            baseColumnNames: surviving_customer_id
+            referencedTableName: t_customers
+            referencedColumnNames: id
+            onDelete: RESTRICT
+        - addForeignKeyConstraint:
+            constraintName: fk_t_customer_merges_merged
+            baseTableName: t_customer_merges
+            baseColumnNames: merged_customer_id
+            referencedTableName: t_customers
+            referencedColumnNames: id
+            onDelete: RESTRICT
+        - addForeignKeyConstraint:
+            constraintName: fk_t_customer_merges_merged_by
+            baseTableName: t_customer_merges
+            baseColumnNames: merged_by
+            referencedTableName: t_users
+            referencedColumnNames: id
+            onDelete: SET NULL
+        - createIndex:
+            indexName: idx_t_customer_merges_surviving
+            tableName: t_customer_merges
+            columns:
+              - column:
+                  name: surviving_customer_id
+        - createIndex:
+            indexName: idx_t_customer_merges_merged
+            tableName: t_customer_merges
+            columns:
+              - column:
+                  name: merged_customer_id
+      rollback:
+        - dropTable:
+            tableName: t_customer_merges

--- a/backend/src/test/java/com/kizuna/DefaultGrantApprovalTests.java
+++ b/backend/src/test/java/com/kizuna/DefaultGrantApprovalTests.java
@@ -5,6 +5,7 @@ import static com.kizuna.user.domain.PermissionCode.CAST_FIELD_DEF_VIEW;
 import static com.kizuna.user.domain.PermissionCode.CAST_INVITE;
 import static com.kizuna.user.domain.PermissionCode.CAST_MANAGE;
 import static com.kizuna.user.domain.PermissionCode.CUSTOMER_MANAGE;
+import static com.kizuna.user.domain.PermissionCode.CUSTOMER_MERGE;
 import static com.kizuna.user.domain.PermissionCode.ORDER_MANAGE;
 import static com.kizuna.user.domain.PermissionCode.ORDER_SET_MANAGE;
 import static com.kizuna.user.domain.PermissionCode.PLATFORM_ASSET_MANAGE;
@@ -56,6 +57,7 @@ class DefaultGrantApprovalTests {
           Map.entry(ORDER_SET_MANAGE, Set.of(HQ_ADMIN, STORE_MANAGER, STORE_STAFF)),
           Map.entry(ORDER_MANAGE, Set.of(STORE_MANAGER, STORE_STAFF)),
           Map.entry(CUSTOMER_MANAGE, Set.of(STORE_MANAGER, STORE_STAFF)),
+          Map.entry(CUSTOMER_MERGE, Set.of(STORE_MANAGER)),
           Map.entry(SHIFT_MANAGE, Set.of(STORE_MANAGER, STORE_STAFF)),
           Map.entry(CAST_MANAGE, Set.of(STORE_MANAGER, STORE_STAFF)),
           Map.entry(CAST_INVITE, Set.of(STORE_MANAGER)),

--- a/backend/src/test/java/com/kizuna/customer/application/CustomerMergeServiceTest.java
+++ b/backend/src/test/java/com/kizuna/customer/application/CustomerMergeServiceTest.java
@@ -1,0 +1,258 @@
+package com.kizuna.customer.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.kizuna.customer.api.dto.CustomerMergeResponse;
+import com.kizuna.customer.domain.Customer;
+import com.kizuna.customer.domain.CustomerMemberLinkRepository;
+import com.kizuna.customer.domain.CustomerMerge;
+import com.kizuna.customer.domain.CustomerMergeRepository;
+import com.kizuna.customer.domain.CustomerRepository;
+import com.kizuna.customer.domain.LinkStatus;
+import com.kizuna.shared.exception.ConflictException;
+import com.kizuna.shared.exception.NotFoundException;
+import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.storescope.StoreContext;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import com.kizuna.user.domain.StoreScopeType;
+import com.kizuna.user.domain.UserType;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * 顧客統合の拒否条件と、付替え・墓標・履歴の書き込み順をサービス層で固定する。
+ *
+ * <p>複数行の照合・部分一意索引・行ロックの実効はモックでは守れないので、そこは {@code CustomerMergeIT}（実 PostgreSQL）に委ね、ここでは 二重管理にしない。
+ */
+@ExtendWith(MockitoExtension.class)
+class CustomerMergeServiceTest {
+
+  private static final String ACTOR_EMAIL = "manager@kizuna.test";
+  private static final long ACTOR_ID = 42L;
+  private static final long STORE_ID = 1L;
+
+  /** 昇順で押さえることを見るため、存続行のほうが辞書順で後になる組にする。 */
+  private static final String SURVIVING_ID = "c-2";
+
+  private static final String MERGED_ID = "c-1";
+
+  @Mock private CustomerRepository customerRepository;
+  @Mock private CustomerMemberLinkRepository customerMemberLinkRepository;
+  @Mock private CustomerMergeRepository customerMergeRepository;
+  @Mock private PlatformUserRepository platformUserRepository;
+  @Mock private StoreContext storeContext;
+
+  @InjectMocks private CustomerMergeService service;
+
+  @Test
+  @DisplayName("同じ顧客同士の統合は 400 系で拒まれ、行を一切押さえないこと")
+  void rejectsSelfMerge() {
+    assertThatThrownBy(() -> service.merge(SURVIVING_ID, SURVIVING_ID, ACTOR_EMAIL))
+        .isInstanceOf(ServiceException.class);
+
+    Mockito.verify(customerRepository, Mockito.never()).findByIdForUpdate(Mockito.anyString());
+  }
+
+  @Test
+  @DisplayName("押さえられない顧客は他店舗も不在も区別なく 404 になること")
+  void rejectsUnknownCustomer() {
+    givenActor();
+    Mockito.when(customerRepository.findByIdForUpdate(MERGED_ID)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.merge(SURVIVING_ID, MERGED_ID, ACTOR_EMAIL))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("2 行は顧客 ID の昇順で押さえられること（同じ 2 行を逆向きに統合する要求とデッドロックしない）")
+  void locksBothRowsInAscendingIdOrder() {
+    givenActor();
+    givenBothRowsLocked();
+    givenNeitherIsMerged();
+    givenNoActiveLinks();
+    givenStore();
+
+    service.merge(SURVIVING_ID, MERGED_ID, ACTOR_EMAIL);
+
+    InOrder inOrder = Mockito.inOrder(customerRepository);
+    inOrder.verify(customerRepository).findByIdForUpdate(MERGED_ID);
+    inOrder.verify(customerRepository).findByIdForUpdate(SURVIVING_ID);
+  }
+
+  @Test
+  @DisplayName("存続行に墓標を指定した統合は 409 で拒まれ、付替えが一切走らないこと")
+  void rejectsMergingIntoATombstone() {
+    givenActor();
+    givenBothRowsLocked();
+    Mockito.when(customerRepository.isMerged(SURVIVING_ID)).thenReturn(true);
+
+    assertThatThrownBy(() -> service.merge(SURVIVING_ID, MERGED_ID, ACTOR_EMAIL))
+        .isInstanceOf(ConflictException.class)
+        .hasMessageContaining("統合済み");
+
+    verifyNothingWasMoved();
+  }
+
+  @Test
+  @DisplayName("既に墓標の行を再度統合しようとすると 409 で拒まれること（応答喪失後の再送が台帳を壊さない）")
+  void rejectsMergingATombstoneAgain() {
+    givenActor();
+    givenBothRowsLocked();
+    Mockito.when(customerRepository.isMerged(SURVIVING_ID)).thenReturn(false);
+    Mockito.when(customerRepository.isMerged(MERGED_ID)).thenReturn(true);
+
+    assertThatThrownBy(() -> service.merge(SURVIVING_ID, MERGED_ID, ACTOR_EMAIL))
+        .isInstanceOf(ConflictException.class)
+        .hasMessageContaining("統合済み");
+
+    verifyNothingWasMoved();
+  }
+
+  @Test
+  @DisplayName("両行が ACTIVE 関連を持つ統合は 409 で拒まれ、先に関連を解除することが応答から判ること")
+  void rejectsWhenBothRowsCarryAnActiveLink() {
+    givenActor();
+    givenBothRowsLocked();
+    givenNeitherIsMerged();
+    Mockito.when(
+            customerMemberLinkRepository.existsByCustomerIdAndStatus(
+                SURVIVING_ID, LinkStatus.ACTIVE))
+        .thenReturn(true);
+    Mockito.when(
+            customerMemberLinkRepository.existsByCustomerIdAndStatus(MERGED_ID, LinkStatus.ACTIVE))
+        .thenReturn(true);
+
+    assertThatThrownBy(() -> service.merge(SURVIVING_ID, MERGED_ID, ACTOR_EMAIL))
+        .isInstanceOf(ConflictException.class)
+        .hasMessageContaining("先に関連を解除");
+
+    verifyNothingWasMoved();
+  }
+
+  @Test
+  @DisplayName("片方だけが ACTIVE 関連を持つ統合は通ること（拒否は「両行とも」のときだけ）")
+  void allowsMergeWhenOnlyOneRowCarriesAnActiveLink() {
+    givenActor();
+    givenBothRowsLocked();
+    givenNeitherIsMerged();
+    Mockito.when(
+            customerMemberLinkRepository.existsByCustomerIdAndStatus(
+                SURVIVING_ID, LinkStatus.ACTIVE))
+        .thenReturn(true);
+    Mockito.when(
+            customerMemberLinkRepository.existsByCustomerIdAndStatus(MERGED_ID, LinkStatus.ACTIVE))
+        .thenReturn(false);
+    givenStore();
+
+    assertThat(service.merge(SURVIVING_ID, MERGED_ID, ACTOR_EMAIL).survivingCustomerId())
+        .isEqualTo(SURVIVING_ID);
+  }
+
+  @Test
+  @DisplayName("統合履歴には一括 UPDATE が報告した件数がそのまま残り、実行者と統合の両行が記録されること")
+  void recordsTheMergeWithTheCountsReportedByTheBulkUpdates() {
+    givenActor();
+    givenBothRowsLocked();
+    givenNeitherIsMerged();
+    givenNoActiveLinks();
+    givenStore();
+    Mockito.when(customerMergeRepository.repointOrders(SURVIVING_ID, MERGED_ID, STORE_ID))
+        .thenReturn(7);
+    Mockito.when(customerMemberLinkRepository.repointCustomer(SURVIVING_ID, MERGED_ID, STORE_ID))
+        .thenReturn(3);
+
+    CustomerMergeResponse response = service.merge(SURVIVING_ID, MERGED_ID, ACTOR_EMAIL);
+
+    assertThat(response.movedOrderCount()).isEqualTo(7);
+    assertThat(response.movedLinkCount()).isEqualTo(3);
+    ArgumentCaptor<CustomerMerge> recorded = ArgumentCaptor.forClass(CustomerMerge.class);
+    Mockito.verify(customerMergeRepository).save(recorded.capture());
+    assertThat(recorded.getValue().getSurvivingCustomerId()).isEqualTo(SURVIVING_ID);
+    assertThat(recorded.getValue().getMergedCustomerId()).isEqualTo(MERGED_ID);
+    assertThat(recorded.getValue().getMergedBy()).isEqualTo(ACTOR_ID);
+    assertThat(recorded.getValue().getMergedAt()).isNotNull();
+    assertThat(recorded.getValue().getMovedOrderCount()).isEqualTo(7);
+    assertThat(recorded.getValue().getMovedLinkCount()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("連鎖の圧平は被統合行を墓標にする前に走ること（自分自身を圧平の対象にしない）")
+  void flattensExistingTombstonesBeforeTurningTheMergedRowIntoOne() {
+    givenActor();
+    Customer merged = givenBothRowsLocked();
+    givenNeitherIsMerged();
+    givenNoActiveLinks();
+    givenStore();
+
+    service.merge(SURVIVING_ID, MERGED_ID, ACTOR_EMAIL);
+
+    InOrder inOrder = Mockito.inOrder(customerRepository);
+    inOrder.verify(customerRepository).flattenMergedInto(SURVIVING_ID, MERGED_ID, STORE_ID);
+    inOrder.verify(customerRepository).save(merged);
+    assertThat(merged.getMergedIntoId()).isEqualTo(SURVIVING_ID);
+  }
+
+  // ==================== 前提の組み立て ====================
+
+  private void givenActor() {
+    PlatformUser actor =
+        PlatformUser.builder()
+            .email(ACTOR_EMAIL)
+            .password("encoded")
+            .displayName("田中花子")
+            .enabled(true)
+            .userType(UserType.STAFF)
+            .storeScopeType(StoreScopeType.SPECIFIC_STORES)
+            .storeIds(Set.of(STORE_ID))
+            .roleIds(Set.of(1L))
+            .build();
+    actor.setId(ACTOR_ID);
+    Mockito.when(platformUserRepository.findByEmail(ACTOR_EMAIL)).thenReturn(Optional.of(actor));
+  }
+
+  /** 両行が押さえられた状態。戻り値は被統合行の実体（墓標化の宛先）。 */
+  private Customer givenBothRowsLocked() {
+    Customer merged = Customer.builder().build();
+    Mockito.when(customerRepository.findByIdForUpdate(MERGED_ID)).thenReturn(Optional.of(merged));
+    Mockito.when(customerRepository.findByIdForUpdate(SURVIVING_ID))
+        .thenReturn(Optional.of(Customer.builder().build()));
+    return merged;
+  }
+
+  private void givenNeitherIsMerged() {
+    Mockito.when(customerRepository.isMerged(SURVIVING_ID)).thenReturn(false);
+    Mockito.when(customerRepository.isMerged(MERGED_ID)).thenReturn(false);
+  }
+
+  private void givenNoActiveLinks() {
+    Mockito.when(
+            customerMemberLinkRepository.existsByCustomerIdAndStatus(
+                SURVIVING_ID, LinkStatus.ACTIVE))
+        .thenReturn(false);
+  }
+
+  private void givenStore() {
+    Mockito.when(storeContext.getStoreId()).thenReturn(STORE_ID);
+  }
+
+  private void verifyNothingWasMoved() {
+    Mockito.verify(customerMergeRepository, Mockito.never())
+        .repointOrders(Mockito.anyString(), Mockito.anyString(), Mockito.anyLong());
+    Mockito.verify(customerMemberLinkRepository, Mockito.never())
+        .repointCustomer(Mockito.anyString(), Mockito.anyString(), Mockito.anyLong());
+    Mockito.verify(customerRepository, Mockito.never())
+        .flattenMergedInto(Mockito.anyString(), Mockito.anyString(), Mockito.anyLong());
+    Mockito.verify(customerMergeRepository, Mockito.never()).save(Mockito.any());
+  }
+}

--- a/backend/src/test/java/com/kizuna/customer/application/CustomerServiceTest.java
+++ b/backend/src/test/java/com/kizuna/customer/application/CustomerServiceTest.java
@@ -3,6 +3,7 @@ package com.kizuna.customer.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,10 +14,12 @@ import com.kizuna.customer.api.dto.CustomerUpdateRequest;
 import com.kizuna.customer.domain.Customer;
 import com.kizuna.customer.domain.CustomerMemberLink;
 import com.kizuna.customer.domain.CustomerMemberLinkRepository;
+import com.kizuna.customer.domain.CustomerMergeRepository;
 import com.kizuna.customer.domain.CustomerPatch;
 import com.kizuna.customer.domain.CustomerRepository;
 import com.kizuna.customer.domain.LinkReason;
 import com.kizuna.customer.domain.LinkStatus;
+import com.kizuna.shared.exception.ConflictException;
 import com.kizuna.shared.exception.NotFoundException;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -38,6 +41,7 @@ class CustomerServiceTest {
 
   @Mock private CustomerRepository customerRepository;
   @Mock private CustomerMemberLinkRepository customerMemberLinkRepository;
+  @Mock private CustomerMergeRepository customerMergeRepository;
   @Mock private CustomerMapper customerMapper;
 
   @InjectMocks private CustomerService customerService;
@@ -237,6 +241,18 @@ class CustomerServiceTest {
     when(customerRepository.existsById("c1")).thenReturn(true);
     customerService.delete("c1");
     verify(customerRepository).deleteById("c1");
+  }
+
+  @Test
+  @DisplayName("統合に関与した顧客の削除は 409 で撥ねられ、行が消えないこと")
+  void delete_rejectsCustomersInvolvedInAMerge() {
+    when(customerRepository.existsById("c1")).thenReturn(true);
+    when(customerMergeRepository.existsInvolving("c1")).thenReturn(true);
+
+    assertThatThrownBy(() -> customerService.delete("c1"))
+        .isInstanceOf(ConflictException.class)
+        .hasMessageContaining("統合");
+    verify(customerRepository, never()).deleteById("c1");
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/user/domain/PermissionCodeTest.java
+++ b/backend/src/test/java/com/kizuna/user/domain/PermissionCodeTest.java
@@ -38,12 +38,13 @@ class PermissionCodeTest {
   }
 
   @Test
-  @DisplayName("STORE コンソールの権限は店舗業務系の 10 個")
+  @DisplayName("STORE コンソールの権限は店舗業務系の 11 個")
   void storePermissions() {
     assertThat(byConsole(PermissionCode.Console.STORE))
         .containsExactlyInAnyOrder(
             PermissionCode.ORDER_MANAGE,
             PermissionCode.CUSTOMER_MANAGE,
+            PermissionCode.CUSTOMER_MERGE,
             PermissionCode.POINT_ADJUST,
             PermissionCode.SHIFT_MANAGE,
             PermissionCode.CAST_MANAGE,
@@ -55,9 +56,9 @@ class PermissionCodeTest {
   }
 
   @Test
-  @DisplayName("権限目録は 17 個で全てコンソール分類を持つ")
+  @DisplayName("権限目録は 18 個で全てコンソール分類を持つ")
   void catalogIsComplete() {
-    assertThat(PermissionCode.values()).hasSize(17);
+    assertThat(PermissionCode.values()).hasSize(18);
     assertThat(Arrays.stream(PermissionCode.values()).map(PermissionCode::getConsole))
         .doesNotContainNull();
   }


### PR DESCRIPTION
## 概要

同一店舗内で重複した顧客行を店長が**統合**できるようにする。存続行へ被統合行の受注（全状態）と関連（ACTIVE・RELEASED の全区間）を付け替え、被統合行は削除せず統合先参照を持つ**墓標**として残す。連鎖統合では被統合行を指していた既存の墓標も新しい統合先へ付け替え、旧 ID の解決が常に一跳で届くようにする（ADR 0010）。

本 PR は統合そのものの成立まで。墓標を電話照合・一覧から外すこと、旧 ID の解決、店舗コンソールの画面は後続票（#673〜#676）が扱う。

Closes #672

## 変更内容

- **v0.21.0（store 層）**: `t_customers.merged_into_id`（自己参照 FK・RESTRICT ＋ 墓標だけの部分索引）と統合履歴テーブル `t_customer_merges`（存続行・被統合行・実行者・実行時刻・移した受注件数・移した関連件数）
- **`POST /store/customers/{存続行}/merges`**（body = `merged_customer_id`）。応答は統合先と移した件数
- **新権限 `CUSTOMER_MERGE`**（店舗コンソール・STORE_MANAGER 限定）。取り返しのつかない台帳級の操作を店長に限る既存の慣行（`POINT_ADJUST` / `CAST_INVITE`）に揃える
- **`CustomerMergeService`**: 2 行を顧客 ID の昇順で悲観排他ロック → 拒否条件を実行の瞬間に判定し直す → 受注・関連の一括付替え → 連鎖の圧平 → 墓標化 → 統合履歴の永続
- **拒否条件**: 自己統合 400 ／ 存続行が墓標 409 ／ 二度目の統合 409 ／ 他店舗は 404（存在の有無を漏らさない）／ 両行が ACTIVE 関連なら 409 で「先に関連を解除する」ことを案内
- **`CustomerService#delete`**: 統合に関与した行は存続行・被統合行とも 409。統合履歴が誤統合の唯一の修復根拠であり、旧 ID の解決も墓標が残っていて初めて届くため
- `DbConstraint` に外部キー 3 本と部分一意索引 1 本を収録（最終防波堤を案内の読める 409 へ写す）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全 24 シナリオ・4.4 分）
- [x] ローカルで code-review 実施済み（Standards / Spec の 2 軸。指摘は下記「備考」に反映済み）

**着手前に統合テストの基線を取得済みで、そちらも全緑**（既存の赤は無し）。新規テストは `CustomerMergeIT` 11 本と `CustomerMergeServiceTest` 8 本。

新しいテストが**赤にできること**を変異で確認した（いずれも実測）:

| 変異 | 赤になったテスト |
| --- | --- |
| `merged_into_id` に `updatable = false` | IT 4 本 |
| 連鎖圧平の呼び出しを落とす | 連鎖の IT 1 本のみ |
| 関連の付替えを ACTIVE 区間だけに絞る | 区間の IT 1 本のみ |
| ロック順を降順にする | 単体 2 本 |

**不波及の IT だけは赤にできない**（構造的なカナリアで、仕訳も帰属記録も顧客を参照しないことが前提そのもの）。空振りでないことは、統合前の残高が正・明細と来店が非空であることを前提として断言することで担保している。

### 視覚確認（UI 変更時）

UI 変更なし（バックエンドのみ。店舗コンソールの画面は #675 / #676）。

## 決定ログ

### 受注の付替えを customer モジュールから行う形

受注の付替えは `CustomerMergeRepository#repointOrders` の HQL 文字列の中でだけ `com.kizuna.order.domain.Order` を名指す。**型として依存すると `order → customer`（受注録入の顧客参照解決、#671）と環になり `ModularityTests` が落ちる**ため。文字列リテラルはバイトコード解析の対象外であることは実測で確認した。

見送った代替案:

- **port interface を customer 側に置き order 側に実装する**（依存の反転）— backend/CLAUDE.md「単一実装の interface を作らない」と、spec #655 の「実装は customer モジュールに閉じる／order 側の変更は顧客参照の解決だけ」の両方に反する。
- **ネイティブ SQL** — HQL なら起動時の検証で綴りの誤りが大声で落ちる利点を捨てることになる。

既存の先例（`OrderRepository.VIEW_SELECT` が Customer を、`CustomerMemberLinkRepository#findHistory` が PlatformUser を FQCN で参照）は読み取りの JOIN であり、**これは書き込みなので一段大きい越境**である。ローカルの Standards 評審も同じ指摘をした。承知のうえで採った形なので、異論があればここで潰したい（→ 備考）。

### 墓標化は実体の behavior、圧平は一括 UPDATE

`@Column(updatable = false)` は**実体状態の flush が生む SQL にしか効かず、HQL の一括 UPDATE には効かない**。連鎖圧平を一括 UPDATE だけで書くと、受入基準「統合先参照の列が後から書き換え可能であること」に守衛が付かない（不変列に変えてもテストが緑のままになる）。

そこで墓標化は `Customer#mergeInto` という実体の behavior で書き、圧平だけ一括 UPDATE にした。これで `updatable = false` の変異が IT 4 本を赤にする。同じ理由（`@Filter` も HQL の一括 UPDATE には掛からない）で、3 本の一括 UPDATE すべての WHERE 句に `store_id` を明示している。

### 拒否の判定を押さえた実体から読まない

悲観排他ロックは既に永続化文脈に載っている実体の状態を更新しないため、統合済みかどうかは `CustomerRepository#isMerged`（集計の投影）で別問い合わせとして読む。既存の関連解決が「顧客行をロック → 関連を別クエリで読む」形になっているのと同じ理由。

### 統合は `CustomerReferenceResolver` を通さない

あちらは「既にある行を指す参照の書き込み先」を解決する口で、墓標を渡されれば統合先へ向け直す（#673 で追加予定）。統合が対象にするのは名指された 2 行そのもので、別の行へ向け直してよい操作ではない — 解除（`CustomerMemberLinkService#unlink`）と同じ理由。

### 統合履歴の件数は数え直さない

一括 UPDATE が報告した件数をそのまま残す。後から存続行を数え直す形にすると、統合後に積まれた受注・関連まで数えてしまい、何が移ったのかの根拠にならない。

## 備考 / レビュー観点

**重点的に見てほしい箇所**

1. **`CustomerMergeRepository#repointOrders` の越境**（決定ログ参照）。HQL 文字列に閉じたことで Modulith の検証は通るが、裏を返せば**この越境は Modulith が捕捉できない**。形として許容するか、それとも別の解（例えば #674 以降でまとめて見直す）を採るかは裁定をいただきたい。
2. **`fk_t_customer_merges_*` / `fk_t_customers_merged_into` の 409 写像は競合時にしか到達しない**ため、テストで赤にできていない。アプリ層の `existsInvolving` が通常経路を先に塞ぐ。3 本とも同じ案内へ写しているのは、削除時に DB がどれを先に報告するかが検査順に依るため。

**既知の妥協点**

- ~~受注の付替えは素の一括 UPDATE なので `@Version` を上げない。~~ **（3 commit 目 `5529fec2` で解消）** Codex 評審の P1 指摘を受けて、圧平（`flattenMergedInto`）と受注の付替え（`repointOrders`）を `update versioned` に変えた。版を上げないと、統合の前に読まれた行を後から保存する経路が自分の読んだ時点の値を書き戻せてしまい、**楽観ロックの述語が成立するので競合として現れない** — 圧平と付替えだけが静かに取り消される。圧平の側は **#674 の複合外部キーでも塞げない**（あの制約は「墓標を指す統合先参照」を禁じない）ため、版が唯一の防波堤になる。関連の付替え（`repointCustomer`）は `CustomerMemberLink.customer_id` が `updatable = false` で実体の flush がその列を含まないため対象外。決定的な回帰として `CustomerMergeIT#advancesTheVersionOfEveryRowItRewrites` を追加し、`versioned` を外すとこの 1 本だけが赤になることを実測済み。**並行する 2 つの要求のどちらが勝つかという外形の固定は #673 の並行テストの範囲**で、本 PR はその競合が検出可能になる前提だけを押さえている。
- **未マップの HTTP メソッドは 405 ではなく 500 になる**（`HttpRequestMethodNotSupportedException` に `CommonExceptionHandler` の写像が無く catch-all へ落ちる）。既存かつ全域の性質で、本 PR が悪化させるものではないため触っていない。そのため「統合を取り消す端点が存在しない」の断言は応答符号を固定せず、「2xx でない ＋ 取消の試みの後も墓標と統合履歴が動かない」という形に下ろしている。

**付随的な変更**

- 権限を 1 つ足したことで既存のカウンタ 3 か所を更新した（`PermissionCodeTest` の総数とコンソール別の列挙、`DefaultGrantApprovalTests` の承認台帳、`PlatformStaffManagementIT` の目録件数。17 → 18）。
- Modulith の canvas は `module-customer.adoc` のみ更新（新しい集約 `CustomerMerge` と `CustomerMergeRepository`）。他ファイルの差分は Rel 行・bean 参照の順序ゆらぎなので CLAUDE.md どおり据え置いた。**Bean references 欄に order が現れていないことが、新しいモジュール依存を作っていないことの記録にもなっている。**

**未解決のまま残した評審指摘（要裁定）**

Codex が「統合履歴が件数しか持たないため、誤統合の修復で『どの受注・関連を戻すか』を同定できない」と指摘した（P1）。観測自体は正しい — 統合後の存続行の受注は、元から自分のものと移ってきたものに分けられない。

本 PR では**対応せず仕様裁定として保留**した。実装は明文に一致している（issue #672 の受入基準、spec #655 の履歴テーブル列・記録方針・API 応答の 3 箇所がいずれも「件数」）。加えて ADR 0010 は undo を却下する理由として「機械的な巻き戻しには解が無い」と述べており、行単位の同定を残すことはその土台を作る方向で裁定と逆を向く。修復が「稀で重い人手作業」になることは ADR が受け入れた代償である。

行単位の記録に変えるかは #676（統合履歴の閲覧）の設計にも波及するため、**別 issue として切り出すかどうかを含めてリポジトリ所有者の裁定を仰ぐ**。当該スレッドは未解決のまま残してある。

**後続票**: #673（墓標の除外・旧 ID の解決・参照作成の直列化）→ #674（DB 側の不変量）／#675（候補提示と統合の実行 UI）／#676（統合履歴の閲覧）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


