### PR TITLE
feat: lint 門禁にテストを含む型検査を追加する

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,8 @@ COPY . .
 RUN --mount=type=cache,id=npm-cache,target=/root/.npm,uid=1000,gid=1000,sharing=locked \
     npm run format:check && \
     npm run lint && \
-    npm run lint:fsd
+    npm run lint:fsd && \
+    npm run typecheck
 
 FROM deps AS test
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix --quiet .",
     "lint:fsd": "steiger ./src",
+    "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",
     "format": "prettier --write --log-level warn .",


### PR DESCRIPTION
## 概要

テストファイルの tsc 型エラーが三門禁（lint / test / build）すべての盲点になっていた問題（#698 の根因調査で判明: Next `runTypeCheck` の ignoreRegex が `__tests__` / `*.test.*` 診断を濾過、jest は SWC 変換のみ）を、lint ステージへの `tsc --noEmit` 追加で閉じる。票面 A 案そのまま。

Closes #699

## 変更内容

- `frontend/package.json`: `"typecheck": "tsc --noEmit"` スクリプトを追加
- `frontend/Dockerfile`: lint ステージの RUN 連鎖末尾に `npm run typecheck` を追記

CI の `Lint and Test (frontend)` は `task -d frontend lint` を実行するため、workflow 変更も required status context の追加も不要でそのまま覆われる。

## 検証

- [x] `task -d frontend lint` exit 0（day-one 緑）
- [x] **赤の実証**: テストファイルに型エラー（`export const p: number = 'red'`）を変異注入 → `task -d frontend lint` が exit 非 0。ログで eslint 步は 0 errors で通過し、失敗が `npm run typecheck` 步の `TS2322`（注入行を名指し）であることを確認 — 赤の出所が型検査そのものであることまで検証済み。変異は復元済み
- [x] `task test service=frontend` exit 0
- [x] `task build service=frontend` exit 0（package.json 変更による deps 層再構築を含む）
- [ ] `task test-integration` / `task e2e` — 門禁配線のみの差分のため免除（#706/#707 と同じ裁定基準）

## 決定ログ

- 一巡目の赤証明は未使用変数の注入だったため、eslint（no-unused-vars）に先取りされた偽証の可能性があり棄却。`export` 形に変えて eslint を素通りさせ、typecheck 步で赤になることを取り直した

## 備考 / レビュー観点

- ローカルで `.next/types/validator.ts` が旧構築残骸の場合に `npm run typecheck` へ既知のノイズが出る件（票面記載）は、コンテナ内では `.dockerignore` が `.next/` を除外するため CI/門禁に影響しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)