### PR TITLE
fix: アカウントメニュー展開中にヘッダー右端がずれるのを gap への置き換えで直す

### DIFF
--- a/frontend/src/widgets/header/ui/Header.tsx
+++ b/frontend/src/widgets/header/ui/Header.tsx
@@ -42,7 +42,7 @@ export function Header() {
         <h2 className="text-lg font-medium text-foreground">管理パネル</h2>
       </div>
 
-      <div className="flex items-center space-x-6">
+      <div className="flex items-center gap-6">
         <Button variant="ghost" size="icon" className="text-muted-foreground">
           <BellIcon className="size-6" />
         </Button>
@@ -75,7 +75,7 @@ export function Header() {
           </DropdownMenu>
         )}
 
-        <div className="flex items-center space-x-4">
+        <div className="flex items-center gap-4">
           <div className="text-right hidden sm:block">
             {meFailure !== null ? (
               <RegionError


### PR DESCRIPTION
## 概要

アカウントメニューを開いている間だけヘッダー右端のかたまりが 16px 左へずれる不具合を、`space-x-*` を flex の `gap-*` へ置き換えて直す。

Closes #760

## 変更内容

- `widgets/header/ui/Header.tsx` の表示名＋アバターの箱を `space-x-4` → `gap-4`
- 同ファイル外側の横並び（通知・表示モード・区切り・店舗切替・アカウント）を `space-x-6` → `gap-6`（予防）

## 検証

- [x] `task lint service=frontend` exit 0（eslint / steiger / tsc）、`task lint-repo` exit 0
- [x] `task test service=frontend` exit 0（121 suites / 1165 tests）
- [x] `task build service=frontend` exit 0
- [x] `task e2e` exit 0（26 シナリオ全通過 / 4.7m。UI 変更のためシナリオは絞らず全量実行した）
- [x] ローカルで code-review 実施済み（Standards / Spec 両軸。結果は下の 備考 節）

バックエンドは無変更のため `task lint` / `task test` / `task build` はフロント側のみ実行した。

### 視覚確認（UI 変更時）

スクリーンショットではなく、実ブラウザ上の DOM 実測値で赤緑を対にした。使い捨て E2E スタック（tmpfs DB）の実 Chromium・ビューポート幅 1728px・`/store/1/orders`。同一 DOM のまま箱の規則だけを差し替えて比較している。

| 規則 | 時点 | 表示名の左端 | かたまりの幅 | アバターボタンの `margin-right` | 箱の子要素数 |
| --- | --- | --- | --- | --- | --- |
| `gap-4`（本 PR） | 展開前 | 1484.00px | 212.00px | 0px | 2 |
| `gap-4`（本 PR） | 展開中 | 1484.00px | 212.00px | 0px | 7 |
| `space-x-4`（修正前） | 展開前 | 1484.00px | 212.00px | 0px | 2 |
| `space-x-4`（修正前） | 展開中 | **1468.00px** | **228.00px** | **16px** | 7 |

外側の箱（`gap-6`）も店舗切替メニューの開閉で子要素が 5 → 10 に増えるが、幅・位置とも不変であることを同じ手順で確認した。

## 決定ログ

**採った案: `gap-*` への置き換え。**

この版に実際に焼かれている CSS を実測したところ、`space-x-N > :not(:last-child) { margin-inline-end: … }` という `:last-child` 依存の形だった。Base UI の DropdownMenu は展開時にトリガの直後・同じ親の中へ focus guard の `<span>` を差し込む（実測で子要素 2 → 7）ため、それまで最後の子だったアバターボタンが `:last-child` から外れて 16px の余白を新たに受け取る。guard 自身は `position: fixed` で場所を取らないので、増えた余白だけが右端に残りかたまりが左へ押し出される。

`gap` は `:last-child` を見ず、`position: fixed` の子には間隔を作らないため、guard が差し込まれても影響を受けない。`DESIGN.md` の余白表もヘッダー・ツールバーの制御群には `gap-*` を挙げており、設計系の既定に寄せる形になる。

**見送った案: guard を箱の外へ出す / トリガを `<span>` で包む。** どちらも Base UI の内部挙動か DOM 構造への追加の依存を作る。`gap` は原因そのもの（`:last-child` 依存）を消すので、将来トリガが箱の末尾に来ても再発しない。

**単体テストは追加していない。** jsdom は Tailwind のスタイルシートを読まないためどの断言も赤にできず、クラス名の断言は実装の写しにしかならない。代わりに上表の実測を検証の根拠とした。

## 備考 / レビュー観点

- issue の 影響範囲 節の裁定どおり、直したのは Header.tsx の 2 箇所のみ。`RolesPage` の `space-x-2`（中身は素の Button）、`StoreCreatePage` / `StoreEditPage` の `space-x-3`（末尾がトリガでないボタン列）、`CastSection` の `space-x-1.5` は対象外として残している。
- 発症条件は「popup のトリガが `space-x-*` 箱の最後の子になること」なので、残した箇所も末尾にトリガを足せば同じ形で再発しうる。今回は横断的な一掃はせず、issue の裁定の範囲に留めた。残る 4 箇所は `DropdownMenuTrigger` / `PopoverTrigger` / `TooltipTrigger` / `SelectTrigger` / `MenuTrigger` のいずれも含まないことを grep で確認済み。
- **`DESIGN.md` の余白表との差（要裁定・本 PR では触っていない）**: 「Control group in a header or toolbar | 12px (`gap-3`)」に対し、この 2 箇所は 24px と 16px。数値は変更前（`space-x-6` / `space-x-4`）と同じで本 PR による退行ではないが、表と同じ語彙（`gap-*`）へ移したことで差が読み取れるようになった。ヘッダーを例外とするのか表の行を直すのかは、目視の裁定が要るため別で決めたい。
- code-review（ローカル 2 軸）の結果: Spec 軸は指摘ゼロ。Standards 軸は Fowler 系の指摘ゼロ、唯一の硬指摘が「bug fix に赤いテストが無い」で、これは同じ規約が併記する例外（テストできない場合は理由を書く）に当たると判断し、理由を commit 本文と上の 決定ログ に記載した。
