### PR TITLE
fix: 管理者作成の表示名の上限を要求で止める

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -421,6 +421,28 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
   }
 
   @Test
+  @DisplayName("列長を超える表示名は 400 で撥ねること（整合性違反まで届かせない）")
+  void overlongDisplayNameIsRejectedAsClientError() {
+    String hq = platformToken(SEED_EMAIL, PASSWORD);
+    String email = "staff-it-longname@kizuna.test";
+    String body =
+        String.format(
+            "{\"email\":\"%s\",\"password\":\"%s\",\"display_name\":\"%s\",\"role_ids\":%s,"
+                + "\"store_scope_type\":\"ALL_STORES\",\"store_ids\":[]}",
+            email, PASSWORD, "あ".repeat(151), rolesJson(HQ_SIDE_ROLE));
+
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/platform/staff", new HttpEntity<>(body, bearerJson(hq)), JsonNode.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(res.getBody().path("details").has("display_name"))
+        .as("列長超過は display_name 由来の検証エラーとして返ること")
+        .isTrue();
+    assertThat(platformUserRepository.findByEmail(email)).isEmpty();
+  }
+
+  @Test
   @DisplayName("検証エラーの details のキーが、要求で送ったのと同じ綴り（snake_case）で返ること")
   void validationDetailKeysMatchRequestSpelling() {
     String hq = platformToken(SEED_EMAIL, PASSWORD);

--- a/backend/src/main/java/com/kizuna/user/api/dto/PlatformStaffCreateRequest.java
+++ b/backend/src/main/java/com/kizuna/user/api/dto/PlatformStaffCreateRequest.java
@@ -30,6 +30,9 @@ public class PlatformStaffCreateRequest {
   private String password;
 
   @NotBlank(message = "display_name is required")
+  // t_users.display_name VARCHAR(150)。列長超過は制約名を持たない整合性違反として写像に載らず 500 に落ちるため、
+  // 上限は要求の側で止める。
+  @Size(max = 150)
   private String displayName;
 
   @NotEmpty(message = "role_ids is required")

--- a/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
+++ b/frontend/src/features/staff-management/ui/StaffCreateModal.tsx
@@ -163,7 +163,7 @@ export function StaffCreateModal({
                 <FormItem className="gap-1">
                   <FormLabel>氏名</FormLabel>
                   <FormControl>
-                    <Input type="text" {...field} />
+                    <Input type="text" maxLength={150} {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>


### PR DESCRIPTION
## 概要

`POST /platform/staff` の `display_name` が列長（`t_users.display_name` VARCHAR(150)）を素通ししていたため、151 文字以上の入力がクライアント起因なのに 500 になっていた。上限を要求の側（`@Size(max = 150)`）で止める。店舗側 (#777) と同じ形。

Closes #

## 変更内容

- `PlatformStaffCreateRequest.displayName` に `@Size(max = 150)` を追加（`StoreStaffCreateRequest` と同じ注釈・同じ理由書き）
- 管理者作成モーダルの氏名 `Input` に `maxLength={150}`
- `PlatformStaffManagementIT#overlongDisplayNameIsRejectedAsClientError` を追加（151 文字 → 400）

## 検証

- [x] `task lint` exit 0（backend / frontend 各側）
- [x] `task test` exit 0（backend unit + 全量 integrationTest、frontend Jest）
- [x] `task build` exit 0（backend / frontend 各側）
- [x] `task e2e` exit 0（実行シナリオ: 全 27 シナリオ、4.6m）
- [ ] ローカルで code-review 実施済み（未実施）

### 赤の確認

修正前に統合テストが 500 で落ちることを実測した。

```
PlatformStaffManagementIT > 列長を超える表示名は 400 で撥ねること（整合性違反まで届かせない） FAILED
expected: 400 BAD_REQUEST
 but was: 500 INTERNAL_SERVER_ERROR
30 tests completed, 1 failed
```

`@Size` を入れたあと、同じクラス・全量 integrationTest とも `BUILD SUCCESSFUL`。

## 決定ログ

**上限を 150（列長そのまま）とした理由。** 同じ DTO の `email` は上限が列長の半分（127）だが、これは永続化前の小文字化で最大 2 倍に伸長する文字（U+0130 等）を見込んだもの。`displayName` には永続化前の変換が無いので、列長をそのまま上限にできる。

**サービス層の写像ではなく要求側で止めた理由。** 列長超過は PostgreSQL が制約名を持たない整合性違反として報告するため、`PlatformStaffService#save` の `DbConstraint` 写像には構造的に載せられない（写像先を引く鍵が無い）。`IntegrityViolations.translate` は写像に無い違反を元例外のまま返し、`CommonExceptionHandler` の全域ハンドラが 500 に落とす。入力の長さは要求の側で止めるのが唯一の落としどころ。

**更新側は対象外。** `PlatformStaffUpdateRequest` は `displayName` を持たない（ロール×店舗集合と停止・再開のみ）ので、同じ欠落は無い。

## 備考 / レビュー観点

- テストの断言は #777 の同型テスト（状態コードのみ）より 2 つ多い。`details` のキーが `display_name` であること（店舗エラーへの誤帰属でないこと）と、行が作られていないこと。同ファイルの既存のメール列長テスト 2 件がこの形なので、そちらへ揃えた。
- `@Size` は UTF-16 コード単位で測るため、`VARCHAR(150)` が文字数で数えるのとは補助文字（絵文字等）でずれる（実測: 絵文字 76 個 = Java 152 単位 / PG 76 文字）。UTF-16 長は常にコードポイント数以上なので上限は安全側にしか外れず、塞いだ 500 が開き直ることはない。厳密なコードポイント基準は共有の独自制約とフロント側の同等規則を両面へ同時に入れる必要があるため、#782 合流後の別票として見送った（codex 指摘 P2、スレッドで回答済み）。
