### PR TITLE
test: 派生 findById の店舗境界を実測で固定し、誤りの注釈を是正する

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/customer/CustomerCrossStoreIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/CustomerCrossStoreIT.java
@@ -52,7 +52,7 @@ class CustomerCrossStoreIT extends CrossStoreTestSupport {
   }
 
   @Test
-  @DisplayName("他店舗の顧客 ID を GET しても取得できないこと（applyToLoadByKey 回帰）")
+  @DisplayName("非授権の店舗文脈からの顧客 ID 直指しはインターセプタが 403 で拒むこと")
   void otherStoreCannotReadForeignCustomerById() {
     String id = createCustomerAs(STORE_A, "統合テスト顧客（負向）");
 
@@ -63,8 +63,8 @@ class CustomerCrossStoreIT extends CrossStoreTestSupport {
             new HttpEntity<>(storeHeaders(STORE_B)),
             JsonNode.class);
 
-    // 越権はインターセプタが JWT と X-Store-ID の不一致を拒否 → 403。
-    // 重要なのは 200 でデータが漏れないこと
+    // 単店授権のスタッフは JWT と X-Store-ID の不一致でインターセプタに拒まれ、SQL まで届かない。
+    // フィルタ層の境界（多店授権者の越境が 404 になること）は StoreScopedLoadByKeyIT が固定する。
     assertThat(leaked.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
   }
 

--- a/backend/src/integrationTest/java/com/kizuna/customer/StoreScopedLoadByKeyIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/StoreScopedLoadByKeyIT.java
@@ -1,0 +1,55 @@
+package com.kizuna.customer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kizuna.shared.CrossStoreTestSupport;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * 派生 findById（EntityManager.find 経路）に storeFilter が掛かることの実測。
+ *
+ * <p>複数店舗を授権された操作者は、店舗 A の文脈のまま店舗 B の実在 id を直接指せる——インターセプタは 授権集合しか見ないため、この越境を止められるのは
+ * applyToLoadByKey を有効にした Hibernate フィルタだけ。 既存の *CrossStoreIT は単店授権者を使うためインターセプタの 403
+ * で止まり、この経路を一度も踏んでいない。
+ */
+class StoreScopedLoadByKeyIT extends CrossStoreTestSupport {
+
+  @Test
+  @DisplayName("2店舗授権の店長が店舗Aの文脈で店舗Bの顧客 id を GET しても 404 で、実データが漏れないこと（正向対照つき）")
+  void derivedFindByIdIsStoreFiltered() {
+    String canary = "実測カナリア顧客_" + UUID.randomUUID();
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/store/customers",
+            new HttpEntity<>("{\"name\": \"" + canary + "\"}", managerHeaders(STORE_B)),
+            JsonNode.class);
+    assertThat(created.getStatusCode()).as("前提: 店舗Bに顧客を作成できること").isEqualTo(HttpStatus.CREATED);
+    String id = created.getBody().path("id").asString();
+
+    ResponseEntity<String> sameStore =
+        rest.exchange(
+            "/store/customers/" + id,
+            HttpMethod.GET,
+            new HttpEntity<>(managerHeaders(STORE_B)),
+            String.class);
+    assertThat(sameStore.getStatusCode()).as("正向対照: 自店文脈では読めること").isEqualTo(HttpStatus.OK);
+
+    ResponseEntity<String> crossStore =
+        rest.exchange(
+            "/store/customers/" + id,
+            HttpMethod.GET,
+            new HttpEntity<>(managerHeaders(STORE_A)),
+            String.class);
+    assertThat(crossStore.getStatusCode())
+        .as("店舗Aの文脈から店舗Bの id の直指しは 404 になること")
+        .isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(crossStore.getBody()).as("生ボディに店舗Bの実データが現れないこと").doesNotContain(canary);
+  }
+}

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
@@ -36,9 +36,9 @@ public interface CustomerRepository
    * PointEntryRepository#findCreditsForUpdate}）。記帳の 2 経路で順序が揃い、解除は台帳を触らないため待ちが環にならない。
    * 読むだけの経路（残高照会・完了の事前計算・紐づけ履歴・顧客の投影）はこのロックを取らない。
    *
-   * <p>Customer は StoreScopedEntity で、JPQL の問い合わせには {@code storeFilter} が掛かる（{@code
-   * EntityManager.find} には掛からないため、派生の {@code findById} に @Lock を足す形では店舗境界が外れる）。{@code @StoreScoped}
-   * の文脈では 他店舗の顧客が空になり、存在の有無が漏れない既存の性質はこの形で保たれる。
+   * <p>Customer は StoreScopedEntity で、この問い合わせにも {@code storeFilter} が掛かる（applyToLoadByKey により派生の
+   * {@code findById} でも同様 — StoreScopedLoadByKeyIT が実測で固定）。{@code @StoreScoped} の文脈では
+   * 他店舗の顧客が空になり、存在の有無が漏れない。
    */
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select c from com.kizuna.customer.domain.Customer c where c.id = :id")

--- a/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
+++ b/backend/src/main/java/com/kizuna/order/domain/OrderRepository.java
@@ -82,9 +82,8 @@ public interface OrderRepository
   /**
    * 現店舗の受注 1 件を集約として引く。
    *
-   * <p>JPQL で書くのは {@code storeFilter} を効かせるため。Order は StoreScopedEntity だが、Hibernate のフィルタは {@code
-   * EntityManager.find} には掛からず、派生の {@code findById} はそこへ落ちる。複数店舗を授権された操作者は現店舗の文脈のまま 他店舗の受注 ID
-   * を指せるので、店舗を跨がない読み書きはこの形で引く。
+   * <p>{@code storeFilter} は applyToLoadByKey により派生の {@code findById} にも掛かる（StoreScopedLoadByKeyIT
+   * が実測で固定）。JPQL で書くのは境界の明示で、フィルタの代替ではない。
    *
    * <p>受注に紐づく帰属記録・伝票トークンは platform 帰属で店舗行分離機構に載らない。それらを受注 ID で引く操作は、 先にこの読み口で店舗の所有を確かめてから行う。
    */


### PR DESCRIPTION
## 概要

#694 の設計調査で確定した実測事実の小件落地。派生 `findById` に storeFilter が掛かること（applyToLoadByKey の実効）を統合テストで恒久固定し、それと矛盾していた誤り注釈 2 箇所と過大申告のテスト名を是正する。設計スペック本体と方式比較は #694 のコメントに発布済み、主防線（宣言監査 fitness test）の実装は #704。

Closes #694

## 変更内容

- `StoreScopedLoadByKeyIT` 新設: 2 店舗授権の店長（tanaka.hanako シード）が店舗 A の文脈で店舗 B の顧客 id を直指し → 404・実データ漏れゼロ（正向対照つき）。既存の *CrossStoreIT は単店授権者のためインターセプタの 403 で止まり、この SQL 経路を一度も踏んでいなかった
- `OrderRepository#findScopedById` / `CustomerRepository#findByIdForUpdate` の「フィルタは `EntityManager.find` に掛からない」注釈を事実に是正（JPQL 形は境界の明示として維持）
- `CustomerCrossStoreIT` の「applyToLoadByKey 回帰」を名乗るテスト名を実態（インターセプタの 403）に改述し、フィルタ層の境界は新 IT が固定する旨を注記

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（unit + integration、新 IT 含む）
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全シナリオ）
- [x] ローカルで code-review 実施済み

### 視覚確認（UI 変更時）

UI 変更なし（backend のみ）。

## 決定ログ

- 変異実証: `applyToLoadByKey` を `false` にすると本 IT が「404 期待・実際 200 + カナリア漏洩」で赤くなることを確認（間接依存で赤くなる既存 IT は 4 件あるが、この語義を直接断言するのは本 IT のみ）。
- `findScopedById` 等の JPQL 形は撤去しない: フィルタが効く以上は冗長だが、境界の明示と @Lock 併用の形として無害。撤去はリファクタであり本票の射程外。

## 備考 / レビュー観点

- 方式比較（A 宣言監査 / B 実行期断言 / C カナリア網羅 / D StatementInspector）と裁定の全文は #694 コメント参照。主防線 A の実装票 = #704（切面 @Order の明示化と釘付けを含む）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
