### PR TITLE
chore: 授権テストと API 規約の残余を補正する

### DIFF
--- a/backend/src/test/java/com/kizuna/ActuatorExposureDeclarationTests.java
+++ b/backend/src/test/java/com/kizuna/ActuatorExposureDeclarationTests.java
@@ -1,0 +1,40 @@
+package com.kizuna;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * actuator の web 露出が承認済みリスト（health のみ）に固定されていることを機械検証する。管理端点は controller ではないため {@code
+ * EndpointAuthorizationDeclarationTests} の走査に掛からず、露出を広げても授権ガードは緑のまま — この断言だけが捉える。
+ *
+ * <p>検証対象は application.yml のリテラルであり、実行時の環境変数上書き（{@code MANAGEMENT_*}）までは捕捉できない。
+ */
+class ActuatorExposureDeclarationTests {
+
+  @Test
+  @DisplayName("management.endpoints.web.exposure.include が health のみに固定されていること")
+  void actuatorExposureIsPinnedToHealth() throws Exception {
+    try (InputStream yml = getClass().getClassLoader().getResourceAsStream("application.yml")) {
+      assertThat(yml).as("main の application.yml がテスト classpath に載っていること").isNotNull();
+      Map<String, Object> root = new Yaml().load(yml);
+
+      Object management = root.get("management");
+      assertThat(management).as("management 節").isNotNull();
+      Object include = dig(management, "endpoints", "web", "exposure", "include");
+      assertThat(include).as("actuator の web 露出。広げるにはこの断言の更新＝レビューを通すこと").isEqualTo("health");
+    }
+  }
+
+  private static Object dig(Object node, String... keys) {
+    for (String key : keys) {
+      assertThat(node).as("経路上の節 %s が Map であること", key).isInstanceOf(Map.class);
+      node = ((Map<?, ?>) node).get(key);
+    }
+    return node;
+  }
+}

--- a/backend/src/test/java/com/kizuna/EndpointAuthorizationDeclarationTests.java
+++ b/backend/src/test/java/com/kizuna/EndpointAuthorizationDeclarationTests.java
@@ -21,9 +21,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.service.annotation.HttpExchange;
 
 /**
- * 全 HTTP handler が<b>方法級</b>の授権宣言を持ち、かつ method security の proxy が advise できる形（public・非 final・非
- * static）であることを機械検証する。{@code SecurityConfig} は {@code anyRequest().permitAll()} なので、宣言漏れも advise
- * 不能も等しく「誰でも叩ける端点」を静默に生む。クラス級の宣言を認めないのは、後から足した handler が公開設定を継承するため。
+ * 全 HTTP handler が<b>方法級</b>の授権宣言を持ち、かつ <b>public・非 final・非 static</b> であることを機械検証する。{@code
+ * SecurityConfig} は {@code anyRequest().permitAll()} なので、宣言漏れも advise
+ * 不能も等しく「誰でも叩ける端点」を静默に生む。クラス級の宣言を認めないのは、後から足した handler が公開設定を継承するため。public 限定は規約（api-guidelines
+ * §7）— CGLIB が advise できないのは private・final・static だけだが、例外形を作らないため public 以外を一律拒否する。
  *
  * <p>枚挙は Spring の {@code RequestMappingHandlerMapping} と同一規則（{@code isHandler} と同じ
  * {@code @Controller} 述語・{@code MethodIntrospector}・{@code @RequestMapping}／{@code @HttpExchange}）。
@@ -76,7 +77,8 @@ class EndpointAuthorizationDeclarationTests {
         .isEmpty();
     assertThat(unadvisable)
         .as(
-            "method security の proxy が advise できない handler（非 public / final / static）。授権注釈があっても実行時に無視され、端点は無防備になる")
+            "public でない・final・static な handler。private / final / static は proxy が advise できず授権注釈が実行時に黙って外れる。"
+                + "protected / package-private は技術上は advise できるが、規約 §7 により handler は public に限る")
         .isEmpty();
   }
 
@@ -86,7 +88,10 @@ class EndpointAuthorizationDeclarationTests {
         || AnnotatedElementUtils.hasAnnotation(method, HttpExchange.class);
   }
 
-  /** CGLIB は非 public・final・static を override できない。MVC は登録するが、授権の助言だけが黙って外れる。 */
+  /**
+   * CGLIB が override できないのは private・final・static。protected / package-private は override
+   * できるが、規約（§7）で handler は public に限るため、判定はあえて厳格側に置く。
+   */
   private static boolean isAdvisable(Method method) {
     int modifiers = method.getModifiers();
     return Modifier.isPublic(modifiers)

--- a/docs/api-guidelines.md
+++ b/docs/api-guidelines.md
@@ -100,6 +100,9 @@
   副キーが無いと、更新のたびに行が別ページへ滑って重複・欠落が起きる。
 - **`CursorPage`（`shared/web/CursorPage.java`）**: 作業キュー、無限スクロール、件数を必要としない履歴。
   総件数を返さない代わりに毎回の count 問い合わせを撒かない。取得件数は `CursorPage.MAX_SIZE` で頭打ちにする。
+  `Page` と同様に**全順序**を要求する。並び順に一意な副キー（`id` 等）を必ず含め、続きの問い合わせは並び順と
+  **同じ列の組**でカーソル比較する（範式は既存実装の `(businessDate, id)` / `(createdAt, id)` 複合述語）。
+  副キーの無いカーソルは同値行の境界で重複・欠落を起こす。
 - **裸の `List`**: 「有界であることを説明できる小集合」に限る。権限カタログ、ロール一覧、公開中のキャスト等、
   上限が業務上明らかなもの。**無界に増える履歴系を裸の `List` で返すのは違反**であり、`CursorPage` を使う。
 
@@ -122,17 +125,23 @@
   したがって **全 handler は `@PreAuthorize` か `@PermitAll` を明示する**。書き忘れは 403 ではなく
   「誰でも叩ける公開端点」を静默に生む。
 - この不変量は `EndpointAuthorizationDeclarationTests`（`backend/src/test/java/com/kizuna/`）が機械強制する。
-  豁免リストは持たない。
+  豁免リストは持たない。**handler メソッドは public に限る**。private / final / static は method security の
+  proxy が advise できず、授権注釈があっても実行時に黙って外れる。protected / package-private は CGLIB 上は
+  advise できるが、例外形を作らないため同テストは public 以外を一律拒否する。
 - **`@PermitAll` を新設するときは、公開端点の四点セットを同時に配線する**:
   1. handler に `@PermitAll`
   2. **CSRF 免除**: 状態を変える（`GET` 以外の）匿名端点は `SecurityConfig` の `CSRF_IGNORED_MATCHERS` へ追加する。
      既存の一括免除は「Bearer 付きリクエスト」が条件なので、匿名 POST はそこに当たらず個別列挙が要る。
      エントリは `PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/...")` の形で
-     **メソッド + パス**を指定する。パスだけで書くと、同一パス上の認証必須な別メソッドの handler まで CSRF 保護を失う。
+     **メソッド + パス**を指定する。`HttpMethod.POST` は例示であり、**端点の実メソッド**を渡す
+     （匿名の PUT / PATCH / DELETE を免除するのに POST を写経すると、免除は一致せず匿名リクエストが 403 になる）。
+     パスだけで書くと、同一パス上の認証必須な別メソッドの handler まで CSRF 保護を失う。
   3. **Bearer 免除**: `PlatformBearerTokenResolver` の `BEARER_EXEMPT_MATCHERS` へ追加する。
      陳腐化した token cookie を持つ利用者が、`@PermitAll` の判定に届く前に 401 で弾かれるのを防ぐ。
      こちらも **メソッド + パス**で指定する。パスだけで書くと、同一パス上の認証必須な別メソッドの handler でも Bearer が
      捨てられ、その handler の `@PreAuthorize` は常に匿名を見ることになる — その端点は誰にも通せない恒久的な 401/403 になる。
+     免除してよいのは「陳腐な token を持つ利用者にも通すべき端点」だけ。`@PermitAll` でも `Principal` を見て
+     応答を出し分ける**任意認証**の端点は免除してはならない — 免除すると正当な Bearer まで捨てられ、常に匿名として扱われる。
   4. **店舗文脈**: `/store/**` と `/files/**` は `StoreIdInterceptor` の対象で、店舗文脈ヘッダ（`X-Role` / `X-Store-ID`）が
      無いリクエストを fail-closed で 403 にする。匿名でも店舗文脈は要る。文脈無しで通す端点だけが `@StoreOptional` を明示する。
 


### PR DESCRIPTION
## 概要

API 規約制定 PR（#696）クローズ時に転記された Codex 四巡指摘 5 件を、裁定に沿って全件消化する。規約文言の精緻化＋守衛テストの補正で、生産コードの変更は無い。

Closes #697

## 変更内容

- **advise 判定（裁定: 厳格維持＋規約明文化）**: `EndpointAuthorizationDeclarationTests` の判定ロジックは不変のまま、注釈と失敗メッセージを事実に揃えた — CGLIB が advise できないのは private / final / static のみで、protected / package-private の拒否は「handler は public に限る」という規約由来であることを明記。規約 §7 にも同文を追加
- **§7 CSRF 免除の例**: `HttpMethod.POST` は例示であり端点の実メソッドを渡すこと、POST を写経すると匿名 PUT/PATCH/DELETE の免除が一致せず 403 になることを追記
- **§7 Bearer 免除の適用条件**: `Principal` を見て応答を出し分ける任意認証の `@PermitAll` 端点は免除禁止（免除すると正当な Bearer まで捨てられ常に匿名扱い）を追記
- **§5 CursorPage の全順序要求**: `Page` と同様に一意な副キーを含む全順序と、並び順と同列組のカーソル比較を要求として明記。範式として既存実装の `(businessDate, id)` / `(createdAt, id)` 複合述語を名指し（4 リポジトリで実在を確認済み）
- **actuator 露出断言（裁定: 追加）**: `ActuatorExposureDeclarationTests` を新設。application.yml の `management.endpoints.web.exposure.include` が `health` のみに固定されていることを断言する。管理端点は controller 走査に掛からないため、この断言だけが露出拡大を捉える

## 検証

- [x] `task lint` exit 0
- [x] backend 単体テスト全量 exit 0（`./gradlew test`）
- [x] `task build service=backend` exit 0
- [x] 新テストの赤証明: exposure を `health,info` に変異させて exit 1 を確認後、復元
- [ ] `task test-integration` / `task e2e` — docs＋テストのみの差分のため免除（#706 と同じ裁定基準）

## 決定ログ

- advise 判定は「緩めて CGLIB の実挙動に忠実にする」案を見送り: 現在非 public な handler はゼロで、緩めても得る物が無く、境界ケースの検証負担だけを引き受けることになるため。厳格側を規約として固定した
- actuator 断言は yml のリテラル検証であり、実行時の `MANAGEMENT_*` 環境変数上書きまでは捕捉できない旨をテストの Javadoc に明記（リポジトリ内に env 上書きは現存しない）

## 備考 / レビュー観点

- `EndpointAuthorizationDeclarationTests` は文言のみの変更で判定は 1 ビットも変わっていない — diff の判定式部分が不変であることを確認いただきたい

🤖 Generated with [Claude Code](https://claude.com/claude-code)