### PR TITLE
feat: 出勤タイムラインに日付ナビゲーションを追加する

### DIFF
--- a/frontend/src/_pages/store-shifts/lib/datetime.ts
+++ b/frontend/src/_pages/store-shifts/lib/datetime.ts
@@ -29,6 +29,12 @@ export function monthGrid(month: Date): { date: Date; inMonth: boolean }[] {
   return days;
 }
 
+/** 'yyyy-MM-dd' に日数を加算する（ローカルタイム基準。月末・年末の繰り上がりは Date が解決する）。 */
+export function addDaysStr(date: string, days: number): string {
+  const [y, m, d] = date.split('-').map(Number);
+  return toDateStr(new Date(y, m - 1, d + days));
+}
+
 /** 'HH:mm:ss' または 'HH:mm' を深夜 0 時からの分に変換する。 */
 export function timeToMinutes(time: string | undefined): number {
   const [h, m] = (time ?? '').split(':');

--- a/frontend/src/_pages/store-shifts/ui/ShiftTimeline.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftTimeline.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { PlusIcon } from 'lucide-react';
+import { ChevronLeftIcon, ChevronRightIcon, PlusIcon } from 'lucide-react';
 import { CastResponse } from '@/entities/cast';
 import { ShiftResponse } from '@/entities/shift';
-import { Button } from '@/shared/ui';
-import { shiftSpan, toDateStr } from '../lib/datetime';
+import { Button, Input } from '@/shared/ui';
+import { addDaysStr, shiftSpan, toDateStr } from '../lib/datetime';
 
 interface ShiftTimelineProps {
   /** 表示日 'yyyy-MM-dd'。 */
@@ -12,9 +12,18 @@ interface ShiftTimelineProps {
   shifts: ShiftResponse[];
   casts: CastResponse[];
   loading: boolean;
+  onChangeDate: (date: string) => void;
   onAddShift: () => void;
   onEditShift: (shift: ShiftResponse) => void;
 }
+
+/** クイックジャンプは選択中の日ではなく実際の今日を基準にする。 */
+const QUICK_JUMPS = [
+  { label: '昨日', offset: -1 },
+  { label: '今日', offset: 0 },
+  { label: '明日', offset: 1 },
+  { label: '明後日', offset: 2 },
+] as const;
 
 const SLOT_MINUTES = 30;
 const LABEL_COL = 'w-28';
@@ -26,6 +35,7 @@ export function ShiftTimeline({
   shifts,
   casts,
   loading,
+  onChangeDate,
   onAddShift,
   onEditShift,
 }: ShiftTimelineProps) {
@@ -65,12 +75,57 @@ export function ShiftTimeline({
 
   return (
     <div className="rounded-lg border bg-card shadow-sm">
-      <div className="flex items-center justify-between border-b px-6 py-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b px-6 py-4">
         <h2 className="text-lg font-semibold text-foreground">{date} の出勤</h2>
-        <Button type="button" onClick={onAddShift}>
-          <PlusIcon />
-          シフト追加
-        </Button>
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => onChangeDate(addDaysStr(date, -1))}
+              aria-label="前日"
+            >
+              <ChevronLeftIcon />
+            </Button>
+            {/* クリアで空文字が飛んでくるため無視する（表示日が無い状態は作らない） */}
+            <Input
+              type="date"
+              value={date}
+              onChange={e => {
+                if (e.target.value) onChangeDate(e.target.value);
+              }}
+              aria-label="表示する日付"
+              className="w-40"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => onChangeDate(addDaysStr(date, 1))}
+              aria-label="翌日"
+            >
+              <ChevronRightIcon />
+            </Button>
+          </div>
+          <div className="flex items-center gap-1">
+            {QUICK_JUMPS.map(({ label, offset }) => (
+              <Button
+                key={label}
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => onChangeDate(addDaysStr(toDateStr(new Date()), offset))}
+              >
+                {label}
+              </Button>
+            ))}
+          </div>
+          <Button type="button" onClick={onAddShift}>
+            <PlusIcon />
+            シフト追加
+          </Button>
+        </div>
       </div>
 
       {loading ? (

--- a/frontend/src/_pages/store-shifts/ui/ShiftTimeline.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftTimeline.tsx
@@ -3,7 +3,7 @@
 import { ChevronLeftIcon, ChevronRightIcon, PlusIcon } from 'lucide-react';
 import { CastResponse } from '@/entities/cast';
 import { ShiftResponse } from '@/entities/shift';
-import { Button, Input } from '@/shared/ui';
+import { Button, Input, RegionError } from '@/shared/ui';
 import { addDaysStr, shiftSpan, toDateStr } from '../lib/datetime';
 
 interface ShiftTimelineProps {
@@ -12,6 +12,9 @@ interface ShiftTimelineProps {
   shifts: ShiftResponse[];
   casts: CastResponse[];
   loading: boolean;
+  /** 取得失敗。ヘッダ（日付ナビ）は残し、本体だけが失敗を名乗る — 別の日へ動くことが復旧経路を兼ねる。 */
+  failed: boolean;
+  onRetry: () => void;
   onChangeDate: (date: string) => void;
   onAddShift: () => void;
   onEditShift: (shift: ShiftResponse) => void;
@@ -35,6 +38,8 @@ export function ShiftTimeline({
   shifts,
   casts,
   loading,
+  failed,
+  onRetry,
   onChangeDate,
   onAddShift,
   onEditShift,
@@ -128,7 +133,13 @@ export function ShiftTimeline({
         </div>
       </div>
 
-      {loading ? (
+      {failed ? (
+        <RegionError
+          message="シフトの取得に失敗しました"
+          onRetry={onRetry}
+          className="justify-center p-8"
+        />
+      ) : loading ? (
         <div className="p-8 text-center text-muted-foreground">読み込み中...</div>
       ) : !hasShifts ? (
         <div className="p-12 text-center">

--- a/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
@@ -152,6 +152,7 @@ export default function ShiftsPage() {
               shifts={shifts}
               casts={casts}
               loading={loading}
+              onChangeDate={setSelectedDate}
               onAddShift={openAdd}
               onEditShift={openEdit}
             />

--- a/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
+++ b/frontend/src/_pages/store-shifts/ui/ShiftsPage.tsx
@@ -77,8 +77,8 @@ export default function ShiftsPage() {
     setTab(TIMELINE_TAB);
   };
 
-  // シフトはカレンダーとタイムラインの二つの器に描かれる。どちらの器も同じ 1 件の取得の
-  // 産物なので、失敗の姿も同じものを置く。
+  // カレンダーは取得失敗で器ごと失敗態に差し替える。タイムラインは日付ナビが復旧経路を
+  // 兼ねる（別の日へ動けば取り直す）ため、ヘッダを残して本体だけが失敗を名乗る。
   const shiftsError = (
     <RegionError
       message="シフトの取得に失敗しました"
@@ -144,19 +144,17 @@ export default function ShiftsPage() {
           )}
         </TabsContent>
         <TabsContent value={TIMELINE_TAB} className="mt-6">
-          {shiftsFailure !== null ? (
-            shiftsError
-          ) : (
-            <ShiftTimeline
-              date={selectedDate}
-              shifts={shifts}
-              casts={casts}
-              loading={loading}
-              onChangeDate={setSelectedDate}
-              onAddShift={openAdd}
-              onEditShift={openEdit}
-            />
-          )}
+          <ShiftTimeline
+            date={selectedDate}
+            shifts={shifts}
+            casts={casts}
+            loading={loading}
+            failed={shiftsFailure !== null}
+            onRetry={() => void reloadShifts()}
+            onChangeDate={setSelectedDate}
+            onAddShift={openAdd}
+            onEditShift={openEdit}
+          />
         </TabsContent>
         <TabsContent value={REQUESTS_TAB} className="mt-6">
           <ShiftRequestInbox casts={casts} onApproved={() => void reloadShifts()} />

--- a/frontend/src/_pages/store-shifts/ui/__tests__/ShiftsPage.test.tsx
+++ b/frontend/src/_pages/store-shifts/ui/__tests__/ShiftsPage.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import ShiftsPage from '../ShiftsPage';
 import { castApi } from '@/entities/cast';
 import { shiftApi } from '@/entities/shift';
-import { toDateStr } from '../../lib/datetime';
+import { addDaysStr, toDateStr } from '../../lib/datetime';
 
 jest.mock('@/entities/cast', () => ({
   castApi: { list: jest.fn() },
@@ -92,6 +92,59 @@ describe('ShiftsPage のタブ遷移', () => {
 
     await waitFor(() => expect(mockedShiftCreate).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(mockedShiftList.mock.calls.length).toBeGreaterThan(callsBeforeSave));
+  });
+});
+
+describe('タイムラインの日付ナビゲーション', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCastList.mockResolvedValue(castPage());
+    mockedShiftList.mockResolvedValue([]);
+  });
+
+  const openTimeline = async () => {
+    render(<ShiftsPage />);
+    fireEvent.click(screen.getByRole('tab', { name: 'タイムライン' }));
+    const today = toDateStr(new Date());
+    expect(await screen.findByText(`${today} の出勤`)).toBeInTheDocument();
+    return today;
+  };
+
+  it('翌日ボタンで表示日が進み、その日の区間で取り直すこと', async () => {
+    const today = await openTimeline();
+    const callsBefore = mockedShiftList.mock.calls.length;
+
+    fireEvent.click(screen.getByRole('button', { name: '翌日' }));
+
+    const tomorrow = addDaysStr(today, 1);
+    expect(await screen.findByText(`${tomorrow} の出勤`)).toBeInTheDocument();
+    await waitFor(() => expect(mockedShiftList.mock.calls.length).toBeGreaterThan(callsBefore));
+    expect(mockedShiftList.mock.calls.at(-1)?.[0]).toEqual({ from: tomorrow, to: tomorrow });
+  });
+
+  it('クイックボタンは選択中の日ではなく実際の今日を基準にジャンプすること', async () => {
+    const today = await openTimeline();
+
+    // 先に前日へ動かしてから明後日を押す — 選択中の日基準なら today+1 に化ける
+    fireEvent.click(screen.getByRole('button', { name: '前日' }));
+    expect(await screen.findByText(`${addDaysStr(today, -1)} の出勤`)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '明後日' }));
+    expect(await screen.findByText(`${addDaysStr(today, 2)} の出勤`)).toBeInTheDocument();
+  });
+
+  it('日付入力で任意の日へ切り替わり、その日の区間で取り直すこと', async () => {
+    await openTimeline();
+
+    fireEvent.change(screen.getByLabelText('表示する日付'), { target: { value: '2031-01-05' } });
+
+    expect(await screen.findByText('2031-01-05 の出勤')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mockedShiftList.mock.calls.at(-1)?.[0]).toEqual({
+        from: '2031-01-05',
+        to: '2031-01-05',
+      })
+    );
   });
 });
 

--- a/frontend/src/_pages/store-shifts/ui/__tests__/ShiftsPage.test.tsx
+++ b/frontend/src/_pages/store-shifts/ui/__tests__/ShiftsPage.test.tsx
@@ -133,6 +133,23 @@ describe('タイムラインの日付ナビゲーション', () => {
     expect(await screen.findByText(`${addDaysStr(today, 2)} の出勤`)).toBeInTheDocument();
   });
 
+  it('取得に失敗しても日付ナビは残り、別の日へ動けば取り直して復旧すること', async () => {
+    const today = await openTimeline();
+    mockedShiftList.mockRejectedValueOnce(new Error('boom'));
+
+    fireEvent.click(screen.getByRole('button', { name: '翌日' }));
+
+    // 本体だけが失敗を名乗り、ヘッダのナビは操作可能なまま
+    const region = await screen.findByRole('alert');
+    expect(within(region).getByText('シフトの取得に失敗しました')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '翌日' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '翌日' }));
+
+    expect(await screen.findByText(`${addDaysStr(today, 2)} の出勤`)).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+  });
+
   it('日付入力で任意の日へ切り替わり、その日の区間で取り直すこと', async () => {
     await openTimeline();
 


### PR DESCRIPTION
## 概要

出勤管理のタイムラインに日付ナビゲーションを追加する。従来は別の日を見るのに「カレンダータブへ戻る→日セルをクリック」の三跳が唯一の経路で、タイムライン上には日付を変える操作面が無かった。

Closes #726

## 変更内容

- `ShiftTimeline` ヘッダに日付ナビゲーションを追加 — 前日/翌日のステップボタン、昨日・今日・明日・明後日のクイックボタン（実際の今日基準）、`Input type="date"` による自由選択
- `ShiftsPage` は `setSelectedDate` を渡すだけ（取得区間・カレンダー遷移の機構は不変）
- `datetime.ts` に `addDaysStr`（'yyyy-MM-dd' の日数加算）を追加
- `ShiftsPage.test.tsx` に 3 件追加 — 翌日ステップで区間を取り直す / クイックボタンが選択中の日ではなく今日基準（前日へ動かしてから明後日を押すと today+2 に着くことで基準の取り違えを赤にできる）/ 日付入力で任意日へ

## 検証

- [x] `task -d frontend lint` exit 0
- [x] `task test service=frontend` exit 0（119 suites / 1071 tests、新規 3 件含む）
- [x] `task build service=frontend` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全 26 シナリオ）
- [x] ローカルで code-review 実施済み（mattpocock 二軸 — Standards: ハード違反ゼロ / Spec: 適合。指摘は下記備考）
- バックエンドは無変更のため backend 側ゲートは対象外

### 視覚確認（UI 変更時）

実機で確認済み（スクリーンショットは会話で共有）:
- 通常幅: ヘッダ 1 行に「‹ 日付入力 › / 昨日・今日・明日・明後日 / シフト追加」が収まる
- 704px フロア幅（DESIGN.md）: `document.scrollWidth 960 = clientWidth 960`（水平溢れなし）、flex-wrap で 3 行に折り返しクリップなし
- 翌日→明後日→日付入力の操作系列で見出しと取得区間が正しく追随

## 決定ログ

- クイックボタンの基準は「実際の今日」に固定した。選択中の日基準だと「明日」を二度押すと明後日に着く — ボタンの字面と挙動が乖離する。ステップ移動は前日/翌日が担うので役割は重ならない
- 日付入力は `ShiftFormModal` と同じ `Input type="date"` の踏襲。クリア（空文字）は無視して「表示日が無い状態」を作らない
- ヘッダは flex-wrap 化。狭い幅ではナビ群が折り返し、フロアを新たな下限で縛らない

## 備考 / レビュー観点

- code-review の残指摘（対応せず理由記載）: ①クイック 4 ボタンのうちテストが直接押すのは明後日のみ — 4 つは同一 map 由来で分岐が無いため 1 点で足りると判断 ②日付フィルタの `aria-label` 単独は `OrdersPage` の可視 `Label` 併用と二流儀になる — ツールバー文脈のシェブロン `aria-label` 慣行に揃えた
- タイムライン下に公開パネルが載る予定（#722 裁定の B+A 混成、#379 再計画で実装）。日単位一括の公開操作はこの日付ナビが前提整備になる
