### PR TITLE
feat: 墓標が生きた顧客として振る舞わなくなる（除外・旧 ID の解決・参照作成の直列化）

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/customer/CustomerMergeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/CustomerMergeIT.java
@@ -560,6 +560,52 @@ class CustomerMergeIT extends CrossStoreTestSupport {
     assertThat(linksOn(tombstone)).as("墓標に着地した関連が 0 件であること").isZero();
   }
 
+  @Test
+  @DisplayName("統合先が別の統合に押さえられているときの解決は、待たずにやり直しの判る 409 になること")
+  void reportsAConflictInsteadOfWaitingWhenTheMergeTargetIsHeld() throws Exception {
+    // 墓標を押さえたまま統合先を待つと、その統合先を更に統合する要求（圧平で墓標の行を押さえる）と
+    // 待ちが環になる。追う先は待たずに取り、取れなければ競合として返す。
+    String tombstone = createCustomer("競合墓標-" + nonce);
+    String surviving = createCustomer("競合存続-" + nonce);
+    String memberCode = registerMember("merge-nowait");
+
+    CountDownLatch survivingHeld = new CountDownLatch(1);
+    CountDownLatch releaseSurviving = new CountDownLatch(1);
+    CountDownLatch tombstoneHeld = new CountDownLatch(1);
+    CountDownLatch releaseTombstone = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(3);
+    try {
+      Future<?> holdSurviving =
+          pool.submit(() -> holdCustomerRow(surviving, null, survivingHeld, releaseSurviving));
+      assertThat(survivingHeld.await(30, TimeUnit.SECONDS)).as("前提: 統合先が押さえられること").isTrue();
+      Future<?> holdTombstone =
+          pool.submit(() -> holdCustomerRow(tombstone, surviving, tombstoneHeld, releaseTombstone));
+      assertThat(tombstoneHeld.await(30, TimeUnit.SECONDS)).as("前提: 墓標化が確定直前で待つこと").isTrue();
+
+      Future<ResponseEntity<JsonNode>> blocked =
+          pool.submit(() -> linkResponse(tombstone, memberCode));
+      assertThatThrownBy(() -> blocked.get(3, TimeUnit.SECONDS))
+          .as("解決は墓標化の確定を待つこと")
+          .isInstanceOf(TimeoutException.class);
+
+      releaseTombstone.countDown();
+      holdTombstone.get(30, TimeUnit.SECONDS);
+
+      // 統合先はまだ押さえられたまま。ここで待たずに返ることが、待ちが環にならない根拠になる
+      ResponseEntity<JsonNode> refused = blocked.get(30, TimeUnit.SECONDS);
+      assertThat(refused.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+      assertThat(refused.getBody().path("error").asString()).contains("統合中の顧客です");
+      releaseSurviving.countDown();
+      holdSurviving.get(30, TimeUnit.SECONDS);
+    } finally {
+      releaseTombstone.countDown();
+      releaseSurviving.countDown();
+      pool.shutdownNow();
+    }
+    assertThat(linksOn(tombstone)).as("墓標に着地した関連が無いこと").isZero();
+    assertThat(linksOn(surviving)).as("撥ねた要求は存続行にも何も残さないこと").isZero();
+  }
+
   /**
    * 顧客行を押さえたままコミットせずに待つ。{@code mergeInto} に統合先を渡すと、押さえた行を墓標にしてから待つ —
    * 統合の実行そのものは他のテストが固定するので、ここで再現するのは行の状態と保持だけである。

--- a/backend/src/integrationTest/java/com/kizuna/customer/CustomerMergeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/CustomerMergeIT.java
@@ -230,7 +230,7 @@ class CustomerMergeIT extends CrossStoreTestSupport {
     assertThat(byOldId.getBody().path("merged_from_id").asString()).isEqualTo(merged);
 
     ResponseEntity<JsonNode> live = getCustomer(surviving);
-    assertThat(live.getBody().hasNonNull("merged")).as("生きた行には標識が載らないこと").isFalse();
+    assertThat(live.getBody().has("merged")).as("生きた行には標識の欄そのものが現れないこと").isFalse();
   }
 
   @Test

--- a/backend/src/integrationTest/java/com/kizuna/customer/CustomerMergeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/CustomerMergeIT.java
@@ -1,6 +1,7 @@
 package com.kizuna.customer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.kizuna.customer.domain.Customer;
 import com.kizuna.customer.domain.CustomerMemberLinkRepository;
@@ -14,8 +15,17 @@ import com.kizuna.order.domain.OrderStatus;
 import com.kizuna.shared.CrossStoreTestSupport;
 import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.PersistenceContext;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +36,9 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import tools.jackson.databind.JsonNode;
 
 /**
@@ -40,8 +53,10 @@ import tools.jackson.databind.JsonNode;
  * <p>統合は店長権限（{@code CUSTOMER_MERGE}）を要するため、基底クラスの店員トークン（山田次郎）ではなく {@link
  * #managerHeaders(long)}（田中花子・店舗{1,2} 授権）で叩く。店員では 403 になることも併せて見る。
  *
- * <p>墓標を電話照合・一覧から外すこと、旧 ID を渡された解決を統合先へ届けることは後続の作業の範囲で、本テストは扱わない。
- * 応答に出ない事実（統合先参照・統合履歴・付替え後の受注の顧客）は、行を直接読んで固定する。
+ * <p>統合後の読み書きは非対称になる。墓標は一覧にも電話照合にも現れない一方、旧 ID を渡された解決は統合先へ届き、
+ * 墓標そのものを名指した書き換え（更新・削除・ポイント調整・解除）は案内の読める 409 になる。
+ *
+ * <p>応答に出ない事実（統合先参照・統合履歴・付替え後の受注の顧客）は、行を直接読んで固定する。
  */
 class CustomerMergeIT extends CrossStoreTestSupport {
 
@@ -59,6 +74,9 @@ class CustomerMergeIT extends CrossStoreTestSupport {
   @Autowired private CustomerMergeRepository customerMergeRepository;
   @Autowired private OrderRepository orderRepository;
   @Autowired private PlatformUserRepository platformUserRepository;
+  @Autowired private JdbcTemplate jdbcTemplate;
+  @Autowired private PlatformTransactionManager transactionManager;
+  @PersistenceContext private EntityManager entityManager;
 
   private final long nonce = System.nanoTime();
 
@@ -148,6 +166,127 @@ class CustomerMergeIT extends CrossStoreTestSupport {
     // ここではその競合が検出可能になる前提だけを決定的に押さえる。
     assertThat(versionOfCustomer(a)).as("圧平した墓標の版").isGreaterThan(tombstoneVersionBefore);
     assertThat(versionOfOrder(orderId)).as("付け替えた受注の版").isGreaterThan(orderVersionBefore);
+  }
+
+  // ==================== 墓標の除外 ====================
+
+  @Test
+  @DisplayName("統合後、墓標が顧客一覧に出ないこと")
+  void keepsTombstonesOutOfTheCustomerList() {
+    String marker = "一覧" + nonce;
+    String surviving = createCustomer(marker + "-存続");
+    String merged = createCustomer(marker + "-被統合");
+    assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    ResponseEntity<JsonNode> listed =
+        rest.exchange(
+            "/store/customers?search=" + marker,
+            HttpMethod.GET,
+            new HttpEntity<>(managerHeaders(STORE_A)),
+            JsonNode.class);
+
+    assertThat(listed.getStatusCode()).isEqualTo(HttpStatus.OK);
+    // 「統合済みも表示」の切替は設けない。同じ人が二重に並ばないことが統合の目的である
+    assertThat(listed.getBody().path("content"))
+        .singleElement()
+        .satisfies(row -> assertThat(row.path("id").asString()).isEqualTo(surviving));
+  }
+
+  @Test
+  @DisplayName("統合前は複数一致で顧客未設定に落ちていた番号が、統合後は存続行に着くこと")
+  void collapsesAMultipleMatchIntoTheSurvivingRow() {
+    String phoneNumber = phone("照合");
+    String surviving = createCustomerWithPhone("照合存続-" + nonce, phoneNumber);
+    String merged = createCustomerWithPhone("照合被統合-" + nonce, phoneNumber);
+
+    ResponseEntity<JsonNode> beforeMerge = orderByPhone(phoneNumber, "照合前");
+    assertThat(beforeMerge.getBody().hasNonNull("customer_id"))
+        .as("前提: 統合前は複数一致で自動照合を断念すること")
+        .isFalse();
+
+    assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    // 重複を畳んだ番号が 1 行へ収束する。これが果たされないと統合した意味が無い
+    ResponseEntity<JsonNode> afterMerge = orderByPhone(phoneNumber, "照合後");
+    assertThat(afterMerge.getBody().path("customer_id").asString()).isEqualTo(surviving);
+  }
+
+  // ==================== 旧 ID の解決 ====================
+
+  @Test
+  @DisplayName("詳細を旧 ID で取得すると統合先の行が返り、統合済みであることと元の ID が判ること")
+  void resolvesADetailRequestedByTheOldIdToTheSurvivingRow() {
+    String surviving = createCustomer("詳細存続-" + nonce);
+    String merged = createCustomer("詳細被統合-" + nonce);
+    assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    ResponseEntity<JsonNode> byOldId = getCustomer(merged);
+
+    // 3xx にはしない。HTTP クライアントが透過的に追随すると、画面が統合の発生を知れなくなる
+    assertThat(byOldId.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(byOldId.getBody().path("id").asString()).isEqualTo(surviving);
+    assertThat(byOldId.getBody().path("name").asString()).isEqualTo("詳細存続-" + nonce);
+    assertThat(byOldId.getBody().path("merged").asBoolean()).isTrue();
+    assertThat(byOldId.getBody().path("merged_from_id").asString()).isEqualTo(merged);
+
+    ResponseEntity<JsonNode> live = getCustomer(surviving);
+    assertThat(live.getBody().hasNonNull("merged")).as("生きた行には標識が載らないこと").isFalse();
+  }
+
+  @Test
+  @DisplayName("受注の顧客指定に旧 ID を渡すと、受注が存続行に着くこと")
+  void landsAnOrderOnTheSurvivingRowWhenGivenTheOldCustomerId() {
+    String surviving = createCustomer("受注存続-" + nonce);
+    String merged = createCustomer("受注被統合-" + nonce);
+    assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    String orderId = orderFor(merged, "旧ID指定");
+
+    assertThat(customerOf(orderId)).isEqualTo(surviving);
+    assertThat(ordersOn(merged)).as("墓標に着いた受注が無いこと").isZero();
+  }
+
+  @Test
+  @DisplayName("関連の成立先に旧 ID を渡すと、存続行に対して関連が成立すること")
+  void establishesTheLinkOnTheSurvivingRowWhenGivenTheOldCustomerId() {
+    String surviving = createCustomer("関連解決存続-" + nonce);
+    String merged = createCustomer("関連解決被統合-" + nonce);
+    assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    link(merged, registerMember("merge-resolve-link"));
+
+    assertThat(customerMemberLinkRepository.findByCustomerIdAndStatus(surviving, LinkStatus.ACTIVE))
+        .as("会員が死んだ行へ紐づかないこと")
+        .isPresent();
+    assertThat(linksOn(merged)).isZero();
+  }
+
+  @Test
+  @DisplayName("墓標そのものへの更新・削除・ポイント調整・解除は、統合先を編集することが判る 409 になること")
+  void refusesEveryWriteAimedAtTheTombstoneItself() {
+    String surviving = createCustomer("拒否存続-" + nonce);
+    String merged = createCustomer("拒否被統合-" + nonce);
+    link(surviving, registerMember("merge-refusal"));
+    assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    List<ResponseEntity<JsonNode>> refusals =
+        List.of(
+            updateCustomer(merged, "書き換え-" + nonce),
+            deleteCustomer(merged),
+            adjustPoints(merged),
+            unlinkResponse(merged));
+
+    assertThat(refusals)
+        .allSatisfy(
+            refusal -> {
+              assertThat(refusal.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+              assertThat(refusal.getBody().path("error").asString()).contains("統合先の顧客を編集");
+            });
+    // ポイント調整と解除は、統合で関連が存続行へ移っているぶん「紐づいていない」の分岐に落ちやすい。
+    // 統合済みであることが伝わらなければ、利用者は次に何をすればよいか判らない
+    assertThat(customer(merged).getName()).as("撥ねた要求は何も書き換えないこと").isEqualTo("拒否被統合-" + nonce);
+    assertThat(customerMemberLinkRepository.findByCustomerIdAndStatus(surviving, LinkStatus.ACTIVE))
+        .isPresent();
   }
 
   // ==================== 統合履歴 ====================
@@ -302,6 +441,155 @@ class CustomerMergeIT extends CrossStoreTestSupport {
     assertThat(memberGet("/platform/me/visits", member).getBody()).isEqualTo(visitsBefore);
   }
 
+  // ==================== 並行 ====================
+
+  @Test
+  @DisplayName("統合が墓標化を済ませて保持している間に走った受注録入は、待ってから存続行に着くこと")
+  void anOrderCreatedWhileAMergeHoldsTheRowLandsOnTheSurvivingRow() throws Exception {
+    // 統合と受注録入を HTTP 2 本の外から整列させる手段が無いので、断言面を配線へ下ろす。
+    // 「墓標化を済ませてまだコミットしていない統合」を別トランザクションで作り、電話照合が
+    // 統合前の行を掴んだ受注録入がそれを待ってから、統合先へ着くことを固定する。
+    String phoneNumber = phone("並行照合");
+    String surviving = createCustomer("並行照合存続-" + nonce);
+    String tombstone = createCustomerWithPhone("並行照合被統合-" + nonce, phoneNumber);
+    String castId = createCast("並行照合キャスト-" + nonce);
+
+    CountDownLatch mergeHeld = new CountDownLatch(1);
+    CountDownLatch releaseMerge = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    try {
+      Future<?> inFlightMerge =
+          pool.submit(() -> holdCustomerRow(tombstone, surviving, mergeHeld, releaseMerge));
+      assertThat(mergeHeld.await(30, TimeUnit.SECONDS)).as("前提: 統合が墓標化を済ませて待つこと").isTrue();
+
+      Future<ResponseEntity<JsonNode>> concurrentOrder =
+          pool.submit(() -> orderByPhone(phoneNumber, castId, "並行照合"));
+      assertThatThrownBy(() -> concurrentOrder.get(3, TimeUnit.SECONDS))
+          .as("受注録入は統合の確定を待つこと")
+          .isInstanceOf(TimeoutException.class);
+
+      releaseMerge.countDown();
+      inFlightMerge.get(30, TimeUnit.SECONDS);
+
+      ResponseEntity<JsonNode> created = concurrentOrder.get(30, TimeUnit.SECONDS);
+      // 押さえた実体から統合先を読むと、電話照合が先に載せた古い値（統合先なし）を見て墓標に着く
+      assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+      assertThat(created.getBody().path("customer_id").asString()).isEqualTo(surviving);
+    } finally {
+      releaseMerge.countDown();
+      pool.shutdownNow();
+    }
+    assertThat(ordersOn(tombstone)).as("墓標に着地した受注が 0 件であること").isZero();
+  }
+
+  @Test
+  @DisplayName("統合が存続行のロックを待っている間に成立した受注は、統合の付替えが拾うこと")
+  void anOrderCreatedWhileAMergeWaitsIsPickedUpByTheRepointing() throws Exception {
+    // もう一方の順序。統合は顧客 ID の昇順で押さえるので、存続行を小さい方に選ぶと、統合は
+    // 被統合行に触れないまま待つ — その隙に電話照合が生きた被統合行を掴む形を決定的に作れる。
+    List<String> pair = customerPairInIdOrder("並行受注先");
+    String surviving = pair.get(0);
+    String merged = pair.get(1);
+    String phoneNumber = phone("並行受注先");
+    setPhoneNumber(merged, phoneNumber);
+    String castId = createCast("並行受注先キャスト-" + nonce);
+
+    CountDownLatch survivingHeld = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    String orderId;
+    try {
+      Future<?> holder =
+          pool.submit(() -> holdCustomerRow(surviving, null, survivingHeld, release));
+      assertThat(survivingHeld.await(30, TimeUnit.SECONDS)).as("前提: 存続行が押さえられること").isTrue();
+
+      Future<ResponseEntity<JsonNode>> blockedMerge =
+          pool.submit(() -> merge(STORE_A, surviving, merged));
+      assertThatThrownBy(() -> blockedMerge.get(3, TimeUnit.SECONDS))
+          .as("統合は存続行のロックを待つこと")
+          .isInstanceOf(TimeoutException.class);
+
+      ResponseEntity<JsonNode> created = orderByPhone(phoneNumber, castId, "並行受注先");
+      orderId = created.getBody().path("id").asString();
+      assertThat(created.getBody().path("customer_id").asString())
+          .as("前提: 統合の前に成立した受注は、まだ生きている行に着くこと")
+          .isEqualTo(merged);
+
+      release.countDown();
+      holder.get(30, TimeUnit.SECONDS);
+      assertThat(blockedMerge.get(30, TimeUnit.SECONDS).getStatusCode()).isEqualTo(HttpStatus.OK);
+    } finally {
+      release.countDown();
+      pool.shutdownNow();
+    }
+    assertThat(customerOf(orderId)).isEqualTo(surviving);
+    assertThat(ordersOn(merged)).as("墓標に着地した受注が 0 件であること").isZero();
+  }
+
+  @Test
+  @DisplayName("統合が墓標化を済ませて保持している間に走った関連の成立は、待ってから存続行に着くこと")
+  void aLinkEstablishedWhileAMergeHoldsTheRowLandsOnTheSurvivingRow() throws Exception {
+    String surviving = createCustomer("並行関連存続-" + nonce);
+    String tombstone = createCustomer("並行関連被統合-" + nonce);
+    String memberCode = registerMember("merge-race-link");
+
+    CountDownLatch mergeHeld = new CountDownLatch(1);
+    CountDownLatch releaseMerge = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    try {
+      Future<?> inFlightMerge =
+          pool.submit(() -> holdCustomerRow(tombstone, surviving, mergeHeld, releaseMerge));
+      assertThat(mergeHeld.await(30, TimeUnit.SECONDS)).as("前提: 統合が墓標化を済ませて待つこと").isTrue();
+
+      Future<ResponseEntity<JsonNode>> concurrentLink =
+          pool.submit(() -> linkResponse(tombstone, memberCode));
+      assertThatThrownBy(() -> concurrentLink.get(3, TimeUnit.SECONDS))
+          .as("関連の成立は統合の確定を待つこと")
+          .isInstanceOf(TimeoutException.class);
+
+      releaseMerge.countDown();
+      inFlightMerge.get(30, TimeUnit.SECONDS);
+
+      assertThat(concurrentLink.get(30, TimeUnit.SECONDS).getStatusCode()).isEqualTo(HttpStatus.OK);
+    } finally {
+      releaseMerge.countDown();
+      pool.shutdownNow();
+    }
+    assertThat(customerMemberLinkRepository.findByCustomerIdAndStatus(surviving, LinkStatus.ACTIVE))
+        .isPresent();
+    assertThat(linksOn(tombstone)).as("墓標に着地した関連が 0 件であること").isZero();
+  }
+
+  /**
+   * 顧客行を押さえたままコミットせずに待つ。{@code mergeInto} に統合先を渡すと、押さえた行を墓標にしてから待つ —
+   * 統合の実行そのものは他のテストが固定するので、ここで再現するのは行の状態と保持だけである。
+   */
+  private Object holdCustomerRow(
+      String customerId, String mergeInto, CountDownLatch held, CountDownLatch release) {
+    return new TransactionTemplate(transactionManager)
+        .execute(
+            status -> {
+              Customer row =
+                  entityManager.find(Customer.class, customerId, LockModeType.PESSIMISTIC_WRITE);
+              if (mergeInto != null) {
+                row.mergeInto(mergeInto);
+                entityManager.flush();
+              }
+              held.countDown();
+              awaitQuietly(release);
+              return null;
+            });
+  }
+
+  /** 保持側のトランザクション内で待つ。中断はテストの失敗として現れるので、ここでは握り潰さず状態だけ戻す。 */
+  private static void awaitQuietly(CountDownLatch latch) {
+    try {
+      latch.await(30, TimeUnit.SECONDS);
+    } catch (InterruptedException interrupted) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
   // ==================== 統合の呼び出し ====================
 
   private static String mergePath(String survivingCustomerId) {
@@ -348,6 +636,19 @@ class CustomerMergeIT extends CrossStoreTestSupport {
     return orderRepository.findById(orderId).map(Order::getStatus).orElseThrow();
   }
 
+  /** 墓標に着地した参照の件数。行を直接数えるのは、着地の誤りが読み口からは見えないため。 */
+  private int ordersOn(String customerId) {
+    return jdbcTemplate.queryForObject(
+        "select count(*) from t_orders where customer_id = ?", Integer.class, customerId);
+  }
+
+  private int linksOn(String customerId) {
+    return jdbcTemplate.queryForObject(
+        "select count(*) from t_customer_member_links where customer_id = ?",
+        Integer.class,
+        customerId);
+  }
+
   private Long managerId() {
     return platformUserRepository.findByEmail(MANAGER_EMAIL).map(PlatformUser::getId).orElseThrow();
   }
@@ -359,15 +660,76 @@ class CustomerMergeIT extends CrossStoreTestSupport {
   }
 
   private String createCustomerAt(long storeId, String name) {
+    return postCustomer(storeId, "{\"name\": \"" + name + "\"}");
+  }
+
+  /** 同店同号の重複。電話照合の複数一致は正規に起こりうるので、実行ごとに違う番号で起こす。 */
+  private String createCustomerWithPhone(String name, String phoneNumber) {
+    return postCustomer(
+        STORE_A, "{\"name\": \"" + name + "\", \"phone_number\": \"" + phoneNumber + "\"}");
+  }
+
+  private String postCustomer(long storeId, String body) {
     ResponseEntity<JsonNode> created =
         rest.postForEntity(
-            "/store/customers",
-            new HttpEntity<>("{\"name\": \"" + name + "\"}", managerHeaders(storeId)),
-            JsonNode.class);
+            "/store/customers", new HttpEntity<>(body, managerHeaders(storeId)), JsonNode.class);
     assertThat(created.getStatusCode().is2xxSuccessful())
         .as("前提: store %d での顧客作成が成功すること", storeId)
         .isTrue();
     return created.getBody().path("id").asString();
+  }
+
+  /** 顧客 2 行を ID の昇順で返す。統合がどちらを先に押さえるかを決めたいときに使う。 */
+  private List<String> customerPairInIdOrder(String label) {
+    return List.of(createCustomer(label + "甲-" + nonce), createCustomer(label + "乙-" + nonce))
+        .stream()
+        .sorted()
+        .toList();
+  }
+
+  /** 実行ごと・用途ごとに異なる照合キー。列は VARCHAR(50)。 */
+  private String phone(String label) {
+    return "090" + Math.abs((label + nonce).hashCode()) + nonce;
+  }
+
+  private ResponseEntity<JsonNode> getCustomer(String customerId) {
+    return rest.exchange(
+        "/store/customers/" + customerId,
+        HttpMethod.GET,
+        new HttpEntity<>(managerHeaders(STORE_A)),
+        JsonNode.class);
+  }
+
+  private ResponseEntity<JsonNode> updateCustomer(String customerId, String name) {
+    return putCustomer(customerId, "{\"name\": \"" + name + "\"}");
+  }
+
+  private void setPhoneNumber(String customerId, String phoneNumber) {
+    assertThat(
+            putCustomer(customerId, "{\"phone_number\": \"" + phoneNumber + "\"}").getStatusCode())
+        .as("前提: 電話番号を後から設定できること")
+        .isEqualTo(HttpStatus.OK);
+  }
+
+  private ResponseEntity<JsonNode> putCustomer(String customerId, String body) {
+    return rest.exchange(
+        "/store/customers/" + customerId,
+        HttpMethod.PUT,
+        new HttpEntity<>(body, managerHeaders(STORE_A)),
+        JsonNode.class);
+  }
+
+  private ResponseEntity<JsonNode> adjustPoints(String customerId) {
+    String body =
+        "{\"delta\": 100, \"reason\": \"統合検証の調整\", \"idempotency_key\": \"merge-it-"
+            + nonce
+            + "-"
+            + System.nanoTime()
+            + "\"}";
+    return rest.postForEntity(
+        "/store/customers/" + customerId + "/point-adjustments",
+        new HttpEntity<>(body, managerHeaders(STORE_A)),
+        JsonNode.class);
   }
 
   private ResponseEntity<JsonNode> deleteCustomer(String customerId) {
@@ -398,6 +760,32 @@ class CustomerMergeIT extends CrossStoreTestSupport {
             "/store/orders", new HttpEntity<>(body, managerHeaders(STORE_A)), JsonNode.class);
     assertThat(created.getStatusCode().is2xxSuccessful()).as("前提: 受注作成が成功すること").isTrue();
     return created.getBody().path("id").asString();
+  }
+
+  /** 顧客 ID を指定せず電話番号だけで録入する受注。着地先は台帳の照合が決める。 */
+  private ResponseEntity<JsonNode> orderByPhone(String phoneNumber, String label) {
+    return orderByPhone(phoneNumber, createCast(label + "-" + nonce), label);
+  }
+
+  private ResponseEntity<JsonNode> orderByPhone(
+      String phoneNumber, String castId, String customerName) {
+    String body =
+        "{\"receptionist_id\": "
+            + SEED_RECEPTIONIST_ID
+            + ", \"business_date\": \""
+            + LocalDate.now()
+            + "\", \"cast_id\": \""
+            + castId
+            + "\", \"customer_name\": \""
+            + customerName
+            + "\", \"phone_number\": \""
+            + phoneNumber
+            + "\"}";
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/store/orders", new HttpEntity<>(body, managerHeaders(STORE_A)), JsonNode.class);
+    assertThat(created.getStatusCode()).as("前提: 電話番号での受注録入が成立すること").isEqualTo(HttpStatus.CREATED);
+    return created;
   }
 
   /** 店舗が起こす受注は確定で出生するため、作成だけで確定済みになる。 */
@@ -444,25 +832,31 @@ class CustomerMergeIT extends CrossStoreTestSupport {
   }
 
   private void link(String customerId, String memberCode) {
-    ResponseEntity<JsonNode> linked =
-        rest.exchange(
-            "/store/customers/" + customerId + "/member-link",
-            HttpMethod.POST,
-            new HttpEntity<>("{\"member_code\": \"" + memberCode + "\"}", managerHeaders(STORE_A)),
-            JsonNode.class);
-    assertThat(linked.getStatusCode()).as("前提: 会員の紐づけが成功すること").isEqualTo(HttpStatus.OK);
+    assertThat(linkResponse(customerId, memberCode).getStatusCode())
+        .as("前提: 会員の紐づけが成功すること")
+        .isEqualTo(HttpStatus.OK);
+  }
+
+  private ResponseEntity<JsonNode> linkResponse(String customerId, String memberCode) {
+    return rest.exchange(
+        "/store/customers/" + customerId + "/member-link",
+        HttpMethod.POST,
+        new HttpEntity<>("{\"member_code\": \"" + memberCode + "\"}", managerHeaders(STORE_A)),
+        JsonNode.class);
   }
 
   private void unlink(String customerId) {
-    assertThat(
-            rest.exchange(
-                    "/store/customers/" + customerId + "/member-link",
-                    HttpMethod.DELETE,
-                    new HttpEntity<>(managerHeaders(STORE_A)),
-                    JsonNode.class)
-                .getStatusCode())
+    assertThat(unlinkResponse(customerId).getStatusCode())
         .as("前提: 会員の紐づけを解除できること")
         .isEqualTo(HttpStatus.NO_CONTENT);
+  }
+
+  private ResponseEntity<JsonNode> unlinkResponse(String customerId) {
+    return rest.exchange(
+        "/store/customers/" + customerId + "/member-link",
+        HttpMethod.DELETE,
+        new HttpEntity<>(managerHeaders(STORE_A)),
+        JsonNode.class);
   }
 
   // ==================== 会員 ====================

--- a/backend/src/main/java/com/kizuna/customer/api/dto/CustomerMapper.java
+++ b/backend/src/main/java/com/kizuna/customer/api/dto/CustomerMapper.java
@@ -8,9 +8,12 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface CustomerMapper {
 
-  // 会員紐づけは別集約の投影なので、application 層が写像後に補う。
+  // 会員紐づけは別集約の投影なので、application 層が写像後に補う。統合の標識も同様で、
+  // 「要求された ID が何だったか」は写す元の行が持たない事実である。
   @Mapping(target = "memberLinked", ignore = true)
   @Mapping(target = "linkedMemberCode", ignore = true)
+  @Mapping(target = "merged", ignore = true)
+  @Mapping(target = "mergedFromId", ignore = true)
   CustomerResponse toResponse(Customer customer);
 
   // 同上。一覧は紐づけの有無だけを持ち、会員コードは載せない。

--- a/backend/src/main/java/com/kizuna/customer/api/dto/CustomerResponse.java
+++ b/backend/src/main/java/com/kizuna/customer/api/dto/CustomerResponse.java
@@ -29,4 +29,10 @@ public class CustomerResponse {
 
   /** 紐づけ済みの会員コード。未紐づけなら null。 */
   private String linkedMemberCode;
+
+  /** 統合済みの旧 ID で引かれたか。生きた行を引いた応答では null（欄が現れない）。 */
+  private Boolean merged;
+
+  /** 要求された旧 ID。本体は統合先の行なので、{@code id} との対で「どれがどれへ統合されたか」が判る。 */
+  private String mergedFromId;
 }

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerMemberLinkService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerMemberLinkService.java
@@ -34,6 +34,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CustomerMemberLinkService {
 
+  /** 墓標そのものを名指した解除の案内。文面は顧客情報の更新・削除と揃える（同じ「統合先を編集する」次の一手）。 */
+  private static final String MERGED_CUSTOMER_NOT_EDITABLE = "統合済みの顧客です。統合先の顧客を編集してください";
+
   private final CustomerRepository customerRepository;
   private final CustomerMemberLinkRepository customerMemberLinkRepository;
   private final CustomerReferenceResolver customerReferenceResolver;
@@ -97,6 +100,11 @@ public class CustomerMemberLinkService {
     // 解除も紐づけと同じく顧客行を押さえてから現在の紐づけを読む。
     // 契約は CustomerRepository#findByIdForUpdate に記す。
     lockCustomer(customerId);
+    // 墓標の判定は関連の照会より前。統合は関連を存続行へ移しているので、後ろに置くと
+    // 「紐づけられている会員がいません」に落ち、統合済みであることが利用者に伝わらない。
+    if (customerRepository.isMerged(customerId)) {
+      throw new ConflictException(MERGED_CUSTOMER_NOT_EDITABLE);
+    }
     CustomerMemberLink current =
         customerMemberLinkRepository
             .findByCustomerIdAndStatus(customerId, LinkStatus.ACTIVE)

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerMemberLinkService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerMemberLinkService.java
@@ -34,7 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CustomerMemberLinkService {
 
-  /** 墓標そのものを名指した解除の案内。文面は顧客情報の更新・削除と揃える（同じ「統合先を編集する」次の一手）。 */
+  /** 文面と、4 経路で揃えている理由は {@code CustomerService} の同名の定数に記す。 */
   private static final String MERGED_CUSTOMER_NOT_EDITABLE = "統合済みの顧客です。統合先の顧客を編集してください";
 
   private final CustomerRepository customerRepository;
@@ -100,8 +100,7 @@ public class CustomerMemberLinkService {
     // 解除も紐づけと同じく顧客行を押さえてから現在の紐づけを読む。
     // 契約は CustomerRepository#findByIdForUpdate に記す。
     lockCustomer(customerId);
-    // 墓標の判定は関連の照会より前。統合は関連を存続行へ移しているので、後ろに置くと
-    // 「紐づけられている会員がいません」に落ち、統合済みであることが利用者に伝わらない。
+    // 墓標の判定を関連の照会より前に置く理由は CustomerPointService#adjust に記す。
     if (customerRepository.isMerged(customerId)) {
       throw new ConflictException(MERGED_CUSTOMER_NOT_EDITABLE);
     }

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerMergeService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerMergeService.java
@@ -68,13 +68,7 @@ public class CustomerMergeService {
     Customer merged = lockBothInIdOrder(survivingCustomerId, mergedCustomerId);
 
     // 可否は実行の瞬間に判定し直す。確認画面を開いた時点の判定は、その後の統合で古くなりうる。
-    // 判定は押さえた実体の状態からではなく別問い合わせで行う（CustomerRepository#isMerged の契約）。
-    if (customerRepository.isMerged(survivingCustomerId)) {
-      throw new ConflictException("統合先の顧客は既に統合済みです。統合先の顧客を指定してください");
-    }
-    if (customerRepository.isMerged(mergedCustomerId)) {
-      throw new ConflictException("この顧客は既に統合済みです");
-    }
+    rejectTombstones(survivingCustomerId, mergedCustomerId);
     if (hasActiveLink(survivingCustomerId) && hasActiveLink(mergedCustomerId)) {
       // 部分一意索引により両者は必ず別会員を指す。二人の本人がそれぞれ認領している行なので、
       // 台帳級の「同一人物か」の判断と一緒に片付けさせない（ADR 0010）。
@@ -110,8 +104,22 @@ public class CustomerMergeService {
   private Customer lockBothInIdOrder(String survivingCustomerId, String mergedCustomerId) {
     boolean survivingFirst = survivingCustomerId.compareTo(mergedCustomerId) < 0;
     Customer first = lockCustomer(survivingFirst ? survivingCustomerId : mergedCustomerId);
+    // 2 本目を待つ前に、墓標を名指した要求（再送・墓標を存続行に指定）を撥ねる。参照の解決は
+    // 墓標 → 統合先の順に押さえるので、ここで待つと ID 昇順と逆向きの待ちが環になりうる。
+    // 墓標は取消が無く元に戻らないため、ロック前の読みで撥ねても判定を誤らない。
+    rejectTombstones(survivingCustomerId, mergedCustomerId);
     Customer second = lockCustomer(survivingFirst ? mergedCustomerId : survivingCustomerId);
     return survivingFirst ? second : first;
+  }
+
+  /** 判定は押さえた実体の状態からではなく別問い合わせで行う（{@code CustomerRepository#isMerged} の契約）。 */
+  private void rejectTombstones(String survivingCustomerId, String mergedCustomerId) {
+    if (customerRepository.isMerged(survivingCustomerId)) {
+      throw new ConflictException("統合先の顧客は既に統合済みです。統合先の顧客を指定してください");
+    }
+    if (customerRepository.isMerged(mergedCustomerId)) {
+      throw new ConflictException("この顧客は既に統合済みです");
+    }
   }
 
   private Customer lockCustomer(String customerId) {

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerPointService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerPointService.java
@@ -29,7 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CustomerPointService {
 
-  /** 墓標そのものを名指した調整の案内。文面は顧客情報の更新・削除と揃える（同じ「統合先を編集する」次の一手）。 */
+  /** 文面と、4 経路で揃えている理由は {@code CustomerService} の同名の定数に記す。 */
   private static final String MERGED_CUSTOMER_NOT_EDITABLE = "統合済みの顧客です。統合先の顧客を編集してください";
 
   private final CustomerRepository customerRepository;

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerPointService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerPointService.java
@@ -7,6 +7,7 @@ import com.kizuna.customer.domain.CustomerMemberLinkRepository;
 import com.kizuna.customer.domain.CustomerRepository;
 import com.kizuna.customer.domain.LinkStatus;
 import com.kizuna.point.application.PointLedgerService;
+import com.kizuna.shared.exception.ConflictException;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.exception.StaleSessionException;
@@ -27,6 +28,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class CustomerPointService {
+
+  /** 墓標そのものを名指した調整の案内。文面は顧客情報の更新・削除と揃える（同じ「統合先を編集する」次の一手）。 */
+  private static final String MERGED_CUSTOMER_NOT_EDITABLE = "統合済みの顧客です。統合先の顧客を編集してください";
 
   private final CustomerRepository customerRepository;
   private final CustomerMemberLinkRepository customerMemberLinkRepository;
@@ -58,6 +62,11 @@ public class CustomerPointService {
     customerRepository
         .findByIdForUpdate(customerId)
         .orElseThrow(() -> new NotFoundException("顧客が見つかりません: " + customerId));
+    // 墓標の判定は関連の照会より前に置く。統合は関連を存続行へ移しているので、後ろに置くと
+    // 「紐づいていない顧客」の分岐に落ち、統合済みであることが利用者に伝わらない。
+    if (customerRepository.isMerged(customerId)) {
+      throw new ConflictException(MERGED_CUSTOMER_NOT_EDITABLE);
+    }
     Long memberId = activeMemberId(customerId);
     if (memberId == null) {
       throw new ServiceException("会員に紐づいていない顧客のポイントは調整できません");

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerReferenceResolver.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerReferenceResolver.java
@@ -37,6 +37,9 @@ public class CustomerReferenceResolver {
    *
    * <p>呼出側のトランザクションに必ず参加する（{@code MANDATORY}）。自分でトランザクションを開くと新しい Session になり、 呼出側の
    * {@code @StoreScoped} が有効にした storeFilter が掛からないまま他店舗の行を押さえたうえ、 呼出側が書き込む前に行ロックを手放してしまう。
+   *
+   * <p>追うのは一跳だけでよい。圧平により、コミット済みの状態に二段の連鎖は存在しない（ADR 0010）。
+   * 存続行を統合する要求はこちらが押さえている墓標を圧平しなければ進めないので、押さえた時点で 存続行が墓標になっていることもない。
    */
   @StoreScopeExempt(
       reason = "呼出元のトランザクションに必ず参加し（MANDATORY）、店舗境界は呼出元の storeFilter か呼出元が明示する storeId が引く")
@@ -53,10 +56,6 @@ public class CustomerReferenceResolver {
     return survivingCustomerId.get();
   }
 
-  /**
-   * 追うのは一跳だけでよい。圧平により、コミット済みの状態に二段の連鎖は存在しない（ADR 0010）。
-   * 存続行を統合する要求はこちらが押さえている墓標を圧平しなければ進めないので、押さえた時点で 存続行が墓標になっていることもない。
-   */
   private void lock(String customerId) {
     customerRepository
         .findByIdForUpdate(customerId)

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerReferenceResolver.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerReferenceResolver.java
@@ -1,10 +1,12 @@
 package com.kizuna.customer.application;
 
 import com.kizuna.customer.domain.CustomerRepository;
+import com.kizuna.shared.exception.ConflictException;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.storescope.StoreScopeExempt;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.modulith.NamedInterface;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -29,6 +31,9 @@ import org.springframework.transaction.annotation.Transactional;
 @NamedInterface("application")
 public class CustomerReferenceResolver {
 
+  /** 統合の飛行中に参照を作ろうとした場合の案内。やり直せば統合の確定した後の存続行に着く。 */
+  private static final String MERGE_IN_FLIGHT = "統合中の顧客です。統合の完了後にやり直してください";
+
   private final CustomerRepository customerRepository;
 
   /**
@@ -38,27 +43,42 @@ public class CustomerReferenceResolver {
    * <p>呼出側のトランザクションに必ず参加する（{@code MANDATORY}）。自分でトランザクションを開くと新しい Session になり、 呼出側の
    * {@code @StoreScoped} が有効にした storeFilter が掛からないまま他店舗の行を押さえたうえ、 呼出側が書き込む前に行ロックを手放してしまう。
    *
-   * <p>追うのは一跳だけでよい。圧平により、コミット済みの状態に二段の連鎖は存在しない（ADR 0010）。
-   * 存続行を統合する要求はこちらが押さえている墓標を圧平しなければ進めないので、押さえた時点で 存続行が墓標になっていることもない。
+   * <p>押さえるのは着地する行だけで、統合先の下見はロックを取らずに読む。墓標を押さえたまま統合先を待つと、 その統合先を更に統合する要求と待ちが環になる — 統合は 2
+   * 行を押さえた後に墓標の圧平（＝墓標の行の更新）へ進むので、 こちらが墓標を持ったまま統合先を待つと双方が相手の行を待つ。
    */
   @StoreScopeExempt(
       reason = "呼出元のトランザクションに必ず参加し（MANDATORY）、店舗境界は呼出元の storeFilter か呼出元が明示する storeId が引く")
   @Transactional(propagation = Propagation.MANDATORY)
   public String resolveForWrite(String customerId) {
-    lock(customerId);
-    Optional<String> survivingCustomerId = customerRepository.findMergedIntoId(customerId);
-    if (survivingCustomerId.isEmpty()) {
-      return customerId;
+    String target = customerRepository.findMergedIntoId(customerId).orElse(customerId);
+    lock(target);
+    Optional<String> movedWhileWaiting = customerRepository.findMergedIntoId(target);
+    if (movedWhileWaiting.isEmpty()) {
+      return target;
     }
-    // 着地する行も押さえる。押さえないと、存続行を更に統合する要求が付替えを済ませた後で墓標の
-    // 圧平を待つ間にこの書き込みが割り込み、付替えの済んだ行へ着いたまま取り残される。
-    lock(survivingCustomerId.get());
-    return survivingCustomerId.get();
+    // 下見から押さえるまでの間に、その行を被統合行とする統合が確定した。追う先は既に押さえた行の
+    // 統合先なので、ここから先は待たずに取る（待つと上の環がそのまま生まれる）。
+    return lockWithoutWaiting(movedWhileWaiting.get());
   }
 
   private void lock(String customerId) {
     customerRepository
         .findByIdForUpdate(customerId)
         .orElseThrow(() -> new NotFoundException("顧客が見つかりません"));
+  }
+
+  /** 待たずに取れなければ競合として返す。取れた行が更に統合済みなら、追い続けずに同じ競合として返す（環を作らない）。 */
+  private String lockWithoutWaiting(String customerId) {
+    try {
+      customerRepository
+          .findByIdForUpdateNoWait(customerId)
+          .orElseThrow(() -> new NotFoundException("顧客が見つかりません"));
+    } catch (CannotAcquireLockException contended) {
+      throw new ConflictException(MERGE_IN_FLIGHT);
+    }
+    if (customerRepository.isMerged(customerId)) {
+      throw new ConflictException(MERGE_IN_FLIGHT);
+    }
+    return customerId;
   }
 }

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerReferenceResolver.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerReferenceResolver.java
@@ -3,6 +3,7 @@ package com.kizuna.customer.application;
 import com.kizuna.customer.domain.CustomerRepository;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.storescope.StoreScopeExempt;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.modulith.NamedInterface;
 import org.springframework.stereotype.Service;
@@ -31,7 +32,8 @@ public class CustomerReferenceResolver {
   private final CustomerRepository customerRepository;
 
   /**
-   * 顧客参照の書き込み先。押さえられない顧客（不在・他店舗）は 404 で、存在の有無は漏れない。
+   * 顧客参照の書き込み先。押さえられない顧客（不在・他店舗）は 404 で、存在の有無は漏れない。 墓標を渡されたら統合先へ向け直す — 参照が着くのは常に生きている行である（ADR
+   * 0010）。
    *
    * <p>呼出側のトランザクションに必ず参加する（{@code MANDATORY}）。自分でトランザクションを開くと新しい Session になり、 呼出側の
    * {@code @StoreScoped} が有効にした storeFilter が掛からないまま他店舗の行を押さえたうえ、 呼出側が書き込む前に行ロックを手放してしまう。
@@ -40,9 +42,24 @@ public class CustomerReferenceResolver {
       reason = "呼出元のトランザクションに必ず参加し（MANDATORY）、店舗境界は呼出元の storeFilter か呼出元が明示する storeId が引く")
   @Transactional(propagation = Propagation.MANDATORY)
   public String resolveForWrite(String customerId) {
+    lock(customerId);
+    Optional<String> survivingCustomerId = customerRepository.findMergedIntoId(customerId);
+    if (survivingCustomerId.isEmpty()) {
+      return customerId;
+    }
+    // 着地する行も押さえる。押さえないと、存続行を更に統合する要求が付替えを済ませた後で墓標の
+    // 圧平を待つ間にこの書き込みが割り込み、付替えの済んだ行へ着いたまま取り残される。
+    lock(survivingCustomerId.get());
+    return survivingCustomerId.get();
+  }
+
+  /**
+   * 追うのは一跳だけでよい。圧平により、コミット済みの状態に二段の連鎖は存在しない（ADR 0010）。
+   * 存続行を統合する要求はこちらが押さえている墓標を圧平しなければ進めないので、押さえた時点で 存続行が墓標になっていることもない。
+   */
+  private void lock(String customerId) {
     customerRepository
         .findByIdForUpdate(customerId)
         .orElseThrow(() -> new NotFoundException("顧客が見つかりません"));
-    return customerId;
   }
 }

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
@@ -115,13 +115,13 @@ public class CustomerService {
   @StoreScoped
   @Transactional(readOnly = true)
   public CustomerResponse get(String id) {
-    String targetId = customerRepository.findMergedIntoId(id).orElse(id);
-    return customerRepository
-        .findById(targetId)
-        .map(customerMapper::toResponse)
-        .map(response -> withMemberLink(response, activeMemberCodeOf(targetId)))
-        .map(response -> withMergeMark(response, id, targetId))
-        .orElseThrow(() -> new NotFoundException("顧客が見つかりません"));
+    Customer customer =
+        customerRepository
+            .findResolvingMerge(id)
+            .orElseThrow(() -> new NotFoundException("顧客が見つかりません"));
+    CustomerResponse response = customerMapper.toResponse(customer);
+    withMemberLink(response, activeMemberCodeOf(customer.getId()));
+    return withMergeMark(response, id, customer.getId());
   }
 
   @StoreScoped

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
@@ -41,6 +41,9 @@ public class CustomerService {
   private static final String MERGED_CUSTOMER_UNDELETABLE =
       "統合に関与した顧客は削除できません。統合履歴と旧 ID の解決の根拠になります";
 
+  /** 墓標そのものを名指した書き換えの案内。統合先へ黙って向け直してよいのは参照の書き込み先だけである（ADR 0010）。 */
+  private static final String MERGED_CUSTOMER_NOT_EDITABLE = "統合済みの顧客です。統合先の顧客を編集してください";
+
   private final CustomerRepository customerRepository;
   private final CustomerMemberLinkRepository customerMemberLinkRepository;
   private final CustomerMergeRepository customerMergeRepository;
@@ -79,6 +82,9 @@ public class CustomerService {
       String search, String rank, String classification) {
     return (root, query, cb) -> {
       List<Predicate> predicates = new ArrayList<>();
+      // 墓標は台帳に並ばない。「統合済みも表示」の切替は設けない — 墓標の存在を知る必要があるのは
+      // 旧 ID の解決と統合履歴の閲覧だけである（ADR 0010）。
+      predicates.add(cb.isNull(root.get("mergedIntoId")));
       if (search != null) {
         char escape = LIKE_ESCAPE.getEscapeCharacter();
         String pattern = "%" + LIKE_ESCAPE.escape(search.toLowerCase()) + "%";
@@ -98,13 +104,20 @@ public class CustomerService {
     };
   }
 
+  /**
+   * 顧客詳細。旧 ID を渡されたら統合先の行を返し、統合済みであることと元の ID を応答に載せる。
+   *
+   * <p>3xx リダイレクトは採らない — HTTP クライアントが透過的に追随するため、画面が統合の発生そのものを知れなくなる。
+   */
   @StoreScoped
   @Transactional(readOnly = true)
   public CustomerResponse get(String id) {
+    String targetId = customerRepository.findMergedIntoId(id).orElse(id);
     return customerRepository
-        .findById(id)
+        .findById(targetId)
         .map(customerMapper::toResponse)
-        .map(response -> withMemberLink(response, activeMemberCodeOf(id)))
+        .map(response -> withMemberLink(response, activeMemberCodeOf(targetId)))
+        .map(response -> withMergeMark(response, id, targetId))
         .orElseThrow(() -> new NotFoundException("顧客が見つかりません"));
   }
 
@@ -122,6 +135,9 @@ public class CustomerService {
   public CustomerResponse update(String id, CustomerUpdateRequest request) {
     Customer customer =
         customerRepository.findById(id).orElseThrow(() -> new NotFoundException("顧客が見つかりません"));
+    if (customerRepository.isMerged(id)) {
+      throw new ConflictException(MERGED_CUSTOMER_NOT_EDITABLE);
+    }
 
     customer.apply(customerMapper.toPatch(request));
 
@@ -138,6 +154,11 @@ public class CustomerService {
   public void delete(String id) {
     if (!customerRepository.existsById(id)) {
       throw new NotFoundException("顧客が見つかりません");
+    }
+    // 墓標も「統合に関与した行」なので下の判定でも撥ねられるが、次の一手が違う — 墓標を消したい人が
+    // 求めているのは統合先の編集である。先に判定して案内を分ける。
+    if (customerRepository.isMerged(id)) {
+      throw new ConflictException(MERGED_CUSTOMER_NOT_EDITABLE);
     }
     if (customerMergeRepository.existsInvolving(id)) {
       throw new ConflictException(MERGED_CUSTOMER_UNDELETABLE);
@@ -168,6 +189,17 @@ public class CustomerService {
         .findByCustomerIdAndStatus(customerId, LinkStatus.ACTIVE)
         .map(CustomerMemberLink::getMemberCode)
         .orElse(null);
+  }
+
+  /** 旧 ID で引かれたときだけ統合の標識を載せる。生きた行を引いた応答には欄そのものが現れない（non_null 直列化）ので、 欄の有無が「この ID は統合済みか」の答えになる。 */
+  private static CustomerResponse withMergeMark(
+      CustomerResponse response, String requestedId, String targetId) {
+    if (requestedId.equals(targetId)) {
+      return response;
+    }
+    response.setMerged(true);
+    response.setMergedFromId(requestedId);
+    return response;
   }
 
   /** 会員紐づけの投影を載せる。memberLinked は関連状態の有無そのものなので、常に真偽値が入る。 */

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerService.java
@@ -41,7 +41,10 @@ public class CustomerService {
   private static final String MERGED_CUSTOMER_UNDELETABLE =
       "統合に関与した顧客は削除できません。統合履歴と旧 ID の解決の根拠になります";
 
-  /** 墓標そのものを名指した書き換えの案内。統合先へ黙って向け直してよいのは参照の書き込み先だけである（ADR 0010）。 */
+  /**
+   * 墓標そのものを名指した書き換えの案内。更新・削除・ポイント調整・解除の 4 経路が同じ文面を返すのは、どれも次の一手が同じ
+   * （統合先の行を編集する）だからである。統合先へ黙って向け直してよいのは参照の書き込み先だけで、名指した行への書き換えは撥ねる（ADR 0010）。
+   */
   private static final String MERGED_CUSTOMER_NOT_EDITABLE = "統合済みの顧客です。統合先の顧客を編集してください";
 
   private final CustomerRepository customerRepository;

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
@@ -47,14 +47,27 @@ public interface CustomerRepository
   Optional<Customer> findByPhoneNumber(String phoneNumber);
 
   /**
-   * 店舗台帳のうち電話番号が一致する顧客。索引 {@code idx_t_customers_phone (phone_number, store_id)}
+   * 店舗台帳のうち電話番号が一致する生きた顧客の ID。索引 {@code idx_t_customers_phone (phone_number, store_id)}
    * は非一意で、同店同号の行は正規に起こりうる — 同伴者が連絡先を共有する場合や旧システムからの移行分がそれにあたる。
    *
    * <p>だから戻り値は複数行を許す形でなければならない。1 件に絞る形（{@code Optional}）で受けると、重複のある番号を引いた瞬間に {@code
    * IncorrectResultSizeDataAccessException} で呼出側ごと落ちる。複数一致をどう扱うかは呼出側の判断で、 電話番号は台帳内の検索の手がかりに留まる（ADR
    * 0009）。
+   *
+   * <p>墓標は照合の候補にならない（ADR 0010）。統合の目的そのものが、重複で複数一致に落ちていた番号を 1 行へ収束させることなので、
+   * 墓標が候補に残ると統合しても自動照合は断念のままになる。
+   *
+   * <p>実体ではなく ID を返すのは、照合した行を永続化文脈へ載せないため。載せると、この後の {@link #findByIdForUpdate}
+   * がロックの獲得（実体は第一次キャッシュのまま）に版の照合を伴い、照合と着地の間に走った統合・顧客更新が 版を上げているだけで受注録入が 409 に落ちる —
+   * 顧客行を書きもしない経路が、読んだだけの行の版で失敗する。
    */
-  List<Customer> findByPhoneNumberAndStoreId(String phoneNumber, Long storeId);
+  @Query(
+      """
+      select c.id from com.kizuna.customer.domain.Customer c
+      where c.phoneNumber = :phoneNumber and c.storeId = :storeId and c.mergedIntoId is null
+      """)
+  List<String> findAliveIdsByPhoneNumberAndStoreId(
+      @Param("phoneNumber") String phoneNumber, @Param("storeId") Long storeId);
 
   /**
    * その顧客が既に墓標（統合済み）かどうか。
@@ -69,6 +82,19 @@ public interface CustomerRepository
       where c.id = :id and c.mergedIntoId is not null
       """)
   boolean isMerged(@Param("id") String id);
+
+  /**
+   * その顧客の統合先。生きている行と存在しない行はどちらも空で返る — 呼出側はどちらの場合も「渡された ID がそのまま着地点」として扱うため、区別する必要がない。
+   *
+   * <p>{@link #isMerged} と同じく別問い合わせで読む。押さえた実体のフィールドから読むと第一次キャッシュの古い値を見る（{@link #findByIdForUpdate}
+   * の契約）。
+   */
+  @Query(
+      """
+      select c.mergedIntoId from com.kizuna.customer.domain.Customer c
+      where c.id = :id
+      """)
+  Optional<String> findMergedIntoId(@Param("id") String id);
 
   /**
    * 連鎖統合の圧平。被統合行を指していた既存の墓標を、新しい統合先へ付け替える。A→B の後で B→C を統合すると A は直接 C を指し、旧 ID の解決は常に一跳で届く（ADR

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
@@ -55,11 +55,10 @@ public interface CustomerRepository
    * 0009）。
    *
    * <p>墓標は照合の候補にならない（ADR 0010）。統合の目的そのものが、重複で複数一致に落ちていた番号を 1 行へ収束させることなので、
-   * 墓標が候補に残ると統合しても自動照合は断念のままになる。
+   * 墓標が候補に残ると統合しても自動照合は断念のままになる。統合は値を合併しないため、被統合行にしかない番号は 統合後どの行にも一致しない — 残したい値の転記は人手である。
    *
-   * <p>実体ではなく ID を返すのは、照合した行を永続化文脈へ載せないため。載せると、この後の {@link #findByIdForUpdate}
-   * がロックの獲得（実体は第一次キャッシュのまま）に版の照合を伴い、照合と着地の間に走った統合・顧客更新が 版を上げているだけで受注録入が 409 に落ちる —
-   * 顧客行を書きもしない経路が、読んだだけの行の版で失敗する。
+   * <p>実体ではなく ID を返すのは、照合した行を永続化文脈へ載せないため。載せると {@link #findByIdForUpdate}
+   * のロック獲得が版の照合を伴い、照合と着地の間に統合や顧客更新が版を上げただけで、顧客行を書きもしない受注録入が 409 に落ちる。
    */
   @Query(
       """
@@ -70,24 +69,11 @@ public interface CustomerRepository
       @Param("phoneNumber") String phoneNumber, @Param("storeId") Long storeId);
 
   /**
-   * その顧客が既に墓標（統合済み）かどうか。
-   *
-   * <p>押さえた行の実体からではなく別問い合わせで判定する。悲観排他ロックは既に永続化文脈に載っている実体の状態を更新しないため、
-   * ロック後に実体のフィールドを読むと第一次キャッシュの古い値を見る（{@link #findByIdForUpdate} の契約）。集計の投影は 実体を経由しないので、押さえた直後の DB
-   * の値をそのまま返す。
-   */
-  @Query(
-      """
-      select count(c) > 0 from com.kizuna.customer.domain.Customer c
-      where c.id = :id and c.mergedIntoId is not null
-      """)
-  boolean isMerged(@Param("id") String id);
-
-  /**
    * その顧客の統合先。生きている行と存在しない行はどちらも空で返る — 呼出側はどちらの場合も「渡された ID がそのまま着地点」として扱うため、区別する必要がない。
    *
-   * <p>{@link #isMerged} と同じく別問い合わせで読む。押さえた実体のフィールドから読むと第一次キャッシュの古い値を見る（{@link #findByIdForUpdate}
-   * の契約）。
+   * <p>押さえた行の実体からではなく別問い合わせで読む。悲観排他ロックは既に永続化文脈に載っている実体の状態を更新しないため、
+   * ロック後に実体のフィールドを読むと第一次キャッシュの古い値を見る（{@link #findByIdForUpdate} の契約）。投影は実体を経由しないので、 押さえた直後の DB
+   * の値をそのまま返す。
    */
   @Query(
       """
@@ -95,6 +81,11 @@ public interface CustomerRepository
       where c.id = :id
       """)
   Optional<String> findMergedIntoId(@Param("id") String id);
+
+  /** その顧客が既に墓標（統合済み）かどうか。統合先そのものは要らないが、判定の出所は一つに保つ。 */
+  default boolean isMerged(String id) {
+    return findMergedIntoId(id).isPresent();
+  }
 
   /**
    * 連鎖統合の圧平。被統合行を指していた既存の墓標を、新しい統合先へ付け替える。A→B の後で B→C を統合すると A は直接 C を指し、旧 ID の解決は常に一跳で届く（ADR

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerRepository.java
@@ -1,6 +1,7 @@
 package com.kizuna.customer.domain;
 
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 public interface CustomerRepository
@@ -43,6 +45,32 @@ public interface CustomerRepository
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select c from com.kizuna.customer.domain.Customer c where c.id = :id")
   Optional<Customer> findByIdForUpdate(@Param("id") String id);
+
+  /**
+   * {@link #findByIdForUpdate} と同じロックを、待たずに取れるときだけ取る（{@code FOR UPDATE NOWAIT}）。取れなければ {@code
+   * CannotAcquireLockException}。
+   *
+   * <p>行を押さえたまま次の行を待つ経路で使う。統合は存続行と被統合行を押さえた後で、被統合行を指す墓標を圧平（＝墓標の行を押さえる）するため、
+   * 「墓標を押さえたまま統合先を待つ」形は統合と待ちが環になる。待たない取得なら環は生まれず、取れなかった競合は案内の読める応答に写せる。
+   */
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "0"))
+  @Query("select c from com.kizuna.customer.domain.Customer c where c.id = :id")
+  Optional<Customer> findByIdForUpdateNoWait(@Param("id") String id);
+
+  /**
+   * 旧 ID を渡されても統合先の生きた行を返す読み口。統合先参照の解決と行の取得を 1 文で行う。
+   *
+   * <p>2 文に分けると、READ COMMITTED では文ごとに異なるスナップショットを見るため、統合先を読んだ後に連鎖統合が確定すると 既に墓標になった行を本体として返してしまう。1
+   * 文なら解決と取得が同じスナップショットで、返る行は必ず生きている。
+   */
+  @Query(
+      """
+      select c from com.kizuna.customer.domain.Customer c
+      where c.id = coalesce(
+        (select m.mergedIntoId from com.kizuna.customer.domain.Customer m where m.id = :id), :id)
+      """)
+  Optional<Customer> findResolvingMerge(@Param("id") String id);
 
   Optional<Customer> findByPhoneNumber(String phoneNumber);
 

--- a/backend/src/main/java/com/kizuna/order/application/OrderService.java
+++ b/backend/src/main/java/com/kizuna/order/application/OrderService.java
@@ -735,8 +735,8 @@ public class OrderService {
       return;
     }
     if (req.getPhoneNumber() != null && !req.getPhoneNumber().isEmpty()) {
-      List<Customer> matched =
-          customerRepository.findByPhoneNumberAndStoreId(
+      List<String> matched =
+          customerRepository.findAliveIdsByPhoneNumberAndStoreId(
               req.getPhoneNumber(), storeContext.getStoreId());
       if (matched.isEmpty()) {
         // 起こしたばかりの行は他の経路の書き換えに晒されていないため、解決を経ずにそのまま着ける。
@@ -744,7 +744,7 @@ public class OrderService {
         order.linkCustomer(customerRepository.save(orderMapper.toCustomer(req)).getId());
       } else if (matched.size() == 1) {
         // 照合は行を押さえない問い合わせなので、着ける前に解決を通す（照合そのものの 3 分岐は変わらない）。
-        order.linkCustomer(customerReferenceResolver.resolveForWrite(matched.get(0).getId()));
+        order.linkCustomer(customerReferenceResolver.resolveForWrite(matched.get(0)));
       }
     }
     order.recordContactIfUnlinked(req.getCustomerName(), req.getPhoneNumber());

--- a/backend/src/test/java/com/kizuna/customer/application/CustomerMemberLinkServiceTest.java
+++ b/backend/src/test/java/com/kizuna/customer/application/CustomerMemberLinkServiceTest.java
@@ -281,6 +281,23 @@ class CustomerMemberLinkServiceTest {
   }
 
   @Test
+  @DisplayName("墓標の解除は、関連の照会より先に統合済みとして撥ねられること")
+  void unlinkRejectsTombstonesBeforeReadingTheLink() {
+    // 解除は名指された行そのものを対象にするので統合先へ向け直さない。統合で関連は存続行へ
+    // 移っているため、後ろに置くと「紐づけられている会員がいません」に落ちて理由が伝わらない
+    givenActor();
+    givenCustomerLocked();
+    Mockito.when(customerRepository.isMerged(CUSTOMER_ID)).thenReturn(true);
+
+    assertThatThrownBy(() -> service.unlink(CUSTOMER_ID, ACTOR_EMAIL))
+        .isInstanceOf(ConflictException.class)
+        .hasMessageContaining("統合済みの顧客です。統合先の顧客を編集してください");
+    Mockito.verify(customerMemberLinkRepository, Mockito.never())
+        .findByCustomerIdAndStatus(any(), any());
+    Mockito.verify(customerMemberLinkRepository, Mockito.never()).save(any());
+  }
+
+  @Test
   @DisplayName("紐づけは成立先を解決（＝顧客行を排他ロック）してから現在の紐づけを読むこと")
   void linkTakesTheCustomerRowLockBeforeResolving() {
     // 記帳（受注完了・手動調整）と同じ行を直列化点にすることで、置換の途中の紐づけを記帳側に見せない

--- a/backend/src/test/java/com/kizuna/customer/application/CustomerMergeServiceTest.java
+++ b/backend/src/test/java/com/kizuna/customer/application/CustomerMergeServiceTest.java
@@ -91,16 +91,19 @@ class CustomerMergeServiceTest {
   }
 
   @Test
-  @DisplayName("存続行に墓標を指定した統合は 409 で拒まれ、付替えが一切走らないこと")
+  @DisplayName("存続行に墓標を指定した統合は、2 本目のロックを待つ前に 409 で拒まれること")
   void rejectsMergingIntoATombstone() {
     givenActor();
-    givenBothRowsLocked();
+    givenFirstRowLocked();
     Mockito.when(customerRepository.isMerged(SURVIVING_ID)).thenReturn(true);
 
     assertThatThrownBy(() -> service.merge(SURVIVING_ID, MERGED_ID, ACTOR_EMAIL))
         .isInstanceOf(ConflictException.class)
         .hasMessageContaining("統合済み");
 
+    // 参照の解決は墓標 → 統合先の順に押さえるので、墓標を名指した要求がここで 2 本目を待つと
+    // ID 昇順と逆向きの待ちが環になる
+    Mockito.verify(customerRepository, Mockito.never()).findByIdForUpdate(SURVIVING_ID);
     verifyNothingWasMoved();
   }
 
@@ -108,7 +111,7 @@ class CustomerMergeServiceTest {
   @DisplayName("既に墓標の行を再度統合しようとすると 409 で拒まれること（応答喪失後の再送が台帳を壊さない）")
   void rejectsMergingATombstoneAgain() {
     givenActor();
-    givenBothRowsLocked();
+    givenFirstRowLocked();
     Mockito.when(customerRepository.isMerged(SURVIVING_ID)).thenReturn(false);
     Mockito.when(customerRepository.isMerged(MERGED_ID)).thenReturn(true);
 
@@ -116,6 +119,7 @@ class CustomerMergeServiceTest {
         .isInstanceOf(ConflictException.class)
         .hasMessageContaining("統合済み");
 
+    Mockito.verify(customerRepository, Mockito.never()).findByIdForUpdate(SURVIVING_ID);
     verifyNothingWasMoved();
   }
 
@@ -222,6 +226,12 @@ class CustomerMergeServiceTest {
   }
 
   /** 両行が押さえられた状態。戻り値は被統合行の実体（墓標化の宛先）。 */
+  /** 昇順の 1 本目（被統合行）だけを押さえられる状態。墓標の判定で 2 本目より前に撥ねる経路で使う。 */
+  private void givenFirstRowLocked() {
+    Mockito.when(customerRepository.findByIdForUpdate(MERGED_ID))
+        .thenReturn(Optional.of(Customer.builder().build()));
+  }
+
   private Customer givenBothRowsLocked() {
     Customer merged = Customer.builder().build();
     Mockito.when(customerRepository.findByIdForUpdate(MERGED_ID)).thenReturn(Optional.of(merged));

--- a/backend/src/test/java/com/kizuna/customer/application/CustomerPointServiceTest.java
+++ b/backend/src/test/java/com/kizuna/customer/application/CustomerPointServiceTest.java
@@ -16,6 +16,7 @@ import com.kizuna.customer.domain.CustomerRepository;
 import com.kizuna.customer.domain.LinkReason;
 import com.kizuna.customer.domain.LinkStatus;
 import com.kizuna.point.application.PointLedgerService;
+import com.kizuna.shared.exception.ConflictException;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.exception.StaleSessionException;
@@ -174,6 +175,24 @@ class CustomerPointServiceTest {
 
     Mockito.verify(customerRepository).findByIdForUpdate(CUSTOMER_ID);
     Mockito.verify(customerRepository, Mockito.never()).existsById(anyString());
+  }
+
+  @Test
+  @DisplayName("墓標への調整は、関連の照会より先に統合済みとして撥ねられること")
+  void adjustRejectsTombstonesBeforeResolvingTheMember() {
+    // 統合は関連を存続行へ移しているので、後ろに置くと「未紐づけの顧客」の分岐に落ち、
+    // 統合済みであることが利用者に伝わらない
+    givenCustomerLocked();
+    Mockito.when(customerRepository.isMerged(CUSTOMER_ID)).thenReturn(true);
+
+    assertThatThrownBy(
+            () -> service.adjust(CUSTOMER_ID, request(300, "来店記念の付与", null), ACTOR_EMAIL))
+        .isInstanceOf(ConflictException.class)
+        .hasMessageContaining("統合済みの顧客です。統合先の顧客を編集してください");
+    Mockito.verify(customerMemberLinkRepository, Mockito.never())
+        .findByCustomerIdAndStatus(anyString(), any());
+    Mockito.verify(pointLedgerService, Mockito.never())
+        .adjust(anyLong(), any(), anyInt(), anyString(), any(), any(), anyString());
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/customer/application/CustomerReferenceResolverTest.java
+++ b/backend/src/test/java/com/kizuna/customer/application/CustomerReferenceResolverTest.java
@@ -6,16 +6,17 @@ import static org.mockito.ArgumentMatchers.any;
 
 import com.kizuna.customer.domain.Customer;
 import com.kizuna.customer.domain.CustomerRepository;
+import com.kizuna.shared.exception.ConflictException;
 import com.kizuna.shared.exception.NotFoundException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.CannotAcquireLockException;
 
 @ExtendWith(MockitoExtension.class)
 class CustomerReferenceResolverTest {
@@ -42,38 +43,68 @@ class CustomerReferenceResolverTest {
   }
 
   @Test
-  @DisplayName("墓標を渡されたら、統合先を別問い合わせで読んで存続行を返すこと")
-  void resolveFollowsTheMergeTargetReadWithASeparateQuery() {
-    // 悲観排他ロックは既に永続化文脈に載っている実体の状態を更新しない。統合先を持たない実体を
-    // 返しつつ問い合わせだけが統合先を答える形で、実体ではなく問い合わせを読んでいることを固定する
-    // （この規律は経路が実体を先に載せるかどうかに依らず、解決口の契約そのものである）。
-    Mockito.when(customerRepository.findByIdForUpdate(CUSTOMER_ID))
-        .thenReturn(Optional.of(Customer.builder().name("統合先を持たない実体").build()));
-    Mockito.when(customerRepository.findByIdForUpdate(SURVIVING_CUSTOMER_ID))
-        .thenReturn(Optional.of(Customer.builder().build()));
+  @DisplayName("墓標を渡されたとき押さえるのは着地する存続行だけで、墓標は押さえないこと")
+  void resolveLocksOnlyTheRowItLandsOn() {
     Mockito.when(customerRepository.findMergedIntoId(CUSTOMER_ID))
         .thenReturn(Optional.of(SURVIVING_CUSTOMER_ID));
+    Mockito.when(customerRepository.findByIdForUpdate(SURVIVING_CUSTOMER_ID))
+        .thenReturn(Optional.of(Customer.builder().build()));
 
     assertThat(resolver.resolveForWrite(CUSTOMER_ID)).isEqualTo(SURVIVING_CUSTOMER_ID);
+
+    // 墓標を押さえたまま統合先を待つと、その統合先を更に統合する要求（墓標の圧平で墓標の行を押さえる）
+    // と待ちが環になる
+    Mockito.verify(customerRepository, Mockito.never()).findByIdForUpdate(CUSTOMER_ID);
   }
 
   @Test
-  @DisplayName("統合先へ向け直すときは、着地する存続行も押さえること")
-  void resolveLocksTheSurvivingRowAsWell() {
+  @DisplayName("下見の後に統合が確定したら、統合先は待たずに取りに行くこと")
+  void resolveChasesTheLateMergeWithoutWaiting() {
+    // 下見の時点では生きていたので押さえに行き、押さえた時には墓標になっていた形。ここで待つと
+    // 「墓標を押さえたまま統合先を待つ」形になり、圧平と待ちが環になる
+    Mockito.when(customerRepository.findMergedIntoId(CUSTOMER_ID))
+        .thenReturn(Optional.empty())
+        .thenReturn(Optional.of(SURVIVING_CUSTOMER_ID));
     Mockito.when(customerRepository.findByIdForUpdate(CUSTOMER_ID))
         .thenReturn(Optional.of(Customer.builder().build()));
-    Mockito.when(customerRepository.findByIdForUpdate(SURVIVING_CUSTOMER_ID))
+    Mockito.when(customerRepository.findByIdForUpdateNoWait(SURVIVING_CUSTOMER_ID))
         .thenReturn(Optional.of(Customer.builder().build()));
+
+    assertThat(resolver.resolveForWrite(CUSTOMER_ID)).isEqualTo(SURVIVING_CUSTOMER_ID);
+
+    Mockito.verify(customerRepository, Mockito.never()).findByIdForUpdate(SURVIVING_CUSTOMER_ID);
+  }
+
+  @Test
+  @DisplayName("統合先を待たずに取れなかったら、やり直しの判る 409 になること")
+  void resolveReportsAConflictWhenTheTargetIsHeldByAMerge() {
     Mockito.when(customerRepository.findMergedIntoId(CUSTOMER_ID))
+        .thenReturn(Optional.empty())
         .thenReturn(Optional.of(SURVIVING_CUSTOMER_ID));
+    Mockito.when(customerRepository.findByIdForUpdate(CUSTOMER_ID))
+        .thenReturn(Optional.of(Customer.builder().build()));
+    Mockito.when(customerRepository.findByIdForUpdateNoWait(SURVIVING_CUSTOMER_ID))
+        .thenThrow(new CannotAcquireLockException("statement timeout"));
 
-    resolver.resolveForWrite(CUSTOMER_ID);
+    assertThatThrownBy(() -> resolver.resolveForWrite(CUSTOMER_ID))
+        .isInstanceOf(ConflictException.class)
+        .hasMessageContaining("統合中の顧客です");
+  }
 
-    // 押さえるのは書き込みが着地する行。押さえないと、存続行を更に統合する要求が付替えを
-    // 済ませた後にこの書き込みが割り込み、付替えの済んだ行へ着いたまま取り残される。
-    InOrder locks = Mockito.inOrder(customerRepository);
-    locks.verify(customerRepository).findByIdForUpdate(CUSTOMER_ID);
-    locks.verify(customerRepository).findByIdForUpdate(SURVIVING_CUSTOMER_ID);
+  @Test
+  @DisplayName("統合先の判定は押さえた実体からではなく別問い合わせで行うこと")
+  void resolveReadsTheMergeTargetWithASeparateQuery() {
+    // 悲観排他ロックは既に永続化文脈に載っている実体の状態を更新しない。統合先を持たない実体を
+    // 押さえつつ問い合わせだけが統合先を答える形で、実体ではなく問い合わせを読んでいることを固定する。
+    Mockito.when(customerRepository.findByIdForUpdate(CUSTOMER_ID))
+        .thenReturn(Optional.of(Customer.builder().name("統合先を持たない実体").build()));
+    Mockito.when(customerRepository.findMergedIntoId(CUSTOMER_ID))
+        .thenReturn(Optional.empty())
+        .thenReturn(Optional.of(SURVIVING_CUSTOMER_ID));
+    Mockito.when(customerRepository.findByIdForUpdateNoWait(SURVIVING_CUSTOMER_ID))
+        .thenReturn(Optional.of(Customer.builder().build()));
+
+    assertThat(resolver.resolveForWrite(CUSTOMER_ID)).isEqualTo(SURVIVING_CUSTOMER_ID);
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/customer/application/CustomerReferenceResolverTest.java
+++ b/backend/src/test/java/com/kizuna/customer/application/CustomerReferenceResolverTest.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -20,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class CustomerReferenceResolverTest {
 
   private static final String CUSTOMER_ID = "c1";
+  private static final String SURVIVING_CUSTOMER_ID = "c2";
 
   @Mock private CustomerRepository customerRepository;
 
@@ -40,14 +42,38 @@ class CustomerReferenceResolverTest {
   }
 
   @Test
-  @DisplayName("ロックした実体からは状態を読まないこと")
-  void resolveDoesNotReadTheLockedEntity() {
-    // 悲観排他ロックは既に永続化文脈に載っている実体の状態を更新しないため、ロック後に読んだ値は古い。
-    // id を持たない実体を返しても解決結果が変わらないことで、実体を読んでいないことが判る。
+  @DisplayName("墓標を渡されたら、統合先を別問い合わせで読んで存続行を返すこと")
+  void resolveFollowsTheMergeTargetReadWithASeparateQuery() {
+    // 悲観排他ロックは既に永続化文脈に載っている実体の状態を更新しない。統合先を持たない実体を
+    // 返しつつ問い合わせだけが統合先を答える形で、実体ではなく問い合わせを読んでいることを固定する
+    // （この規律は経路が実体を先に載せるかどうかに依らず、解決口の契約そのものである）。
     Mockito.when(customerRepository.findByIdForUpdate(CUSTOMER_ID))
-        .thenReturn(Optional.of(Customer.builder().name("氏名だけの実体").build()));
+        .thenReturn(Optional.of(Customer.builder().name("統合先を持たない実体").build()));
+    Mockito.when(customerRepository.findByIdForUpdate(SURVIVING_CUSTOMER_ID))
+        .thenReturn(Optional.of(Customer.builder().build()));
+    Mockito.when(customerRepository.findMergedIntoId(CUSTOMER_ID))
+        .thenReturn(Optional.of(SURVIVING_CUSTOMER_ID));
 
-    assertThat(resolver.resolveForWrite(CUSTOMER_ID)).isEqualTo(CUSTOMER_ID);
+    assertThat(resolver.resolveForWrite(CUSTOMER_ID)).isEqualTo(SURVIVING_CUSTOMER_ID);
+  }
+
+  @Test
+  @DisplayName("統合先へ向け直すときは、着地する存続行も押さえること")
+  void resolveLocksTheSurvivingRowAsWell() {
+    Mockito.when(customerRepository.findByIdForUpdate(CUSTOMER_ID))
+        .thenReturn(Optional.of(Customer.builder().build()));
+    Mockito.when(customerRepository.findByIdForUpdate(SURVIVING_CUSTOMER_ID))
+        .thenReturn(Optional.of(Customer.builder().build()));
+    Mockito.when(customerRepository.findMergedIntoId(CUSTOMER_ID))
+        .thenReturn(Optional.of(SURVIVING_CUSTOMER_ID));
+
+    resolver.resolveForWrite(CUSTOMER_ID);
+
+    // 押さえるのは書き込みが着地する行。押さえないと、存続行を更に統合する要求が付替えを
+    // 済ませた後にこの書き込みが割り込み、付替えの済んだ行へ着いたまま取り残される。
+    InOrder locks = Mockito.inOrder(customerRepository);
+    locks.verify(customerRepository).findByIdForUpdate(CUSTOMER_ID);
+    locks.verify(customerRepository).findByIdForUpdate(SURVIVING_CUSTOMER_ID);
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/customer/application/CustomerServiceTest.java
+++ b/backend/src/test/java/com/kizuna/customer/application/CustomerServiceTest.java
@@ -93,7 +93,7 @@ class CustomerServiceTest {
     CustomerResponse resp = new CustomerResponse();
     resp.setId("c1");
 
-    when(customerRepository.findById("c1")).thenReturn(Optional.of(c));
+    when(customerRepository.findResolvingMerge("c1")).thenReturn(Optional.of(c));
     when(customerMapper.toResponse(c)).thenReturn(resp);
 
     assertThat(customerService.get("c1").getId()).isEqualTo("c1");
@@ -101,7 +101,7 @@ class CustomerServiceTest {
 
   @Test
   void get_throwsWhenNotFound() {
-    when(customerRepository.findById("missing")).thenReturn(Optional.empty());
+    when(customerRepository.findResolvingMerge("missing")).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> customerService.get("missing"))
         .isInstanceOf(NotFoundException.class)
@@ -208,7 +208,7 @@ class CustomerServiceTest {
     CustomerResponse resp = new CustomerResponse();
     resp.setId("c1");
 
-    when(customerRepository.findById("c1")).thenReturn(Optional.of(c));
+    when(customerRepository.findResolvingMerge("c1")).thenReturn(Optional.of(c));
     when(customerMapper.toResponse(c)).thenReturn(resp);
     when(customerMemberLinkRepository.findByCustomerIdAndStatus("c1", LinkStatus.ACTIVE))
         .thenReturn(Optional.of(activeLink("c1", "123456789012")));
@@ -233,8 +233,9 @@ class CustomerServiceTest {
     CustomerResponse resp = new CustomerResponse();
     resp.setId("c2");
 
-    when(customerRepository.findMergedIntoId("c1")).thenReturn(Optional.of("c2"));
-    when(customerRepository.findById("c2")).thenReturn(Optional.of(surviving));
+    // 解決と取得を 1 文で行う。2 文に分けると、統合先を読んだ後に連鎖統合が確定した場合に
+    // 既に墓標になった行を本体として返してしまう
+    when(customerRepository.findResolvingMerge("c1")).thenReturn(Optional.of(surviving));
     when(customerMapper.toResponse(surviving)).thenReturn(resp);
 
     CustomerResponse result = customerService.get("c1");
@@ -242,8 +243,7 @@ class CustomerServiceTest {
     assertThat(result.getId()).isEqualTo("c2");
     assertThat(result.getMerged()).isTrue();
     assertThat(result.getMergedFromId()).isEqualTo("c1");
-    // 墓標の内容は返さない。返すのは常に統合先の行そのもの
-    verify(customerRepository, never()).findById("c1");
+    verify(customerRepository, never()).findById(any());
   }
 
   @Test
@@ -254,7 +254,7 @@ class CustomerServiceTest {
     CustomerResponse resp = new CustomerResponse();
     resp.setId("c1");
 
-    when(customerRepository.findById("c1")).thenReturn(Optional.of(c));
+    when(customerRepository.findResolvingMerge("c1")).thenReturn(Optional.of(c));
     when(customerMapper.toResponse(c)).thenReturn(resp);
 
     CustomerResponse result = customerService.get("c1");

--- a/backend/src/test/java/com/kizuna/customer/application/CustomerServiceTest.java
+++ b/backend/src/test/java/com/kizuna/customer/application/CustomerServiceTest.java
@@ -225,6 +225,72 @@ class CustomerServiceTest {
     assertThat(unlinked.getLinkedMemberCode()).isNull();
   }
 
+  @Test
+  @DisplayName("詳細を旧 ID で引くと統合先の行が返り、統合済みであることと元の ID が載ること")
+  void get_resolvesAMergedIdToTheSurvivingRow() {
+    Customer surviving = new Customer();
+    surviving.setId("c2");
+    CustomerResponse resp = new CustomerResponse();
+    resp.setId("c2");
+
+    when(customerRepository.findMergedIntoId("c1")).thenReturn(Optional.of("c2"));
+    when(customerRepository.findById("c2")).thenReturn(Optional.of(surviving));
+    when(customerMapper.toResponse(surviving)).thenReturn(resp);
+
+    CustomerResponse result = customerService.get("c1");
+
+    assertThat(result.getId()).isEqualTo("c2");
+    assertThat(result.getMerged()).isTrue();
+    assertThat(result.getMergedFromId()).isEqualTo("c1");
+    // 墓標の内容は返さない。返すのは常に統合先の行そのもの
+    verify(customerRepository, never()).findById("c1");
+  }
+
+  @Test
+  @DisplayName("生きた行の詳細には統合の標識が載らないこと")
+  void get_leavesTheMergeMarkOffALiveRow() {
+    Customer c = new Customer();
+    c.setId("c1");
+    CustomerResponse resp = new CustomerResponse();
+    resp.setId("c1");
+
+    when(customerRepository.findById("c1")).thenReturn(Optional.of(c));
+    when(customerMapper.toResponse(c)).thenReturn(resp);
+
+    CustomerResponse result = customerService.get("c1");
+
+    assertThat(result.getMerged()).isNull();
+    assertThat(result.getMergedFromId()).isNull();
+  }
+
+  @Test
+  @DisplayName("墓標への更新は 409 で撥ねられ、統合先を編集することが判ること")
+  void update_rejectsTombstones() {
+    Customer tombstone = new Customer();
+    tombstone.setId("c1");
+    when(customerRepository.findById("c1")).thenReturn(Optional.of(tombstone));
+    when(customerRepository.isMerged("c1")).thenReturn(true);
+
+    assertThatThrownBy(() -> customerService.update("c1", new CustomerUpdateRequest()))
+        .isInstanceOf(ConflictException.class)
+        .hasMessageContaining("統合済みの顧客です。統合先の顧客を編集してください");
+    verify(customerRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("墓標の削除は、統合に関与した行の案内より先に統合済みとして撥ねられること")
+  void delete_rejectsTombstonesBeforeTheInvolvementCheck() {
+    when(customerRepository.existsById("c1")).thenReturn(true);
+    when(customerRepository.isMerged("c1")).thenReturn(true);
+
+    assertThatThrownBy(() -> customerService.delete("c1"))
+        .isInstanceOf(ConflictException.class)
+        .hasMessageContaining("統合済みの顧客です。統合先の顧客を編集してください");
+    // 墓標は「統合に関与した行」でもあるので、後ろに置くと次の一手の違う案内に潰れる
+    verify(customerMergeRepository, never()).existsInvolving(any());
+    verify(customerRepository, never()).deleteById(any());
+  }
+
   private static CustomerMemberLink activeLink(String customerId, String memberCode) {
     return CustomerMemberLink.builder()
         .customerId(customerId)

--- a/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
+++ b/backend/src/test/java/com/kizuna/order/application/OrderServiceTest.java
@@ -309,7 +309,8 @@ class OrderServiceTest {
 
     when(storeContext.getStoreId()).thenReturn(1L);
     when(orderMapper.toEntity(req)).thenReturn(Order.builder().build());
-    when(customerRepository.findByPhoneNumberAndStoreId("09012345678", 1L)).thenReturn(List.of());
+    when(customerRepository.findAliveIdsByPhoneNumberAndStoreId("09012345678", 1L))
+        .thenReturn(List.of());
     when(nominatableCast.find(STORE_ID, "g1")).thenReturn(Optional.of(nominatable("g1")));
     when(platformUserRepository.findById(1L)).thenReturn(Optional.of(authorizedReceptionist()));
 
@@ -340,8 +341,8 @@ class OrderServiceTest {
 
     when(storeContext.getStoreId()).thenReturn(STORE_ID);
     when(orderMapper.toEntity(req)).thenReturn(Order.builder().build());
-    when(customerRepository.findByPhoneNumberAndStoreId("09012345678", STORE_ID))
-        .thenReturn(List.of(customerWithId("c1")));
+    when(customerRepository.findAliveIdsByPhoneNumberAndStoreId("09012345678", STORE_ID))
+        .thenReturn(List.of("c1"));
     // 照合は行を押さえない問い合わせなので、着ける前に共有の解決口を通る
     when(customerReferenceResolver.resolveForWrite("c1")).thenReturn("c1");
     stubCreateHappyPath();
@@ -363,8 +364,8 @@ class OrderServiceTest {
 
     when(storeContext.getStoreId()).thenReturn(STORE_ID);
     when(orderMapper.toEntity(req)).thenReturn(Order.builder().build());
-    when(customerRepository.findByPhoneNumberAndStoreId("09012345678", STORE_ID))
-        .thenReturn(List.of(customerWithId("c1"), customerWithId("c2")));
+    when(customerRepository.findAliveIdsByPhoneNumberAndStoreId("09012345678", STORE_ID))
+        .thenReturn(List.of("c1", "c2"));
     stubCreateHappyPath();
 
     service.create(req, ACTOR_EMAIL);
@@ -406,12 +407,6 @@ class OrderServiceTest {
     req.setCastId("g1");
     req.setReceptionistId(1L);
     return req;
-  }
-
-  private Customer customerWithId(String id) {
-    Customer customer = Customer.builder().phoneNumber("09012345678").build();
-    customer.setId(id);
-    return customer;
   }
 
   /** 顧客照合の後に続く検証（指名・受付担当）と応答の組み立てを通す stub。 */

--- a/frontend/src/_pages/store-customers/__tests__/CustomerEditPage.test.tsx
+++ b/frontend/src/_pages/store-customers/__tests__/CustomerEditPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { notify } from '@/shared/notify';
 import CustomerEditPage from '../ui/CustomerEditPage';
 import { customerApi } from '@/entities/customer';
@@ -146,6 +146,47 @@ describe('顧客編集ページの注文履歴', () => {
 
     expect(await screen.findByText('確定')).toBeInTheDocument();
     expect(screen.queryByText('CONFIRMED')).not.toBeInTheDocument();
+  });
+});
+
+describe('顧客編集ページを統合済みの旧 ID で開いたとき', () => {
+  const surviving = {
+    ...customer,
+    id: 'cus-2',
+    name: '山田花子',
+    merged: true,
+    merged_from_id: 'cus-1',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentParams.id = 'cus-1';
+    mockedCustomerApi.get.mockResolvedValue(surviving);
+    mockedCustomerApi.update.mockResolvedValue(surviving);
+    mockedCustomerApi.memberLink.mockRejectedValue({ response: { status: 404 } });
+    mockedCustomerApi.memberLinkHistory.mockResolvedValue({ rows: [], nextCursor: null });
+    mockedCustomerApi.memberPointBalance.mockResolvedValue({ linked: false });
+    mockedOrderApi.list.mockResolvedValue(emptyOrderPage);
+  });
+
+  it('附属区画と保存が、表示している存続行を相手にすること', async () => {
+    // URL の旧 ID のまま続けると、表示は存続行なのに履歴と紐づけと保存だけが墓標を相手にする。
+    // 墓標には受注も関連も残っていないので、空の区画と 409 が並ぶ画面になる
+    render(<CustomerEditPage />);
+
+    expect(await screen.findByDisplayValue('山田花子')).toBeInTheDocument();
+    expect(mockedOrderApi.list).toHaveBeenLastCalledWith(
+      expect.objectContaining({ customer_id: 'cus-2' })
+    );
+    expect(mockedCustomerApi.memberLinkHistory).toHaveBeenLastCalledWith('cus-2', {
+      cursor: undefined,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    await waitFor(() =>
+      expect(mockedCustomerApi.update).toHaveBeenCalledWith('cus-2', expect.anything())
+    );
   });
 });
 

--- a/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
@@ -31,6 +31,11 @@ export default function CustomerEditPage() {
     failure,
     reload: reloadCustomer,
   } = useResource(() => customerApi.get(id), [id]);
+  // 統合済みの旧 ID で開かれたときだけ、以後の読み書きを応答の id（＝統合先）へ向ける。URL の id の
+  // まま続けると、表示は存続行なのに附属区画と保存だけが墓標を相手にする。差し替えの条件を
+  // 「この URL の旧 ID に対する応答であること」に限るのは、顧客を切り替えた直後にまだ前の顧客が
+  // 残っている一瞬に、前の顧客へ向けてしまわないため。
+  const resolvedId = customer?.merged_from_id === id ? (customer.id ?? id) : id;
   // 注文履歴は附属区画。プロフィールの取得とは独立に取り、独立に再試行できる
   const {
     data: ordersData,
@@ -40,9 +45,9 @@ export default function CustomerEditPage() {
   } = useResource(
     () =>
       orderApi
-        .list({ customer_id: id, size: 20, sort: 'businessDate,desc' })
+        .list({ customer_id: resolvedId, size: 20, sort: 'businessDate,desc' })
         .then(page => page.rows),
-    [id]
+    [resolvedId]
   );
   const orders = ordersData ?? [];
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -50,7 +55,7 @@ export default function CustomerEditPage() {
   const handleSubmit = async (data: CustomerFormData) => {
     try {
       setIsSubmitting(true);
-      await customerApi.update(id, toCustomerRequest(data));
+      await customerApi.update(resolvedId, toCustomerRequest(data));
       notify.success('顧客情報を更新しました');
       router.push(storePath(storeId, '/customers'));
     } catch {
@@ -118,7 +123,7 @@ export default function CustomerEditPage() {
       {/* 顧客が変わったら区画ごと作り直す。中の履歴はカーソルで辿る読み口で、マウント時にしか
           取りに行かない — 同じ画面位置で [id] だけが変わる遷移では前の顧客の行が残る。
           入力途中の会員コードも同時に捨てる。 */}
-      <MemberLinkSection key={id} customerId={id} />
+      <MemberLinkSection key={resolvedId} customerId={resolvedId} />
 
       {/* 注文履歴 */}
       <TableCard>

--- a/frontend/src/entities/customer/model/types.ts
+++ b/frontend/src/entities/customer/model/types.ts
@@ -17,6 +17,10 @@ export interface CustomerResponse {
   member_linked?: boolean;
   // 紐づけ済みの会員コード。未紐づけなら欠落
   linked_member_code?: string;
+  // 統合済みの旧 ID で取得したか。生きた行を取得した応答では欠落する
+  merged?: boolean;
+  // 要求した旧 ID。本体は統合先の行なので、id との対で統合の向きが判る
+  merged_from_id?: string;
 }
 
 /**


### PR DESCRIPTION
## 概要

統合後の読み書きを ADR 0010 の非対称な規則へ揃える。墓標は着地点にならないが、旧 ID を渡された解決は前へ進んで統合先に着き、墓標そのものを名指した書き換えは案内の読める 409 で撥ねる。あわせて、統合と並行する参照作成が墓標に着地しないようにする。

Closes #673

## 変更内容

- **除外**（生きている行だけを見る）
  - 受注録入の電話照合と顧客一覧の検索条件から墓標を外した。統合前は複数一致で自動照合を断念していた番号が、統合後は存続行へ収束する。
- **解決**（旧 ID を渡されたら統合先へ）
  - `CustomerReferenceResolver#resolveForWrite` に「統合先を無ロックで下見 → 着地する行を押さえる → 押さえた後にもう一度確かめる」を足した。**顧客参照を書く 5 経路が同時に正しくなり、呼出側は無改修**（受注の顧客 ID 指定・電話照合 1 件一致・会員申請確定時の自動整備・会員ポータルの予約申請・関連の成立）。
  - 顧客詳細は旧 ID で統合先の行を返し、`merged` / `merged_from_id`（要求された旧 ID）で統合の発生を伝える。3xx は採らない — HTTP クライアントが透過的に追随し、画面が統合を知れなくなるため。
- **拒否**（名指した行そのものへの書き換え）
  - 更新・削除・ポイント調整・解除の 4 経路を 409 にした。ポイント調整と解除は**関連の照会より前**に判定する — 統合で関連は存続行へ移っているので、後ろに置くと「紐づいていない」の分岐に落ちて統合済みであることが伝わらない。
- **並行**
  - 解決と統合の待ちが環にならない形にした（下記「決定ログ」）。統合側にも、待つ意味の無い要求を待たせない fail-fast を足している。
- フロントエンドは wire 契約の型を写したうえで、**顧客編集ページの附属区画と保存を応答の id（＝統合先）へ向けた**。詳細が統合先を返すようになったため、URL の旧 ID のまま続けると「表示は存続行、受注履歴・会員紐づけ・保存だけが墓標」という食い違いが出るため。統合済みであることの画面表示（案内・URL の書き換え）は #676 の範囲。DB スキーマは #674 の範囲で本 PR は触っていない。

## 検証

- [x] `task lint` exit 0（`task -d backend lint` / `task -d frontend lint`）
- [x] `task test` exit 0（`task -d backend test-unit` ＋ `task test-integration` 全量）
- [x] `task build` exit 0（`task build service=backend`）
- [x] `task e2e` exit 0（26 シナリオ全通過。受注録入の顧客照合を触ったため全量実行）
- [x] ローカルで code-review 実施済み（Standards / Spec の二軸。指摘は 2 コミット目で反映）

### 赤証（新規テストが規律の入っていない実装に対して赤になること・全部実測）

| 変異 | 赤になったテスト |
| --- | --- |
| 解決口の統合先追随を外す | IT 4 本（受注旧 ID・関連旧 ID・並行受注録入・並行関連成立） |
| 電話照合から墓標述語を外す | IT 1 本（複数一致の収束） |
| 一覧述語・詳細の解決・4 経路の守衛を外す | IT 3 本 |
| 統合が受注を付け替えないようにする | IT 1 本（統合待ちの受注） |
| ポイント調整の墓標判定を関連照会の後ろへ移す | 単体 1 本 |
| 統合先を押さえた実体から読む | 解決口の単体 2 本 |
| 統合の墓標判定を 2 本目のロック後へ戻す | 単体 2 本 |

Codex の指摘を受けた修正（`fd46f281`）の分は、解決口の単体 4 本と `CustomerMergeIT#reportsAConflictInsteadOfWaitingWhenTheMergeTargetIsHeld`（統合先を押さえたまま解決を走らせ、待たずに 409 が返ることを実測）で押さえている。

## 決定ログ

**電話照合の戻り値を実体から ID の投影へ変えた（本 PR で一番効いた判断）**。並行 IT が 409「他の操作と競合しました」を捕まえたのが発端。照合が `List<Customer>` を返すとその実体が永続化文脈に載り、直後の `findByIdForUpdate` が**ロック獲得ではなくロック昇格**になって版を照合する。待っている間に統合が版を上げていると、`t_customers` を書きもしない受注録入が読んだだけの行の版で落ちる。呼出側は id しか使っていないので投影で無損失に閉じ、spec の「並行した受注作成は拒否されずに正しく存続行へ着く」が成り立つようになった。逐次テストは全部緑のままだったので、並行テストが無ければ気付けない類の欠陥。

**解決口は着地する行だけを押さえ、統合先の下見はロックを取らずに読む**（Codex の P1 指摘を受けた修正）。当初は「墓標を押さえる → 統合先も押さえる」形にしていたが、統合は 2 行を押さえた後に墓標の圧平（＝墓標の行の更新）へ進むため、墓標を持ったまま統合先を待つと双方が相手の行を待つ。しかも被統合行が墓標になるのは統合の最後なので、統合側の事前拒否では防げない。下見を無ロックにすれば環そのものが生まれない。下見と押さえるまでの間に統合が確定した場合だけ統合先を追い、そこは `FOR UPDATE NOWAIT` で取って、取れなければ 409「統合中の顧客です」に写す（待てば同じ環になるため）。NOWAIT が実際に待たないことは IT で実測している。

**顧客詳細の解決と取得を 1 文にした**（Codex の P2 指摘）。READ COMMITTED では文ごとにスナップショットが違うため、統合先を読んだ後に連鎖統合が確定すると既に墓標になった行を本体として返していた。

**詳細応答の標識は `merged` + `merged_from_id`**（spec 字面の `merged_into_id` ではない）。本体は統合先の行なので `id` が既に統合先であり、`merged_into_id` は `id` と同値の冗長になる。要求された旧 ID を返すほうが、画面が「開いたのは A、表示しているのは B」を組み立てられる。ユーザー裁定済み。

**解除（`DELETE …/member-link`）も撥ねる対象に含めた**。#673 の受入基準は更新・削除・ポイント調整の 3 つだけを名指しているが、解除も統合で関連が存続行へ移るぶん同じ欠陥類（「紐づけられている会員がいません」に落ちて理由が伝わらない）。ユーザー裁定済み。

**見送った代替案**: 追う先を待つ通常のロックで取る形（統合の圧平と環になる）／追わずに常に 409 を返す形（統合が飛行中の受注録入が必ず拒否され、spec の「拒否されずに正しく存続行へ着く」を満たせない）／並行 IT を HTTP 2 本の素のレースで書く形（どちらが勝つかで赤が出たり出なかったりするため採らず、存続行を小さい ID に選んで統合を待たせる決定的な形にした）。

## 備考 / レビュー観点

- **統合は値を合併しないので、被統合行にしかない電話番号は統合後どの行にも一致せず、次の録入が新しい行を起こす**。ADR 0010（フィールドの自動合併なし・転記は人手）の帰結であり欠陥ではないが、#676 の UI が転記を促す必要がある。照合クエリの契約コメントに明記した。
- Codex の P1（連鎖統合とのデッドロック）は前提を実コードで確認したうえで採り、環を作らない形へ設計を変えた。統合側の事前拒否（2 本目のロック前）は環の対策としては不十分と判明したが、待つ意味の無い要求を待たせない fail-fast として残している。
- 並行 IT のうち 2 本は、統合の飛行中の状態をテスト所有のトランザクションで作っている（HTTP の統合を途中で止める手段が無いため）。統合の端点そのものを走らせる並行 IT は 3 本目が担当している。
- `CustomerRepository#isMerged` は `findMergedIntoId` の既定メソッドへ寄せた。同じ問いに 2 本の問い合わせがある状態を作らないため。
- **統合後にポイント調整の再送（同じ冪等キー）を行うと 409 になる**（codex 指摘・不採用）。統合で関連が存続行へ移っているためで、**本 PR 以前も 400「会員に紐づいていない顧客のポイントは調整できません」で失敗していた**性質であり、本 PR はその文言を「統合済みなので統合先で操作する」と読める 409 に変えるだけ。成功させる形にすると、名指された行への書き込みを統合先へ向け直すことになり ADR 0010 / #673 の裁定と衝突するため、ADR 0007 の契約に触れる別段の裁定として切り出す。台帳は冪等キーで守られており二重記帳は起きない。
- 墓標を撥ねる文面は 3 サービスに同じ literal があるが、理由は `CustomerService` の定数に 1 か所だけ書き、他は参照に留めている（本リポジトリが利用者向け文言を扱っている流儀に合わせた）。
