### PR TITLE
feat: 統合履歴を顧客編集ページから読めるようにする

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/customer/CustomerMergeIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/customer/CustomerMergeIT.java
@@ -488,6 +488,119 @@ class CustomerMergeIT extends CrossStoreTestSupport {
     assertThat(customerMergeRepository.findByMergedCustomerId(merged)).hasSize(1);
   }
 
+  @Test
+  @DisplayName("統合履歴が両方向で読め、実行者・実行時刻・相手の行・移した件数が並ぶこと")
+  void readsTheHistoryFromBothSidesOfTheMerge() {
+    String surviving = createCustomer("履歴読み存続-" + nonce);
+    String merged = createCustomer("履歴読み被統合-" + nonce);
+    orderFor(merged, "履歴読み受注");
+    link(merged, registerMember("merge-history-read"));
+
+    assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    JsonNode fromSurviving = onlyHistoryRow(surviving);
+    assertThat(fromSurviving.path("direction").asString()).isEqualTo("SURVIVING");
+    assertThat(fromSurviving.path("counterpart_customer_id").asString()).isEqualTo(merged);
+    // 相手の名前まで出す。統合は値を合併しないので墓標にも名前が残り、これが「どの行を畳んだか」の根拠になる
+    assertThat(fromSurviving.path("counterpart_customer_name").asString())
+        .isEqualTo("履歴読み被統合-" + nonce);
+    assertThat(fromSurviving.path("merged_by_name").asString()).isEqualTo(managerDisplayName());
+    assertThat(fromSurviving.path("merged_at").asString()).isNotBlank();
+    assertThat(fromSurviving.path("moved_order_count").asInt()).isEqualTo(1);
+    assertThat(fromSurviving.path("moved_link_count").asInt()).isEqualTo(1);
+
+    // 被統合行そのものを名指した読みでは、同じ 1 件が反対向きで現れる
+    JsonNode fromMerged = onlyHistoryRow(merged);
+    assertThat(fromMerged.path("id").asString()).isEqualTo(fromSurviving.path("id").asString());
+    assertThat(fromMerged.path("direction").asString()).isEqualTo("MERGED");
+    assertThat(fromMerged.path("counterpart_customer_id").asString()).isEqualTo(surviving);
+    assertThat(fromMerged.path("counterpart_customer_name").asString())
+        .isEqualTo("履歴読み存続-" + nonce);
+  }
+
+  @Test
+  @DisplayName("統合の無い顧客の履歴は空で返り、顧客そのものが無い場合の 404 と分かれること")
+  void separatesAnEmptyHistoryFromAFailedRead() {
+    String neverMerged = createCustomer("履歴無し-" + nonce);
+
+    assertThat(historyPage(STORE_A, neverMerged, null, null).path("content")).isEmpty();
+    // 空を 404 に潰すと、呼出側は「統合が無い」と「読めなかった」を区別できない。
+    // 404 は顧客そのものが引けないときだけに留める
+    assertThat(historyResponse(STORE_A, "0", null, null).getStatusCode())
+        .isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("実行者が削除済みでも履歴の行は返り、実行者名だけが欠けること")
+  void keepsTheRowWhenTheActorIsGone() {
+    String surviving = createCustomer("実行者不明存続-" + nonce);
+    String merged = createCustomer("実行者不明被統合-" + nonce);
+    assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    // 利用者の削除は FK が merged_by を NULL にする。ここで見たいのは「実行者が引けない履歴」の
+    // 読みなので、他のテストが依存する種の利用者を消さずに同じ状態を直に作る
+    jdbcTemplate.update(
+        "update t_customer_merges set merged_by = null where merged_customer_id = ?", merged);
+
+    JsonNode row = onlyHistoryRow(surviving);
+    assertThat(row.has("merged_by_name")).as("non_null 直列化で欄ごと欠けること").isFalse();
+    assertThat(row.path("counterpart_customer_id").asString()).isEqualTo(merged);
+    assertThat(row.path("merged_at").asString()).isNotBlank();
+  }
+
+  @Test
+  @DisplayName("続きを辿ると 1 ページ目に載らなかった統合へ到達でき、両方向の行が重複しないこと")
+  void reachesOlderMergesThroughTheCursor() {
+    String surviving = createCustomer("履歴頁存続-" + nonce);
+    List<String> mergedIds = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      String merged = createCustomer("履歴頁被統合" + i + "-" + nonce);
+      assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.OK);
+      mergedIds.add(merged);
+    }
+
+    // 続きの条件が両方向の述語と正しく結合していないと、2 ページ目に 1 ページ目の行が混ざる
+    JsonNode firstPage = historyPage(STORE_A, surviving, null, 2);
+    List<String> collected = new ArrayList<>(counterpartsOf(firstPage));
+    assertThat(collected).hasSize(2);
+    JsonNode secondPage = historyPage(STORE_A, surviving, nextCursorOf(firstPage), 2);
+    collected.addAll(counterpartsOf(secondPage));
+
+    assertThat(collected).containsExactlyInAnyOrderElementsOf(mergedIds);
+    assertThat(nextCursorOf(secondPage)).as("3 件を取り切ったら続きは無いこと").isNull();
+  }
+
+  @Test
+  @DisplayName("統合履歴の閲覧は店長権限を要し、スタッフ権限では 403 になること")
+  void requiresTheManagerOnlyMergePermissionToReadTheHistory() {
+    String surviving = createCustomer("履歴権限存続-" + nonce);
+    String merged = createCustomer("履歴権限被統合-" + nonce);
+    assertThat(merge(STORE_A, surviving, merged).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    ResponseEntity<JsonNode> asStaff =
+        rest.exchange(
+            mergePath(surviving),
+            HttpMethod.GET,
+            new HttpEntity<>(storeHeaders(STORE_A)),
+            JsonNode.class);
+
+    assertThat(asStaff.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("他店舗の顧客の統合履歴は 404 になり、存在の有無が漏れないこと")
+  void hidesForeignStoreHistoryBehindNotFound() {
+    String survivingInB = createCustomerAt(STORE_B, "履歴越境存続-" + nonce);
+    String mergedInB = createCustomerAt(STORE_B, "履歴越境被統合-" + nonce);
+    assertThat(merge(STORE_B, survivingInB, mergedInB).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    // 田中花子は両店舗に授権されるためヘッダは通り、越境は storeFilter による 404 として現れる
+    assertThat(historyResponse(STORE_A, survivingInB, null, null).getStatusCode())
+        .isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(historyResponse(STORE_A, mergedInB, null, null).getStatusCode())
+        .isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
   // ==================== 拒否 ====================
 
   @Test
@@ -814,6 +927,47 @@ class CustomerMergeIT extends CrossStoreTestSupport {
         HttpMethod.POST,
         new HttpEntity<>(mergeBody(mergedCustomerId), managerHeaders(storeId)),
         JsonNode.class);
+  }
+
+  // ==================== 統合履歴の読み ====================
+
+  private ResponseEntity<JsonNode> historyResponse(
+      long storeId, String customerId, String cursor, Integer size) {
+    String query =
+        (cursor == null ? "" : "?cursor=" + cursor)
+            + (size == null ? "" : (cursor == null ? "?" : "&") + "size=" + size);
+    return rest.exchange(
+        mergePath(customerId) + query,
+        HttpMethod.GET,
+        new HttpEntity<>(managerHeaders(storeId)),
+        JsonNode.class);
+  }
+
+  private JsonNode historyPage(long storeId, String customerId, String cursor, Integer size) {
+    ResponseEntity<JsonNode> response = historyResponse(storeId, customerId, cursor, size);
+    assertThat(response.getStatusCode()).as("前提: 統合履歴を読めること").isEqualTo(HttpStatus.OK);
+    return response.getBody();
+  }
+
+  /** 履歴は顧客 ID で絞られるので、他のテストが起こした統合は混ざらない。 */
+  private JsonNode onlyHistoryRow(String customerId) {
+    JsonNode content = historyPage(STORE_A, customerId, null, null).path("content");
+    assertThat(content).as("統合履歴が 1 件だけあること").hasSize(1);
+    return content.get(0);
+  }
+
+  private static List<String> counterpartsOf(JsonNode page) {
+    List<String> counterparts = new ArrayList<>();
+    page.path("content")
+        .forEach(row -> counterparts.add(row.path("counterpart_customer_id").asString()));
+    return counterparts;
+  }
+
+  private String managerDisplayName() {
+    return platformUserRepository
+        .findByEmail(MANAGER_EMAIL)
+        .map(PlatformUser::getDisplayName)
+        .orElseThrow();
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/customer/api/dto/CustomerMergeHistoryResponse.java
+++ b/backend/src/main/java/com/kizuna/customer/api/dto/CustomerMergeHistoryResponse.java
@@ -1,0 +1,19 @@
+package com.kizuna.customer.api.dto;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 統合履歴 1 件の応答。JSON キーは Jackson 設定により snake_case（merged_at）。
+ *
+ * <p>相手の行は id と表示名の両方を持つ。統合に取消は無く、誤統合の修復は「どの行をどの行へ」を根拠とする人手作業なので（ADR 0010）、 id
+ * だけでは読み手が相手を思い出せない。実行者名は欠けうる（利用者の削除）が、その場合も行は返る。
+ */
+public record CustomerMergeHistoryResponse(
+    String id,
+    MergeDirection direction,
+    String counterpartCustomerId,
+    String counterpartCustomerName,
+    String mergedByName,
+    OffsetDateTime mergedAt,
+    int movedOrderCount,
+    int movedLinkCount) {}

--- a/backend/src/main/java/com/kizuna/customer/api/dto/MergeDirection.java
+++ b/backend/src/main/java/com/kizuna/customer/api/dto/MergeDirection.java
@@ -1,0 +1,14 @@
+package com.kizuna.customer.api.dto;
+
+/**
+ * 統合履歴 1 件が、問い合わせた顧客から見てどちら側だったか。
+ *
+ * <p>統合そのものの属性ではなく読み手との関係なので、記録（{@code CustomerMerge}）ではなく応答の側に置く。同じ 1 件が、存続行の画面では {@link
+ * #SURVIVING}、被統合行の画面では {@link #MERGED} として現れる。
+ */
+public enum MergeDirection {
+  /** この行が存続行として統合を受けた。 */
+  SURVIVING,
+  /** この行が被統合となり、墓標になった。 */
+  MERGED
+}

--- a/backend/src/main/java/com/kizuna/customer/api/store/CustomerMergeController.java
+++ b/backend/src/main/java/com/kizuna/customer/api/store/CustomerMergeController.java
@@ -1,17 +1,21 @@
 package com.kizuna.customer.api.store;
 
+import com.kizuna.customer.api.dto.CustomerMergeHistoryResponse;
 import com.kizuna.customer.api.dto.CustomerMergeRequest;
 import com.kizuna.customer.api.dto.CustomerMergeResponse;
 import com.kizuna.customer.application.CustomerMergeService;
+import com.kizuna.shared.web.CursorPage;
 import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -34,5 +38,23 @@ public class CustomerMergeController {
       Principal principal) {
     return ResponseEntity.ok(
         customerMergeService.merge(customerId, request.getMergedCustomerId(), principal.getName()));
+  }
+
+  /**
+   * その顧客に関する統合履歴。存続行として受けた統合と、自分が被統合となった統合の両方が新しい順に返る。続きは応答の {@code next_cursor} をそのまま {@code
+   * cursor} に渡して取る。
+   *
+   * <p>パスの意味が POST と非対称なのは意図したもの。POST の {@code customerId} は存続行を名指すが、GET
+   * は「この行が関与した統合」の集合を指すので、被統合となった側も含む。
+   *
+   * <p>統合の実行と同じ {@code CUSTOMER_MERGE} で守る。履歴は誰がどの顧客を畳んだかを明かす機微情報で、 誤統合の修復に当たる者だけが読めばよい（ADR 0010）。
+   */
+  @GetMapping
+  @PreAuthorize("hasAuthority('PERM_CUSTOMER_MERGE')")
+  public ResponseEntity<CursorPage<CustomerMergeHistoryResponse>> history(
+      @PathVariable String customerId,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(defaultValue = "20") int size) {
+    return ResponseEntity.ok(customerMergeService.history(customerId, cursor, size));
   }
 }

--- a/backend/src/main/java/com/kizuna/customer/api/store/CustomerMergeController.java
+++ b/backend/src/main/java/com/kizuna/customer/api/store/CustomerMergeController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 顧客統合の実行。パスが名指すのが存続行で、本文が被統合行を指す。
+ * 顧客統合の実行と、その履歴の閲覧。パスの {@code customerId} が指す行はメソッドで異なる（各 handler に記す）。
  *
  * <p>統合を取り消す端点は無い。誤統合の修復は統合履歴を根拠とする人手作業である（ADR 0010）。
  */
@@ -30,6 +30,7 @@ public class CustomerMergeController {
 
   private final CustomerMergeService customerMergeService;
 
+  /** 統合を実行する。パスが名指すのが存続行で、本文が被統合行を指す。 */
   @PostMapping
   @PreAuthorize("hasAuthority('PERM_CUSTOMER_MERGE')")
   public ResponseEntity<CustomerMergeResponse> merge(

--- a/backend/src/main/java/com/kizuna/customer/application/CustomerMergeService.java
+++ b/backend/src/main/java/com/kizuna/customer/application/CustomerMergeService.java
@@ -1,10 +1,13 @@
 package com.kizuna.customer.application;
 
+import com.kizuna.customer.api.dto.CustomerMergeHistoryResponse;
 import com.kizuna.customer.api.dto.CustomerMergeResponse;
+import com.kizuna.customer.api.dto.MergeDirection;
 import com.kizuna.customer.domain.Customer;
 import com.kizuna.customer.domain.CustomerMemberLinkRepository;
 import com.kizuna.customer.domain.CustomerMerge;
 import com.kizuna.customer.domain.CustomerMergeRepository;
+import com.kizuna.customer.domain.CustomerMergeView;
 import com.kizuna.customer.domain.CustomerRepository;
 import com.kizuna.customer.domain.LinkStatus;
 import com.kizuna.shared.exception.ConflictException;
@@ -15,11 +18,15 @@ import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.exception.StaleSessionException;
 import com.kizuna.shared.storescope.StoreContext;
 import com.kizuna.shared.storescope.StoreScoped;
+import com.kizuna.shared.web.CursorPage;
+import com.kizuna.shared.web.PageCursor;
 import com.kizuna.user.domain.PlatformUserRepository;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -93,6 +100,60 @@ public class CustomerMergeService {
             movedLinkCount));
 
     return new CustomerMergeResponse(survivingCustomerId, movedOrderCount, movedLinkCount);
+  }
+
+  /**
+   * 顧客 1 件の統合履歴。存続行として受けた統合と、自分が被統合となった統合の両方を新しい順に返す。続きはカーソルで辿る。
+   *
+   * <p>統合を 1 件も持たない顧客は空で返る。404 にしないのは、「統合が無い」と「読めなかった」を呼出側が区別できるようにするため — 404 は顧客そのものが引けないときだけである。
+   *
+   * <p>統合履歴は機微情報なので、読むにも実行と同じ {@code CUSTOMER_MERGE} を要する（強制は端点の注釈）。
+   *
+   * @param cursor 続きの位置。null なら先頭から
+   * @param requestedSize 1 回に返す件数の希望値（上限に丸められる）
+   */
+  @StoreScoped
+  @Transactional(readOnly = true)
+  public CursorPage<CustomerMergeHistoryResponse> history(
+      String customerId, String cursor, int requestedSize) {
+    if (!customerRepository.existsById(customerId)) {
+      throw new NotFoundException("顧客が見つかりません");
+    }
+    int size = CursorPage.clampSize(requestedSize);
+    // 続きの有無は上限より 1 件多く取って判る。総件数の問い合わせを毎回撒かずに済む。
+    Limit limit = Limit.of(size + 1);
+    List<CustomerMergeView> fetched =
+        cursor == null
+            ? customerMergeRepository.findHistory(customerId, limit)
+            : fetchHistoryAfter(customerId, PageCursor.decode(cursor), limit);
+    return CursorPage.of(fetched, size, CustomerMergeService::cursorOf)
+        .map(view -> toHistoryResponse(customerId, view));
+  }
+
+  private List<CustomerMergeView> fetchHistoryAfter(
+      String customerId, PageCursor cursor, Limit limit) {
+    return customerMergeRepository.findHistoryAfter(
+        customerId, cursor.timestampKey(), cursor.id(), limit);
+  }
+
+  /** 続きの位置は一覧の並び（統合時刻 + id）と同じ組で作る。組が並びとずれると、続きが手前へ戻るか行を飛ばす。 */
+  private static String cursorOf(CustomerMergeView view) {
+    return new PageCursor(view.getMergedAt().toString(), view.getId()).encode();
+  }
+
+  /** 「相手」は問い合わせた顧客によって変わる。向きの判定を記録の側に持たせず、読み手ごとにここで解く。 */
+  private static CustomerMergeHistoryResponse toHistoryResponse(
+      String customerId, CustomerMergeView view) {
+    boolean surviving = customerId.equals(view.getSurvivingCustomerId());
+    return new CustomerMergeHistoryResponse(
+        view.getId(),
+        surviving ? MergeDirection.SURVIVING : MergeDirection.MERGED,
+        surviving ? view.getMergedCustomerId() : view.getSurvivingCustomerId(),
+        surviving ? view.getMergedCustomerName() : view.getSurvivingCustomerName(),
+        view.getMergedByName(),
+        view.getMergedAt(),
+        view.getMovedOrderCount(),
+        view.getMovedLinkCount());
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerMergeRepository.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerMergeRepository.java
@@ -1,7 +1,9 @@
 package com.kizuna.customer.domain;
 
+import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -63,4 +65,53 @@ public interface CustomerMergeRepository extends JpaRepository<CustomerMerge, St
 
   /** ある行が被統合となった統合。統合履歴を両方向で読むうちの片側で、もう一方は存続行として受けた統合。 */
   List<CustomerMerge> findByMergedCustomerId(String mergedCustomerId);
+
+  // 実行者と両行の表示名は ID 参照のため JPQL join で取得する。PlatformUser は FQCN で参照する
+  // （HQL の予約語衝突を避ける既存規約）。実行者が削除されると merged_by は NULL になるため
+  // join は left。相手の行の名前まで引くのは、誤統合の修復が「どの行をどの行へ」を根拠にする
+  // 人手作業だからで（ADR 0010）、id だけでは読み手が相手を思い出せない。統合は値を合併しないので
+  // 墓標にも名前は残る。
+  String HISTORY_SELECT =
+      """
+      select m.id as id,
+             m.survivingCustomerId as survivingCustomerId, sc.name as survivingCustomerName,
+             m.mergedCustomerId as mergedCustomerId, mc.name as mergedCustomerName,
+             mu.displayName as mergedByName, m.mergedAt as mergedAt,
+             m.movedOrderCount as movedOrderCount, m.movedLinkCount as movedLinkCount
+      from com.kizuna.customer.domain.CustomerMerge m
+        left join com.kizuna.customer.domain.Customer sc on sc.id = m.survivingCustomerId
+        left join com.kizuna.customer.domain.Customer mc on mc.id = m.mergedCustomerId
+        left join com.kizuna.user.domain.PlatformUser mu on mu.id = m.mergedBy
+      """;
+
+  // 両方向を 1 文で引く。括弧は必須 — 外すと続きの位置の条件が `or` の片方の枝にしか掛からず、
+  // 2 ページ目が 1 ページ目をそのまま返して末尾へ到達できなくなる（外して実測）。
+  String HISTORY_WHERE =
+      " where (m.survivingCustomerId = :customerId or m.mergedCustomerId = :customerId) ";
+
+  // 新しい統合が先頭。mergedAt の同値は id で決定的に解く。カーソルの比較も同じ組で行う。
+  String HISTORY_ORDER = " order by m.mergedAt desc, m.id desc";
+
+  /** 顧客 1 件の統合履歴の先頭。並びは mergedAt の降順に一意な副キー id を重ねて全順序にする。 */
+  @Query(HISTORY_SELECT + HISTORY_WHERE + HISTORY_ORDER)
+  List<CustomerMergeView> findHistory(@Param("customerId") String customerId, Limit limit);
+
+  /**
+   * 顧客 1 件の統合履歴の続き。渡された位置より後ろ（＝より古い側）だけを返す。
+   *
+   * <p>id は Snowflake の文字列で、比較も文字列の順序で行う。求めるのは全順序の決定性だけなので、 並び（{@link #HISTORY_ORDER}）と同じ順序であれば足りる。
+   */
+  @Query(
+      HISTORY_SELECT
+          + HISTORY_WHERE
+          + """
+            and (m.mergedAt < :cursorMergedAt
+                 or (m.mergedAt = :cursorMergedAt and m.id < :cursorId))
+            """
+          + HISTORY_ORDER)
+  List<CustomerMergeView> findHistoryAfter(
+      @Param("customerId") String customerId,
+      @Param("cursorMergedAt") OffsetDateTime cursorMergedAt,
+      @Param("cursorId") String cursorId,
+      Limit limit);
 }

--- a/backend/src/main/java/com/kizuna/customer/domain/CustomerMergeView.java
+++ b/backend/src/main/java/com/kizuna/customer/domain/CustomerMergeView.java
@@ -1,0 +1,29 @@
+package com.kizuna.customer.domain;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 統合履歴の読み側 projection。実行者と両行の表示名は ID 参照のため JPQL join で取得する。
+ *
+ * <p>両行を持ったまま返すのは、どちらが「相手」かが問い合わせた顧客によって変わるため。向きの判定と相手の取り出しは 呼出側が行う。
+ */
+public interface CustomerMergeView {
+
+  String getId();
+
+  String getSurvivingCustomerId();
+
+  String getMergedCustomerId();
+
+  String getSurvivingCustomerName();
+
+  String getMergedCustomerName();
+
+  String getMergedByName();
+
+  OffsetDateTime getMergedAt();
+
+  int getMovedOrderCount();
+
+  int getMovedLinkCount();
+}

--- a/backend/src/test/java/com/kizuna/customer/api/store/CustomerMergeControllerTest.java
+++ b/backend/src/test/java/com/kizuna/customer/api/store/CustomerMergeControllerTest.java
@@ -1,0 +1,131 @@
+package com.kizuna.customer.api.store;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.kizuna.customer.api.dto.CustomerMergeHistoryResponse;
+import com.kizuna.customer.api.dto.MergeDirection;
+import com.kizuna.customer.application.CustomerMergeService;
+import com.kizuna.settings.application.SystemConfigService;
+import com.kizuna.shared.exception.CommonExceptionHandler;
+import com.kizuna.shared.storescope.StoreContext;
+import com.kizuna.shared.storescope.StoreExistenceCheck;
+import com.kizuna.shared.web.CursorPage;
+import com.kizuna.store.application.StoreActivationService;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * 統合履歴の読み口の授権と契約の単体テスト。
+ *
+ * <p>実行（{@code POST}）と読み（{@code GET}）が同じパスに載るので、権限の要求が両方に掛かっていることと、 続きの位置・件数が素通しで渡ることを固定する。
+ */
+@WebMvcTest(CustomerMergeController.class)
+@Import({
+  CustomerMergeControllerTest.MethodSecurityConfig.class,
+  StoreContext.class,
+  CommonExceptionHandler.class
+})
+class CustomerMergeControllerTest {
+
+  /** テスト用にメソッドセキュリティ（@PreAuthorize）を有効化する設定 */
+  @TestConfiguration
+  @EnableMethodSecurity
+  static class MethodSecurityConfig {}
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private CustomerMergeService customerMergeService;
+
+  // MaintenanceModeInterceptor / StoreExistenceInterceptor は HandlerInterceptor として
+  // @WebMvcTest に自動で取り込まれるため、その依存もモックで満たす必要がある。
+  @MockitoBean private SystemConfigService systemConfigService;
+  @MockitoBean private StoreExistenceCheck storeExistenceCheck;
+  @MockitoBean private StoreActivationService storeActivationService;
+
+  @Test
+  @DisplayName("履歴は向き・相手の行・実行者・移した件数を snake_case で返すこと")
+  @WithMockUser(authorities = "PERM_CUSTOMER_MERGE")
+  void historyExposesTheEvidenceInSnakeCase() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+    when(customerMergeService.history(anyString(), any(), anyInt()))
+        .thenReturn(
+            new CursorPage<>(
+                List.of(
+                    new CustomerMergeHistoryResponse(
+                        "m1",
+                        MergeDirection.SURVIVING,
+                        "c2",
+                        "山田太郎",
+                        "田中花子",
+                        OffsetDateTime.parse("2026-08-10T10:00:00+09:00"),
+                        3,
+                        1)),
+                null));
+
+    mockMvc
+        .perform(storeGet("/store/customers/c1/merges"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].direction").value("SURVIVING"))
+        .andExpect(jsonPath("$.content[0].counterpart_customer_id").value("c2"))
+        .andExpect(jsonPath("$.content[0].counterpart_customer_name").value("山田太郎"))
+        .andExpect(jsonPath("$.content[0].merged_by_name").value("田中花子"))
+        .andExpect(jsonPath("$.content[0].moved_order_count").value(3))
+        .andExpect(jsonPath("$.content[0].moved_link_count").value(1))
+        // 続きが無いときは non_null 直列化で欄ごと現れない
+        .andExpect(jsonPath("$.next_cursor").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("続きの位置と件数がそのまま渡ること")
+  @WithMockUser(authorities = "PERM_CUSTOMER_MERGE")
+  void historyForwardsTheCursorAndSize() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+    when(customerMergeService.history(anyString(), any(), anyInt()))
+        .thenReturn(new CursorPage<>(List.of(), null));
+
+    mockMvc
+        .perform(storeGet("/store/customers/c1/merges?cursor=abc&size=5"))
+        .andExpect(status().isOk());
+
+    verify(customerMergeService).history("c1", "abc", 5);
+  }
+
+  @Test
+  @DisplayName("統合権限を持たない利用者は履歴を読めず、読み口にも届かないこと")
+  @WithMockUser(authorities = "PERM_CUSTOMER_MANAGE")
+  void historyIsForbiddenWithoutTheMergePermission() throws Exception {
+    when(storeExistenceCheck.exists(anyLong())).thenReturn(true);
+
+    mockMvc.perform(storeGet("/store/customers/c1/merges")).andExpect(status().isForbidden());
+
+    // 履歴は誰がどの顧客を畳んだかを明かす。拒否は読み取りの手前で成立していること
+    verify(customerMergeService, never()).history(anyString(), any(), anyInt());
+  }
+
+  private MockHttpServletRequestBuilder storeGet(String path) {
+    return get(path)
+        .header("X-Role", "store")
+        .header("X-Store-ID", "1")
+        .principal(() -> "tanaka.hanako@kizuna.test");
+  }
+}

--- a/backend/src/test/java/com/kizuna/customer/application/CustomerMergeServiceTest.java
+++ b/backend/src/test/java/com/kizuna/customer/application/CustomerMergeServiceTest.java
@@ -3,21 +3,28 @@ package com.kizuna.customer.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.kizuna.customer.api.dto.CustomerMergeHistoryResponse;
 import com.kizuna.customer.api.dto.CustomerMergeResponse;
+import com.kizuna.customer.api.dto.MergeDirection;
 import com.kizuna.customer.domain.Customer;
 import com.kizuna.customer.domain.CustomerMemberLinkRepository;
 import com.kizuna.customer.domain.CustomerMerge;
 import com.kizuna.customer.domain.CustomerMergeRepository;
+import com.kizuna.customer.domain.CustomerMergeView;
 import com.kizuna.customer.domain.CustomerRepository;
 import com.kizuna.customer.domain.LinkStatus;
 import com.kizuna.shared.exception.ConflictException;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreContext;
+import com.kizuna.shared.web.CursorPage;
+import com.kizuna.shared.web.PageCursor;
 import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
@@ -29,6 +36,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Limit;
 
 /**
  * 顧客統合の拒否条件と、付替え・墓標・履歴の書き込み順をサービス層で固定する。
@@ -46,6 +54,8 @@ class CustomerMergeServiceTest {
   private static final String SURVIVING_ID = "c-2";
 
   private static final String MERGED_ID = "c-1";
+
+  private static final OffsetDateTime MERGED_AT = OffsetDateTime.parse("2026-08-10T10:00:00+09:00");
 
   @Mock private CustomerRepository customerRepository;
   @Mock private CustomerMemberLinkRepository customerMemberLinkRepository;
@@ -207,7 +217,150 @@ class CustomerMergeServiceTest {
     assertThat(merged.getMergedIntoId()).isEqualTo(SURVIVING_ID);
   }
 
+  // ==================== 統合履歴の読み ====================
+
+  @Test
+  @DisplayName("履歴の向きと相手は、問い合わせた顧客がどちら側かで決まること")
+  void resolvesTheDirectionAndCounterpartAgainstTheRequestedCustomer() {
+    HistoryRow row = new HistoryRow("m-1", SURVIVING_ID, MERGED_ID, MERGED_AT);
+    givenCustomerExists(SURVIVING_ID);
+    givenCustomerExists(MERGED_ID);
+    Mockito.when(customerMergeRepository.findHistory(Mockito.anyString(), Mockito.any()))
+        .thenReturn(List.of(row));
+
+    CustomerMergeHistoryResponse fromSurviving =
+        service.history(SURVIVING_ID, null, 20).content().get(0);
+    CustomerMergeHistoryResponse fromMerged = service.history(MERGED_ID, null, 20).content().get(0);
+
+    assertThat(fromSurviving.direction()).isEqualTo(MergeDirection.SURVIVING);
+    assertThat(fromSurviving.counterpartCustomerId()).isEqualTo(MERGED_ID);
+    assertThat(fromSurviving.counterpartCustomerName()).isEqualTo(MERGED_ID + "-名");
+    // 同じ 1 件が、被統合行から見ると反対向きで、相手も入れ替わる
+    assertThat(fromMerged.direction()).isEqualTo(MergeDirection.MERGED);
+    assertThat(fromMerged.counterpartCustomerId()).isEqualTo(SURVIVING_ID);
+    assertThat(fromMerged.counterpartCustomerName()).isEqualTo(SURVIVING_ID + "-名");
+    assertThat(fromMerged.id()).isEqualTo(fromSurviving.id());
+    assertThat(fromMerged.movedOrderCount()).isEqualTo(2);
+    assertThat(fromMerged.movedLinkCount()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("統合の無い顧客は空の一覧で返り、404 にならないこと")
+  void returnsAnEmptyPageInsteadOfNotFoundWhenThereAreNoMerges() {
+    givenCustomerExists(SURVIVING_ID);
+    Mockito.when(customerMergeRepository.findHistory(Mockito.anyString(), Mockito.any()))
+        .thenReturn(List.of());
+
+    CursorPage<CustomerMergeHistoryResponse> page = service.history(SURVIVING_ID, null, 20);
+
+    assertThat(page.content()).isEmpty();
+    assertThat(page.nextCursor()).isNull();
+  }
+
+  @Test
+  @DisplayName("引けない顧客の履歴は 404 になり、統合の記録を読みに行かないこと")
+  void refusesToReadTheHistoryOfACustomerItCannotSee() {
+    Mockito.when(customerRepository.existsById(SURVIVING_ID)).thenReturn(false);
+
+    assertThatThrownBy(() -> service.history(SURVIVING_ID, null, 20))
+        .isInstanceOf(NotFoundException.class);
+
+    Mockito.verify(customerMergeRepository, Mockito.never())
+        .findHistory(Mockito.anyString(), Mockito.any());
+  }
+
+  @Test
+  @DisplayName("上限より 1 件多く取り、余分は返さずに続きの位置だけを組むこと")
+  void fetchesOneExtraRowAndTurnsItIntoTheNextCursor() {
+    HistoryRow first = new HistoryRow("m-2", SURVIVING_ID, MERGED_ID, MERGED_AT);
+    HistoryRow last = new HistoryRow("m-1", SURVIVING_ID, "c-0", MERGED_AT.minusDays(1));
+    givenCustomerExists(SURVIVING_ID);
+    Mockito.when(customerMergeRepository.findHistory(Mockito.anyString(), Mockito.any()))
+        .thenReturn(List.of(first, last));
+
+    CursorPage<CustomerMergeHistoryResponse> page = service.history(SURVIVING_ID, null, 1);
+
+    ArgumentCaptor<Limit> limit = ArgumentCaptor.forClass(Limit.class);
+    Mockito.verify(customerMergeRepository).findHistory(Mockito.eq(SURVIVING_ID), limit.capture());
+    assertThat(limit.getValue().max()).isEqualTo(2);
+    assertThat(page.content()).hasSize(1);
+    // 続きの位置は返した最後の行から組む。余分の 1 件から組むと、その行が次の頁で消える
+    assertThat(PageCursor.decode(page.nextCursor()))
+        .isEqualTo(new PageCursor(MERGED_AT.toString(), "m-2"));
+  }
+
+  @Test
+  @DisplayName("続きの位置は復号した組のまま問い合わせへ渡ること")
+  void passesTheDecodedCursorStraightToTheQuery() {
+    givenCustomerExists(SURVIVING_ID);
+    Mockito.when(
+            customerMergeRepository.findHistoryAfter(
+                Mockito.anyString(), Mockito.any(), Mockito.anyString(), Mockito.any()))
+        .thenReturn(List.of());
+
+    service.history(SURVIVING_ID, new PageCursor(MERGED_AT.toString(), "m-9").encode(), 20);
+
+    Mockito.verify(customerMergeRepository)
+        .findHistoryAfter(
+            Mockito.eq(SURVIVING_ID), Mockito.eq(MERGED_AT), Mockito.eq("m-9"), Mockito.any());
+  }
+
   // ==================== 前提の組み立て ====================
+
+  /** 読み側 projection の代役。向きの判定と相手の取り出しを見るので、件数と実行者名は固定でよい。 */
+  private record HistoryRow(
+      String id, String survivingCustomerId, String mergedCustomerId, OffsetDateTime mergedAt)
+      implements CustomerMergeView {
+
+    @Override
+    public String getId() {
+      return id;
+    }
+
+    @Override
+    public String getSurvivingCustomerId() {
+      return survivingCustomerId;
+    }
+
+    @Override
+    public String getMergedCustomerId() {
+      return mergedCustomerId;
+    }
+
+    @Override
+    public String getSurvivingCustomerName() {
+      return survivingCustomerId + "-名";
+    }
+
+    @Override
+    public String getMergedCustomerName() {
+      return mergedCustomerId + "-名";
+    }
+
+    @Override
+    public String getMergedByName() {
+      return "田中花子";
+    }
+
+    @Override
+    public OffsetDateTime getMergedAt() {
+      return mergedAt;
+    }
+
+    @Override
+    public int getMovedOrderCount() {
+      return 2;
+    }
+
+    @Override
+    public int getMovedLinkCount() {
+      return 1;
+    }
+  }
+
+  private void givenCustomerExists(String customerId) {
+    Mockito.lenient().when(customerRepository.existsById(customerId)).thenReturn(true);
+  }
 
   private void givenActor() {
     PlatformUser actor =

--- a/frontend/src/_pages/store-customers/__tests__/CustomerEditPage.test.tsx
+++ b/frontend/src/_pages/store-customers/__tests__/CustomerEditPage.test.tsx
@@ -3,6 +3,7 @@ import { notify } from '@/shared/notify';
 import CustomerEditPage from '../ui/CustomerEditPage';
 import { customerApi } from '@/entities/customer';
 import { orderApi } from '@/entities/order';
+import { TokenClaims, readTokenClaims } from '@/shared/lib';
 
 const mockPush = jest.fn();
 
@@ -15,7 +16,14 @@ jest.mock('@/entities/customer', () => ({
     memberLink: jest.fn(),
     memberLinkHistory: jest.fn(),
     memberPointBalance: jest.fn(),
+    mergeHistory: jest.fn(),
   },
+}));
+
+// hasPermission は実物のまま（PERM_ 接頭辞の対応も検証対象に含める）
+jest.mock('@/shared/lib', () => ({
+  ...jest.requireActual('@/shared/lib'),
+  readTokenClaims: jest.fn(),
 }));
 
 jest.mock('@/entities/order', () => ({
@@ -37,6 +45,16 @@ jest.mock('@/shared/notify', () => ({
 
 const mockedCustomerApi = customerApi as jest.Mocked<typeof customerApi>;
 const mockedOrderApi = orderApi as jest.Mocked<typeof orderApi>;
+const mockedReadClaims = readTokenClaims as jest.MockedFunction<typeof readTokenClaims>;
+
+/** 指定権限を claim（PERM_ 接頭辞）として持つ token claim を返すヘルパ（UI 出し分けは権限ベース）。 */
+function claimsWith(permissions: string[]): TokenClaims {
+  return {
+    authorities: permissions.map(permission => `PERM_${permission}`),
+    userType: 'STAFF',
+    storeBridge: true,
+  };
+}
 
 const customer = {
   id: 'cus-1',
@@ -166,6 +184,8 @@ describe('顧客編集ページを統合済みの旧 ID で開いたとき', () 
     mockedCustomerApi.memberLink.mockRejectedValue({ response: { status: 404 } });
     mockedCustomerApi.memberLinkHistory.mockResolvedValue({ rows: [], nextCursor: null });
     mockedCustomerApi.memberPointBalance.mockResolvedValue({ linked: false });
+    mockedCustomerApi.mergeHistory.mockResolvedValue({ rows: [], nextCursor: null });
+    mockedReadClaims.mockReturnValue(claimsWith(['CUSTOMER_MERGE']));
     mockedOrderApi.list.mockResolvedValue(emptyOrderPage);
   });
 
@@ -181,12 +201,48 @@ describe('顧客編集ページを統合済みの旧 ID で開いたとき', () 
     expect(mockedCustomerApi.memberLinkHistory).toHaveBeenLastCalledWith('cus-2', {
       cursor: undefined,
     });
+    // 統合履歴も同じ紀律。旧 ID のまま引くと、頁が語る行と区画が語る行が食い違う
+    expect(mockedCustomerApi.mergeHistory).toHaveBeenLastCalledWith('cus-2', {
+      cursor: undefined,
+    });
 
     fireEvent.click(screen.getByRole('button', { name: '保存する' }));
 
     await waitFor(() =>
       expect(mockedCustomerApi.update).toHaveBeenCalledWith('cus-2', expect.anything())
     );
+  });
+});
+
+describe('顧客編集ページの統合履歴区画', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentParams.id = 'cus-1';
+    mockedCustomerApi.get.mockResolvedValue(customer);
+    mockedCustomerApi.memberLink.mockRejectedValue({ response: { status: 404 } });
+    mockedCustomerApi.memberLinkHistory.mockResolvedValue({ rows: [], nextCursor: null });
+    mockedCustomerApi.memberPointBalance.mockResolvedValue({ linked: false });
+    mockedCustomerApi.mergeHistory.mockResolvedValue({ rows: [], nextCursor: null });
+    mockedOrderApi.list.mockResolvedValue(emptyOrderPage);
+  });
+
+  it('統合権限があれば区画が出て、統合の無い顧客でもその旨が読めること', async () => {
+    mockedReadClaims.mockReturnValue(claimsWith(['CUSTOMER_MERGE']));
+
+    render(<CustomerEditPage />);
+
+    expect(await screen.findByText('統合履歴')).toBeInTheDocument();
+    expect(await screen.findByText('統合履歴がありません')).toBeInTheDocument();
+  });
+
+  it('統合権限が無ければ区画ごと出さず、必ず 403 になる読み口も叩かないこと', async () => {
+    mockedReadClaims.mockReturnValue(claimsWith(['CUSTOMER_MANAGE']));
+
+    render(<CustomerEditPage />);
+
+    expect(await screen.findByDisplayValue('山田太郎')).toBeInTheDocument();
+    expect(screen.queryByText('統合履歴')).not.toBeInTheDocument();
+    expect(mockedCustomerApi.mergeHistory).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/_pages/store-customers/__tests__/MergeHistorySection.test.tsx
+++ b/frontend/src/_pages/store-customers/__tests__/MergeHistorySection.test.tsx
@@ -43,8 +43,12 @@ describe('MergeHistorySection', () => {
     mockedApi.mergeHistory.mockResolvedValue(historyPage([]));
   });
 
-  it('統合が無ければ、その旨を空表示で示すこと', async () => {
+  it('読み込み中を経て、統合が無いことを空表示で示すこと', async () => {
     render(<MergeHistorySection customerId="c1" />);
+
+    // 読み込み中を空表示と同じ姿で描くと、まだ取りに行っている間ずっと「無い」と言い続ける
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    expect(screen.queryByText('統合履歴がありません')).not.toBeInTheDocument();
 
     expect(await screen.findByText('統合履歴がありません')).toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();

--- a/frontend/src/_pages/store-customers/__tests__/MergeHistorySection.test.tsx
+++ b/frontend/src/_pages/store-customers/__tests__/MergeHistorySection.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MergeHistorySection } from '../ui/MergeHistorySection';
+import { customerApi } from '@/entities/customer';
+
+jest.mock('@/entities/customer', () => ({
+  customerApi: { mergeHistory: jest.fn() },
+}));
+
+const mockedApi = customerApi as jest.Mocked<typeof customerApi>;
+
+/** 履歴 1 頁分。続きの有無は呼出側が指定する。 */
+function historyPage(rows: unknown[], nextCursor: string | null = null) {
+  return { rows, nextCursor } as never;
+}
+
+/** この顧客が存続行として受けた統合。 */
+const receivedRow = {
+  id: 'm2',
+  direction: 'SURVIVING' as const,
+  counterpart_customer_id: 'cus-old',
+  counterpart_customer_name: '山田太郎（旧）',
+  merged_by_name: '田中花子',
+  merged_at: '2026-08-10T10:00:00+09:00',
+  moved_order_count: 3,
+  moved_link_count: 1,
+};
+
+/** この顧客が被統合となり、墓標になった統合。 */
+const absorbedRow = {
+  id: 'm1',
+  direction: 'MERGED' as const,
+  counterpart_customer_id: 'cus-new',
+  counterpart_customer_name: '山田太郎',
+  merged_by_name: '山田次郎',
+  merged_at: '2026-07-01T10:00:00+09:00',
+  moved_order_count: 0,
+  moved_link_count: 0,
+};
+
+describe('MergeHistorySection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApi.mergeHistory.mockResolvedValue(historyPage([]));
+  });
+
+  it('統合が無ければ、その旨を空表示で示すこと', async () => {
+    render(<MergeHistorySection customerId="c1" />);
+
+    expect(await screen.findByText('統合履歴がありません')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('存続行として受けた統合と被統合となった統合が、向きの分かる形で並ぶこと', async () => {
+    mockedApi.mergeHistory.mockResolvedValue(historyPage([receivedRow, absorbedRow]));
+
+    render(<MergeHistorySection customerId="c1" />);
+
+    const received = within(await screen.findByRole('row', { name: /山田太郎（旧）/ }));
+    expect(received.getByText('存続行として受けた')).toBeInTheDocument();
+    // 相手の行は名前と ID の両方を出す。誤統合の修復は「どの行をどの行へ」を根拠にする
+    expect(received.getByText('cus-old')).toBeInTheDocument();
+    expect(received.getByText(/田中花子・/)).toBeInTheDocument();
+    expect(received.getByText('3 件')).toBeInTheDocument();
+    expect(received.getByText('1 件')).toBeInTheDocument();
+
+    const absorbed = within(screen.getByRole('row', { name: /cus-new/ }));
+    expect(absorbed.getByText('被統合となった')).toBeInTheDocument();
+    expect(absorbed.getByText(/山田次郎・/)).toBeInTheDocument();
+  });
+
+  it('実行者が削除済みでも行は残り、実行者だけが不明として出ること', async () => {
+    mockedApi.mergeHistory.mockResolvedValue(
+      historyPage([{ ...receivedRow, merged_by_name: undefined }])
+    );
+
+    render(<MergeHistorySection customerId="c1" />);
+
+    const row = within(await screen.findByRole('row', { name: /山田太郎（旧）/ }));
+    expect(row.getByText(/不明・/)).toBeInTheDocument();
+    expect(row.getByText('cus-old')).toBeInTheDocument();
+  });
+
+  it('統合を取り消す導線が存在しないこと', async () => {
+    mockedApi.mergeHistory.mockResolvedValue(historyPage([receivedRow, absorbedRow]));
+
+    render(<MergeHistorySection customerId="c1" />);
+
+    await screen.findByRole('row', { name: /山田太郎（旧）/ });
+    // 統合に undo は無い（ADR 0010）。押せる導線が 1 つでも出れば、取り消せるという誤解を招く
+    expect(screen.queryAllByRole('button').map(button => button.textContent)).not.toContainEqual(
+      expect.stringMatching(/取消|取り消|戻す|復元/)
+    );
+  });
+
+  it('取得に失敗したら空表示に化けず、区画自身が失敗を名乗って再試行できること', async () => {
+    mockedApi.mergeHistory.mockRejectedValueOnce(new Error('boom'));
+
+    render(<MergeHistorySection customerId="c1" />);
+
+    const region = await screen.findByRole('alert');
+    expect(within(region).getByText('統合履歴の取得に失敗しました')).toBeInTheDocument();
+    // 読めなかった履歴を「ありません」と言い切ると、読み取り失敗が事実に化ける
+    expect(screen.queryByText('統合履歴がありません')).not.toBeInTheDocument();
+
+    mockedApi.mergeHistory.mockResolvedValue(historyPage([receivedRow]));
+    fireEvent.click(within(region).getByRole('button', { name: '再試行' }));
+
+    expect(await screen.findByRole('row', { name: /山田太郎（旧）/ })).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('続きがあれば追加で読み込め、返ったカーソルをそのまま次の要求に渡すこと', async () => {
+    // Once の並びで 1 頁目・2 頁目を決める（クリック後に積むと、先に走る要求が既定値を掴む）
+    mockedApi.mergeHistory
+      .mockResolvedValueOnce(historyPage([receivedRow], 'cur-1'))
+      .mockResolvedValueOnce(historyPage([absorbedRow]));
+
+    render(<MergeHistorySection customerId="c1" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'さらに読み込む' }));
+
+    await waitFor(() =>
+      expect(mockedApi.mergeHistory).toHaveBeenLastCalledWith('c1', { cursor: 'cur-1' })
+    );
+    expect(await screen.findByRole('row', { name: /cus-new/ })).toBeInTheDocument();
+    expect(screen.getByRole('row', { name: /山田太郎（旧）/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'さらに読み込む' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
+++ b/frontend/src/_pages/store-customers/ui/CustomerEditPage.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { CustomerForm, CustomerFormData, toCustomerRequest } from './CustomerForm';
 import { MemberLinkSection } from './MemberLinkSection';
+import { MergeHistorySection } from './MergeHistorySection';
 import { customerApi } from '@/entities/customer';
 import { ORDER_STATUS_LABELS, orderApi } from '@/entities/order';
 import { notify } from '@/shared/notify';
-import { storePath, useResource } from '@/shared/lib';
+import { hasPermission, readTokenClaims, storePath, useResource } from '@/shared/lib';
 import {
   RegionError,
   Table,
@@ -51,6 +52,12 @@ export default function CustomerEditPage() {
   );
   const orders = ordersData ?? [];
   const [isSubmitting, setIsSubmitting] = useState(false);
+  // 権限による UI 出し分け（強制はサーバ側 @PreAuthorize — ここは導線の表示制御のみ）。
+  // token claim の authorities から読む。token 無し・壊れは導線を出さない（fail-closed）。
+  const [canMerge, setCanMerge] = useState(false);
+  useEffect(() => {
+    setCanMerge(hasPermission(readTokenClaims(), 'CUSTOMER_MERGE'));
+  }, []);
 
   const handleSubmit = async (data: CustomerFormData) => {
     try {
@@ -124,6 +131,10 @@ export default function CustomerEditPage() {
           取りに行かない — 同じ画面位置で [id] だけが変わる遷移では前の顧客の行が残る。
           入力途中の会員コードも同時に捨てる。 */}
       <MemberLinkSection key={resolvedId} customerId={resolvedId} />
+
+      {/* 統合履歴は統合権限を持つ者だけの読み口なので、持たない利用者には区画ごと出さない。
+          出したままにすると必ず 403 になる区画が居座る（強制はサーバ側 @PreAuthorize）。 */}
+      {canMerge && <MergeHistorySection key={resolvedId} customerId={resolvedId} />}
 
       {/* 注文履歴 */}
       <TableCard>

--- a/frontend/src/_pages/store-customers/ui/MergeHistorySection.tsx
+++ b/frontend/src/_pages/store-customers/ui/MergeHistorySection.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { customerApi } from '@/entities/customer';
+import { useCursorList } from '@/shared/lib';
+import {
+  Badge,
+  Button,
+  RegionError,
+  Table,
+  TableBody,
+  TableCard,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/ui';
+
+interface MergeHistorySectionProps {
+  customerId: string;
+}
+
+/**
+ * 顧客編集ページの統合履歴区画。統合に取消は無く、誤統合の修復は「誰が・いつ・どの行を
+ * どの行へ・何を移したか」を根拠とする人手作業である（ADR 0010）。この区画はその根拠を
+ * 出すためだけにあり、統合を取り消す導線は持たない。
+ */
+export function MergeHistorySection({ customerId }: MergeHistorySectionProps) {
+  const { rows, isLoading, failed, hasMore, reload, loadMore } = useCursorList(cursor =>
+    customerApi.mergeHistory(customerId, { cursor })
+  );
+
+  return (
+    <TableCard>
+      <div className="border-b bg-muted/50 px-6 py-4">
+        <h2 className="text-lg font-medium text-foreground">統合履歴</h2>
+      </div>
+
+      {isLoading ? (
+        <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
+      ) : failed ? (
+        // 読めなかった履歴を残すと「統合履歴がありません」に化ける。区画自身が失敗を名乗る
+        <RegionError
+          message="統合履歴の取得に失敗しました"
+          onRetry={() => reload()}
+          className="justify-center p-8"
+        />
+      ) : rows.length === 0 ? (
+        <div className="p-8 text-center text-muted-foreground">統合履歴がありません</div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>向き</TableHead>
+              <TableHead>相手の顧客</TableHead>
+              <TableHead>実行者・日時</TableHead>
+              <TableHead>移した受注</TableHead>
+              <TableHead>移した関連</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map(row => (
+              <TableRow key={row.id}>
+                <TableCell>
+                  {row.direction === 'SURVIVING' ? (
+                    <Badge
+                      variant="outline"
+                      className="border-transparent bg-success/10 text-success-strong"
+                    >
+                      存続行として受けた
+                    </Badge>
+                  ) : (
+                    <Badge variant="outline">被統合となった</Badge>
+                  )}
+                </TableCell>
+                <TableCell className="text-foreground">
+                  {/* 名前だけでは同名の別行と見分けが付かないので、根拠になる ID も並べて出す */}
+                  <div>{row.counterpart_customer_name || '名称なし'}</div>
+                  <div className="text-xs text-muted-foreground">{row.counterpart_customer_id}</div>
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {/* 実行者は削除で欠けうるが、そのときも行は消さない */}
+                  {`${row.merged_by_name || '不明'}・${new Date(row.merged_at).toLocaleString('ja-JP')}`}
+                </TableCell>
+                <TableCell className="text-muted-foreground">{row.moved_order_count} 件</TableCell>
+                <TableCell className="text-muted-foreground">{row.moved_link_count} 件</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {hasMore && (
+        <div className="flex justify-center border-t p-4">
+          <Button variant="outline" onClick={() => loadMore()} disabled={isLoading}>
+            さらに読み込む
+          </Button>
+        </div>
+      )}
+    </TableCard>
+  );
+}

--- a/frontend/src/entities/customer/__tests__/customer-api.test.ts
+++ b/frontend/src/entities/customer/__tests__/customer-api.test.ts
@@ -62,6 +62,21 @@ describe('customerApi', () => {
       merged_customer_id: 'c2',
     });
   });
+  it('mergeHistory は同じ merges を GET し、カーソルページを正規化する', async () => {
+    // 実行（POST）と読み（GET）が同じパスに載る。GET は両方向の統合を返すので、
+    // パスの {id} は「存続行」ではなく「この統合に関与した行」を意味する
+    mockedGet.mockResolvedValueOnce({
+      data: { content: [{ id: 'm1', direction: 'SURVIVING' }], next_cursor: 'abc' },
+    });
+
+    await expect(customerApi.mergeHistory('c1', { cursor: 'x' })).resolves.toEqual({
+      rows: [{ id: 'm1', direction: 'SURVIVING' }],
+      nextCursor: 'abc',
+    });
+    expect(mockedGet).toHaveBeenLastCalledWith('/store/customers/c1/merges', {
+      params: { cursor: 'x' },
+    });
+  });
   it('create は /store/customers を POST する', async () => {
     expect(await customerApi.create({ name: 'A' })).toEqual({
       ok: true,

--- a/frontend/src/entities/customer/api/customer.ts
+++ b/frontend/src/entities/customer/api/customer.ts
@@ -12,6 +12,7 @@ import {
   CustomerDuplicateGroupResponse,
   CustomerMemberLinkHistoryResponse,
   CustomerMemberLinkResponse,
+  CustomerMergeHistoryResponse,
   CustomerMergeResponse,
   CustomerPointAdjustmentRequest,
   CustomerPointBalanceResponse,
@@ -74,6 +75,18 @@ export const customerApi = {
       merged_customer_id: mergedCustomerId,
     });
     return response.data;
+  },
+  /**
+   * その顧客に関する統合履歴を新しい順に取得する。存続行として受けた統合と、自分が被統合と
+   * なった統合の両方が返る。統合権限が要る読み口で、権限が無ければサーバが 403 を返す。
+   * 続きは応答の nextCursor をそのまま cursor に渡して取る。
+   */
+  mergeHistory: async (
+    id: string,
+    params?: CursorParams
+  ): Promise<CursorPageResult<CustomerMergeHistoryResponse>> => {
+    const response = await apiClient.get(`/store/customers/${id}/merges`, { params });
+    return fromCursorPage(response.data);
   },
   /** 会員コードで会員を顧客へ紐づける（既に別の会員と紐づいていれば付け替える） */
   linkMember: async (id: string, memberCode: string): Promise<CustomerMemberLinkResponse> => {

--- a/frontend/src/entities/customer/model/types.ts
+++ b/frontend/src/entities/customer/model/types.ts
@@ -93,6 +93,37 @@ export interface CustomerMergeResponse {
   moved_link_count: number;
 }
 
+/**
+ * 統合履歴 1 件が、開いている顧客から見てどちら側だったか。
+ * customer/api/dto/MergeDirection.java に対応。
+ *
+ * SURVIVING はこの行が存続行として統合を受けた側、MERGED はこの行が被統合となり
+ * 墓標になった側。同じ 1 件が、相手の画面では逆の値で現れる。
+ */
+export type CustomerMergeDirection = 'SURVIVING' | 'MERGED';
+
+/**
+ * 統合履歴 1 件（GET /store/customers/{id}/merges）。
+ * customer/api/dto/CustomerMergeHistoryResponse.java に対応。
+ *
+ * 統合に取消は無く、誤統合の修復は「誰が・いつ・どの行をどの行へ・何を移したか」を根拠と
+ * する人手作業である（ADR 0010）。相手の行は id と表示名の両方を持つ。
+ */
+export interface CustomerMergeHistoryResponse {
+  id: string;
+  direction: CustomerMergeDirection;
+  counterpart_customer_id: string;
+  /** 相手の行の名前。台帳の name 列は NOT NULL ではないため欠けうる。 */
+  counterpart_customer_name?: string;
+  /** 実行者の表示名。実行者が削除されると欠ける（行そのものは残る）。 */
+  merged_by_name?: string;
+  merged_at: string;
+  /** Java 側が primitive のため、キーは必ず応答に含まれる。 */
+  moved_order_count: number;
+  /** Java 側が primitive のため、キーは必ず応答に含まれる。 */
+  moved_link_count: number;
+}
+
 /** 会員紐づけの関連状態。customer/domain/LinkStatus.java と対応。 */
 export type CustomerMemberLinkStatus = 'ACTIVE' | 'RELEASED';
 


### PR DESCRIPTION
## 概要

顧客統合の履歴を人が読めるようにする。統合に取消は無く、誤統合の修復は「誰が・いつ・どの行を
どの行へ・受注何件と関連何件を移したか」を根拠とする人手作業なので（ADR 0010）、その根拠を
読み口と画面の両方で出す。

Closes #676

## 変更内容

- `GET /store/customers/{customerId}/merges` を新設（`CursorPage`・`CUSTOMER_MERGE` 権限）
- 統合履歴の読み側 projection `CustomerMergeView` と、両方向を 1 文で引く HQL 2 本（先頭 / 続き）
- 応答 DTO `CustomerMergeHistoryResponse` と、読み手との関係を表す `MergeDirection`
- 顧客編集ページに「統合履歴」区画を新設（会員紐づけ区画と同じ形・同じ三態）
- 前端 wire 型 `CustomerMergeHistoryResponse` / `CustomerMergeDirection` と `customerApi.mergeHistory`
- 統合テスト 6 件・単体テスト 8 件・Jest 8 件

### API 契約

| 項目 | 内容 |
| --- | --- |
| 端点 | `GET /store/customers/{customerId}/merges` |
| 授権 | `@PreAuthorize("hasAuthority('PERM_CUSTOMER_MERGE')")`（統合の実行・重複候補と同じ） |
| ステータス | 200 / 400（cursor 不正）/ 403（権限なし）/ 404（顧客が引けない） |
| クエリ | `cursor`（任意）・`size`（既定 20、`CursorPage.MAX_SIZE` で頭打ち） |
| ページング | `CursorPage`。並びは `merged_at desc, id desc`（副キー id で全順序） |

応答 1 件は `id` / `direction` / `counterpart_customer_id` / `counterpart_customer_name` /
`merged_by_name` / `merged_at` / `moved_order_count` / `moved_link_count`。

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [x] `task e2e` exit 0（26 passed / 実行シナリオ: 既存 feature 全件）
- [x] ローカルで code-review 実施済み（Standards / Spec 二軸）

赤の証拠として、要となる断言はすべて実装を壊して赤くなることを確認した:

| 壊した箇所 | 赤くなったテスト |
| --- | --- |
| `HISTORY_WHERE` から `or` を落とす | 統合履歴が両方向で読め、…並ぶこと |
| `HISTORY_WHERE` の括弧を外す | 続きを辿ると 1 ページ目に載らなかった統合へ到達でき、両方向の行が重複しないこと |
| 実行者の join を `left` から内部結合へ | 実行者が削除済みでも履歴の行は返り、実行者名だけが欠けること |
| 向きの三項演算子を `SURVIVING` 固定に | 履歴の向きと相手は、問い合わせた顧客がどちら側かで決まること |
| `Limit.of(size + 1)` を `Limit.of(size)` に | 上限より 1 件多く取り、余分は返さずに続きの位置だけを組むこと |
| 履歴の行に取消ボタンを足す | 統合を取り消す導線が存在しないこと |
| `canMerge &&` の門を外す | 統合権限が無ければ区画ごと出さず、必ず 403 になる読み口も叩かないこと |
| 区画の相手を `resolvedId` から URL の `id` へ | 附属区画と保存が、表示している存続行を相手にすること |

### 視覚確認（UI 変更時）

実スタック（`task build` → `task up`）で明・暗の両テーマを目視済み。画像はこの PR には
添付していない。確認したのは以下:

- 「統合履歴」区画が会員紐づけ区画と注文履歴の間に、同じ `TableCard` の形で出ること
- 実データ（統合 2 件）で向きのバッジ・相手の名前と ID・実行者と日時・移した件数が並ぶこと
- 暗テーマでも配色が崩れないこと

## 決定ログ

**両方向を 1 文で引き、向きは読み手ごとに解く。** `direction` は統合そのものの属性ではなく
読み手との関係なので、記録（`CustomerMerge`）ではなく応答の側に置いた。同じ 1 件が、存続行の
画面では `SURVIVING`、被統合行の画面では `MERGED` として現れる。

**述語の括弧は必須。** 外すと続きの位置の条件が `or` の片方の枝にしか掛からず、2 ページ目が
1 ページ目をそのまま返して末尾へ到達できなくなる（外して実測。上の赤の表を参照）。

**相手の行は id と表示名の両方を返す。** 統合は値を合併しないので墓標にも名前が残る。id だけ
では読み手が相手を思い出せず、根拠にならない。

**実行者の join は `left`。** 利用者が削除されると `merged_by` は NULL になるが、行そのものは
消してはならない（`CustomerMemberLink` の実行者と同じ紀律）。

**統合の無い顧客は 404 ではなく空で返す。** 404 は顧客そのものが引けないときだけに留め、
「統合が無い」と「読めなかった」を呼出側が区別できるようにする。

**区画は `resolvedId`（＝解決後の存続行）に対して引く。** 顧客編集ページは既に墓標の URL を
統合先へ解決しており、区画だけ URL の生 id を使うと、頁の本体と区画が別の行を語ることになる。

**見送った代替案:**

- *区画を URL の `id` で引く* — 墓標の URL でその行自身の履歴が読めるようになるが、頁の本体は
  統合先を表示しているので、同じ画面に 2 行分のデータが混ざる。
- *連鎖を辿って展開する* — 存続行の頁に「その行へ畳まれた墓標」が関与した統合も出す案。根拠は
  最も完全になるが、issue の「両方向」を超える。下の既知の妥協点を参照。
- *読み口を存続側だけに収斂する* — 実装は単純になるが受入基準 2 を満たさなくなる。

## 備考 / レビュー観点

**`MERGED` は画面上に現れない（既知の妥協点）。** 顧客編集ページは墓標の URL を必ず存続行へ
解決し、存続行は定義上どの統合の被統合側でもない。したがって `direction: MERGED` と
「被統合となった」バッジは、この画面からは一度も描かれない。読み口としては両方向を返し、
`CustomerMergeIT#readsTheHistoryFromBothSidesOfTheMerge` が墓標 id を直接叩いて固定している。

分岐を残したのは、端点が正当に返しうる値に対して誤ったバッジを描くほうが害が大きいため。
#714（顧客一覧からの統合）が墓標を直接指す画面を持つなら、そこが自然な出口になる。

**連鎖統合の中間の事実は、どの画面からも見えない。** A→B のあと B→C を統合すると、
`t_customer_merges` の `(surviving=B, merged=A)` 行は残るが、A と B の URL はどちらも C へ
解決し、C の履歴は `surviving=C or merged=C` にしか一致しない。圧平が書き換えるのは
`Customer.merged_into_id` だけで履歴行は動かさない（動かすと「何が起きたか」を偽ることになる）。
この形は実装前に裁定を得ている。

**重点的に見てほしい箇所:**

- `CustomerMergeRepository.HISTORY_WHERE` の括弧（上の理由）
- `POST` と `GET` でパスの `{customerId}` の意味が非対称であること（POST は存続行、GET は
  「この行が関与した統合」）。契約として意図したもので、各 handler の javadoc に記した
- 区画を統合権限で出し分けている点（強制はサーバ側。画面側は導線の表示制御のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
