### PR TITLE
fix: PlatformPermission 連合型に CUSTOMER_MERGE を補う

### DIFF
--- a/frontend/src/entities/user/model/types.ts
+++ b/frontend/src/entities/user/model/types.ts
@@ -27,6 +27,7 @@ export type PlatformPermission =
   | 'ORDER_MANAGE'
   | 'ORDER_CORRECT'
   | 'CUSTOMER_MANAGE'
+  | 'CUSTOMER_MERGE'
   | 'POINT_ADJUST'
   | 'SHIFT_MANAGE'
   | 'CAST_MANAGE'


### PR DESCRIPTION
## 概要

バックエンド `PermissionCode` は 19 権限だが、フロントの `PlatformPermission` 連合型は 18 個しか列挙しておらず、`GET /platform/permissions` が実際に返す `CUSTOMER_MERGE` が型宣言に存在しなかった。連合型に 1 行補う。

## 変更内容

- `frontend/src/entities/user/model/types.ts` の `PlatformPermission` に `'CUSTOMER_MERGE'` を追加（`CUSTOMER_MANAGE` の直後、enum 宣言順）

## 検証

- [x] `npm run lint`（frontend ローカル）exit 0
- [x] `task test service=frontend` exit 0（123 suites / 1187 tests）
- [x] `task build service=frontend` exit 0（Docker 内 tsc 全量を含む）
- [ ] `task e2e` — 型宣言 1 行の追加のみで実行時挙動に変化がないため未実施

## 決定ログ

- 連合の網羅性に依存する switch / Record を前端全体で grep 確認：該当なし（唯一の連合キー `Record` は 3 値の `PermissionConsole`、ロール編集の権限一覧はサーバ応答から描画）。随伴修正は不要と判断。
- 顧客統合 UI の権限判定は JWT claims（文字列）経由のため、この型欠落は tsc を赤にせず潜伏していた。

## 備考 / レビュー観点

- ローカルの `npx tsc --noEmit` は本変更と無関係に `.next/types` の陳腐化した生成物（旧ルート構成参照）で exit 1 になる既知事象がある。src 側のエラーはゼロで、Docker のクリーンビルドでは発生しない。
- 後端に権限コードを足すとフロント連合型が黙って漂流するクラスの問題は再発しうる。対照テストの導入は本 PR の範囲外として見送り。

🤖 Generated with [Claude Code](https://claude.com/claude-code)