### PR TITLE
fix: 生成系を 201・削除系を 204 に揃え、店舗作成が新規 id を返すようにする

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/customer/CustomerMemberLinkIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/CustomerMemberLinkIT.java
@@ -135,7 +135,7 @@ class CustomerMemberLinkIT extends CrossStoreTestSupport {
             HttpMethod.DELETE,
             new HttpEntity<>(storeHeaders(STORE_A)),
             JsonNode.class);
-    assertThat(released.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(released.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
 
     ResponseEntity<JsonNode> detail =
         rest.exchange(

--- a/backend/src/integrationTest/java/com/kizuna/customer/CustomerMergeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/CustomerMergeIT.java
@@ -462,7 +462,7 @@ class CustomerMergeIT extends CrossStoreTestSupport {
                     JsonNode.class)
                 .getStatusCode())
         .as("前提: 会員の紐づけを解除できること")
-        .isEqualTo(HttpStatus.OK);
+        .isEqualTo(HttpStatus.NO_CONTENT);
   }
 
   // ==================== 会員 ====================

--- a/backend/src/integrationTest/java/com/kizuna/order/MemberRequestProvisioningIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/MemberRequestProvisioningIT.java
@@ -200,7 +200,7 @@ class MemberRequestProvisioningIT extends CrossStoreTestSupport {
                     Void.class)
                 .getStatusCode())
         .as("前提: 紐づけを解除できること")
-        .isEqualTo(HttpStatus.OK);
+        .isEqualTo(HttpStatus.NO_CONTENT);
     linkByMemberCode(shared, other.memberCode());
 
     ResponseEntity<JsonNode> confirmed = confirm(orderId, storeHeaders(STORE_A));

--- a/backend/src/integrationTest/java/com/kizuna/storage/FileUploadCrossStoreIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/storage/FileUploadCrossStoreIT.java
@@ -103,7 +103,7 @@ class FileUploadCrossStoreIT {
   }
 
   @Test
-  @DisplayName("HQ トークン（詐称ヘッダ無し）の /files/upload は platform 領域へ 200 で保存されること")
+  @DisplayName("HQ トークン（詐称ヘッダ無し）の /files/upload は platform 領域へ 201 で保存されること")
   void hqTokenWithoutSpoofUploadsToPlatform() {
     HttpHeaders headers = new HttpHeaders();
     headers.setBearerAuth(platformLogin(HQ_EMAIL));
@@ -111,7 +111,7 @@ class FileUploadCrossStoreIT {
     ResponseEntity<JsonNode> res =
         rest.exchange("/files/upload", HttpMethod.POST, uploadRequest(headers), JsonNode.class);
 
-    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     assertThat(res.getBody().path("url").asString()).contains("/platform/");
   }
 }

--- a/backend/src/integrationTest/java/com/kizuna/store/PlatformStoreApiIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/store/PlatformStoreApiIT.java
@@ -76,7 +76,7 @@ class PlatformStoreApiIT {
   }
 
   @Test
-  @DisplayName("POST /platform/stores は HQ 管理者で 204 になること")
+  @DisplayName("POST /platform/stores は HQ 管理者で 201 になり、新規 id を返すこと")
   void hqAdminCanCreateStore() {
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
@@ -90,10 +90,11 @@ class PlatformStoreApiIT {
                 + " \"email\": \"store-create-it@kizuna.test\"}",
             UUID.randomUUID());
 
-    ResponseEntity<Void> res =
-        rest.postForEntity("/platform/stores", new HttpEntity<>(body, headers), Void.class);
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity("/platform/stores", new HttpEntity<>(body, headers), JsonNode.class);
 
-    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(res.getBody().path("id").asLong()).isPositive();
   }
 
   // ドメインは管理画面で店舗サイトへのリンクとして描画される。`/` `:` `@` を通すと
@@ -177,10 +178,10 @@ class PlatformStoreApiIT {
                 + " \"email\": \"store-create-it@kizuna.test\"}",
             maxLabel);
 
-    ResponseEntity<Void> res =
-        rest.postForEntity("/platform/stores", new HttpEntity<>(body, headers), Void.class);
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity("/platform/stores", new HttpEntity<>(body, headers), JsonNode.class);
 
-    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.CREATED);
   }
 
   // 編集画面は name と email を送る。更新 DTO が受け取らない項目は
@@ -243,26 +244,18 @@ class PlatformStoreApiIT {
         .isEqualTo("keep@kizuna.test");
   }
 
-  /** 店舗を作成し、その id を返す。POST は 204 で本文を返さないため、一意な name で検索して引く。 */
+  /** 店舗を作成し、その id を返す。 */
   private String createStore(String token, String name, String domain, String email) {
     HttpHeaders headers = bearer(token);
     headers.setContentType(MediaType.APPLICATION_JSON);
     String body =
         String.format(
             "{\"name\": \"%s\", \"domain\": \"%s\", \"email\": \"%s\"}", name, domain, email);
-    ResponseEntity<Void> created =
-        rest.postForEntity("/platform/stores", new HttpEntity<>(body, headers), Void.class);
-    assertThat(created.getStatusCode()).as("前提: 店舗が作成されること").isEqualTo(HttpStatus.NO_CONTENT);
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity("/platform/stores", new HttpEntity<>(body, headers), JsonNode.class);
+    assertThat(created.getStatusCode()).as("前提: 店舗が作成されること").isEqualTo(HttpStatus.CREATED);
 
-    ResponseEntity<JsonNode> found =
-        rest.exchange(
-            "/platform/stores?search=" + name,
-            HttpMethod.GET,
-            new HttpEntity<>(bearer(token)),
-            JsonNode.class);
-    assertThat(found.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(found.getBody().path("content").size()).as("前提: 作成した店舗が一意に引けること").isEqualTo(1);
-    return found.getBody().path("content").get(0).path("id").asString();
+    return created.getBody().path("id").asString();
   }
 
   @Test
@@ -357,9 +350,9 @@ class PlatformStoreApiIT {
                 + " \"email\": \"store-it-likeesc@kizuna.test\"}",
             name, uniqueSuffix);
 
-    ResponseEntity<Void> created =
-        rest.postForEntity("/platform/stores", new HttpEntity<>(body, headers), Void.class);
-    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity("/platform/stores", new HttpEntity<>(body, headers), JsonNode.class);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 
     String wildcardSearch = name.replace("acb", "a_b");
     ResponseEntity<JsonNode> underscore =

--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -179,7 +179,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
                 createBody(CASE1_EMAIL, rolesJson("店長"), "SPECIFIC_STORES", "[" + storeAId + "]"),
                 bearerJson(hq)),
             JsonNode.class);
-    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     assertThat(created.getBody().path("id").asLong()).isPositive();
 
     ResponseEntity<String> stores =
@@ -228,7 +228,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
                 createBody(CASE3_EMAIL, rolesJson("店長"), "SPECIFIC_STORES", "[" + storeAId + "]"),
                 bearerJson(hq)),
             JsonNode.class);
-    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     long staffId = created.getBody().path("id").asLong();
     long version = created.getBody().path("version").asLong();
 
@@ -274,7 +274,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
     ResponseEntity<JsonNode> first =
         rest.postForEntity(
             "/platform/staff", new HttpEntity<>(body, bearerJson(hq)), JsonNode.class);
-    assertThat(first.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(first.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 
     ResponseEntity<JsonNode> second =
         rest.postForEntity(
@@ -647,7 +647,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
                     email, rolesJson("HQ管理者", "店長"), "SPECIFIC_STORES", "[" + storeAId + "]"),
                 bearerJson(hq)),
             JsonNode.class);
-    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 
     String token = platformToken(email, PASSWORD);
 
@@ -677,7 +677,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
             new HttpEntity<>(
                 createBody(email, rolesJson("店舗スタッフ"), "ALL_STORES", "[]"), bearerJson(hq)),
             JsonNode.class);
-    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     long staffId = created.getBody().path("id").asLong();
     long version = created.getBody().path("version").asLong();
 
@@ -752,7 +752,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
                 createBody(email, rolesJson("店長"), "SPECIFIC_STORES", "[" + storeAId + "]"),
                 bearerJson(hq)),
             JsonNode.class);
-    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     long staffId = created.getBody().path("id").asLong();
     long initialVersion = created.getBody().path("version").asLong();
 
@@ -809,7 +809,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
             new HttpEntity<>(
                 createBody(email, rolesJson("店舗スタッフ"), "ALL_STORES", "[]"), bearerJson(hq)),
             JsonNode.class);
-    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     long staffId = created.getBody().path("id").asLong();
     long preStopVersion = created.getBody().path("version").asLong();
 
@@ -908,7 +908,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
             new HttpEntity<>(
                 "{\"name\":\"スタッフ管理IT_受付担当\",\"permissions\":[\"ORDER_MANAGE\"]}", bearerJson(hq)),
             JsonNode.class);
-    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     long roleId = created.getBody().path("id").asLong();
     assertThat(created.getBody().path("system").asBoolean()).isFalse();
     assertThat(created.getBody().path("permissions").get(0).asString()).isEqualTo("ORDER_MANAGE");
@@ -943,7 +943,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
                     "staff-it-customrole@kizuna.test", "[" + roleId + "]", "ALL_STORES", "[]"),
                 bearerJson(hq)),
             JsonNode.class);
-    assertThat(staff.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(staff.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 
     ResponseEntity<String> deleteInUse =
         rest.exchange(
@@ -981,7 +981,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
                 "{\"name\":\"スタッフ管理IT_未授与\",\"permissions\":[\"CUSTOMER_MANAGE\"]}",
                 bearerJson(hq)),
             JsonNode.class);
-    assertThat(unused.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(unused.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     ResponseEntity<String> deleted =
         rest.exchange(
             "/platform/roles/" + unused.getBody().path("id").asLong(),

--- a/backend/src/main/java/com/kizuna/auth/api/platform/PlatformAuthController.java
+++ b/backend/src/main/java/com/kizuna/auth/api/platform/PlatformAuthController.java
@@ -39,7 +39,7 @@ public class PlatformAuthController {
 
   @PostMapping("/logout")
   @PermitAll
-  public ResponseEntity<?> logout(
+  public ResponseEntity<Void> logout(
       @RequestHeader(name = "Authorization", required = false) String authHeader) {
     authSessionService.invalidate(authHeader);
     return ResponseEntity.noContent().build();
@@ -48,9 +48,6 @@ public class PlatformAuthController {
   @GetMapping("/me")
   @PreAuthorize("isAuthenticated()")
   public ResponseEntity<PlatformMeResponse> me(Principal principal) {
-    if (principal == null || principal.getName() == null) {
-      return ResponseEntity.status(401).build();
-    }
     // 行が引けない＝無効なのはセッション（トークンの指す主体が存在しない）。404 にすると
     // 前端の全域 401 経路（再ログインへの差し戻し）に乗らないため、updateMe と同じ例外へ揃える。
     return authService

--- a/backend/src/main/java/com/kizuna/cast/api/store/CastController.java
+++ b/backend/src/main/java/com/kizuna/cast/api/store/CastController.java
@@ -67,7 +67,7 @@ public class CastController {
   @PreAuthorize("hasAuthority('PERM_CAST_MANAGE')")
   public ResponseEntity<Void> delete(@PathVariable String id) {
     castService.delete(id);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 
   @PostMapping("/{id}/invitation")

--- a/backend/src/main/java/com/kizuna/cast/api/store/CastFieldDefinitionController.java
+++ b/backend/src/main/java/com/kizuna/cast/api/store/CastFieldDefinitionController.java
@@ -53,6 +53,6 @@ public class CastFieldDefinitionController {
   @PreAuthorize("hasAuthority('PERM_CAST_FIELD_DEF_MANAGE')")
   public ResponseEntity<Void> delete(@PathVariable String id) {
     service.delete(id);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 }

--- a/backend/src/main/java/com/kizuna/customer/api/store/CustomerController.java
+++ b/backend/src/main/java/com/kizuna/customer/api/store/CustomerController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -49,7 +50,7 @@ public class CustomerController {
   @PreAuthorize("hasAuthority('PERM_CUSTOMER_MANAGE')")
   public ResponseEntity<CustomerResponse> create(
       @Valid @RequestBody CustomerCreateRequest request) {
-    return ResponseEntity.ok(customerService.create(request));
+    return ResponseEntity.status(HttpStatus.CREATED).body(customerService.create(request));
   }
 
   @PutMapping("/{id}")
@@ -63,6 +64,6 @@ public class CustomerController {
   @PreAuthorize("hasAuthority('PERM_CUSTOMER_MANAGE')")
   public ResponseEntity<Void> delete(@PathVariable String id) {
     customerService.delete(id);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 }

--- a/backend/src/main/java/com/kizuna/customer/api/store/CustomerMemberLinkController.java
+++ b/backend/src/main/java/com/kizuna/customer/api/store/CustomerMemberLinkController.java
@@ -40,7 +40,7 @@ public class CustomerMemberLinkController {
   @PreAuthorize("hasAuthority('PERM_CUSTOMER_MANAGE')")
   public ResponseEntity<Void> unlink(@PathVariable String customerId, Principal principal) {
     customerMemberLinkService.unlink(customerId, principal.getName());
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 
   /** 現に有効な紐づけ。紐づいていない顧客では 404 で返る。 */

--- a/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
+++ b/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
@@ -39,6 +39,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -159,7 +160,7 @@ public class OrderController {
   @PreAuthorize("hasAuthority('PERM_ORDER_MANAGE')")
   public ResponseEntity<OrderResponse> create(
       @Valid @RequestBody OrderCreateRequest request, Principal principal) {
-    return ResponseEntity.status(org.springframework.http.HttpStatus.CREATED)
+    return ResponseEntity.status(HttpStatus.CREATED)
         .body(orderService.create(request, principal.getName()));
   }
 

--- a/backend/src/main/java/com/kizuna/shift/api/store/ShiftController.java
+++ b/backend/src/main/java/com/kizuna/shift/api/store/ShiftController.java
@@ -56,7 +56,7 @@ public class ShiftController {
   @PreAuthorize("hasAuthority('PERM_SHIFT_MANAGE')")
   public ResponseEntity<Void> delete(@PathVariable String id) {
     shiftService.delete(id);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 
   @GetMapping("/public")

--- a/backend/src/main/java/com/kizuna/storage/api/store/FileUploadController.java
+++ b/backend/src/main/java/com/kizuna/storage/api/store/FileUploadController.java
@@ -7,6 +7,7 @@ import com.kizuna.storage.api.dto.FileUploadResponse;
 import com.kizuna.storage.application.FileStorageService;
 import com.kizuna.user.domain.PermissionCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -43,7 +44,7 @@ public class FileUploadController {
             .size(file.getSize())
             .build();
 
-    return ResponseEntity.ok(response);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/store/api/dto/PlatformStoreCreationResponse.java
+++ b/backend/src/main/java/com/kizuna/store/api/dto/PlatformStoreCreationResponse.java
@@ -1,0 +1,4 @@
+package com.kizuna.store.api.dto;
+
+/** 店舗作成の応答。呼出側が一覧を引き直さずに新しい店舗を名指しできるよう id だけを返す。 */
+public record PlatformStoreCreationResponse(Long id) {}

--- a/backend/src/main/java/com/kizuna/store/api/platform/PlatformStoreController.java
+++ b/backend/src/main/java/com/kizuna/store/api/platform/PlatformStoreController.java
@@ -1,5 +1,6 @@
 package com.kizuna.store.api.platform;
 
+import com.kizuna.store.api.dto.PlatformStoreCreationResponse;
 import com.kizuna.store.api.dto.PlatformStoreResponse;
 import com.kizuna.store.api.dto.StoreCreateDTO;
 import com.kizuna.store.api.dto.StoreStatusVO;
@@ -15,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -80,9 +82,10 @@ public class PlatformStoreController {
 
   @PostMapping
   @PreAuthorize("hasAuthority('PERM_STORE_MANAGE')")
-  public ResponseEntity<Void> create(@Valid @RequestBody StoreCreateDTO store) {
-    storeRegistryService.create(store);
-    return ResponseEntity.noContent().build();
+  public ResponseEntity<PlatformStoreCreationResponse> create(
+      @Valid @RequestBody StoreCreateDTO store) {
+    Long id = storeRegistryService.create(store);
+    return ResponseEntity.status(HttpStatus.CREATED).body(new PlatformStoreCreationResponse(id));
   }
 
   @PutMapping("/{id}")

--- a/backend/src/main/java/com/kizuna/store/application/StoreRegistryService.java
+++ b/backend/src/main/java/com/kizuna/store/application/StoreRegistryService.java
@@ -62,7 +62,7 @@ public class StoreRegistryService {
    * <p>ドメインの重複は、制約違反を捕まえるのではなく事前に照会して判定する — 一意制約はここを擦り抜けた競合を受け止める 最後の一枚（409）であり、業務上の重複判定を委ねる先ではない。
    */
   @Transactional
-  public void create(StoreCreateDTO req) {
+  public Long create(StoreCreateDTO req) {
     if (storeRepository.findByDomain(req.getDomain()).isPresent()) {
       throw new ServiceException("このドメインは既に登録されています");
     }
@@ -72,6 +72,7 @@ public class StoreRegistryService {
     t.setEmail(req.getEmail());
     Store saved = storeRepository.save(t);
     storeProfileRepository.save(StoreProfile.createDefault(saved.getId()));
+    return saved.getId();
   }
 
   // storeByDomain のキーは domain。だが注釈の式から見えるのは引数の id と戻り値（void）だけで、

--- a/backend/src/main/java/com/kizuna/user/api/platform/PlatformStaffController.java
+++ b/backend/src/main/java/com/kizuna/user/api/platform/PlatformStaffController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -48,7 +49,7 @@ public class PlatformStaffController {
   @PreAuthorize("hasAuthority('PERM_STAFF_MANAGE')")
   public ResponseEntity<PlatformStaffResponse> create(
       @Valid @RequestBody PlatformStaffCreateRequest req) {
-    return ResponseEntity.ok(platformStaffService.create(req));
+    return ResponseEntity.status(HttpStatus.CREATED).body(platformStaffService.create(req));
   }
 
   @PutMapping("/{id}")

--- a/backend/src/main/java/com/kizuna/user/api/platform/RoleController.java
+++ b/backend/src/main/java/com/kizuna/user/api/platform/RoleController.java
@@ -8,6 +8,7 @@ import com.kizuna.user.application.RoleService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -43,7 +44,7 @@ public class RoleController {
   @PostMapping
   @PreAuthorize("hasAuthority('PERM_STAFF_MANAGE')")
   public ResponseEntity<RoleResponse> create(@Valid @RequestBody RoleCreateRequest req) {
-    return ResponseEntity.ok(roleService.create(req));
+    return ResponseEntity.status(HttpStatus.CREATED).body(roleService.create(req));
   }
 
   @PutMapping("/{id}")

--- a/backend/src/test/java/com/kizuna/cast/api/store/CastControllerTest.java
+++ b/backend/src/test/java/com/kizuna/cast/api/store/CastControllerTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -30,7 +32,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-/** 呼出側の {@code ?sort=} 上書きで一意な副キー id が消えないことの単体テスト（offset ページングの安定性）。 */
+/** ハンドラ層で閉じている約束（offset ページングの全順序、削除 204）の単体テスト。 */
 @WebMvcTest(CastController.class)
 @Import({CastControllerTest.MethodSecurityConfig.class, StoreContext.class})
 class CastControllerTest {
@@ -85,5 +87,20 @@ class CastControllerTest {
         .andExpect(status().isOk());
 
     assertThat(searchCaptor.getValue()).isNull();
+  }
+
+  @Test
+  @DisplayName("DELETE /store/casts/{id} は本体無しの 204 で返ること")
+  @WithMockUser(authorities = "PERM_CAST_MANAGE")
+  void deleteRespondsWithNoContent() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+
+    mockMvc
+        .perform(
+            delete("/store/casts/cast-1")
+                .with(csrf())
+                .header("X-Role", "store")
+                .header("X-Store-ID", "1"))
+        .andExpect(status().isNoContent());
   }
 }

--- a/backend/src/test/java/com/kizuna/customer/api/store/CustomerControllerTest.java
+++ b/backend/src/test/java/com/kizuna/customer/api/store/CustomerControllerTest.java
@@ -4,9 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.kizuna.customer.api.dto.CustomerResponse;
 import com.kizuna.customer.api.dto.CustomerSummaryResponse;
 import com.kizuna.customer.application.CustomerService;
 import com.kizuna.settings.application.SystemConfigService;
@@ -24,12 +28,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-/** 呼出側の {@code ?sort=} 上書きで一意な副キー id が消えないことの単体テスト（offset ページングの安定性）。 */
+/** ハンドラ層で閉じている約束（offset ページングの全順序、生成 201 / 削除 204）の単体テスト。 */
 @WebMvcTest(CustomerController.class)
 @Import({CustomerControllerTest.MethodSecurityConfig.class, StoreContext.class})
 class CustomerControllerTest {
@@ -104,5 +109,38 @@ class CustomerControllerTest {
         .andExpect(status().isOk());
 
     assertThat(searchCaptor.getValue()).isNull();
+  }
+
+  @Test
+  @DisplayName("POST /store/customers は 201 で生成された顧客を返すこと")
+  @WithMockUser(authorities = "PERM_CUSTOMER_MANAGE")
+  void createRespondsWithCreated() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+    when(customerService.create(any())).thenReturn(CustomerResponse.builder().id("c1").build());
+
+    mockMvc
+        .perform(
+            post("/store/customers")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\": \"山田太郎\"}")
+                .header("X-Role", "store")
+                .header("X-Store-ID", "1"))
+        .andExpect(status().isCreated());
+  }
+
+  @Test
+  @DisplayName("DELETE /store/customers/{id} は本体無しの 204 で返ること")
+  @WithMockUser(authorities = "PERM_CUSTOMER_MANAGE")
+  void deleteRespondsWithNoContent() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+
+    mockMvc
+        .perform(
+            delete("/store/customers/c1")
+                .with(csrf())
+                .header("X-Role", "store")
+                .header("X-Store-ID", "1"))
+        .andExpect(status().isNoContent());
   }
 }

--- a/backend/src/test/java/com/kizuna/customer/api/store/CustomerMemberLinkControllerTest.java
+++ b/backend/src/test/java/com/kizuna/customer/api/store/CustomerMemberLinkControllerTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -115,6 +117,24 @@ class CustomerMemberLinkControllerTest {
         .andExpect(status().isOk());
 
     verify(customerMemberLinkService).history("c1", "abc", 5);
+  }
+
+  @Test
+  @DisplayName("解除は本体無しの 204 で返ること")
+  @WithMockUser(authorities = "PERM_CUSTOMER_MANAGE")
+  void unlinkRespondsWithNoContent() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+
+    mockMvc
+        .perform(
+            delete("/store/customers/c1/member-link")
+                .with(csrf())
+                .header("X-Role", "store")
+                .header("X-Store-ID", "1")
+                .principal(() -> "tanaka.hanako@kizuna.test"))
+        .andExpect(status().isNoContent());
+
+    verify(customerMemberLinkService).unlink("c1", "tanaka.hanako@kizuna.test");
   }
 
   private MockHttpServletRequestBuilder storeGet(String path) {

--- a/backend/src/test/java/com/kizuna/storage/api/store/FileUploadControllerTest.java
+++ b/backend/src/test/java/com/kizuna/storage/api/store/FileUploadControllerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -70,7 +71,7 @@ class FileUploadControllerTest {
 
     ResponseEntity<FileUploadResponse> res = controller.upload(file, "public");
 
-    assertThat(res.getStatusCode().is2xxSuccessful()).isTrue();
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     verify(fileStorageService).store("platform", "public", file);
     assertThat(res.getBody().getUrl()).isEqualTo("/static/uploads/public/platform/x.jpg");
   }
@@ -97,7 +98,7 @@ class FileUploadControllerTest {
 
     ResponseEntity<FileUploadResponse> res = controller.upload(file, "public");
 
-    assertThat(res.getStatusCode().is2xxSuccessful()).isTrue();
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     verify(fileStorageService).store("5", "public", file);
   }
 }

--- a/backend/src/test/java/com/kizuna/store/api/platform/PlatformStoreControllerTest.java
+++ b/backend/src/test/java/com/kizuna/store/api/platform/PlatformStoreControllerTest.java
@@ -8,7 +8,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.kizuna.settings.application.SystemConfigService;
@@ -84,5 +86,24 @@ class PlatformStoreControllerTest {
         .andExpect(status().isBadRequest());
 
     verify(storeRegistryService, never()).update(anyString(), any());
+  }
+
+  // 作成応答が id を載せるのは、呼出側が一覧を引き直さずに新しい店舗を名指しできるようにするため。
+  @Test
+  @DisplayName("POST /platform/stores は 201 で新規 id を返すこと")
+  @WithMockUser(authorities = "PERM_STORE_MANAGE")
+  void createRespondsWithCreatedAndTheNewId() throws Exception {
+    when(storeRegistryService.create(any())).thenReturn(42L);
+
+    mockMvc
+        .perform(
+            post("/platform/stores")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"name\": \"新店舗\", \"domain\": \"new-store.kizuna.test\","
+                        + " \"email\": \"new-store@kizuna.test\"}"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(42));
   }
 }

--- a/backend/src/test/java/com/kizuna/store/application/StoreRegistryServiceTest.java
+++ b/backend/src/test/java/com/kizuna/store/application/StoreRegistryServiceTest.java
@@ -50,7 +50,7 @@ class StoreRegistryServiceTest {
   }
 
   @Test
-  void create_savesStoreAndDefaultStoreProfile() {
+  void create_savesStoreAndDefaultStoreProfileAndReturnsTheNewId() {
     StoreCreateDTO req = new StoreCreateDTO();
     req.setName("T1");
     req.setDomain("d1.com");
@@ -59,7 +59,7 @@ class StoreRegistryServiceTest {
     t.setId(1L);
     when(storeRepository.save(any())).thenReturn(t);
 
-    storeRegistryService.create(req);
+    assertThat(storeRegistryService.create(req)).isEqualTo(1L);
 
     verify(storeRepository).save(any());
     verify(storeProfileRepository).save(any());

--- a/frontend/src/__tests__/platform-store-api.test.ts
+++ b/frontend/src/__tests__/platform-store-api.test.ts
@@ -33,12 +33,13 @@ describe('platform store api wrappers', () => {
     expect(byId).toEqual({ id: '2' });
     expect(mockGet).toHaveBeenCalledWith('/platform/stores/2');
 
-    // 作成・更新の端点は 204 No Content。body は返らない。
-    mockPost.mockResolvedValueOnce({});
+    // 作成の端点は 201 Created。body には作成された店舗の id だけが載る。
+    mockPost.mockResolvedValueOnce({ data: { id: 1 } });
     const created = await platformStoreApi.create({ name: 't' } as any);
-    expect(created).toBeUndefined();
+    expect(created).toEqual({ id: 1 });
     expect(mockPost).toHaveBeenCalledWith('/platform/stores', { name: 't' });
 
+    // 更新の端点は 204 No Content。body は返らない。
     mockPut.mockResolvedValueOnce({});
     const updated = await platformStoreApi.update('3', { name: 'u' } as any);
     expect(updated).toBeUndefined();

--- a/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
+++ b/frontend/src/_pages/platform-stores/__tests__/pages.test.tsx
@@ -240,7 +240,7 @@ describe('店舗管理 3 画面の挙動', () => {
   });
 
   it('新規作成は name/domain/email を送信し一覧へ遷移すること', async () => {
-    mockedApi.create.mockResolvedValue(undefined);
+    mockedApi.create.mockResolvedValue({ id: 1 });
 
     render(<StoreCreatePage />);
     fireEvent.change(screen.getByLabelText(/店舗名/), { target: { value: 'ガンマ店' } });

--- a/frontend/src/entities/store/api/platform.ts
+++ b/frontend/src/entities/store/api/platform.ts
@@ -1,5 +1,11 @@
 import { apiClient, PageResult, fromSpringPage, toSpringPageParams } from '@/shared/api';
-import { CreateStoreRequest, Store, StoreStats, UpdateStoreRequest } from '../model/types';
+import {
+  CreateStoreRequest,
+  CreateStoreResponse,
+  Store,
+  StoreStats,
+  UpdateStoreRequest,
+} from '../model/types';
 
 export const platformStoreApi = {
   /** 店舗一覧を取得する。page は他一覧と同じ 0 起点（Spring Page 形） */
@@ -22,9 +28,10 @@ export const platformStoreApi = {
     const response = await apiClient.get(`/platform/stores/${id}`);
     return response.data;
   },
-  /** 端点は 204 No Content。body は返らない。 */
-  create: async (data: CreateStoreRequest): Promise<void> => {
-    await apiClient.post('/platform/stores', data);
+  /** 端点は 201 Created。body には作成された店舗の id だけが載る。 */
+  create: async (data: CreateStoreRequest): Promise<CreateStoreResponse> => {
+    const response = await apiClient.post('/platform/stores', data);
+    return response.data;
   },
   /** 端点は 204 No Content。body は返らない。 */
   update: async (id: string, data: UpdateStoreRequest): Promise<void> => {

--- a/frontend/src/entities/store/model/types.ts
+++ b/frontend/src/entities/store/model/types.ts
@@ -16,6 +16,11 @@ export interface CreateStoreRequest {
   email: string;
 }
 
+// 店舗作成レスポンス（作成された店舗の id だけを返す）
+export interface CreateStoreResponse {
+  id: number;
+}
+
 // 店舗更新リクエスト
 export interface UpdateStoreRequest {
   name: string;


### PR DESCRIPTION
## 概要

docs/api-guidelines.md §4 の是正バッチ。生成系 5 端点を 201 に、削除系 5 端点を 204 に揃え、`POST /platform/stores` が新規店舗の id を返すようにする。あわせて logout の戻り型定型化・`/me` の到達不能な手書き 401 分岐の除去・インライン FQCN の import 化を行う。

Closes #692

## 変更内容

- 生成 → 201（ボディは従来のまま）: `POST /store/customers` / `POST /platform/roles` / `POST /platform/staff` / `POST /files/upload`
- 削除 → 204: `DELETE /store/customers/{id}` / `DELETE /store/casts/{id}` / `DELETE /store/casts/fields/{id}` / `DELETE /store/shifts/{id}` / `DELETE /store/customers/{customerId}/member-link`
- `POST /platform/stores`: 204 → 201 + `PlatformStoreCreationResponse(id)`（`StoreRegistryService.create` が id を返すよう変更）。フロントの `platformStoreApi.create` の戻り型と過期注釈を追随
- `PlatformAuthController#logout`: `ResponseEntity<?>` → `ResponseEntity<Void>`
- `GET /platform/me`: `@PreAuthorize("isAuthenticated()")` 済みで到達不能な手書き 401 分岐を除去
- `OrderController`: インライン FQCN（`org.springframework.http.HttpStatus`）を import に是正
- テスト: 既存コントローラテスト 5 クラスに `isCreated()` / `isNoContent()` 断言を追加（全断言、旧実装に対する赤を確認済み）。IT 6 ファイルの精確状態断言を追随。`PlatformStoreApiIT.createStore` は 201 ボディの id を直読し、name 検索での引き直しを撤去

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（unit + integration）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全シナリオ）
- [x] ローカルで code-review 実施済み（実装=Opus / QA=Sonnet の二層。QA 指摘 2 件を反映済み）

### 視覚確認（UI 変更時）

UI 変更なし（フロントは型と mock の追随のみ。axios は 2xx を一律成功扱いで、削除系の呼出側はボディを読まないことを全数確認済み）。

## 決定ログ

- `POST /store/customers/{customerId}/point-adjustments` は issue 記載の「生成 → 201」から除外し 200 のまま維持（承認済み）。名詞化した動作サブリソースで、応答は新規資源の id ではなく調整後残高 — §4「ドメイン動作 = 200 + 動作結果の表現」に現状で合致する。
- 店舗作成の応答は id のみの新設 record とした（承認済み）。既存 `PlatformStoreResponse(id, name)` の流用は、呼出側が消費しない name を運ぶため見送り。
- 削除系は issue 記載の 4 件に加え、同族走査で見つかった `DELETE /store/casts/fields/{id}` も是正（QA 指摘）。
- テストクラスが存在しない端点（roles 作成・shifts 削除・logout・me）には新設クラスを起こしていない。IT・e2e が実挙動を押さえている。

## 備考 / レビュー観点

- `PlatformStoreApiIT.createStore` の name 検索引き直し撤去は補助メソッドの前提断言の削減にあたるが、検索経路は同ファイルの LIKE エスケープテストが `total_elements == 1` まで固定しており、カバレッジは承継済み。
- `POST /store/orders/{id}/receipt-token`（再発行）は §4 の「トークン発行等は 201」に照らすと 200 のままの既存乖離。本 PR のスコープ外につき手を付けず、#693 側で扱う。
- `_pages/platform-stores/__tests__/pages.test.tsx` の `create` mock 型追随は、Next の runTypeCheck がテスト診断を濾すため既存 3 門番では検出されない類（#699 の提案対象）。QA で捕捉し修正済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
