### PR TITLE
chore: 言語政策違反の英文コメントと定型コメントを一掃する

### DIFF
--- a/backend/src/main/java/com/kizuna/menu/api/dto/MenuVO.java
+++ b/backend/src/main/java/com/kizuna/menu/api/dto/MenuVO.java
@@ -9,8 +9,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class MenuVO {
-  private String name; // Label
-  private String path; // Href
+  private String name;
+  private String path;
   private String icon;
-  private List<MenuVO> items; // Children
+  private List<MenuVO> items;
 }

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderMapper.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderMapper.java
@@ -12,8 +12,6 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface OrderMapper {
 
-  // ==================== View(projection) -> Response ====================
-
   /** 読み側 projection をレスポンスDTOに変換します。 */
   OrderResponse toResponse(OrderView view);
 
@@ -29,14 +27,7 @@ public interface OrderMapper {
   /** 平台横断一覧の projection をレスポンスDTOに変換します（集合作用域）。 */
   PlatformOrderResponse toPlatformResponse(PlatformOrderView view);
 
-  // ==================== CreateRequest -> Entity ====================
-
-  /**
-   * 注文作成リクエストDTOを注文エンティティに変換します。 注: 関連 ID（顧客、キャスト、受付担当）はサービス層で存在確認後に割り当てます。
-   *
-   * @param request 注文作成リクエスト
-   * @return 注文エンティティ
-   */
+  /** 注文作成リクエストDTOを注文エンティティに変換します。 */
   @Mapping(target = "locationAddress", source = "address")
   @Mapping(target = "locationBuilding", source = "buildingName")
   // 店舗・HQ が起こす受注は確定で出生する。電話口で受けると決めた時点で可否は判断済みであり、
@@ -66,13 +57,10 @@ public interface OrderMapper {
   @Mapping(target = "cancelledAt", ignore = true)
   Order toEntity(OrderCreateRequest request);
 
-  // ==================== UpdateRequest -> Patch ====================
-
   /** 注文更新リクエストをドメインの部分更新コマンドに変換します。null フィールドは「変更しない」。 */
   OrderPatch toPatch(OrderUpdateRequest request);
 
-  // ==================== CreateRequest -> Customer（電話番号からの顧客スマートリンク用） ====================
-
+  /** 電話番号からの顧客スマートリンク用に、作成リクエストから顧客行を起こします。 */
   @Mapping(target = "name", source = "customerName")
   // rank は DB デフォルト（'SILVER'）と同義。注文経由の顧客作成でも通常作成と揃える
   @Mapping(target = "rank", constant = "SILVER")

--- a/backend/src/main/java/com/kizuna/order/api/dto/OrderResponse.java
+++ b/backend/src/main/java/com/kizuna/order/api/dto/OrderResponse.java
@@ -16,17 +16,17 @@ import lombok.NoArgsConstructor;
 public class OrderResponse {
   private String id;
   private Long receptionistId;
-  private String receptionistName; // Helper for display
+  private String receptionistName;
   private LocalDate businessDate;
   private LocalTime arrivalScheduledStartTime;
   private LocalTime arrivalScheduledEndTime;
   private String customerId;
-  private String customerName; // Helper
+  private String customerName;
   // 受付で録入された連絡先。顧客が着かなかった受注にだけ入る（着いた受注では台帳の行が名乗りを持つ）
   private String contactName;
   private String contactPhoneNumber;
   private String castId;
-  private String castName; // Helper
+  private String castName;
   private Integer pax;
   private Integer courseMinutes;
   private Integer extensionMinutes;

--- a/backend/src/main/java/com/kizuna/shared/persistence/SnowflakeIdGenerator.java
+++ b/backend/src/main/java/com/kizuna/shared/persistence/SnowflakeIdGenerator.java
@@ -7,12 +7,12 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.id.IdentifierGenerator;
 
 /**
- * Simple snowflake ID generator that produces 64-bit numeric IDs encoded as decimal strings. This
- * implementation is deterministic and not cluster-coordinated; set workerId appropriately.
+ * 64bit の snowflake ID を 10 進文字列として払い出す {@link IdentifierGenerator}。 クラスタ間の調整は持たないため、多重起動する場合は
+ * workerId を重複させないこと。
  */
 public class SnowflakeIdGenerator implements IdentifierGenerator {
 
-  // epoch: 2020-01-01
+  // 起点は 2020-01-01
   private static final long EPOCH = 1577836800000L;
   private static final long WORKER_ID_BITS = 10L;
   private static final long SEQUENCE_BITS = 12L;
@@ -25,7 +25,6 @@ public class SnowflakeIdGenerator implements IdentifierGenerator {
   private long sequence = 0L;
 
   public SnowflakeIdGenerator() {
-    // default worker id 1; consider injecting via property or environment
     this(1L);
   }
 
@@ -40,13 +39,13 @@ public class SnowflakeIdGenerator implements IdentifierGenerator {
   private synchronized long nextId() {
     long timestamp = Instant.now().toEpochMilli();
     if (timestamp < lastTimestamp) {
-      // clock moved backwards, wait until lastTimestamp
+      // 時計の巻き戻り。前回時刻まで待って ID の重複を防ぐ
       timestamp = waitUntil(lastTimestamp);
     }
     if (timestamp == lastTimestamp) {
       sequence = (sequence + 1) & SEQUENCE_MASK;
       if (sequence == 0) {
-        // sequence overflow on the same millisecond
+        // 同一ミリ秒内で連番が尽きたため、次のミリ秒まで待つ
         timestamp = waitUntil(lastTimestamp + 1);
       }
     } else {

--- a/backend/src/main/java/com/kizuna/shared/storescope/StoreFilterEnable.java
+++ b/backend/src/main/java/com/kizuna/shared/storescope/StoreFilterEnable.java
@@ -9,13 +9,8 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 /**
- * Aspect that enables Hibernate store filtering for methods annotated with {@code @StoreScoped}.
- *
- * <p>When a method is annotated with {@code @StoreScoped}, this aspect intercepts the call and
- * enables the Hibernate {@code storeFilter}, setting the store ID from the {@link StoreContext}.
- * This ensures that all database operations within the method are scoped to the current store.
- *
- * @author kanghouchao
+ * {@code @StoreScoped} メソッドの呼び出しを囲み、現在の Session に Hibernate の {@code storeFilter} を有効化する。
+ * 店舗文脈が無い場合は何もしない — 絞り込み無しのまま実行される。
  */
 @Aspect
 @Component

--- a/backend/src/main/java/com/kizuna/shared/storescope/StoreScoped.java
+++ b/backend/src/main/java/com/kizuna/shared/storescope/StoreScoped.java
@@ -5,23 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Indicates that the annotated method should have automatic store filtering applied.
- *
- * <p>When this annotation is present, the system will automatically inject the current store's ID
- * and apply store-specific filtering logic to the method.
- *
- * <p><b>Usage Example:</b>
- *
- * <pre>{@code
- * @StoreScoped
- * public List<User> getUsersForStore() {
- *     // Implementation that will be automatically filtered by store
- * }
- * }</pre>
- *
- * @author kanghouchao
- */
+/** メソッドの実行中、現在の店舗文脈で Hibernate の storeFilter を有効化することを宣言する。 */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface StoreScoped {}

--- a/backend/src/main/java/com/kizuna/shared/web/RequestCorrelationFilter.java
+++ b/backend/src/main/java/com/kizuna/shared/web/RequestCorrelationFilter.java
@@ -16,9 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-/**
- * Assigns a correlation identifier to every request and ensures store context data exits cleanly.
- */
+/** 全リクエストに相関 ID を割り当て、応答後に ThreadContext と店舗文脈を確実に掃除する。 */
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/kizuna/storage/application/S3FileStorage.java
+++ b/backend/src/main/java/com/kizuna/storage/application/S3FileStorage.java
@@ -28,29 +28,24 @@ public class S3FileStorage implements FileStorageService, ApplicationRunner {
   public String store(String prefix, String bucket, MultipartFile file) {
     AppProperties.Upload upload = appProperties.getUpload();
 
-    // プレフィックスのバリデーション (パストラバーサル防止)
+    // prefix・bucket は object key に組み込まれるため、英数字類に絞ってパストラバーサルを防ぐ
     if (prefix == null || !prefix.matches("^[a-zA-Z0-9_-]+$")) {
       throw new ServiceException("不正なプレフィックスです");
     }
 
-    // バケット名のバリデーション (パストラバーサル防止)
-    // 英数字、ハイフン、アンダースコアのみを許可
     if (bucket == null || !bucket.matches("^[a-zA-Z0-9_-]+$")) {
       throw new ServiceException("不正なバケット名です");
     }
 
-    // ファイルサイズのバリデーション
     if (file.getSize() > upload.getMaxFileSize()) {
       throw new ServiceException("ファイルサイズが上限を超えています");
     }
 
-    // MIMEタイプのバリデーション
     String contentType = file.getContentType();
     if (contentType == null || !upload.getAllowedTypes().contains(contentType)) {
       throw new ServiceException("許可されていないファイル形式です");
     }
 
-    // 拡張子を元のファイル名から取得
     String originalFilename = file.getOriginalFilename();
     String extension = "";
     if (originalFilename != null && originalFilename.contains(".")) {

--- a/frontend/src/_pages/store-settings/ui/StoreProfileForm.tsx
+++ b/frontend/src/_pages/store-settings/ui/StoreProfileForm.tsx
@@ -275,7 +275,7 @@ export function StoreProfileForm({ initialData, onSubmit, isSubmitting }: StoreP
                     value={value}
                     onChange={onChange}
                     bucket="public"
-                    className="w-32 h-32" // Square
+                    className="w-32 h-32"
                   />
                 )}
               />
@@ -296,7 +296,7 @@ export function StoreProfileForm({ initialData, onSubmit, isSubmitting }: StoreP
                   value={value}
                   onChange={onChange}
                   bucket="public"
-                  className="w-full h-40 max-w-2xl" // Wide rectangle
+                  className="w-full h-40 max-w-2xl"
                 />
               )}
             />
@@ -345,7 +345,7 @@ export function StoreProfileForm({ initialData, onSubmit, isSubmitting }: StoreP
                   value={value}
                   onChange={onChange}
                   bucket="public"
-                  className="w-full h-64" // Taller wide rectangle
+                  className="w-full h-64"
                 />
               )}
             />
@@ -519,7 +519,6 @@ export function StoreProfileForm({ initialData, onSubmit, isSubmitting }: StoreP
           </div>
         </section>
 
-        {/* Buttons */}
         <div className="flex justify-end gap-4 pt-6 border-t">
           <Button type="submit" disabled={isSubmitting}>
             {isSubmitting ? '保存中...' : '設定を保存する'}

--- a/frontend/src/_pages/store-site/templates/_sections/Banner.tsx
+++ b/frontend/src/_pages/store-site/templates/_sections/Banner.tsx
@@ -12,7 +12,7 @@ function sanitizeBannerUrl(url: string | undefined): string | undefined {
     const parsed = new URL(trimmed);
     if (['http:', 'https:'].includes(parsed.protocol)) return parsed.toString();
   } catch {
-    // Invalid URL
+    // URL として解釈できない値は未設定として扱う
   }
   return undefined;
 }

--- a/frontend/src/_pages/store-site/templates/classic/page.tsx
+++ b/frontend/src/_pages/store-site/templates/classic/page.tsx
@@ -10,17 +10,8 @@ import MVSection from '../_sections/MVSection';
 import './theme.css';
 
 /**
- * classic 模版のテナントページ (Server Component)
- *
- * 構成（排布差: キャッチコピー帯を Banner の直上に置き明るい第一印象を作る）:
- * 1. AgeGate    - 年齢確認オーバーレイ（Client Component / localStorage）
- * 2. Header     - スティッキーヘッダー
- * 3. キャッチコピー帯（設定時のみ）
- * 4. Banner     - フルスクリーンヒーローセクション
- * 5. MVSection  - メインビジュアル
- * 6. CastSection - キャスト紹介カルーセル
- * 7. Advertisement - キャンペーン情報
- * 8. Footer     - フッター
+ * classic 模版の店舗トップページ（Server Component）。
+ * 既定模版との排布差: キャッチコピー帯を Banner の直上に置き、明るい第一印象を作る。
  */
 export default async function ClassicTemplate() {
   const cookieStore = await cookies();

--- a/frontend/src/_pages/store-site/templates/default/page.tsx
+++ b/frontend/src/_pages/store-site/templates/default/page.tsx
@@ -9,18 +9,7 @@ import Header from '../_sections/Header';
 import MVSection from '../_sections/MVSection';
 import './theme.css';
 
-/**
- * デフォルトのテナントページ模版 (Server Component)
- *
- * 構成:
- * 1. AgeGate    - 年齢確認オーバーレイ（Client Component / localStorage）
- * 2. Header     - スティッキーヘッダー
- * 3. Banner     - フルスクリーンヒーローセクション
- * 4. MVSection  - メインビジュアル
- * 5. CastSection - キャスト紹介カルーセル
- * 6. Advertisement - キャンペーン情報
- * 7. Footer     - フッター
- */
+/** 既定模版の店舗トップページ（Server Component）。 */
 export default async function DefaultTemplate() {
   const cookieStore = await cookies();
   const storeName = cookieStore.get('x-mw-store-name')?.value || 'Store';

--- a/frontend/src/app/(admin)/platform/layout.tsx
+++ b/frontend/src/app/(admin)/platform/layout.tsx
@@ -13,15 +13,11 @@ export default function PlatformLayout({ children }: { children: React.ReactNode
           値はヘッダー全体の最悪所要幅 674px（見出し 90 + 操作行 520 + 左右余白 64。
           操作行は店舗セレクタが上限まで伸びた場合）の上に取る。 */}
         <div className="flex h-screen bg-background overflow-x-auto">
-          {/* Sidebar Component */}
           <Sidebar />
 
-          {/* Main Container */}
           <div className="flex-1 flex flex-col min-w-[44rem] overflow-hidden">
-            {/* Header Component */}
             <Header />
 
-            {/* Main Content Area */}
             {/* relative: 絶対配置の子（Select が描画するフォーム互換用の隠し input 等）の
               包含ブロックをこのスクロール領域に閉じ込め、ページ全体が伸びるのを防ぐ */}
             <main className="relative flex-1 overflow-y-auto p-8">

--- a/frontend/src/app/(admin)/store/layout.tsx
+++ b/frontend/src/app/(admin)/store/layout.tsx
@@ -13,15 +13,11 @@ export default function StoreLayout({ children }: { children: React.ReactNode })
           値はヘッダー全体の最悪所要幅 674px（見出し 90 + 操作行 520 + 左右余白 64。
           操作行は店舗セレクタが上限まで伸びた場合）の上に取る。 */}
         <div className="flex h-screen bg-background overflow-x-auto">
-          {/* Sidebar Component */}
           <Sidebar />
 
-          {/* Main Container */}
           <div className="flex-1 flex flex-col min-w-[44rem] overflow-hidden">
-            {/* Header Component */}
             <Header />
 
-            {/* Main Content Area */}
             {/* relative: 絶対配置の子（Select が描画するフォーム互換用の隠し input 等）の
               包含ブロックをこのスクロール領域に閉じ込め、ページ全体が伸びるのを防ぐ */}
             <main className="relative flex-1 overflow-y-auto p-8">

--- a/frontend/src/entities/order/model/types.ts
+++ b/frontend/src/entities/order/model/types.ts
@@ -273,7 +273,6 @@ export interface OrderCreateRequest {
   media_name?: string;
   remarks?: string;
   cast_driver_message?: string;
-  // Customer Creation Fields
   phone_number?: string;
   phone_number2?: string;
   address?: string;

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -8,16 +8,13 @@ export const config = {
 };
 
 export async function proxy(request: NextRequest) {
-  // 1. Identify Role & Store
   const { role, storeData } = await resolveStore(request);
 
-  // 2. Route Protection (Security Guard)
   const redirectResponse = handleRouteProtection(request, role);
   if (redirectResponse) {
     return redirectResponse;
   }
 
-  // 3. Prepare Response & Cookies
   const response = NextResponse.next();
   const isHttps = request.nextUrl.protocol === 'https:';
   const cookieOptions = {
@@ -27,7 +24,6 @@ export async function proxy(request: NextRequest) {
     path: '/',
   };
 
-  // Set Role Cookie
   response.cookies.set('x-mw-role', role, cookieOptions);
 
   // 平台ドメインをクライアントへ渡す。店舗ドメインから会員ポータルへ渡す導線は絶対 URL を
@@ -35,7 +31,6 @@ export async function proxy(request: NextRequest) {
   // 実行時に決まる値は proxy が cookie で運ぶ（role と同じ流儀）。
   response.cookies.set('x-mw-platform-domain', PLATFORM_DOMAIN, cookieOptions);
 
-  // Set Store Cookies (if applicable)
   if (role === 'store' && storeData?.isValid) {
     // ドメインを保存して、後続リクエストで検証に使用
     const hostname = (

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -41,7 +41,7 @@ apiClient.interceptors.request.use(
           (config.headers as any)['X-Store-ID'] = storeId;
         }
       } else {
-        // Attach role and store context from middleware cookies
+        // proxy が焼いた x-mw cookie から役割と店舗文脈をヘッダへ移す
         const role = Cookies.get('x-mw-role');
         if (role) {
           (config.headers as any)['X-Role'] = role;
@@ -54,7 +54,7 @@ apiClient.interceptors.request.use(
         }
       }
     } catch {
-      // noop
+      // cookie が読めない環境ではヘッダ無しで送る（受否はバックエンドが fail-closed に判定する）
     }
     return config;
   },

--- a/frontend/src/shared/lib/hooks/useManagedList.ts
+++ b/frontend/src/shared/lib/hooks/useManagedList.ts
@@ -44,7 +44,7 @@ export function useManagedList<T>(fetcher: () => Promise<T[]>) {
   useEffect(() => {
     void refetch();
     return () => {
-      // requestIdRef is a request counter, not a DOM ref.
+      // requestIdRef は DOM ref ではなくリクエスト連番のカウンタ。
       // eslint-disable-next-line react-hooks/exhaustive-deps
       requestIdRef.current++;
     };

--- a/frontend/src/shared/lib/navigation.ts
+++ b/frontend/src/shared/lib/navigation.ts
@@ -1,4 +1,4 @@
-// navigation helper with injectable navigator for easier testing
+// 遷移の実行部を差し替え可能にしたナビゲーション（テストでは navigator を注入する）
 
 type NavigatorFn = (url: string) => void;
 
@@ -7,7 +7,7 @@ function defaultNavigator(url: string) {
     try {
       window.location.assign(url);
     } catch {
-      // jsdom may not implement navigation; swallow in environments where it's unsupported
+      // jsdom などページ遷移を実装しない環境では握りつぶす
     }
   }
 }
@@ -33,12 +33,11 @@ export function redirectToLogin(reason?: string) {
         navigatorFn(loginPath(reason));
       }
     } catch {
-      // reading pathname may throw in some environments; ignore
+      // pathname の読み取りが例外になる環境では何もしない
     }
   }
 }
 
-// Test helpers
 export function __setNavigatorForTests(fn: NavigatorFn) {
   navigatorFn = fn;
 }

--- a/frontend/src/shared/lib/proxy/routeGuard.ts
+++ b/frontend/src/shared/lib/proxy/routeGuard.ts
@@ -34,23 +34,16 @@ export function handleRouteProtection(request: NextRequest, role: 'platform' | '
   // 無限リダイレクト（ERR_TOO_MANY_REDIRECTS）に陥る。
   const isPublicPlatformRoute = isPublicPlatformPath(path);
 
-  // 1. Platform Route Protection
-  // If accessing a protected /platform/* route without a token, redirect to /platform/login
   if (path.startsWith('/platform') && !isPublicPlatformRoute && !hasToken) {
     console.error('🔒 Unauthorized access to /platform, redirecting to login');
     return NextResponse.redirect(new URL('/platform/login', request.url));
   }
 
-  // 2. Store Route Protection
-  // If accessing /store/* without a token, redirect to root (/)
-  // This logic applies even if role is 'platform' but accessing store routes (though rare)
-  // But strictly, we mostly care about store role here.
   if (path.startsWith('/store') && !hasToken) {
     console.error('🔒 Unauthorized access to /store, redirecting to root');
     return NextResponse.redirect(new URL('/', request.url));
   }
 
-  // 2.5. Cast Portal Route Protection
   // /cast/** はキャストポータル専用の認証済み領域。専用ログイン画面は無く /platform/login が
   // 入口のため、未トークンはそちらへ差し戻す（/store の既定遷移先である「/」とは別系統）。
   // 公開ストアフロントの /casts・/casts/:id を巻き込まないため厳密一致＋/cast/ 配下に限定する。
@@ -59,7 +52,6 @@ export function handleRouteProtection(request: NextRequest, role: 'platform' | '
     return NextResponse.redirect(new URL('/platform/login', request.url));
   }
 
-  // 2.6. Member Portal Route Protection
   // /member/** は会員ポータル専用の認証済み領域。入口は /platform/login（キャストと同様、
   // 専用ログイン画面は無い）。厳密一致＋/member/ 配下に限定するのも同じ理由。
   //
@@ -82,7 +74,6 @@ export function handleRouteProtection(request: NextRequest, role: 'platform' | '
     return response;
   }
 
-  // 3. Console/area alignment
   // 店舗文脈のまま /platform/* を直打ちすると、サイドバー（能力由来）と本文（URL 由来）が
   // 食い違ったまま描画され、平台 API も 403 になる。トークン保持者のコンソールと URL エリアが
   // 一致しない場合は自コンソールのホームへ差し戻す。cookie 不在（レガシーセッション）や
@@ -108,7 +99,6 @@ export function handleRouteProtection(request: NextRequest, role: 'platform' | '
     }
   }
 
-  // 4. Legacy id-less / retired store URL handling
   // id 無しの店舗 URL（例 /store/orders、ブックマーク・共有リンクに残りうる）は
   // /store/[storeId]/... にも /store/entry にもマッチせず 404 になる。
   // 廃止済みルート（/store/dashboard・/store/5/dashboard 等）も同じく遷移先が無い。
@@ -121,5 +111,5 @@ export function handleRouteProtection(request: NextRequest, role: 'platform' | '
     return NextResponse.redirect(new URL(storeEntryPath(path), request.url));
   }
 
-  return null; // No redirection needed
+  return null;
 }

--- a/frontend/src/widgets/sidebar/ui/Sidebar.tsx
+++ b/frontend/src/widgets/sidebar/ui/Sidebar.tsx
@@ -98,7 +98,7 @@ export function Sidebar() {
         setNavigation(mappedNavigation);
       } catch (error) {
         console.error('Failed to fetch menus', error);
-        // Fallback to basic Dashboard if API fails
+        // メニュー取得に失敗したら最低限の導線に落とす。
         // role state ではなく role effect と同じ解決順（platform console → x-mw-role cookie）で直接判定する。
         const platformConsole = getPlatformConsole();
         const isStore = platformConsole


### PR DESCRIPTION
## 概要

フロントエンド生産コードとバックエンドから、Comment Policy の削除対象（英文コメント・番号付き手順・分節横幅・署名復唱の `@param`/`@return`・コード復唱のラベル）を一掃する。コメントのみの差分で挙動変更ゼロ。

Closes #695

## 変更内容

- フロントエンド: `routeGuard.ts`/`proxy.ts` の番号手順、2 レイアウトと `StoreProfileForm` の JSX 分節横幅、`templates/{classic,default}/page.tsx` の目次式ヘッダ（classic は排布差の理由のみ残置）、`navigation.ts`/`client.ts`/`Banner.tsx`/`Sidebar.tsx` 等の英文コメントを削除または日本語の短い形へ書き替え
- バックエンド: `MenuVO`/`OrderResponse` の行末ラベル、`OrderMapper` の `====` 横幅と署名復唱 `@param`/`@return`、`SnowflakeIdGenerator` の英文ブロックと TODO 偽装、`S3FileStorage` のラベル型コメント（パストラバーサル防止の理由は 1 箇所に圧縮して残置）、`StoreScoped`/`StoreFilterEnable`/`RequestCorrelationFilter` の英文 Javadoc と `@author` 2 件を整理
- 差分の非コメント行はすべて行末コメント摘除で、コード部分は同一（機械検証済み）

## 検証

- [x] `task lint` exit 0
- [x] `task test-unit` exit 0
- [x] `task build` exit 0
- [ ] `task test-integration` / `task e2e` — コメントのみの差分のため免除（ユーザー裁定）
- [x] ローカルで QA レビュー実施済み（削除対象の全件が禁止形態であること・書き替え後の日本語コメントがコードと一致すること・残存英文コメントゼロを個別確認、指摘ゼロ）

## 決定ログ

- 票面の約 317 行は起票時の値で、#691〜#694 の fix-on-touch により実残は約 60 行・21 ファイルだった
- `token-claims.ts` の `/** STAFF / CAST / MEMBER。 */` と `AppProperties` の `/** app.jwt.* */` 等は識別子の列挙であり英文散文ではないため対象外と判定
- `StoreFilterEnable` の書き替え Javadoc は「店舗文脈が無い場合は何もしない（fail-open）」を明記 — #694 の実測結果に整合
- `OrderMapper.toEntity` の Javadoc から落とした「関連 ID はサービス層で割り当て」は、既存のインライン注釈（`@Mapping` 群）に単一ソース化済みで情報欠落なし

## 備考 / レビュー観点

- 削除ではなく圧縮に留めた箇所: `S3FileStorage` のパストラバーサル防止理由、`classic/page.tsx` の排布差
- `proxy.ts` 等に残る「模版」「テナント」の語彙は本票の射程外（コメント言語政策のみを扱う）

🤖 Generated with [Claude Code](https://claude.com/claude-code)