### PR TITLE
feat: 読み取り側 StoreScope の宣言監査 fitness test を実装する

### DIFF
--- a/backend/src/main/java/com/kizuna/cast/application/CastInvitationAcceptanceService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastInvitationAcceptanceService.java
@@ -12,6 +12,7 @@ import com.kizuna.shared.exception.DbConstraint;
 import com.kizuna.shared.exception.IntegrityViolations;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.storescope.StoreScopeExempt;
 import com.kizuna.store.domain.Store;
 import com.kizuna.store.domain.StoreRepository;
 import com.kizuna.user.domain.PlatformUser;
@@ -42,6 +43,9 @@ public class CastInvitationAcceptanceService {
   private static final String DUPLICATE_EMAIL_MESSAGE =
       "このメールアドレスは既に登録されています。既存アカウントでログインして受諾してください";
 
+  private static final String TOKEN_IS_THE_BOUNDARY =
+      "招待 token は店舗横断で一意かつ推測不能で、辿れる档案・店舗は token が指す 1 件に限られる";
+
   private final CastInvitationRepository castInvitationRepository;
   private final CastRepository castRepository;
   private final PlatformUserRepository platformUserRepository;
@@ -49,6 +53,7 @@ public class CastInvitationAcceptanceService {
   private final PasswordEncoder passwordEncoder;
 
   /** 招待を照会する。受諾可否のビュー状態（VALID/EXPIRED/USED）と店舗名・档案名を返す。 */
+  @StoreScopeExempt(reason = TOKEN_IS_THE_BOUNDARY)
   @Transactional(readOnly = true)
   public CastInvitationDetailResponse view(String token) {
     CastInvitation invitation = findByToken(token);
@@ -61,6 +66,7 @@ public class CastInvitationAcceptanceService {
   }
 
   /** 新規登録で受諾する。CAST・SPECIFIC_STORES{招待店舗} の身分を作成し、档案へ紐づけて招待を受諾済みにする。 */
+  @StoreScopeExempt(reason = TOKEN_IS_THE_BOUNDARY)
   @Transactional
   public CastAcceptanceResponse acceptAsNewUser(String token, CastInvitationAcceptRequest request) {
     CastInvitation invitation = findByToken(token);
@@ -91,6 +97,7 @@ public class CastInvitationAcceptanceService {
    * 既存の CAST アカウントで受諾する。SPECIFIC_STORES は所属店舗集合に招待店舗を冪等 union し、ALL_STORES
    * は全店アクセス権をそのまま保持する（降格しない）。 いずれも档案へ紐づけて招待を受諾済みにする。
    */
+  @StoreScopeExempt(reason = TOKEN_IS_THE_BOUNDARY)
   @Transactional
   public CastAcceptanceResponse acceptAsExistingUser(String token, String email) {
     CastInvitation invitation = findByToken(token);

--- a/backend/src/main/java/com/kizuna/cast/application/CastInvitationService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastInvitationService.java
@@ -10,6 +10,7 @@ import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.exception.DbConstraint;
 import com.kizuna.shared.exception.IntegrityViolations;
 import com.kizuna.shared.exception.NotFoundException;
+import com.kizuna.shared.storescope.StoreScopeExempt;
 import com.kizuna.shared.storescope.StoreScoped;
 import java.security.SecureRandom;
 import java.time.OffsetDateTime;
@@ -99,6 +100,7 @@ public class CastInvitationService {
   }
 
   /** ページ内の档案について招待状態（四態）を一括導出する。呼び出し元の storeFilter 有効なトランザクション内で使う。 */
+  @StoreScopeExempt(reason = "storeFilter を有効化した呼出元のトランザクション内でのみ使う内部一括導出で、境界は呼出元が引く")
   public Map<String, CastInvitationStatus> deriveStatuses(List<Cast> casts) {
     if (casts.isEmpty()) {
       return Map.of();

--- a/backend/src/main/java/com/kizuna/cast/application/CastSelfService.java
+++ b/backend/src/main/java/com/kizuna/cast/application/CastSelfService.java
@@ -3,6 +3,7 @@ package com.kizuna.cast.application;
 import com.kizuna.cast.api.dto.CastStoreResponse;
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.exception.StaleSessionException;
+import com.kizuna.shared.storescope.StoreScopeExempt;
 import com.kizuna.user.domain.PlatformUserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ public class CastSelfService {
   private final PlatformUserRepository platformUserRepository;
   private final CastRepository castRepository;
 
+  @StoreScopeExempt(reason = "認証済み email から逆引きした本人の platform_user_id が唯一の境界で、所属店舗の跨店解決自体が業務要件")
   @Transactional(readOnly = true)
   public List<CastStoreResponse> myStores(String email) {
     Long userId =

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerReferenceResolver.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerReferenceResolver.java
@@ -2,6 +2,7 @@ package com.kizuna.customer.application;
 
 import com.kizuna.customer.domain.CustomerRepository;
 import com.kizuna.shared.exception.NotFoundException;
+import com.kizuna.shared.storescope.StoreScopeExempt;
 import lombok.RequiredArgsConstructor;
 import org.springframework.modulith.NamedInterface;
 import org.springframework.stereotype.Service;
@@ -35,6 +36,8 @@ public class CustomerReferenceResolver {
    * <p>呼出側のトランザクションに必ず参加する（{@code MANDATORY}）。自分でトランザクションを開くと新しい Session になり、 呼出側の
    * {@code @StoreScoped} が有効にした storeFilter が掛からないまま他店舗の行を押さえたうえ、 呼出側が書き込む前に行ロックを手放してしまう。
    */
+  @StoreScopeExempt(
+      reason = "呼出元のトランザクションに必ず参加し（MANDATORY）、店舗境界は呼出元の storeFilter か呼出元が明示する storeId が引く")
   @Transactional(propagation = Propagation.MANDATORY)
   public String resolveForWrite(String customerId) {
     customerRepository

--- a/backend/src/main/java/com/kizuna/order/application/MemberOrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/MemberOrderService.java
@@ -19,6 +19,7 @@ import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.exception.StaleSessionException;
 import com.kizuna.shared.storescope.StoreExistenceCheck;
+import com.kizuna.shared.storescope.StoreScopeExempt;
 import com.kizuna.shared.web.CursorPage;
 import com.kizuna.shared.web.PageCursor;
 import com.kizuna.shift.application.ConfirmedShiftLookupService;
@@ -60,6 +61,7 @@ public class MemberOrderService {
   private final AppProperties appProperties;
 
   /** 予約を申請する。申請は受注（Order）の CREATED として起き、店舗の確定で同じ行が CONFIRMED になる。 */
+  @StoreScopeExempt(reason = "会員は店舗文脈を確立できないため、店舗の実在を確かめたうえで store_id を明示設定して書く")
   @Transactional
   public MemberOrderResponse request(String email, MemberOrderCreateRequest request) {
     MemberLookup member = resolveMember(email);
@@ -100,6 +102,7 @@ public class MemberOrderService {
    * @param cursor 続きの位置。null なら先頭から
    * @param requestedSize 1 回に返す件数の希望値（上限に丸められる）
    */
+  @StoreScopeExempt(reason = "会員は店舗文脈を確立できないため、申請者（requesterMemberId）の一致を問い合わせ自体に載せることが唯一の境界")
   @Transactional(readOnly = true)
   public CursorPage<MemberOrderResponse> list(String email, String cursor, int requestedSize) {
     MemberLookup member = resolveMember(email);
@@ -124,6 +127,7 @@ public class MemberOrderService {
   }
 
   /** 本人が申請した未確定の予約を取り下げる。確定後は店舗との調整が要るため取り下げられない。 */
+  @StoreScopeExempt(reason = "会員は店舗文脈を確立できないため、申請者（requesterMemberId）の一致を取り出しの条件に載せることが唯一の境界")
   @Transactional
   public MemberOrderResponse cancel(String email, String orderId) {
     MemberLookup member = resolveMember(email);

--- a/backend/src/main/java/com/kizuna/order/application/MemberReceiptClaimService.java
+++ b/backend/src/main/java/com/kizuna/order/application/MemberReceiptClaimService.java
@@ -13,6 +13,7 @@ import com.kizuna.order.infrastructure.ReceiptTokenGenerator;
 import com.kizuna.point.application.PointLedgerService;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.StaleSessionException;
+import com.kizuna.shared.storescope.StoreScopeExempt;
 import com.kizuna.user.domain.PlatformUserRepository;
 import java.time.OffsetDateTime;
 import lombok.RequiredArgsConstructor;
@@ -55,6 +56,7 @@ public class MemberReceiptClaimService {
    * @param rawToken QR が運ぶトークンの生値。保存された鍵付きダイジェストとの一致だけで照合する
    * @return 記帳したポイント（付与予定額 0 の伝票では 0 で、台帳に行は書かない）
    */
+  @StoreScopeExempt(reason = "トークンの鍵付きダイジェスト一致だけが申領を成立させる材料で、受注は店舗を跨いで引く（店舗で絞ると照合が成立しない）")
   @Transactional
   public MemberReceiptClaimResponse claim(String email, String rawToken) {
     Long platformUserId = resolvePlatformUserId(email);

--- a/backend/src/main/java/com/kizuna/order/application/NominatableCastLookup.java
+++ b/backend/src/main/java/com/kizuna/order/application/NominatableCastLookup.java
@@ -2,6 +2,7 @@ package com.kizuna.order.application;
 
 import com.kizuna.cast.domain.Cast;
 import com.kizuna.cast.domain.CastRepository;
+import com.kizuna.shared.storescope.StoreScopeExempt;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,9 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 class NominatableCastLookup {
 
+  private static final String EXPLICIT_STORE_PREDICATE =
+      "キャスト読み取りの暗黙の絞り込みに頼らず、店舗の一致を引き当ての述語に明示することが境界";
+
   /** 指名を成立させる在籍状態。 */
   private static final String ACTIVE_STATUS = "ACTIVE";
 
@@ -36,6 +40,7 @@ class NominatableCastLookup {
   private final CastRepository castRepository;
 
   /** 指名先として成立するキャストを引く。成立しないときは空を返し、何を投げるかは呼び出し側が決める。 */
+  @StoreScopeExempt(reason = EXPLICIT_STORE_PREDICATE)
   Optional<Cast> find(Long storeId, String castId) {
     return castRepository
         .findById(castId)
@@ -48,6 +53,7 @@ class NominatableCastLookup {
    *
    * <p>検索語なし（null・空白のみ）は絞り込みなしと同じに扱う。コンボボックスは開いた時点で語なしに一度取りに行くため、 ここで空を返すと候補が何も出ないまま打ち始めることになる。
    */
+  @StoreScopeExempt(reason = EXPLICIT_STORE_PREDICATE)
   List<Cast> searchCandidates(Long storeId, String keyword) {
     String name = keyword == null ? "" : keyword.trim();
     return castRepository

--- a/backend/src/main/java/com/kizuna/order/application/PlatformOrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/PlatformOrderService.java
@@ -6,6 +6,7 @@ import com.kizuna.order.api.dto.PlatformOrderCreateRequest;
 import com.kizuna.order.api.dto.PlatformOrderResponse;
 import com.kizuna.order.domain.OrderRepository;
 import com.kizuna.shared.storescope.StoreScopeExecutor;
+import com.kizuna.shared.storescope.StoreScopeExempt;
 import com.kizuna.shared.storescope.StoreSetScoped;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -36,6 +37,8 @@ public class PlatformOrderService {
    * <p>店舗側の作成へそのまま委譲するため、出生確定・WEB 拒否・受付担当の省略補完はこちらでも同じに効く — 入口によって受注の生まれ方は変わらない。実行者は受付担当の補完に要るので
    * 渡す（HQ 管理者は受付候補の適格条件を満たさないため、省略した要求は 400 になる）。
    */
+  @StoreScopeExempt(
+      reason = "repository を自ら読まず、StoreScopeExecutor で店舗文脈を確立して @StoreScoped な店舗側の作成へ委譲する")
   public OrderResponse create(PlatformOrderCreateRequest request, String actorEmail) {
     return storeScopeExecutor.runInStore(
         request.getStoreId(), () -> orderService.create(request, actorEmail));

--- a/backend/src/main/java/com/kizuna/shared/storescope/StoreFilterEnable.java
+++ b/backend/src/main/java/com/kizuna/shared/storescope/StoreFilterEnable.java
@@ -5,16 +5,20 @@ import lombok.AllArgsConstructor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 /**
  * {@code @StoreScoped} メソッドの呼び出しを囲み、現在の Session に Hibernate の {@code storeFilter} を有効化する。
  * 店舗文脈が無い場合は何もしない — 絞り込み無しのまま実行される。
+ *
+ * <p>{@code @Order} は最低優先度で固定する。値を下げるとトランザクション advisor の外側へ出て、OSIV=off の共有 EntityManager が使い捨ての
+ * Session を作って即閉じるため、フィルタは死んだ Session に掛かり本体は別 Session で走る（＝隔離が静默に外れる）。
  */
 @Aspect
 @Component
-@Order
+@Order(Ordered.LOWEST_PRECEDENCE)
 @AllArgsConstructor
 public class StoreFilterEnable {
 

--- a/backend/src/main/java/com/kizuna/shared/storescope/StoreScopeExempt.java
+++ b/backend/src/main/java/com/kizuna/shared/storescope/StoreScopeExempt.java
@@ -1,0 +1,19 @@
+package com.kizuna.shared.storescope;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 店舗フィルタ（{@code storeFilter} / {@code storeSetFilter}）を有効化しないまま実行する方法であることを宣言する。
+ *
+ * <p>{@code reason} には代償制御（呼出前の属主検証、推測不能な鍵での指名、跨店舗であること自体が業務要件、等）か、
+ * その方法が店舗スコープ表を自ら読まない理由（{@code @StoreScoped} な方法への委譲、等）を一文で書く。既定値は置かない — 理由の無い豁免は作らせない。
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface StoreScopeExempt {
+
+  String reason();
+}

--- a/backend/src/main/java/com/kizuna/shared/storescope/StoreSetFilterEnable.java
+++ b/backend/src/main/java/com/kizuna/shared/storescope/StoreSetFilterEnable.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -20,7 +21,7 @@ import org.springframework.stereotype.Component;
  */
 @Aspect
 @Component
-@Order
+@Order(Ordered.LOWEST_PRECEDENCE)
 @AllArgsConstructor
 public class StoreSetFilterEnable {
 

--- a/backend/src/main/java/com/kizuna/shift/application/CastScheduleService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/CastScheduleService.java
@@ -3,6 +3,7 @@ package com.kizuna.shift.application;
 import com.kizuna.cast.domain.CastRepository;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.exception.StaleSessionException;
+import com.kizuna.shared.storescope.StoreScopeExempt;
 import com.kizuna.shift.api.dto.CastScheduleResponse;
 import com.kizuna.shift.api.dto.ShiftMapper;
 import com.kizuna.shift.domain.ShiftRepository;
@@ -31,6 +32,7 @@ public class CastScheduleService {
   private final ShiftRepository shiftRepository;
   private final ShiftMapper shiftMapper;
 
+  @StoreScopeExempt(reason = "認証済み email から逆引きした本人の cast_id 集合が唯一の境界で、本人の档案は所属店にしか存在しない")
   @Transactional(readOnly = true)
   public List<CastScheduleResponse> myWeek(String email, LocalDate from, LocalDate to) {
     if (to.isBefore(from) || ChronoUnit.DAYS.between(from, to) > MAX_SPAN_DAYS) {

--- a/backend/src/main/java/com/kizuna/shift/application/CastShiftRequestService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/CastShiftRequestService.java
@@ -5,6 +5,7 @@ import com.kizuna.shared.config.AppProperties;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.exception.StaleSessionException;
+import com.kizuna.shared.storescope.StoreScopeExempt;
 import com.kizuna.shared.web.CursorPage;
 import com.kizuna.shared.web.PageCursor;
 import com.kizuna.shift.api.dto.CastShiftRequestResponse;
@@ -46,6 +47,7 @@ public class CastShiftRequestService {
   private final ShiftRequestMapper shiftRequestMapper;
   private final AppProperties appProperties;
 
+  @StoreScopeExempt(reason = "所属判定は「指定店舗に本人の cast 行が存在すること」で行い、store_id はその判定に通った店舗を明示設定する")
   @Transactional
   public ShiftRequestResponse submit(String email, ShiftRequestCreateRequest request) {
     validateRequestedSlot(request.getWorkDate(), request.getStartTime(), request.getEndTime());
@@ -73,6 +75,7 @@ public class CastShiftRequestService {
    * 確定シフトへの変更申請を提出する。対象シフトは本人の cast 行に属し（cast_id 自限がそのまま店舗自限として機能する）、かつ CONFIRMED
    * であることを要求する。店舗はシフトから導出し、シフト自体はこの時点では変更しない（店舗の承認で更新される）。
    */
+  @StoreScopeExempt(reason = "対象シフトを本人の cast_id 集合に属するものだけへ絞ることが境界で、store_id はそのシフトから導出する")
   @Transactional
   public ShiftRequestResponse submitChange(String email, ShiftChangeRequestCreateRequest request) {
     validateRequestedSlot(request.getWorkDate(), request.getStartTime(), request.getEndTime());
@@ -114,6 +117,7 @@ public class CastShiftRequestService {
    * @param cursor 続きの位置。null なら先頭から
    * @param requestedSize 1 回に返す件数の希望値（上限に丸められる）
    */
+  @StoreScopeExempt(reason = "本人の cast_id 集合の一致を問い合わせ自体に載せることが唯一の境界（cast 自限が店舗自限としても働く）")
   @Transactional(readOnly = true)
   public CursorPage<CastShiftRequestResponse> history(
       String email, String cursor, int requestedSize) {

--- a/backend/src/main/java/com/kizuna/shift/application/ConfirmedShiftLookupService.java
+++ b/backend/src/main/java/com/kizuna/shift/application/ConfirmedShiftLookupService.java
@@ -3,6 +3,7 @@ package com.kizuna.shift.application;
 import com.kizuna.shared.config.AppProperties;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreExistenceCheck;
+import com.kizuna.shared.storescope.StoreScopeExempt;
 import com.kizuna.shift.api.dto.PublicShiftResponse;
 import com.kizuna.shift.domain.ConfirmedShiftCastView;
 import com.kizuna.shift.domain.ShiftRepository;
@@ -33,11 +34,15 @@ public class ConfirmedShiftLookupService {
 
   private static final String CONFIRMED = "CONFIRMED";
 
+  private static final String EXPLICIT_STORE_ID_IS_THE_BOUNDARY =
+      "呼び手（会員）は店舗文脈を確立できないため、問い合わせへの storeId 明示指定が唯一の境界";
+
   private final ShiftRepository shiftRepository;
   private final StoreExistenceCheck storeExistenceCheck;
   private final AppProperties appProperties;
 
   /** 指定店舗・指定日の確定シフトに入っている ACTIVE キャストを返す。 */
+  @StoreScopeExempt(reason = EXPLICIT_STORE_ID_IS_THE_BOUNDARY)
   @Transactional(readOnly = true)
   public List<PublicShiftResponse> listConfirmedCasts(Long storeId, LocalDate workDate) {
     if (!storeExistenceCheck.exists(storeId)) {
@@ -63,6 +68,7 @@ public class ConfirmedShiftLookupService {
   }
 
   /** 指定店舗・指定キャスト・指定日に確定シフトがあるか。 */
+  @StoreScopeExempt(reason = EXPLICIT_STORE_ID_IS_THE_BOUNDARY)
   @Transactional(readOnly = true)
   public boolean hasConfirmedShift(Long storeId, String castId, LocalDate workDate) {
     return shiftRepository.existsByStoreIdAndCastIdAndWorkDateAndStatus(

--- a/backend/src/main/java/com/kizuna/store/application/StoreRegistryService.java
+++ b/backend/src/main/java/com/kizuna/store/application/StoreRegistryService.java
@@ -3,6 +3,7 @@ package com.kizuna.store.application;
 import com.kizuna.point.application.PointLedgerService;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
+import com.kizuna.shared.storescope.StoreScopeExempt;
 import com.kizuna.store.api.dto.StoreCreateDTO;
 import com.kizuna.store.api.dto.StoreStatusVO;
 import com.kizuna.store.api.dto.StoreUpdateDTO;
@@ -28,11 +29,15 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class StoreRegistryService {
 
+  /** 店舗台帳（Store）は店舗スコープ表ではない。StoreProfile を触るのは {@code create} だけで、他の方法は素通しにならない。 */
+  private static final String REGISTRY_ONLY = "店舗スコープ表（StoreProfile）を読まず、店舗台帳（Store）だけを扱う HQ 管理面";
+
   private final StoreRepository storeRepository;
   private final StoreProfileRepository storeProfileRepository;
   private final CompletedOrderCheck completedOrderCheck;
   private final PointLedgerService pointLedgerService;
 
+  @StoreScopeExempt(reason = REGISTRY_ONLY)
   @Transactional(readOnly = true)
   public Page<StoreVO> list(String search, Pageable pageable) {
     // 派生クエリの Containing は null を渡せないため、絞り込み無し（null）は空パターンで表す。
@@ -42,11 +47,13 @@ public class StoreRegistryService {
         .map(this::toDto);
   }
 
+  @StoreScopeExempt(reason = REGISTRY_ONLY)
   @Transactional(readOnly = true)
   public StoreVO getById(String id) {
     return storeRepository.findById(parseId(id)).map(this::toDto).orElseThrow(() -> notFound(id));
   }
 
+  @StoreScopeExempt(reason = REGISTRY_ONLY)
   @Transactional(readOnly = true)
   // Optional は unwrap されるため未登録ドメインは null。cache-null-values=false の Redis に
   // null を書くと IllegalArgumentException → 500 になるのでキャッシュ対象外にする
@@ -61,6 +68,7 @@ public class StoreRegistryService {
    *
    * <p>ドメインの重複は、制約違反を捕まえるのではなく事前に照会して判定する — 一意制約はここを擦り抜けた競合を受け止める 最後の一枚（409）であり、業務上の重複判定を委ねる先ではない。
    */
+  @StoreScopeExempt(reason = "HQ の店舗登録で既定 StoreProfile を起こす書き込みで、store_id は今作った店舗の id を明示設定する")
   @Transactional
   public Long create(StoreCreateDTO req) {
     if (storeRepository.findByDomain(req.getDomain()).isPresent()) {
@@ -77,6 +85,7 @@ public class StoreRegistryService {
 
   // storeByDomain のキーは domain。だが注釈の式から見えるのは引数の id と戻り値（void）だけで、
   // domain はメソッド本体のローカルにしか現れずキーとして書けない。delete と同じ全件失効に揃える。
+  @StoreScopeExempt(reason = REGISTRY_ONLY)
   @Transactional
   @CacheEvict(value = "storeByDomain", allEntries = true)
   public void update(String id, StoreUpdateDTO req) {
@@ -94,6 +103,7 @@ public class StoreRegistryService {
    * <p>記録の側は、完了済みの受注とポイント台帳の帰属の両方を見る。台帳の仕訳は会員が持ち店舗が消えても行は残る（発生店舗が 外れるだけ）ため、DB の外部キーは削除を止めない —
    * 「その店舗で起きた記録が読めなくなる」ことを止めるのはここだけである。
    */
+  @StoreScopeExempt(reason = REGISTRY_ONLY)
   @Transactional
   @CacheEvict(value = "storeByDomain", allEntries = true)
   public void delete(String id) {
@@ -109,6 +119,7 @@ public class StoreRegistryService {
     storeRepository.deleteById(storeId);
   }
 
+  @StoreScopeExempt(reason = REGISTRY_ONLY)
   @Transactional(readOnly = true)
   public StoreStatusVO stats() {
     return new StoreStatusVO(storeRepository.count());

--- a/backend/src/test/java/com/kizuna/StoreScopeDeclarationTests.java
+++ b/backend/src/test/java/com/kizuna/StoreScopeDeclarationTests.java
@@ -1,0 +1,195 @@
+package com.kizuna;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kizuna.shared.persistence.StoreScopedEntity;
+import com.kizuna.shared.storescope.StoreFilterEnable;
+import com.kizuna.shared.storescope.StoreScopeExempt;
+import com.kizuna.shared.storescope.StoreScoped;
+import com.kizuna.shared.storescope.StoreSetFilterEnable;
+import com.kizuna.shared.storescope.StoreSetScoped;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.annotation.OrderUtils;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.data.repository.Repository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * 店舗スコープ表を読む application 層の方法が、作用域を<b>宣言</b>していることを機械検証する。
+ *
+ * <p>{@code StoreScopedEntity} を型引数に持つ Spring Data repository を注入したクラスの public
+ * 方法は、{@code @StoreScoped} / {@code @StoreSetScoped} / {@code @StoreScopeExempt}
+ * のいずれか一つを必ず持つ。無宣言は「店舗を跨いで読める読み口」を静默に生む。豁免リストは持たない — 意図的な素通しは注釈と理由で名指しさせる。
+ *
+ * <p>走査の前提と限界（自己申告）:
+ *
+ * <ul>
+ *   <li>注入は<b>宣言フィールドと構築子引数の型</b>で判定する。方法本体は反射から見えないので、判定はクラス粒度＝過剰近似 — repository
+ *       を触らない方法も宣言を要求される（その場合は「委譲するだけ」を {@code reason} に書く）。
+ *   <li>方法局所での repository 取得（{@code getBean} 等）、api 層のクラス、Spring bean でないクラスは見えない。
+ *   <li>検査対象はクラス自身が宣言した非 private・非 static の方法（package-private も他 bean からの入口になるため含む）。 継承した方法は見ない。入口が
+ *       private 補助方法へ委譲する形は、入口が検査されるので覆える。
+ *   <li>これは<b>宣言</b>の監査であって効果の監査ではない。{@code StoreFilterEnable} は fail-open
+ *       なので、宣言済みでも店舗文脈が無ければ濾過されない。
+ * </ul>
+ *
+ * <p>{@code StoreScopeExecutor} は作用域の宣言として数えない。あれは {@code StoreContext} を確立するだけで Hibernate
+ * フィルタは有効化せず（有効化は aspect のみが行う）、加えて方法本体を見ない反射では利用の静的検出自体が信頼できない。
+ */
+class StoreScopeDeclarationTests {
+
+  @Test
+  @DisplayName("店舗スコープ repository を注入した application クラスの全方法（非 private）が作用域を宣言していること")
+  void allStoreScopedApplicationMethodsDeclareScope() throws Exception {
+    ClassPathScanningCandidateComponentProvider scanner =
+        new ClassPathScanningCandidateComponentProvider(false);
+    scanner.addIncludeFilter(new AnnotationTypeFilter(Component.class));
+
+    List<String> undeclared = new ArrayList<>();
+    List<String> multiplyDeclared = new ArrayList<>();
+    List<String> scanned = new ArrayList<>();
+    Set<String> repositories = new LinkedHashSet<>();
+    int methods = 0;
+    for (var candidate : scanner.findCandidateComponents("com.kizuna")) {
+      Class<?> type = Class.forName(candidate.getBeanClassName());
+      if (!isApplicationLayer(type)) {
+        continue;
+      }
+      Set<String> injected = injectedStoreScopedRepositories(type);
+      if (injected.isEmpty()) {
+        continue;
+      }
+      scanned.add(type.getSimpleName());
+      repositories.addAll(injected);
+      for (Method method : type.getDeclaredMethods()) {
+        if (!isAudited(method)) {
+          continue;
+        }
+        methods++;
+        String name = type.getName() + "#" + method.getName();
+        int declarations = countScopeDeclarations(method);
+        if (declarations == 0) {
+          undeclared.add(name);
+        } else if (declarations > 1) {
+          multiplyDeclared.add(name);
+        }
+      }
+    }
+
+    // 暗黙の no-op 防止: 走査が実際にクラス・方法・店舗スコープ repository を捉えていることを担保する。
+    assertThat(scanned).as("店舗スコープ repository を注入した application クラス").isNotEmpty();
+    assertThat(methods).as("検査した方法の総数").isGreaterThan(0);
+    assertThat(repositories).as("型引数が StoreScopedEntity を継承する repository").isNotEmpty();
+
+    assertThat(undeclared)
+        .as("@StoreScoped / @StoreSetScoped / @StoreScopeExempt のいずれも宣言していない方法（店舗フィルタ無しで読める）")
+        .isEmpty();
+    assertThat(multiplyDeclared).as("作用域宣言を二つ以上持つ方法（どれが効くか読めない）").isEmpty();
+  }
+
+  /**
+   * 店舗フィルタの aspect が、トランザクション advisor より<b>内側</b>で回ることを固定する。
+   *
+   * <p>外側へ出ると、OSIV=off の共有 EntityManager は {@code unwrap} のたびに使い捨ての Session を作って即閉じるため、フィルタは死んだ
+   * Session に掛かり本体は別 Session で走る。proxy 鎖は {@code @Order} の小さい方が外側なので、不変量は「aspect の order ≧ tx
+   * advisor の order」。
+   *
+   * <p>同値のときの前後は advisor の収集順（素の Advisor bean が AspectJ 由来より先）で決まり、{@code @Order} では固定されない。tx
+   * advisor は最低優先度に居るため、aspect 側でそれ以上の値は取れない。
+   */
+  @Test
+  @DisplayName("店舗フィルタの aspect がトランザクション advisor より内側の @Order を宣言していること")
+  void filterAspectsRunInsideTransactionAdvisor() {
+    EnableTransactionManagement enableTx =
+        AnnotatedElementUtils.findMergedAnnotation(
+            Application.class, EnableTransactionManagement.class);
+    assertThat(enableTx).as("@EnableTransactionManagement の宣言").isNotNull();
+    int transactionAdvisorOrder = enableTx.order();
+
+    assertThat(OrderUtils.getOrder(StoreFilterEnable.class))
+        .as("StoreFilterEnable の @Order（tx advisor の %d より小さいと外側へ出る）", transactionAdvisorOrder)
+        .isNotNull()
+        .isGreaterThanOrEqualTo(transactionAdvisorOrder);
+    assertThat(OrderUtils.getOrder(StoreSetFilterEnable.class))
+        .as("StoreSetFilterEnable の @Order（tx advisor の %d より小さいと外側へ出る）", transactionAdvisorOrder)
+        .isNotNull()
+        .isGreaterThanOrEqualTo(transactionAdvisorOrder);
+  }
+
+  /** {@code com.kizuna.<module>.application} 本体とその下位パッケージを application 層とみなす。 */
+  private static boolean isApplicationLayer(Class<?> type) {
+    String pkg = type.getPackageName();
+    return pkg.endsWith(".application") || pkg.contains(".application.");
+  }
+
+  /** 宣言フィールドと構築子引数の型から、店舗スコープ repository の注入を拾う。 */
+  private static Set<String> injectedStoreScopedRepositories(Class<?> type) {
+    Set<String> found = new LinkedHashSet<>();
+    for (Field field : type.getDeclaredFields()) {
+      if (isStoreScopedRepository(field.getType())) {
+        found.add(field.getType().getSimpleName());
+      }
+    }
+    for (Constructor<?> constructor : type.getDeclaredConstructors()) {
+      for (Class<?> parameter : constructor.getParameterTypes()) {
+        if (isStoreScopedRepository(parameter)) {
+          found.add(parameter.getSimpleName());
+        }
+      }
+    }
+    return found;
+  }
+
+  /** Spring Data repository の実体型引数が {@link StoreScopedEntity} を継承するか。 */
+  private static boolean isStoreScopedRepository(Class<?> type) {
+    if (!Repository.class.isAssignableFrom(type)) {
+      return false;
+    }
+    Class<?> entity = ResolvableType.forClass(type).as(Repository.class).resolveGeneric(0);
+    return entity != null && StoreScopedEntity.class.isAssignableFrom(entity);
+  }
+
+  /** 検査対象は「クラス自身が宣言した非 private・非 static の方法」。合成・bridge と Object の override は外す。 */
+  private static boolean isAudited(Method method) {
+    if (method.isSynthetic() || method.isBridge()) {
+      return false;
+    }
+    int modifiers = method.getModifiers();
+    if (Modifier.isPrivate(modifiers) || Modifier.isStatic(modifiers)) {
+      return false;
+    }
+    try {
+      Object.class.getMethod(method.getName(), method.getParameterTypes());
+      return false;
+    } catch (NoSuchMethodException expected) {
+      return true;
+    }
+  }
+
+  private static int countScopeDeclarations(Method method) {
+    int count = 0;
+    if (AnnotatedElementUtils.hasAnnotation(method, StoreScoped.class)) {
+      count++;
+    }
+    if (AnnotatedElementUtils.hasAnnotation(method, StoreSetScoped.class)) {
+      count++;
+    }
+    if (AnnotatedElementUtils.hasAnnotation(method, StoreScopeExempt.class)) {
+      count++;
+    }
+    return count;
+  }
+}

--- a/backend/src/test/java/com/kizuna/StoreScopeDeclarationTests.java
+++ b/backend/src/test/java/com/kizuna/StoreScopeDeclarationTests.java
@@ -60,6 +60,7 @@ class StoreScopeDeclarationTests {
 
     List<String> undeclared = new ArrayList<>();
     List<String> multiplyDeclared = new ArrayList<>();
+    List<String> blankReasons = new ArrayList<>();
     List<String> scanned = new ArrayList<>();
     Set<String> repositories = new LinkedHashSet<>();
     int methods = 0;
@@ -86,6 +87,11 @@ class StoreScopeDeclarationTests {
         } else if (declarations > 1) {
           multiplyDeclared.add(name);
         }
+        StoreScopeExempt exempt =
+            AnnotatedElementUtils.findMergedAnnotation(method, StoreScopeExempt.class);
+        if (exempt != null && exempt.reason().isBlank()) {
+          blankReasons.add(name);
+        }
       }
     }
 
@@ -98,6 +104,7 @@ class StoreScopeDeclarationTests {
         .as("@StoreScoped / @StoreSetScoped / @StoreScopeExempt のいずれも宣言していない方法（店舗フィルタ無しで読める）")
         .isEmpty();
     assertThat(multiplyDeclared).as("作用域宣言を二つ以上持つ方法（どれが効くか読めない）").isEmpty();
+    assertThat(blankReasons).as("reason が空白の @StoreScopeExempt（理由の無い豁免は宣言にならない）").isEmpty();
   }
 
   /**


### PR DESCRIPTION
## 概要

#694 の裁定（方式 A・宣言監査）の実装。`@StoreScopeExempt(reason 必須)` を新設し、店舗スコープ repository を注入する application 層クラスの全方法に三択宣言（`@StoreScoped` / `@StoreSetScoped` / `@StoreScopeExempt`）を強制する fitness test を追加する。あわせて切面の `@Order` を明示値に固定し断言で釘付けた。

Closes #704

## 変更内容

- **新設** `shared/storescope/StoreScopeExempt.java` — 方法級・`reason` 必須（既定値なし）
- **新設** `StoreScopeDeclarationTests` — ①宣言監査（豁免リスト無し・恰一宣言・走査前提の自己申告・暗黙 no-op 防止つき）②切面順序の釘付け（aspect の order ≧ tx advisor の order）
- **宣言標注 26 方法 / 12 クラス** — 各 reason は既存 javadoc の補償統制を一文へ圧縮（複数箇所で同一理由の場合は定数で単一ソース化）。既存 javadoc は削除も弱体化もしていない
- `StoreFilterEnable` / `StoreSetFilterEnable` の `@Order` → `@Order(Ordered.LOWEST_PRECEDENCE)` 明示

## 決定ログ

- **審査面は「非 private・非 static の自宣言方法」**: 実装は当初 public 限定だったが、審核で `NominatableCastLookup`（package-private 類・package-private 方法）が CastRepository を注入しながら審査対象外になっている実例を発見。package-private 方法も同パッケージの他 bean からの入口であるため審査面を拡張し、同類の 2 方法へ宣言を補った（拡張時の赤名簿はこの 2 件のみ = 他に可視性の漏れは無い）
- **切面は tx advisor より内側**: OSIV=off の共有 EntityManager は取引外の `unwrap` で使い捨て Session を作って即閉じるため、外側で filter を有効化すると死んだ Session に掛かり隔離が静默に外れる。tx advisor は `Integer.MAX_VALUE` に居るので `LOWEST_PRECEDENCE` が唯一の安全値。**残余の既知事項**: 同値のときの前後は Spring の advisor 収集順（素の Advisor bean が AspectJ 由来より先）で決まり `@Order` では固定できない — 実挙動は `StoreScopedLoadByKeyIT` が統合テストで釘付けており、`@EnableTransactionManagement(order=)` の変更は影響が全域に及ぶため本票では見送り
- **受け入れ基準の改述（1 件）**: 「`@Order` を無値に戻す変異で赤」は反射上充足不能 — `Order.value()` の既定値が `LOWEST_PRECEDENCE` のため、無値と明示既定値は `MergedAnnotation` でも区別できない。実際に隔離を解除する変異 `@Order(0)` で代替して赤を実証した
- **`StoreScopeExecutor` は宣言に数えない**: `StoreContext` を確立するだけでフィルタは有効化しない（有効化は aspect のみ）。加えて方法本体を見ない反射では利用の静的検出が信頼できない
- **クラス粒度の過剰近似は許容**: 注入判定はフィールド/構築子の型で行うため、repository を触らない方法も宣言を要求される（26 方法のうち数件）。その場合の reason は「素通しにならない」旨を正直に書く形にした
- **4 箇所の注釈のみ統制サイトへのカナリア IT は本票では見送り**（票面の「実装時に提示」）: 審核の結果、必要度は一様でなく勾配がある — ①`ConfirmedShiftLookupService`（IT が経路自体を一切踏んでいない・最有力）②`CastSelfService#myStores`（mock 単体のみ）③`CastInvitationAcceptanceService`（受諾経路に跨店カナリア無し）④`StoreRegistryService` は跨店が設計意図の HQ 台帳でありカナリア不成立。①〜③は必要なら後続票で

## 検証

- [x] `task lint` exit 0
- [x] `task test-unit` exit 0（新テスト含む全量）
- [x] `task test-integration` exit 0（`StoreScopedLoadByKeyIT` 等の隔離 IT 含む — `@Order` 明示化後の実挙動を確認）
- [x] `task build service=backend` exit 0
- [x] **変異赤証（宣言監査）**: `@StoreScopeExempt` 1 件除去 → 該当方法を名指しで赤 / 審査面拡張時に package-private 2 方法が名指しで赤（= 新規の無宣言方法が捕まる）→ いずれも復元・標注済み
- [x] **変異赤証（順序釘付け）**: `@Order(0)` へ変異 → 「aspect の order が tx advisor の 2147483647 未満」で赤 → 復元
- [ ] `task e2e` — 挙動変更なし（注釈は受動メタデータ・`@Order` は従前と同実効値）のため免除

## 備考 / レビュー観点

- reason 文字列は機械可読の統制主張なので、標注 26 件の妥当性が最重要のレビュー観点。審核では会員側（requesterMemberId 境界）・`CustomerReferenceResolver`（MANDATORY 伝播）等の主張をコードと突き合わせて確認済み
- 宣言監査は「宣言」の監査であって「効果」の監査ではない（`StoreFilterEnable` は fail-open のまま）。効果側の運転時断言（方式 B）は #694 裁定どおり二段目として留保

🤖 Generated with [Claude Code](https://claude.com/claude-code)