### PR TITLE
fix: 裸動詞の端点を名詞化し PUT の宛先を単一リソースに揃える

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/member/MemberFacingLedgerLeakIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/member/MemberFacingLedgerLeakIT.java
@@ -171,7 +171,7 @@ class MemberFacingLedgerLeakIT extends CrossStoreTestSupport {
   /**
    * 掃き出す会員側の GET 端点。残高系の項目を許すかは端点ごとに決める。
    *
-   * <p>申領（{@code POST /platform/me/receipts/claim}）はこの表に入らない — 一覧の掃き出しは同じ要求を何度でも
+   * <p>申領（{@code POST /platform/me/receipts}）はこの表に入らない — 一覧の掃き出しは同じ要求を何度でも
    * 撃てることが前提で、トークンの状態を進める操作は載せられない。代わりに専用の 1 件（{@link
    * #memberReceiptClaimReturnsOnlyWhitelistedFields}）で同じ掃き出しを当てる。
    *
@@ -522,12 +522,12 @@ class MemberFacingLedgerLeakIT extends CrossStoreTestSupport {
     // トークンは 1 度しか使えないため、生ボディの掃き出しと項目名の白名単を同じ 1 応答から見る
     ResponseEntity<JsonNode> claimed =
         rest.postForEntity(
-            "/platform/me/receipts/claim",
+            "/platform/me/receipts",
             new HttpEntity<>("{\"token\": \"" + rawToken + "\"}", bearer(memberToken)),
             JsonNode.class);
 
-    assertThat(claimed.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertNoLedgerLeak("POST /platform/me/receipts/claim", claimed.getBody().toString(), false);
+    assertThat(claimed.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertNoLedgerLeak("POST /platform/me/receipts", claimed.getBody().toString(), false);
     List<String> fields = new ArrayList<>();
     claimed.getBody().propertyNames().forEach(fields::add);
     assertThat(fields)

--- a/backend/src/integrationTest/java/com/kizuna/order/MemberOrderIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/MemberOrderIT.java
@@ -511,7 +511,7 @@ class MemberOrderIT extends CrossStoreTestSupport {
 
   private ResponseEntity<JsonNode> updateReservationRequest(long storeId, String id, String body) {
     return rest.exchange(
-        "/store/orders/reservation-requests/" + id,
+        "/store/orders/" + id + "/reservation-request",
         HttpMethod.PUT,
         new HttpEntity<>(body, storeHeaders(storeId)),
         JsonNode.class);
@@ -736,7 +736,7 @@ class MemberOrderIT extends CrossStoreTestSupport {
 
     ResponseEntity<JsonNode> foreignDecline =
         rest.exchange(
-            "/store/orders/" + orderId + "/decline",
+            "/store/orders/" + orderId + "/refusal",
             HttpMethod.POST,
             new HttpEntity<>(storeHeaders(STORE_B)),
             JsonNode.class);
@@ -760,7 +760,7 @@ class MemberOrderIT extends CrossStoreTestSupport {
 
     ResponseEntity<JsonNode> declined =
         rest.exchange(
-            "/store/orders/" + orderId + "/decline",
+            "/store/orders/" + orderId + "/refusal",
             HttpMethod.POST,
             new HttpEntity<>(storeHeaders(STORE_A)),
             JsonNode.class);

--- a/backend/src/integrationTest/java/com/kizuna/order/MemberReceiptClaimIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/MemberReceiptClaimIT.java
@@ -73,7 +73,7 @@ class MemberReceiptClaimIT extends CrossStoreTestSupport {
 
     ResponseEntity<JsonNode> claimed = claim(member, issued.token());
 
-    assertThat(claimed.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(claimed.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     assertThat(claimed.getBody().path("granted_points").asInt()).isEqualTo(EXPECTED_PLANNED_POINTS);
 
     OrderAttribution attribution = attributionOf(issued.orderId());
@@ -104,7 +104,7 @@ class MemberReceiptClaimIT extends CrossStoreTestSupport {
 
     ResponseEntity<JsonNode> claimed = claim(member, issued.token());
 
-    assertThat(claimed.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(claimed.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     assertThat(claimed.getBody().path("granted_points").asInt()).isEqualTo(fixedPoints);
     assertThat(balance()).as("台帳へ入るのも発行時の固定額であること").isEqualTo(fixedPoints);
   }
@@ -117,7 +117,7 @@ class MemberReceiptClaimIT extends CrossStoreTestSupport {
 
     ResponseEntity<JsonNode> claimed = claim(member, issued.token());
 
-    assertThat(claimed.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(claimed.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     assertThat(claimed.getBody().path("granted_points").asInt()).isZero();
     assertThat(ledgerRowsFor(issued.orderId())).as("台帳に仕訳を書かないこと").isZero();
     // 帰属は付与の有無と独立している。来店としては見えなければならない
@@ -133,7 +133,7 @@ class MemberReceiptClaimIT extends CrossStoreTestSupport {
     Issued issued = completedOrderWithToken(customerId, "無波及担当-" + nonce, TOTAL_FEE);
     int customersBefore = customerCountAtStoreA();
 
-    assertThat(claim(member, issued.token()).getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(claim(member, issued.token()).getStatusCode()).isEqualTo(HttpStatus.CREATED);
 
     // 正向対照: 申領そのものは確かに成立している（下の不在の断言が空振りでないことの証明）
     assertThat(attributionOf(issued.orderId()).getSource())
@@ -160,7 +160,7 @@ class MemberReceiptClaimIT extends CrossStoreTestSupport {
     Issued used = completedOrderWithToken(null, "使用済み担当-" + nonce, TOTAL_FEE);
     assertThat(claim(member, used.token()).getStatusCode())
         .as("前提: 1 度目は申領できること")
-        .isEqualTo(HttpStatus.OK);
+        .isEqualTo(HttpStatus.CREATED);
 
     ResponseEntity<String> unknown = claimRaw(member, "存在しない伝票-" + nonce);
     ResponseEntity<String> malformed = claimRaw(member, "%%壊れた値%%");
@@ -185,7 +185,7 @@ class MemberReceiptClaimIT extends CrossStoreTestSupport {
   void claimingTwiceBooksOnlyOnce() {
     // 再送の遮断は冪等キーではなく前提状態（未申領）の消滅が担う（ADR 0007 の判定基準）
     Issued issued = completedOrderWithToken(null, "二重申領担当-" + nonce, TOTAL_FEE);
-    assertThat(claim(member, issued.token()).getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(claim(member, issued.token()).getStatusCode()).isEqualTo(HttpStatus.CREATED);
 
     assertThat(claimRaw(member, issued.token()).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
 
@@ -224,11 +224,11 @@ class MemberReceiptClaimIT extends CrossStoreTestSupport {
         responses.add(race.get(30, TimeUnit.SECONDS));
       }
       assertThat(responses)
-          .filteredOn(response -> response.getStatusCode() == HttpStatus.OK)
+          .filteredOn(response -> response.getStatusCode() == HttpStatus.CREATED)
           .as("成立するのは一方だけ")
           .hasSize(1);
       assertThat(responses)
-          .filteredOn(response -> response.getStatusCode() != HttpStatus.OK)
+          .filteredOn(response -> response.getStatusCode() != HttpStatus.CREATED)
           .as("敗者は不在のトークンと同形で返ること")
           .singleElement()
           .satisfies(
@@ -253,7 +253,7 @@ class MemberReceiptClaimIT extends CrossStoreTestSupport {
     HttpHeaders headers = bearer(token);
     ResponseEntity<String> forbidden =
         rest.postForEntity(
-            "/platform/me/receipts/claim",
+            "/platform/me/receipts",
             new HttpEntity<>(claimBody(issued.token()), headers),
             String.class);
 
@@ -265,7 +265,7 @@ class MemberReceiptClaimIT extends CrossStoreTestSupport {
 
   private ResponseEntity<JsonNode> claim(RegisteredMember as, String rawToken) {
     return rest.postForEntity(
-        "/platform/me/receipts/claim",
+        "/platform/me/receipts",
         new HttpEntity<>(claimBody(rawToken), bearer(as.token())),
         JsonNode.class);
   }
@@ -273,7 +273,7 @@ class MemberReceiptClaimIT extends CrossStoreTestSupport {
   /** 応答の形そのものを比べるため、本文を解釈せず生文字列で受ける。 */
   private ResponseEntity<String> claimRaw(RegisteredMember as, String rawToken) {
     return rest.postForEntity(
-        "/platform/me/receipts/claim",
+        "/platform/me/receipts",
         new HttpEntity<>(claimBody(rawToken), bearer(as.token())),
         String.class);
   }

--- a/backend/src/integrationTest/java/com/kizuna/order/MemberRequestProvisioningIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/MemberRequestProvisioningIT.java
@@ -113,7 +113,7 @@ class MemberRequestProvisioningIT extends CrossStoreTestSupport {
     String declined = request(applicant, STORE_A, declinedName);
     assertThat(
             rest.exchange(
-                    "/store/orders/" + declined + "/decline",
+                    "/store/orders/" + declined + "/refusal",
                     HttpMethod.POST,
                     new HttpEntity<>(storeHeaders(STORE_A)),
                     JsonNode.class)

--- a/backend/src/integrationTest/java/com/kizuna/order/OrderAttributionInvalidationIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/OrderAttributionInvalidationIT.java
@@ -144,7 +144,7 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
     Issued original = completedOrderWithToken(castName);
     assertThat(claim(wrongMember, original.token()).getStatusCode())
         .as("前提: 誤った本人が申領できること")
-        .isEqualTo(HttpStatus.OK);
+        .isEqualTo(HttpStatus.CREATED);
     Long staleTarget = activeAttributionIdOf(original.orderId());
 
     // 別の操作者が一巡させる
@@ -154,7 +154,7 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
     String raw = reissue(original.orderId()).getBody().path("receipt_token").asString();
     assertThat(claim(rightMember, raw).getStatusCode())
         .as("前提: 正しい本人が取り戻せること")
-        .isEqualTo(HttpStatus.OK);
+        .isEqualTo(HttpStatus.CREATED);
 
     // 開いたままだった画面が、古い記録を指したまま送信する
     ResponseEntity<JsonNode> stale = invalidate(original.orderId(), staleTarget, "古い理由");
@@ -180,7 +180,7 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
     Issued original = completedOrderWithToken("期限再計算担当-" + nonce);
     assertThat(claim(wrongMember, original.token()).getStatusCode())
         .as("前提: 誤った本人が申領できること")
-        .isEqualTo(HttpStatus.OK);
+        .isEqualTo(HttpStatus.CREATED);
     assertThat(invalidate(original.orderId(), REASON).getStatusCode())
         .as("前提: 無効化できること")
         .isEqualTo(HttpStatus.OK);
@@ -194,7 +194,7 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
 
     ResponseEntity<JsonNode> reissued = reissue(original.orderId());
 
-    assertThat(reissued.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(reissued.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     assertThat(reissued.getBody().path("receipt_token").asString()).isNotBlank();
     OrderReceiptToken token =
         orderReceiptTokenRepository.findById(issuedTokenIdOf(original.orderId())).orElseThrow();
@@ -218,7 +218,7 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
         original.orderId());
     assertThat(claim(wrongMember, original.token()).getStatusCode())
         .as("前提: 誤った本人が申領できること")
-        .isEqualTo(HttpStatus.OK);
+        .isEqualTo(HttpStatus.CREATED);
     assertThat(invalidate(original.orderId(), REASON).getStatusCode())
         .as("前提: 無効化できること")
         .isEqualTo(HttpStatus.OK);
@@ -244,7 +244,7 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
     String raw = reissue(orderId).getBody().path("receipt_token").asString();
     ResponseEntity<JsonNode> claimed = claim(rightMember, raw);
 
-    assertThat(claimed.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(claimed.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     // 付与予定額は完了時点で確定した額を引き継ぐ（訂正の早い遅いで同じ会計が別のポイントにならない）
     assertThat(claimed.getBody().path("granted_points").asInt()).isEqualTo(EXPECTED_POINTS);
 
@@ -296,7 +296,7 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
 
     ResponseEntity<JsonNode> second = reissue(orderId);
 
-    assertThat(second.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(second.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     assertThat(tokenCountFor(orderId)).as("行は削除しないこと").isEqualTo(2);
     assertThat(issuedTokenCountFor(orderId)).as("申領できる伝票は 1 本だけであること").isEqualTo(1);
     // 生値まで確かめる。状態だけを見るテストは、失効した QR が実際には申領できてしまう実装でも緑になる
@@ -306,7 +306,7 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
     assertThat(
             claim(rightMember, second.getBody().path("receipt_token").asString()).getStatusCode())
         .as("最後に発行した QR で取り戻せること")
-        .isEqualTo(HttpStatus.OK);
+        .isEqualTo(HttpStatus.CREATED);
   }
 
   @Test
@@ -349,7 +349,7 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
 
     assertThat(responses)
         .as("前提: 並行する再発行がどちらも 500 を出さないこと")
-        .allMatch(response -> response.getStatusCode() == HttpStatus.OK);
+        .allMatch(response -> response.getStatusCode() == HttpStatus.CREATED);
     assertThat(issuedTokenCountFor(orderId)).as("申領できる伝票は 1 本だけであること").isEqualTo(1);
     // 生値で確かめる。生きているのは 1 本だけなので、申領が成立するのも 1 本だけになる
     assertThat(responses)
@@ -357,7 +357,7 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
             response ->
                 claim(rightMember, response.getBody().path("receipt_token").asString())
                         .getStatusCode()
-                    == HttpStatus.OK)
+                    == HttpStatus.CREATED)
         .as("申領が成立するのは 1 本だけ")
         .hasSize(1);
   }
@@ -371,7 +371,9 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
     assertThat(invalidate(orderId, REASON).getStatusCode())
         .as("前提: 無効化できること")
         .isEqualTo(HttpStatus.OK);
-    assertThat(reissue(orderId).getStatusCode()).as("前提: 1 本目を発行できること").isEqualTo(HttpStatus.OK);
+    assertThat(reissue(orderId).getStatusCode())
+        .as("前提: 1 本目を発行できること")
+        .isEqualTo(HttpStatus.CREATED);
 
     assertThatThrownBy(
             () ->
@@ -400,7 +402,9 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
     assertThat(invalidate(orderId, REASON).getStatusCode())
         .as("前提: 無効化できること")
         .isEqualTo(HttpStatus.OK);
-    assertThat(reissue(orderId).getStatusCode()).as("前提: 訂正用の伝票を発行できること").isEqualTo(HttpStatus.OK);
+    assertThat(reissue(orderId).getStatusCode())
+        .as("前提: 訂正用の伝票を発行できること")
+        .isEqualTo(HttpStatus.CREATED);
     long tokenId = issuedTokenIdOf(orderId);
 
     CountDownLatch claimHeld = new CountDownLatch(1);
@@ -543,7 +547,7 @@ class OrderAttributionInvalidationIT extends CrossStoreTestSupport {
 
   private ResponseEntity<JsonNode> claim(RegisteredMember member, String rawToken) {
     return rest.exchange(
-        "/platform/me/receipts/claim",
+        "/platform/me/receipts",
         HttpMethod.POST,
         new HttpEntity<>("{\"token\": \"" + rawToken + "\"}", bearer(member.token())),
         JsonNode.class);

--- a/backend/src/integrationTest/java/com/kizuna/order/OrderCrossStoreIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/order/OrderCrossStoreIT.java
@@ -245,7 +245,7 @@ class OrderCrossStoreIT extends CrossStoreTestSupport {
     String declineControlId = createOrderAs(STORE_A, castId);
     ResponseEntity<JsonNode> ownDecline =
         rest.exchange(
-            "/store/orders/" + declineControlId + "/decline",
+            "/store/orders/" + declineControlId + "/refusal",
             HttpMethod.POST,
             new HttpEntity<>(storeHeaders(STORE_A)),
             JsonNode.class);
@@ -272,7 +272,7 @@ class OrderCrossStoreIT extends CrossStoreTestSupport {
 
     ResponseEntity<JsonNode> foreignDecline =
         rest.exchange(
-            "/store/orders/" + orderId + "/decline",
+            "/store/orders/" + orderId + "/refusal",
             HttpMethod.POST,
             new HttpEntity<>(storeHeaders(STORE_B)),
             JsonNode.class);

--- a/backend/src/integrationTest/java/com/kizuna/shift/ShiftRequestScopeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/shift/ShiftRequestScopeIT.java
@@ -248,7 +248,7 @@ class ShiftRequestScopeIT extends CrossStoreTestSupport {
 
   private ResponseEntity<JsonNode> decline(long storeId, String id) {
     return rest.exchange(
-        "/store/shift-requests/" + id + "/decline",
+        "/store/shift-requests/" + id + "/rejection",
         HttpMethod.POST,
         new HttpEntity<>(storeHeaders(storeId)),
         JsonNode.class);
@@ -514,7 +514,7 @@ class ShiftRequestScopeIT extends CrossStoreTestSupport {
             JsonNode.class);
     ResponseEntity<JsonNode> crossDecline =
         rest.exchange(
-            "/store/shift-requests/" + id + "/decline",
+            "/store/shift-requests/" + id + "/rejection",
             HttpMethod.POST,
             new HttpEntity<>(managerHeaders(managerToken, STORE_B)),
             JsonNode.class);
@@ -647,7 +647,7 @@ class ShiftRequestScopeIT extends CrossStoreTestSupport {
   }
 
   @Test
-  @DisplayName("変更申請の謝絶で対象シフトが元のまま維持されること")
+  @DisplayName("変更申請の却下で対象シフトが元のまま維持されること")
   void declineChange_keepsTargetShiftUntouched() {
     Shift shift = saveShift(myCastId, STORE_A, "CONFIRMED");
     ResponseEntity<JsonNode> created =
@@ -660,7 +660,7 @@ class ShiftRequestScopeIT extends CrossStoreTestSupport {
     assertThat(declined.getBody().path("status").asString()).isEqualTo("DECLINED");
 
     Shift reloaded = shiftRepository.findById(shift.getId()).orElseThrow();
-    assertThat(reloaded.getWorkDate()).as("謝絶では元の確定シフトが維持されること").isEqualTo(shift.getWorkDate());
+    assertThat(reloaded.getWorkDate()).as("却下では元の確定シフトが維持されること").isEqualTo(shift.getWorkDate());
     assertThat(reloaded.getStartTime()).isEqualTo(shift.getStartTime());
     assertThat(reloaded.getEndTime()).isEqualTo(shift.getEndTime());
     assertThat(reloaded.getStatus()).isEqualTo("CONFIRMED");
@@ -704,7 +704,7 @@ class ShiftRequestScopeIT extends CrossStoreTestSupport {
   }
 
   @Test
-  @DisplayName("対象シフトが削除されても変更申請は履歴に残り(SET NULL)、承認は 400・謝絶は可能なこと")
+  @DisplayName("対象シフトが削除されても変更申請は履歴に残り(SET NULL)、承認は 400・却下は可能なこと")
   void deletedTargetShift_keepsChangeRequestHistoryAndBlocksApproval() {
     Shift shift = saveShift(myCastId, STORE_A, "CONFIRMED");
     ResponseEntity<JsonNode> created =
@@ -721,7 +721,7 @@ class ShiftRequestScopeIT extends CrossStoreTestSupport {
     assertThat(approved.getStatusCode()).as("適用先が無い承認は拒否されること").isEqualTo(HttpStatus.BAD_REQUEST);
 
     ResponseEntity<JsonNode> declined = decline(STORE_A, id);
-    assertThat(declined.getStatusCode()).as("謝絶は可能なこと").isEqualTo(HttpStatus.OK);
+    assertThat(declined.getStatusCode()).as("却下は可能なこと").isEqualTo(HttpStatus.OK);
     assertThat(declined.getBody().path("status").asString()).isEqualTo("DECLINED");
   }
 

--- a/backend/src/integrationTest/java/com/kizuna/storage/FileUploadCrossStoreIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/storage/FileUploadCrossStoreIT.java
@@ -20,7 +20,7 @@ import org.springframework.util.MultiValueMap;
 import tools.jackson.databind.JsonNode;
 
 /**
- * 平台トークンによる {@code /files/upload} のプラットフォーム保存判定を本物の PostgreSQL/Redis/MinIO で固定する統合テスト。
+ * 平台トークンによる {@code POST /files} のプラットフォーム保存判定を本物の PostgreSQL/Redis/MinIO で固定する統合テスト。
  *
  * <p>{@code /files/**} も含め全リクエストが単一 issuer（PlatformAuth）の decoder 検証を通るため、平台トークンで
  * 認証が通る。プラットフォーム領域（platform prefix）への保存は HQ 管理者（role claim = HQ_ADMIN）のみに限定し、それ以外のロール・ 店舗詐称ヘッダは
@@ -77,7 +77,7 @@ class FileUploadCrossStoreIT {
   }
 
   @Test
-  @DisplayName("HQ トークン + X-Role:store + X-Store-ID の /files/upload は 403 で拒否されること（過橋の店舗ロール制限）")
+  @DisplayName("HQ トークン + X-Role:store + X-Store-ID の POST /files は 403 で拒否されること（過橋の店舗ロール制限）")
   void hqTokenWithSpoofedStoreHeaderIsForbidden() {
     HttpHeaders headers = new HttpHeaders();
     headers.setBearerAuth(platformLogin(HQ_EMAIL));
@@ -85,31 +85,31 @@ class FileUploadCrossStoreIT {
     headers.set("X-Store-ID", "1");
 
     ResponseEntity<String> res =
-        rest.exchange("/files/upload", HttpMethod.POST, uploadRequest(headers), String.class);
+        rest.exchange("/files", HttpMethod.POST, uploadRequest(headers), String.class);
 
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
   }
 
   @Test
-  @DisplayName("HQ 以外の平台トークン（店舗スタッフ）の /files/upload は 403 で拒否されプラットフォーム領域に保存されないこと")
+  @DisplayName("HQ 以外の平台トークン（店舗スタッフ）の POST /files は 403 で拒否されプラットフォーム領域に保存されないこと")
   void nonHqPlatformTokenUploadIsForbidden() {
     HttpHeaders headers = new HttpHeaders();
     headers.setBearerAuth(platformLogin(STAFF_EMAIL));
 
     ResponseEntity<String> res =
-        rest.exchange("/files/upload", HttpMethod.POST, uploadRequest(headers), String.class);
+        rest.exchange("/files", HttpMethod.POST, uploadRequest(headers), String.class);
 
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
   }
 
   @Test
-  @DisplayName("HQ トークン（詐称ヘッダ無し）の /files/upload は platform 領域へ 201 で保存されること")
+  @DisplayName("HQ トークン（詐称ヘッダ無し）の POST /files は platform 領域へ 201 で保存されること")
   void hqTokenWithoutSpoofUploadsToPlatform() {
     HttpHeaders headers = new HttpHeaders();
     headers.setBearerAuth(platformLogin(HQ_EMAIL));
 
     ResponseEntity<JsonNode> res =
-        rest.exchange("/files/upload", HttpMethod.POST, uploadRequest(headers), JsonNode.class);
+        rest.exchange("/files", HttpMethod.POST, uploadRequest(headers), JsonNode.class);
 
     assertThat(res.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     assertThat(res.getBody().path("url").asString()).contains("/platform/");

--- a/backend/src/main/java/com/kizuna/auth/api/platform/PlatformAuthController.java
+++ b/backend/src/main/java/com/kizuna/auth/api/platform/PlatformAuthController.java
@@ -64,7 +64,7 @@ public class PlatformAuthController {
   }
 
   /** パスワード変更。成功時は現在のトークンを失効させるため、クライアントは再ログインが必要。 */
-  @PutMapping("/password")
+  @PutMapping("/me/password")
   @PreAuthorize("isAuthenticated()")
   public ResponseEntity<Void> changePassword(
       Principal principal,

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/SecurityConfig.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -33,7 +34,7 @@ public class SecurityConfig {
 
   private static final RequestMatcher[] CSRF_IGNORED_MATCHERS = {
     PathPatternRequestMatcher.withDefaults().matcher("/platform/login"),
-    PathPatternRequestMatcher.withDefaults().matcher("/files/upload"),
+    PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/files"),
     // 匿名 POST の招待照会と新規登録受諾（Bearer なしのため Bearer 免除に該当しない）。既存受諾(/existing)は Bearer 付きで既存免除に該当する。
     // 照会はトークンをパスに載せないため POST であり、読み取りでも CSRF 免除が要る。
     PathPatternRequestMatcher.withDefaults().matcher("/platform/cast-invitations/view"),

--- a/backend/src/main/java/com/kizuna/order/api/platform/PlatformMemberReceiptController.java
+++ b/backend/src/main/java/com/kizuna/order/api/platform/PlatformMemberReceiptController.java
@@ -6,6 +6,7 @@ import com.kizuna.order.application.MemberReceiptClaimService;
 import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,11 +27,12 @@ public class PlatformMemberReceiptController {
 
   private final MemberReceiptClaimService memberReceiptClaimService;
 
-  @PostMapping("/claim")
+  /** 申領は本人の帰属記録を起こす生成なので 201。トークンは本体で受ける（パスに載せるとアクセスログへ残る）。 */
+  @PostMapping
   @PreAuthorize("hasRole('MEMBER')")
   public ResponseEntity<MemberReceiptClaimResponse> claim(
       Principal principal, @Valid @RequestBody MemberReceiptClaimRequest request) {
-    return ResponseEntity.ok(
-        memberReceiptClaimService.claim(principal.getName(), request.getToken()));
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(memberReceiptClaimService.claim(principal.getName(), request.getToken()));
   }
 }

--- a/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
+++ b/backend/src/main/java/com/kizuna/order/api/store/OrderController.java
@@ -168,7 +168,7 @@ public class OrderController {
    * 未確定の予約申請を編集する。指名・受付担当を可空で扱う専用の契約で、汎用更新（{@link #update}）の必須項目に縛られずに
    * 人数・備考を直したり指名を外したりできる。受け取った内容がそのまま新しい申請内容になる。
    */
-  @PutMapping("/reservation-requests/{id}")
+  @PutMapping("/{id}/reservation-request")
   @PreAuthorize("hasAuthority('PERM_ORDER_MANAGE')")
   public ResponseEntity<OrderWorkQueueResponse> updateReservationRequest(
       @PathVariable String id, @Valid @RequestBody ReservationRequestUpdateRequest request) {
@@ -262,7 +262,8 @@ public class OrderController {
   @PostMapping("/{id}/receipt-token")
   @PreAuthorize("hasAuthority('PERM_ORDER_MANAGE')")
   public ResponseEntity<OrderReceiptTokenResponse> reissueReceiptToken(@PathVariable String id) {
-    return ResponseEntity.ok(orderAttributionService.reissueReceiptToken(id));
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(orderAttributionService.reissueReceiptToken(id));
   }
 
   /** 誤帰属の訂正の進み具合（この受注がその会員へ与えた付与の合計と、既に差し引いた合計）。画面の既定値はここから取る。 */
@@ -306,7 +307,7 @@ public class OrderController {
   }
 
   /** 予約申請を謝絶する。確定後の取消は理由必須の専用操作（{@link #cancel}）が受け持つ。 */
-  @PostMapping("/{id}/decline")
+  @PostMapping("/{id}/refusal")
   @PreAuthorize("hasAuthority('PERM_ORDER_MANAGE')")
   public ResponseEntity<Void> decline(@PathVariable String id) {
     orderService.decline(id);

--- a/backend/src/main/java/com/kizuna/settings/api/dto/SystemConfigUpdateRequest.java
+++ b/backend/src/main/java/com/kizuna/settings/api/dto/SystemConfigUpdateRequest.java
@@ -1,16 +1,15 @@
 package com.kizuna.settings.api.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/** 設定更新の要求本体。宛先の設定キーは path が持つため、本体は値だけを運ぶ。 */
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class SystemConfigUpdateRequest {
-  @NotBlank private String configKey;
   private String configValue;
 }

--- a/backend/src/main/java/com/kizuna/settings/api/platform/PlatformConfigController.java
+++ b/backend/src/main/java/com/kizuna/settings/api/platform/PlatformConfigController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,10 +33,10 @@ public class PlatformConfigController {
     return ResponseEntity.ok(systemConfigService.getAllConfigs());
   }
 
-  @PutMapping
+  @PutMapping("/{key}")
   @PreAuthorize("hasAuthority('PERM_SYSTEM_CONFIG_MANAGE')")
   public ResponseEntity<SystemConfigResponse> update(
-      @Valid @RequestBody SystemConfigUpdateRequest request) {
-    return ResponseEntity.ok(systemConfigService.updateConfig(request));
+      @PathVariable String key, @Valid @RequestBody SystemConfigUpdateRequest request) {
+    return ResponseEntity.ok(systemConfigService.updateConfig(key, request));
   }
 }

--- a/backend/src/main/java/com/kizuna/settings/application/SystemConfigService.java
+++ b/backend/src/main/java/com/kizuna/settings/application/SystemConfigService.java
@@ -10,7 +10,7 @@ public interface SystemConfigService {
 
   List<SystemConfigResponse> getConfigsByCategory(String category);
 
-  SystemConfigResponse updateConfig(SystemConfigUpdateRequest request);
+  SystemConfigResponse updateConfig(String configKey, SystemConfigUpdateRequest request);
 
   /** 設定値を取得する（キャッシュされる。バックエンド内部からの設定参照はこのメソッドを使うこと） */
   Optional<String> getConfigValue(String configKey);

--- a/backend/src/main/java/com/kizuna/settings/application/SystemConfigServiceImpl.java
+++ b/backend/src/main/java/com/kizuna/settings/application/SystemConfigServiceImpl.java
@@ -43,11 +43,11 @@ public class SystemConfigServiceImpl implements SystemConfigService {
   @Transactional
   // どのキーが更新されても確実に無効化するため全消去（設定更新は低頻度の管理操作）
   @CacheEvict(value = "systemConfigValues", allEntries = true)
-  public SystemConfigResponse updateConfig(SystemConfigUpdateRequest request) {
+  public SystemConfigResponse updateConfig(String configKey, SystemConfigUpdateRequest request) {
     SystemConfig config =
         systemConfigRepository
-            .findByConfigKey(request.getConfigKey())
-            .orElseThrow(() -> new NotFoundException("設定キーが見つかりません: " + request.getConfigKey()));
+            .findByConfigKey(configKey)
+            .orElseThrow(() -> new NotFoundException("設定キーが見つかりません: " + configKey));
 
     validateValue(config, request.getConfigValue());
     systemConfigMapper.updateEntityFromRequest(request, config);

--- a/backend/src/main/java/com/kizuna/shared/storescope/StoreIdInterceptor.java
+++ b/backend/src/main/java/com/kizuna/shared/storescope/StoreIdInterceptor.java
@@ -55,7 +55,7 @@ public class StoreIdInterceptor implements HandlerInterceptor {
           && StringUtils.isNumeric(request.getHeader(HEADER_STORE_ID))) {
         // 店舗文脈を名乗れるのは STORE コンソール能力の保持者（storeBridge claim）のみ。CAST/MEMBER/HQ が
         // 店舗ヘッダを名乗るのは詐称として 403 で拒否する。授権スコープ検証より前に弾き、
-        // isAuthenticated() のみの端点（/files/upload 等）への店舗文脈確立の漏れを塞ぐ。
+        // isAuthenticated() のみの端点（POST /files 等）への店舗文脈確立の漏れを塞ぐ。
         if (!Boolean.TRUE.equals(claims.getClaimAsBoolean(CLAIM_STORE_BRIDGE))) {
           throw new AccessDeniedException("店舗コンソールの権限がありません");
         }
@@ -74,7 +74,7 @@ public class StoreIdInterceptor implements HandlerInterceptor {
     } else if (claims != null) {
       // 認証済みだが storeId claim を持たない（プラットフォーム PlatformAuth 発行、または storeId 無しの legacy）。
       // ヘッダで店舗を名乗る主張は詐称として 403 で拒否する。詐称ヘッダが無ければ下の
-      // @StoreOptional 判定に委ね、プラットフォームの正当な素通り（例: /files/upload の platform 保存）を保つ。
+      // @StoreOptional 判定に委ね、プラットフォームの正当な素通り（例: POST /files の platform 保存）を保つ。
       if (claimsStoreHeaderPresent) {
         throw new AccessDeniedException("店舗文脈を名乗る権限がありません");
       }

--- a/backend/src/main/java/com/kizuna/shift/api/store/ShiftRequestController.java
+++ b/backend/src/main/java/com/kizuna/shift/api/store/ShiftRequestController.java
@@ -34,7 +34,7 @@ public class ShiftRequestController {
     return ResponseEntity.ok(shiftRequestService.approve(id));
   }
 
-  @PostMapping("/{id}/decline")
+  @PostMapping("/{id}/rejection")
   @PreAuthorize("hasAuthority('PERM_SHIFT_MANAGE')")
   public ResponseEntity<StoreShiftRequestResponse> decline(@PathVariable String id) {
     return ResponseEntity.ok(shiftRequestService.decline(id));

--- a/backend/src/main/java/com/kizuna/storage/api/store/FileUploadController.java
+++ b/backend/src/main/java/com/kizuna/storage/api/store/FileUploadController.java
@@ -28,7 +28,7 @@ public class FileUploadController {
   private final StoreContext storeContext;
   private final AppProperties appProperties;
 
-  @PostMapping("/upload")
+  @PostMapping
   @PreAuthorize("isAuthenticated()")
   @StoreOptional
   public ResponseEntity<FileUploadResponse> upload(

--- a/backend/src/test/java/com/kizuna/order/api/platform/PlatformMemberReceiptControllerTest.java
+++ b/backend/src/test/java/com/kizuna/order/api/platform/PlatformMemberReceiptControllerTest.java
@@ -40,7 +40,7 @@ class PlatformMemberReceiptControllerTest {
   @EnableMethodSecurity
   static class MethodSecurityConfig {}
 
-  private static final String PATH = "/platform/me/receipts/claim";
+  private static final String PATH = "/platform/me/receipts";
 
   private static final String BODY =
       """
@@ -58,13 +58,13 @@ class PlatformMemberReceiptControllerTest {
   @MockitoBean private StoreActivationService storeActivationService;
 
   @Test
-  @DisplayName("会員は伝票を申領できること")
+  @DisplayName("会員は伝票を申領でき、帰属記録の生成として 201 が返ること")
   @WithMockUser(authorities = "ROLE_MEMBER")
   void memberCanClaimAReceipt() throws Exception {
     when(memberReceiptClaimService.claim(anyString(), anyString()))
         .thenReturn(new MemberReceiptClaimResponse(120));
 
-    mockMvc.perform(memberPost()).andExpect(status().isOk());
+    mockMvc.perform(memberPost()).andExpect(status().isCreated());
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/order/api/store/OrderControllerTest.java
+++ b/backend/src/test/java/com/kizuna/order/api/store/OrderControllerTest.java
@@ -19,6 +19,7 @@ import com.kizuna.order.api.dto.OrderArchiveResponse;
 import com.kizuna.order.api.dto.OrderAttributionResponse;
 import com.kizuna.order.api.dto.OrderCompletionPreviewResponse;
 import com.kizuna.order.api.dto.OrderCompletionResponse;
+import com.kizuna.order.api.dto.OrderReceiptTokenResponse;
 import com.kizuna.order.api.dto.OrderSummaryResponse;
 import com.kizuna.order.api.dto.OrderWorkQueueResponse;
 import com.kizuna.order.application.OrderAttributionCorrectionService;
@@ -271,7 +272,7 @@ class OrderControllerTest {
 
     mockMvc.perform(storePost("/store/orders/o1/confirmation")).andExpect(status().isOk());
     // 謝絶は結果を読まれない操作なので 204（本体なし）で返る。
-    mockMvc.perform(storePost("/store/orders/o1/decline")).andExpect(status().isNoContent());
+    mockMvc.perform(storePost("/store/orders/o1/refusal")).andExpect(status().isNoContent());
   }
 
   @Test
@@ -281,7 +282,7 @@ class OrderControllerTest {
     when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
 
     mockMvc.perform(storePost("/store/orders/o1/confirmation")).andExpect(status().isForbidden());
-    mockMvc.perform(storePost("/store/orders/o1/decline")).andExpect(status().isForbidden());
+    mockMvc.perform(storePost("/store/orders/o1/refusal")).andExpect(status().isForbidden());
   }
 
   @Test
@@ -293,7 +294,7 @@ class OrderControllerTest {
         .thenReturn(OrderWorkQueueResponse.builder().build());
 
     mockMvc
-        .perform(storePut("/store/orders/reservation-requests/o1", "{\"pax\": 3}"))
+        .perform(storePut("/store/orders/o1/reservation-request", "{\"pax\": 3}"))
         .andExpect(status().isOk());
   }
 
@@ -304,7 +305,7 @@ class OrderControllerTest {
     when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
 
     mockMvc
-        .perform(storePut("/store/orders/reservation-requests/o1", "{\"pax\": 3}"))
+        .perform(storePut("/store/orders/o1/reservation-request", "{\"pax\": 3}"))
         .andExpect(status().isForbidden());
   }
 
@@ -441,6 +442,20 @@ class OrderControllerTest {
         .andExpect(status().isForbidden());
     mockMvc.perform(storePost("/store/orders/o1/receipt-token")).andExpect(status().isForbidden());
     verifyNoInteractions(orderAttributionService);
+  }
+
+  @Test
+  @DisplayName("伝票トークンの再発行は新たな資源を生むので 201 で返ること")
+  @WithMockUser(authorities = "PERM_ORDER_MANAGE")
+  void receiptTokenReissueRespondsCreated() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+    when(orderAttributionService.reissueReceiptToken(any()))
+        .thenReturn(new OrderReceiptTokenResponse("raw-token"));
+
+    mockMvc
+        .perform(storePost("/store/orders/o1/receipt-token"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.receipt_token").value("raw-token"));
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/settings/api/platform/PlatformConfigControllerTest.java
+++ b/backend/src/test/java/com/kizuna/settings/api/platform/PlatformConfigControllerTest.java
@@ -1,6 +1,8 @@
 package com.kizuna.settings.api.platform;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,6 +20,7 @@ import com.kizuna.store.application.StoreActivationService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -77,10 +80,10 @@ class PlatformConfigControllerTest {
     // 実行・検証
     mockMvc
         .perform(
-            put("/platform/configs")
+            put("/platform/configs/site_name")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"config_key\":\"site_name\",\"config_value\":\"新しい名前\"}"))
+                .content("{\"config_value\":\"新しい名前\"}"))
         .andExpect(status().isForbidden());
   }
 
@@ -89,17 +92,46 @@ class PlatformConfigControllerTest {
   @WithMockUser(authorities = "PERM_SYSTEM_CONFIG_MANAGE")
   void updateUnknownKey() throws Exception {
     // 準備
-    when(systemConfigService.updateConfig(any(SystemConfigUpdateRequest.class)))
+    when(systemConfigService.updateConfig(any(String.class), any(SystemConfigUpdateRequest.class)))
         .thenThrow(new ServiceException("設定キーが見つかりません: unknown_key"));
 
     // 実行・検証
     mockMvc
         .perform(
-            put("/platform/configs")
+            put("/platform/configs/unknown_key")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"config_key\":\"unknown_key\",\"config_value\":\"v\"}"))
+                .content("{\"config_value\":\"v\"}"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.error").value("設定キーが見つかりません: unknown_key"));
+  }
+
+  /** 実在する設定キー（{@code seed} が入れる形）が path 変数として欠けずにサービスへ届くことを固定する。 */
+  @Test
+  @DisplayName("更新の宛先は path の設定キーで、値だけを本体で受けること")
+  @WithMockUser(authorities = "PERM_SYSTEM_CONFIG_MANAGE")
+  void updateAddressesTheKeyInThePath() throws Exception {
+    when(systemConfigService.updateConfig(any(String.class), any(SystemConfigUpdateRequest.class)))
+        .thenReturn(
+            SystemConfigResponse.builder()
+                .configKey("line_channel_id")
+                .configValue("1234567890")
+                .build());
+
+    mockMvc
+        .perform(
+            put("/platform/configs/line_channel_id")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"config_value\":\"1234567890\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.config_key").value("line_channel_id"));
+
+    ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<SystemConfigUpdateRequest> request =
+        ArgumentCaptor.forClass(SystemConfigUpdateRequest.class);
+    verify(systemConfigService).updateConfig(key.capture(), request.capture());
+    assertThat(key.getValue()).isEqualTo("line_channel_id");
+    assertThat(request.getValue().getConfigValue()).isEqualTo("1234567890");
   }
 }

--- a/backend/src/test/java/com/kizuna/settings/application/SystemConfigServiceImplTest.java
+++ b/backend/src/test/java/com/kizuna/settings/application/SystemConfigServiceImplTest.java
@@ -81,7 +81,7 @@ class SystemConfigServiceImplTest {
     String key = "maintenance_mode";
     String newValue = "true";
     SystemConfigUpdateRequest request =
-        SystemConfigUpdateRequest.builder().configKey(key).configValue(newValue).build();
+        SystemConfigUpdateRequest.builder().configValue(newValue).build();
 
     SystemConfig existingConfig =
         SystemConfig.builder().configKey(key).configValue("false").build();
@@ -97,7 +97,7 @@ class SystemConfigServiceImplTest {
     when(systemConfigMapper.toResponse(updatedConfig)).thenReturn(response);
 
     // 実行
-    SystemConfigResponse result = systemConfigService.updateConfig(request);
+    SystemConfigResponse result = systemConfigService.updateConfig(key, request);
 
     // 検証
     assertNotNull(result);
@@ -110,43 +110,42 @@ class SystemConfigServiceImplTest {
   @DisplayName("真偽値型の設定に不正な値を指定すると例外が発生すること")
   void updateConfig_invalidBoolean() {
     SystemConfigUpdateRequest request =
-        SystemConfigUpdateRequest.builder()
-            .configKey("maintenance_mode")
-            .configValue("yes")
-            .build();
+        SystemConfigUpdateRequest.builder().configValue("yes").build();
     SystemConfig config =
         SystemConfig.builder().configKey("maintenance_mode").valueType("BOOLEAN").build();
     when(systemConfigRepository.findByConfigKey("maintenance_mode"))
         .thenReturn(Optional.of(config));
 
-    assertThrows(ServiceException.class, () -> systemConfigService.updateConfig(request));
+    assertThrows(
+        ServiceException.class,
+        () -> systemConfigService.updateConfig("maintenance_mode", request));
   }
 
   @Test
   @DisplayName("数値型の設定に不正な値を指定すると例外が発生すること")
   void updateConfig_invalidNumber() {
     SystemConfigUpdateRequest request =
-        SystemConfigUpdateRequest.builder().configKey("smtp_port").configValue("abc").build();
+        SystemConfigUpdateRequest.builder().configValue("abc").build();
     SystemConfig config = SystemConfig.builder().configKey("smtp_port").valueType("NUMBER").build();
     when(systemConfigRepository.findByConfigKey("smtp_port")).thenReturn(Optional.of(config));
 
-    assertThrows(ServiceException.class, () -> systemConfigService.updateConfig(request));
+    assertThrows(
+        ServiceException.class, () -> systemConfigService.updateConfig("smtp_port", request));
   }
 
   @Test
   @DisplayName("数値型の設定に int の範囲を超える値を指定すると例外が発生すること")
   void updateConfig_numberBeyondIntRange() {
     SystemConfigUpdateRequest request =
-        SystemConfigUpdateRequest.builder()
-            .configKey("point_usage_unit")
-            .configValue("9999999999")
-            .build();
+        SystemConfigUpdateRequest.builder().configValue("9999999999").build();
     SystemConfig config =
         SystemConfig.builder().configKey("point_usage_unit").valueType("NUMBER").build();
     when(systemConfigRepository.findByConfigKey("point_usage_unit"))
         .thenReturn(Optional.of(config));
 
-    assertThrows(ServiceException.class, () -> systemConfigService.updateConfig(request));
+    assertThrows(
+        ServiceException.class,
+        () -> systemConfigService.updateConfig("point_usage_unit", request));
   }
 
   @Test
@@ -154,10 +153,7 @@ class SystemConfigServiceImplTest {
   void updateConfig_numberAtIntMax() {
     String value = String.valueOf(Integer.MAX_VALUE);
     SystemConfigUpdateRequest request =
-        SystemConfigUpdateRequest.builder()
-            .configKey("point_usage_unit")
-            .configValue(value)
-            .build();
+        SystemConfigUpdateRequest.builder().configValue(value).build();
     SystemConfig config =
         SystemConfig.builder().configKey("point_usage_unit").valueType("NUMBER").build();
     when(systemConfigRepository.findByConfigKey("point_usage_unit"))
@@ -166,7 +162,8 @@ class SystemConfigServiceImplTest {
     when(systemConfigMapper.toResponse(config))
         .thenReturn(SystemConfigResponse.builder().configValue(value).build());
 
-    assertEquals(value, systemConfigService.updateConfig(request).getConfigValue());
+    assertEquals(
+        value, systemConfigService.updateConfig("point_usage_unit", request).getConfigValue());
   }
 
   @Test
@@ -216,12 +213,12 @@ class SystemConfigServiceImplTest {
   void updateConfig_NotFound() {
     // 準備
     String key = "unknown_key";
-    SystemConfigUpdateRequest request = SystemConfigUpdateRequest.builder().configKey(key).build();
+    SystemConfigUpdateRequest request = SystemConfigUpdateRequest.builder().build();
 
     when(systemConfigRepository.findByConfigKey(key)).thenReturn(Optional.empty());
 
     // 実行・検証
-    assertThrows(NotFoundException.class, () -> systemConfigService.updateConfig(request));
+    assertThrows(NotFoundException.class, () -> systemConfigService.updateConfig(key, request));
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/shared/storescope/StoreIdInterceptorTest.java
+++ b/backend/src/test/java/com/kizuna/shared/storescope/StoreIdInterceptorTest.java
@@ -300,7 +300,7 @@ class StoreIdInterceptorTest {
   @DisplayName("storeBridge=false の平台トークンは授権スコープでも店舗ヘッダを名乗ると 403 で拒否し文脈を設定しないこと（本人種別線）")
   void preHandle_withoutStoreBridge_rejectsEvenWithAuthorizedScope() {
     // CAST/MEMBER/HQ 系（STORE コンソール能力なし）は ALL_STORES でも過橋不可。scope.authorizes が
-    // 真になる前に storeBridge で弾き、isAuthenticated() のみの端点（/files/upload 等）への店舗文脈確立を塞ぐ。
+    // 真になる前に storeBridge で弾き、isAuthenticated() のみの端点（POST /files 等）への店舗文脈確立を塞ぐ。
     authenticateWithPlatformScope(false, "ALL_STORES", List.of());
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader("X-Role", "store");

--- a/docs/api-guidelines.md
+++ b/docs/api-guidelines.md
@@ -20,6 +20,7 @@
   POST /store/orders/{id}/completion
   POST /store/orders/{id}/cancellation
   POST /store/shift-requests/{id}/approval
+  POST /store/shift-requests/{id}/rejection
   POST /store/customers/{customerId}/merges
   POST /store/orders/{id}/attribution/correction
   ```
@@ -31,10 +32,10 @@
   [ADR 0010](adr/0010-customer-merge-is-repoint-and-tombstone.md) の顧客統合、
   [ADR 0011](adr/0011-receipt-token-reissue-revokes-the-previous-one.md) の伝票トークン再発行も、
   この形で公開している。遷移ごとに端点が分かれることで、権限・冪等性・不正遷移の 400 を遷移単位で表現できる。
-- **裸の動詞は禁止**。動作は名詞化するか、対象資源の生成として表す。
-  この形は既に本仓に存在する（`POST /store/orders/{id}/decline`、`POST /store/shift-requests/{id}/decline`、
-  `POST /files/upload`、`POST /platform/me/receipts/claim`）が、**これらは是正バッチの対象であって 9 章の保護対象ではない**。
-  現状として模倣してよい先例と読まないこと。
+- **裸の動詞は禁止**。動作は名詞化するか、対象資源の生成として表す
+  （`POST /store/orders/{id}/refusal`、`POST /store/shift-requests/{id}/rejection`）。
+  集合への追加として表せる動作は、その集合への生成に寄せる
+  （`POST /files`、`POST /platform/me/receipts`）。
   唯一の例外は 3 章の「秘匿トークンを受ける読み取り」（`/view` 型）で、これは命名ではなく安全上の理由による偏離である。
 - 字面セグメント（`/public`、`/lookup`、`/work-queue`、`/archive` 等）と `{id}` テンプレートの共存は許容する。
   ただしこれらは **`{id}` の値空間を恒久的に侵食する**（同名の id が来ても字面側が勝つ）。

--- a/e2e/steps/store-api.ts
+++ b/e2e/steps/store-api.ts
@@ -341,7 +341,7 @@ export async function linkMemberToCustomer(
 }
 
 /**
- * 予約申請を謝絶する（POST /api/store/orders/{id}/decline, hasAuthority('ORDER_MANAGE')）。
+ * 予約申請を謝絶する（POST /api/store/orders/{id}/refusal, hasAuthority('ORDER_MANAGE')）。
  * 未確定（CREATED）の申請は削除が拒否されるため、後片付けはこちらで CANCELLED にしてから削除する。
  */
 export async function declineOrder(
@@ -349,11 +349,11 @@ export async function declineOrder(
   token: string,
   id: string
 ): Promise<void> {
-  const res = await request.post(`/api/store/orders/${id}/decline`, {
+  const res = await request.post(`/api/store/orders/${id}/refusal`, {
     headers: { ...STORE_HEADERS, Authorization: `Bearer ${token}` },
   });
   if (!res.ok()) {
-    throw new Error(`decline order failed: ${res.status()} ${await res.text()}`);
+    throw new Error(`refuse order failed: ${res.status()} ${await res.text()}`);
   }
 }
 

--- a/frontend/src/_pages/platform-settings/__tests__/page.test.tsx
+++ b/frontend/src/_pages/platform-settings/__tests__/page.test.tsx
@@ -70,8 +70,7 @@ describe('SystemSettingsPage', () => {
     fireEvent.click(toggle);
 
     await waitFor(() =>
-      expect(mockUpdateConfig).toHaveBeenCalledWith({
-        config_key: 'maintenance_mode',
+      expect(mockUpdateConfig).toHaveBeenCalledWith('maintenance_mode', {
         config_value: 'true',
       })
     );
@@ -88,15 +87,14 @@ describe('SystemSettingsPage', () => {
     expect(screen.getByRole('spinbutton')).toBeInTheDocument();
   });
 
-  it('編集した値は config_key と config_value のペイロードで保存される', async () => {
+  it('編集した値は設定キーを宛先に config_value だけを送って保存される', async () => {
     render(<SystemSettingsPage />);
     fireEvent.click(await screen.findByText('25'));
     fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '587' } });
     fireEvent.click(screen.getByRole('button', { name: '保存' }));
 
     await waitFor(() =>
-      expect(mockUpdateConfig).toHaveBeenCalledWith({
-        config_key: 'smtp_port',
+      expect(mockUpdateConfig).toHaveBeenCalledWith('smtp_port', {
         config_value: '587',
       })
     );

--- a/frontend/src/_pages/platform-settings/ui/SettingsPage.tsx
+++ b/frontend/src/_pages/platform-settings/ui/SettingsPage.tsx
@@ -28,10 +28,9 @@ export default function SystemSettingsPage() {
 
   const saveConfig = async (configKey: string, configValue: string) => {
     const request: SystemConfigUpdateRequest = {
-      config_key: configKey,
       config_value: configValue,
     };
-    await systemConfigService.updateConfig(request);
+    await systemConfigService.updateConfig(configKey, request);
     // 更新できた 1 件だけを差し替える。一覧ごと取り直すと編集中の欄が読み込み表示で消える
     setConfigs(
       prev =>

--- a/frontend/src/entities/order/__tests__/order-api.test.ts
+++ b/frontend/src/entities/order/__tests__/order-api.test.ts
@@ -126,7 +126,7 @@ describe('orderApi', () => {
   });
   it('decline は謝絶の子リソースを POST し、本体を返さない', async () => {
     await expect(orderApi.decline('o1')).resolves.toBeUndefined();
-    expect(mockedPost).toHaveBeenLastCalledWith('/store/orders/o1/decline');
+    expect(mockedPost).toHaveBeenLastCalledWith('/store/orders/o1/refusal');
   });
   it('attribution は受注の帰属の現況を GET する', async () => {
     expect(await orderApi.attribution('o1')).toEqual({
@@ -204,12 +204,12 @@ describe('memberVisitApi', () => {
 });
 
 describe('memberReceiptApi', () => {
-  it('claim は /platform/me/receipts/claim を POST し、トークンを本体で送る', async () => {
+  it('claim は /platform/me/receipts を POST し、トークンを本体で送る', async () => {
     // パスや問い合わせ文字列に載せると、90 日有効の生値がアクセスログに残る
     const mockedPost = apiClient.post as jest.Mock;
     mockedPost.mockResolvedValueOnce({ data: { granted_points: 120 } });
 
     await expect(memberReceiptApi.claim('tok3n')).resolves.toEqual({ granted_points: 120 });
-    expect(mockedPost).toHaveBeenCalledWith('/platform/me/receipts/claim', { token: 'tok3n' });
+    expect(mockedPost).toHaveBeenCalledWith('/platform/me/receipts', { token: 'tok3n' });
   });
 });

--- a/frontend/src/entities/order/api/order.ts
+++ b/frontend/src/entities/order/api/order.ts
@@ -138,7 +138,7 @@ export const orderApi = {
     id: string,
     data: ReservationRequestUpdateRequest
   ): Promise<OrderWorkQueueRow> => {
-    const response = await apiClient.put(`/store/orders/reservation-requests/${id}`, data);
+    const response = await apiClient.put(`/store/orders/${id}/reservation-request`, data);
     return response.data;
   },
   /** 予約申請を確定する（受注として受け付ける）。 */
@@ -148,7 +148,7 @@ export const orderApi = {
   },
   /** 予約申請を謝絶する。応答は 204（本体なし）で、呼出側は行を消す。 */
   decline: async (id: string): Promise<void> => {
-    await apiClient.post(`/store/orders/${id}/decline`);
+    await apiClient.post(`/store/orders/${id}/refusal`);
   },
   /**
    * 受注を完了する（会計の確定）。ポイントの利用と自動付与が台帳へ入るのはこの経路だけ。
@@ -247,7 +247,7 @@ export const memberVisitApi = {
 /** 会員本人の伝票トークン申領 API。トークンは本体で送る（パスや問い合わせ文字列はアクセスログに残る）。 */
 export const memberReceiptApi = {
   claim: async (token: string): Promise<MemberReceiptClaim> => {
-    const response = await apiClient.post('/platform/me/receipts/claim', { token });
+    const response = await apiClient.post('/platform/me/receipts', { token });
     return response.data;
   },
 };

--- a/frontend/src/entities/order/model/types.ts
+++ b/frontend/src/entities/order/model/types.ts
@@ -285,7 +285,7 @@ export interface OrderCreateRequest {
   ng_content?: string;
 }
 
-// 未確定の予約申請に対する店舗側の編集（PUT /store/orders/reservation-requests/{id}）。
+// 未確定の予約申請に対する店舗側の編集（PUT /store/orders/{id}/reservation-request）。
 // 送った内容がそのまま新しい申請内容になる部分更新ではない契約で、省略した項目は未設定になる。
 // 指名・受付担当を外せることがこの契約の目的なので、両者は可空。
 export interface ReservationRequestUpdateRequest {
@@ -410,7 +410,7 @@ export interface MemberVisit {
   granted_points: number;
 }
 
-// 伝票トークンの申領の結果（POST /platform/me/receipts/claim）。
+// 伝票トークンの申領の結果（POST /platform/me/receipts）。
 // 来店の内容は来店履歴（MemberVisit）が返すもので、この応答には乗らない。
 export interface MemberReceiptClaim {
   /** Java 側が primitive の int のため、キーは必ず応答に含まれる。0 円完了の伝票では 0。 */

--- a/frontend/src/entities/shift/__tests__/shift-api.test.ts
+++ b/frontend/src/entities/shift/__tests__/shift-api.test.ts
@@ -99,10 +99,10 @@ describe('shiftApi', () => {
       url: '/store/shift-requests/sr1/approval',
     });
   });
-  it('declineShiftRequest は /store/shift-requests/:id/decline を POST する', async () => {
+  it('declineShiftRequest は /store/shift-requests/:id/rejection を POST する', async () => {
     expect(await shiftApi.declineShiftRequest('sr1')).toEqual({
       ok: true,
-      url: '/store/shift-requests/sr1/decline',
+      url: '/store/shift-requests/sr1/rejection',
     });
   });
 });

--- a/frontend/src/entities/shift/api/shift.ts
+++ b/frontend/src/entities/shift/api/shift.ts
@@ -85,9 +85,9 @@ export const shiftApi = {
     const response = await apiClient.post(`/store/shift-requests/${id}/approval`);
     return response.data;
   },
-  /** 出勤希望を辞退する。 */
+  /** 出勤希望を却下する。 */
   declineShiftRequest: async (id: string): Promise<StoreShiftRequestItem> => {
-    const response = await apiClient.post(`/store/shift-requests/${id}/decline`);
+    const response = await apiClient.post(`/store/shift-requests/${id}/rejection`);
     return response.data;
   },
 };

--- a/frontend/src/entities/system-config/__tests__/config-api.test.ts
+++ b/frontend/src/entities/system-config/__tests__/config-api.test.ts
@@ -17,10 +17,10 @@ describe('systemConfigService', () => {
       url: '/platform/configs',
     });
   });
-  it('updateConfig は /platform/configs を PUT する', async () => {
-    expect(await systemConfigService.updateConfig({ config_key: 'k', config_value: 'v' })).toEqual({
+  it('updateConfig は /platform/configs/{key} を PUT する', async () => {
+    expect(await systemConfigService.updateConfig('smtp_port', { config_value: 'v' })).toEqual({
       ok: true,
-      url: '/platform/configs',
+      url: '/platform/configs/smtp_port',
     });
   });
 });

--- a/frontend/src/entities/system-config/api/config.ts
+++ b/frontend/src/entities/system-config/api/config.ts
@@ -11,9 +11,12 @@ export const systemConfigService = {
     return response.data;
   },
 
-  // 設定の更新 (Client Component用)
-  updateConfig: async (data: SystemConfigUpdateRequest): Promise<SystemConfigResponse> => {
-    const response = await apiClient.put<SystemConfigResponse>(BASE_URL, data);
+  // 設定の更新 (Client Component用)。宛先は設定キー 1 件で、本体は値だけを送る
+  updateConfig: async (
+    configKey: string,
+    data: SystemConfigUpdateRequest
+  ): Promise<SystemConfigResponse> => {
+    const response = await apiClient.put<SystemConfigResponse>(`${BASE_URL}/${configKey}`, data);
     return response.data;
   },
 };

--- a/frontend/src/entities/system-config/model/types.ts
+++ b/frontend/src/entities/system-config/model/types.ts
@@ -12,9 +12,8 @@ export interface SystemConfigResponse {
   updated_at?: string;
 }
 
-// システム設定更新リクエスト
+// システム設定更新リクエスト。宛先の設定キーはパスが持つため本体には載せない
 export interface SystemConfigUpdateRequest {
-  config_key: string;
   // Java 側に必須注解が無い
   config_value?: string;
 }

--- a/frontend/src/entities/user/__tests__/platform-auth-api.test.ts
+++ b/frontend/src/entities/user/__tests__/platform-auth-api.test.ts
@@ -35,10 +35,13 @@ describe('platform api', () => {
     const res = await platformAuthApi.stores();
     expect(res).toEqual({ ok: true, url: '/platform/stores/me' });
   });
-  it('changePassword PUTs /platform/password', async () => {
-    await expect(
-      platformAuthApi.changePassword({ current_password: 'a', new_password: 'b' })
-    ).resolves.toBeUndefined();
+  it('changePassword PUTs /platform/me/password', async () => {
+    const client = jest.requireMock('@/shared/api/client').default;
+    const body = { current_password: 'a', new_password: 'b' };
+
+    await expect(platformAuthApi.changePassword(body)).resolves.toBeUndefined();
+
+    expect(client.put).toHaveBeenLastCalledWith('/platform/me/password', body);
   });
   it('logout POSTs /platform/logout', async () => {
     await expect(platformAuthApi.logout()).resolves.toBeUndefined();

--- a/frontend/src/entities/user/api/platform.ts
+++ b/frontend/src/entities/user/api/platform.ts
@@ -33,7 +33,7 @@ export const platformAuthApi = {
     return response.data;
   },
   changePassword: async (data: PasswordChangeRequest): Promise<void> => {
-    await apiClient.put('/platform/password', data);
+    await apiClient.put('/platform/me/password', data);
   },
   logout: async (): Promise<void> => {
     // 失効済みトークンでの退出は 401 になる（パスワード変更が直前にセッションを畳んだ場合など。

--- a/frontend/src/shared/api/__tests__/client-platform.test.ts
+++ b/frontend/src/shared/api/__tests__/client-platform.test.ts
@@ -54,7 +54,7 @@ describe('apiClient platform branch', () => {
       if (key === 'platform-role') return 'platform';
       return undefined;
     });
-    const headers = await requestTo('/files/upload');
+    const headers = await requestTo('/files');
     expect(headers['X-Role']).toBe('store');
     expect(headers['X-Store-ID']).toBe('2');
   });

--- a/frontend/src/shared/api/file.ts
+++ b/frontend/src/shared/api/file.ts
@@ -9,7 +9,7 @@ export const fileApi = {
     // apiClient の既定 Content-Type は application/json のため、この上書きが無いと axios の
     // transformRequest が FormData を JSON へ変換してしまい multipart として送られない。
     // multipart/form-data を明示すると JSON 変換を回避でき、境界はブラウザが自動付与する。
-    const response = await apiClient.post('/files/upload', formData, {
+    const response = await apiClient.post('/files', formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
     });
     return response.data;


### PR DESCRIPTION
## 概要

docs/api-guidelines.md §2・§3 の是正バッチ（最終便・破壊的変更）。裸動詞 4 端点を名詞化し、集合ルートへの PUT と `/platform/password` の宛先を是正、予約申請の編集を単数子リソースへ移し、伝票トークン系 2 動作を 201 に揃える。外部利用者は無いため前後端・e2e を同 PR で改名。

Closes #693

## 変更内容

- `POST /store/orders/{id}/decline` → **`/refusal`**（謝絶・204 不変）/ `POST /store/shift-requests/{id}/decline` → **`/rejection`**（却下・既存 `/approval` と対偶）— 英語層で一語に潰れていた二つのドメイン語を URL 層で復元
- `POST /files/upload` → **`POST /files`**（集合への生成。CSRF 免除は §7 の method+path 形 `matcher(POST, "/files")` へ、`/files/**` 拦截器 3 本と前端 `client.ts` の接頭辞注入は無傷を実証）
- `POST /platform/me/receipts/claim` → **`POST /platform/me/receipts`** + **200→201**（申領は帰属記録の生成。トークンは従来通り本体で受ける）
- `PUT /platform/configs` → **`PUT /platform/configs/{key}`**（§3: 集合ルート PUT 禁止。本体は `config_value` のみに）
- `PUT /platform/password` → **`PUT /platform/me/password`**（§2: 自分自身は `/platform/me` に集約）
- `PUT /store/orders/reservation-requests/{id}` → **`PUT /store/orders/{id}/reservation-request`**（{id} は Order 主キー。至多一つの子リソースとして単数形、汎用 `PUT /store/orders/{id}` とは契約が異なるため併存）
- `POST /store/orders/{id}/receipt-token`: パス不変（§2 の単数子リソース模範例）、**200→201**（§4「トークン発行等は 201」）
- docs/api-guidelines.md §2: 是正対象として名指ししていた 4 端点の記述を正例へ書き換え、`/rejection` を例示ブロックへ追加
- Java/TS 識別子・enum 値・DB 値は一切不変（URL 層のみの改名）。`/platform/login` 等の認証系動詞・`PUT /store/orders/{id}` の部分更新偏差・§9 保護対象は対象外

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（unit + integration。ShiftRequestScopeIT の新パス・claim/reissue の 201 翻転・FileUploadCrossStoreIT の拦截器通過を含む）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全シナリオ。謝絶導線は新 `/refusal` を通過）
- [x] ローカルで code-review 実施済み（実装=Opus / QA=Sonnet の二層。QA 指摘ゼロ）

### 視覚確認（UI 変更時）

UI 変更なし（フロントは URL 文字列・型・テストの追随のみ）。

## 決定ログ

- 二つの decline は日本語ドメイン語が別（謝絶/却下）であり、名詞化で分词各表とした（承認済み）。統一案（rejection / declination）は却下。
- `/files/upload` は `POST /files`（承認済み）。`/files/uploads` 案は無実体の階層が増えるため見送り。
- 申領は `POST /platform/me/receipts` + 201（承認済み）。`/receipts/claims` 案は見送り。201 は §4 第三条（新資源を生む動作）由来で、生成応答の id 要件は資源生成端点の条項であり適用されない。
- 予約申請の編集は汎用更新と統合しない：可空フルリプレース（指名を明示的に外せる）と部分更新で契約が逆であり、統合は「外せる」語彙を失う。
- `MemberReceiptClaimIT` / `OrderAttributionInvalidationIT` の OK→CREATED 翻転は「claim / reissue の呼出しか」を逐行判定して実施（`filteredOn`/`allMatch` 谓词含む）。invalidate / complete / 読み口の OK は不変。

## 備考 / レビュー観点

- `SystemConfigUpdateRequest` から `config_key`（唯一の `@NotBlank`）が消えたため、`PUT /platform/configs/{key}` に空体 `{}` を送ると 400 ではなく 200 の静默 no-op になる（`validateValue` の null 早期返却 + mapper の null 無視）。契約裁定の範囲内の挙動として記録。
- 実在する設定キーは全て snake_case（点号キー無し）。`{key}` パス変数の往復は実在キー `line_channel_id` で単体テスト固定済み（Spring 7 PathPattern に接尾辞截断は無い）。
- `StoreShiftRequestResponse.java` の Javadoc に残る「謝絶」（正しくは却下）は本 PR で触れていないファイルのため fix-on-touch 射程外。後続で扱う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
