### PR TITLE
fix: 門禁の盲点だったテスト 2 件の型エラーを解消する

### DIFF
--- a/frontend/src/entities/customer/__tests__/customer-api.test.ts
+++ b/frontend/src/entities/customer/__tests__/customer-api.test.ts
@@ -88,12 +88,14 @@ describe('customerApi', () => {
         delta: 100,
         reason: '手動付与',
         expires_on: '2026-12-31',
+        idempotency_key: 'idem-1',
       })
     ).resolves.toEqual({ linked: true, balance: 220 });
     expect(mockedPost).toHaveBeenLastCalledWith('/store/customers/c1/point-adjustments', {
       delta: 100,
       reason: '手動付与',
       expires_on: '2026-12-31',
+      idempotency_key: 'idem-1',
     });
   });
 });

--- a/frontend/src/shared/api/__tests__/file.test.ts
+++ b/frontend/src/shared/api/__tests__/file.test.ts
@@ -1,3 +1,4 @@
+import type { AxiosAdapter } from 'axios';
 import { apiClient, fileApi } from '@/shared/api';
 
 // apiClient の既定 Content-Type は application/json のため、上書きが無いと axios の
@@ -8,7 +9,7 @@ describe('fileApi.upload', () => {
   it('multipart のまま送信する（FormData が JSON へ変換されない）', async () => {
     let capturedData: unknown;
     const original = apiClient.defaults.adapter;
-    apiClient.defaults.adapter = (async (config: { data: unknown }) => {
+    const adapter: AxiosAdapter = async config => {
       capturedData = config.data;
       return {
         data: { url: '/uploads/a.png', original_name: 'a.png', size: 1 },
@@ -17,7 +18,8 @@ describe('fileApi.upload', () => {
         headers: {},
         config,
       };
-    }) as typeof apiClient.defaults.adapter;
+    };
+    apiClient.defaults.adapter = adapter;
 
     try {
       await fileApi.upload(new File(['x'], 'a.png', { type: 'image/png' }), 'public');


### PR DESCRIPTION
## 概要

三門禁のいずれにも検出されないテストファイルの tsc 型エラー 2 件を修正した。挙動不変・Jest 緑維持。

Closes #698

## 変更内容

- `customer-api.test.ts`: `adjustPoints` の夾具と `toHaveBeenLastCalledWith` 断言に `idempotency_key: 'idem-1'` を補う（必須化への未追随）
- `file.test.ts`: adapter mock を `AxiosAdapter` の文脈型で宣言し、`config` を `InternalAxiosRequestConfig` として原様回伝。`as typeof apiClient.defaults.adapter` の不正 cast を除去

## 検証

- [x] `npx tsc --noEmit`（`.next/` 濾過後）: 2 件 → **0 件**、新規なし
- [x] `npx jest` 全量: 基線 117 suites / 1022 tests と**完全一致**の緑
- [x] `npx eslint .` exit 0（改動 2 ファイルへの指摘 0）・prettier 緑
- [ ] `task lint` / `task test` / `task build` — 差分はテスト 2 ファイルのみで、Docker 側門禁はこの類のエラーを検出しない（まさに本件の原因）。CI の実行で平価確認
- [ ] `task e2e` — 対象外: テストコードのみの変更

## 決定ログ

- `idempotency_key` の値は可読字面量 `'idem-1'`: 生産側は `crypto.randomUUID()` だが型は `string` であり、断言の精確一致を保つには固定値が要る
- `file.test` は `as unknown as` へ逃げず文脈型で解決: エラーの実体は `config.headers` 欠落のみで、`AxiosAdapter` を宣言すれば `config` が正しい型で降ってくる
- 恒久対策（lint 門禁への `tsc --noEmit` 追加、Next `runTypeCheck` の ignoreRegex が原因でテスト診断が構造的に濾過される件）は #699 に提案として起票

## 備考 / レビュー観点

`file.test.ts` の `config` が `{ data: unknown }` → `InternalAxiosRequestConfig`（実質 any 由来のフィールドを含む）へ広がるが、`no-unsafe-assignment` 級の type-checked 規則は未採用のため lint 上の変化なし。観測点 `expect(capturedData).toBeInstanceOf(FormData)` は原様維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)