### PR TITLE
refactor: 保存時の整合性違反の写像を共通の保存口へ寄せる

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/user/StoreStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/StoreStaffManagementIT.java
@@ -252,6 +252,28 @@ class StoreStaffManagementIT extends CrossStoreTestSupport {
   }
 
   @Test
+  @DisplayName("存在しない storeId での作成は FK 違反を 400 へ変換して拒否すること")
+  void unknownStoreIdRejected() {
+    // ALL_STORES の行使者は担当範囲の検査を素通りするため、店舗 id の在否は保存時の FK でしか止まらない
+    // — 店長からは踏めないが、この面の日常的な行使者である HQ からは決定的に踏める経路である。
+    // 制約名の抽出が壊れれば兜底へ溢れて 500 になり、別の制約へ誤帰属すれば文言が変わる。
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/store/staff-members",
+            new HttpEntity<>(
+                createBody(
+                    "store-staff-it-unknown-store@kizuna.test",
+                    rolesJson(CLERK_ROLE),
+                    "SPECIFIC_STORES",
+                    "[999999]"),
+                headersFor("admin@kizuna.test", STORE_A)),
+            JsonNode.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(res.getBody().path("error").asString()).isEqualTo("指定された店舗が存在しません");
+  }
+
+  @Test
   @DisplayName("HQ 側ロールの付与は行使者を問わず 400 になること（母集団の維持）")
   void hqSideRoleGrantIsRefusedEvenForHq() {
     ResponseEntity<String> res =

--- a/backend/src/main/java/com/kizuna/user/application/IntegrityMappedSaves.java
+++ b/backend/src/main/java/com/kizuna/user/application/IntegrityMappedSaves.java
@@ -1,0 +1,33 @@
+package com.kizuna.user.application;
+
+import com.kizuna.shared.exception.DbConstraint;
+import com.kizuna.shared.exception.IntegrityViolations;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 集約を保存し、整合性違反を業務例外へ写像する。
+ *
+ * <p>@ElementCollection の行（ロール集合・店舗集合・権限集合）はトランザクション commit 時に flush されるため、{@code save} だけでは違反が
+ * この捕捉を突き抜けて 500 になる。{@code saveAndFlush} で違反をここで顕在化させ 400 へ変換する。FK 違反は全域ハンドラでは 4xx にならない
+ * （一意違反のみが兜底の対象）ため、この写像なしでは救えない。
+ *
+ * <p>対応表を呼出側から受け取る理由は {@link IntegrityViolations} を参照。写像に無い違反は元の例外がそのまま送出され、全域ハンドラの分類へ落ちる。
+ */
+final class IntegrityMappedSaves {
+
+  private IntegrityMappedSaves() {}
+
+  static <T> T save(
+      JpaRepository<T, ?> repository,
+      T entity,
+      Map<DbConstraint, Supplier<RuntimeException>> table) {
+    try {
+      return repository.saveAndFlush(entity);
+    } catch (DataIntegrityViolationException ex) {
+      throw IntegrityViolations.translate(ex, table);
+    }
+  }
+}

--- a/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
+++ b/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
@@ -1,7 +1,6 @@
 package com.kizuna.user.application;
 
 import com.kizuna.shared.exception.DbConstraint;
-import com.kizuna.shared.exception.IntegrityViolations;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.user.api.dto.PlatformStaffCreateRequest;
@@ -34,7 +33,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -263,26 +261,19 @@ public class PlatformStaffService {
 
   /**
    * 保存時の整合性違反を制約名で分類する。email 一意制約違反（同一メール二重送信レース）は重複エラー、店舗 FK 違反（存在しない店舗 id）は店舗エラー、ロール FK
-   * 違反（requireRoles 通過後の並行ロール削除）はロール不存在エラーへ変換する（いずれも 400）。FK 違反は全域ハンドラでは 4xx にならない（一意違反のみが兜底の対象）ため、
-   * ここで写像する必要がある。それ以外の整合性違反は実装欠陥であり、握りつぶさず全域ハンドラの分類に委ねる。
-   *
-   * <p>店舗集合等の @ElementCollection 行はトランザクション commit 時に flush されるため、{@code save} だけでは FK 違反が この try
-   * を突き抜けて 500 になる。{@code saveAndFlush} で違反をここで顕在化させ 400 へ変換する。
+   * 違反（requireRoles 通過後の並行ロール削除）はロール不存在エラーへ変換する（いずれも 400）。それ以外の整合性違反は実装欠陥であり、握りつぶさず全域ハンドラの分類に委ねる。
    */
   private PlatformUser save(PlatformUser user) {
-    try {
-      return repository.saveAndFlush(user);
-    } catch (DataIntegrityViolationException ex) {
-      throw IntegrityViolations.translate(
-          ex,
-          Map.of(
-              DbConstraint.UQ_T_USERS_EMAIL,
-              () -> new DuplicateStaffEmailException("このメールアドレスは既に登録されています"),
-              DbConstraint.FK_T_USER_STORES_STORE,
-              () -> new InvalidStoreScopeException("指定された店舗が存在しません"),
-              DbConstraint.FK_T_USER_ROLES_ROLE,
-              () -> new ServiceException("指定されたロールが存在しません")));
-    }
+    return IntegrityMappedSaves.save(
+        repository,
+        user,
+        Map.of(
+            DbConstraint.UQ_T_USERS_EMAIL,
+            () -> new DuplicateStaffEmailException("このメールアドレスは既に登録されています"),
+            DbConstraint.FK_T_USER_STORES_STORE,
+            () -> new InvalidStoreScopeException("指定された店舗が存在しません"),
+            DbConstraint.FK_T_USER_ROLES_ROLE,
+            () -> new ServiceException("指定されたロールが存在しません")));
   }
 
   private static PlatformStaffResponse toResponse(PlatformUser user, Map<Long, String> roleNames) {

--- a/backend/src/main/java/com/kizuna/user/application/RoleService.java
+++ b/backend/src/main/java/com/kizuna/user/application/RoleService.java
@@ -124,17 +124,12 @@ public class RoleService {
 
   /**
    * 保存時の名称一意制約違反（並行作成レース）を事前チェックと同じ 400 へ変換する。それ以外の整合性違反は実装欠陥であり（権限は事前検証済み）、 握りつぶさず全域ハンドラの分類に委ねる。
-   *
-   * <p>権限集合の @ElementCollection 行はトランザクション commit 時に flush されるため、{@code save} だけでは違反がこの try を突き抜けて
-   * 500 になる。{@code saveAndFlush} で違反をここで顕在化させる。
    */
   private Role save(Role role) {
-    try {
-      return roleRepository.saveAndFlush(role);
-    } catch (DataIntegrityViolationException ex) {
-      throw IntegrityViolations.translate(
-          ex, Map.of(DbConstraint.UQ_T_ROLES_NAME, () -> new ServiceException("このロール名は既に使われています")));
-    }
+    return IntegrityMappedSaves.save(
+        roleRepository,
+        role,
+        Map.of(DbConstraint.UQ_T_ROLES_NAME, () -> new ServiceException("このロール名は既に使われています")));
   }
 
   private Map<Long, String> codesById(Set<Long> permissionIds) {

--- a/backend/src/main/java/com/kizuna/user/application/StoreManagerService.java
+++ b/backend/src/main/java/com/kizuna/user/application/StoreManagerService.java
@@ -1,7 +1,6 @@
 package com.kizuna.user.application;
 
 import com.kizuna.shared.exception.DbConstraint;
-import com.kizuna.shared.exception.IntegrityViolations;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreExistenceCheck;
@@ -28,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -287,22 +285,16 @@ public class StoreManagerService {
   /**
    * 保存時の整合性違反を制約名で分類する。email 一意制約違反（同一メール二重送信レース）は重複エラー、店舗 FK 違反（事前検証と保存の間に
    * 店舗が消えるレース）は店舗エラーへ変換する（いずれも 400）。ロール FK は既定ロールが削除不能なので写像を持たない。
-   *
-   * <p>店舗集合の @ElementCollection 行はトランザクション commit 時に flush されるため、{@code save} だけでは FK 違反がこの try
-   * を突き抜けて 500 になる。{@code saveAndFlush} で違反をここで顕在化させ 400 へ変換する。
    */
   private PlatformUser save(PlatformUser user) {
-    try {
-      return repository.saveAndFlush(user);
-    } catch (DataIntegrityViolationException ex) {
-      throw IntegrityViolations.translate(
-          ex,
-          Map.of(
-              DbConstraint.UQ_T_USERS_EMAIL,
-              () -> new DuplicateStaffEmailException("このメールアドレスは既に登録されています"),
-              DbConstraint.FK_T_USER_STORES_STORE,
-              () -> new InvalidStoreScopeException("指定された店舗が存在しません")));
-    }
+    return IntegrityMappedSaves.save(
+        repository,
+        user,
+        Map.of(
+            DbConstraint.UQ_T_USERS_EMAIL,
+            () -> new DuplicateStaffEmailException("このメールアドレスは既に登録されています"),
+            DbConstraint.FK_T_USER_STORES_STORE,
+            () -> new InvalidStoreScopeException("指定された店舗が存在しません")));
   }
 
   private static StoreManagerResponse toResponse(PlatformUser user) {

--- a/backend/src/main/java/com/kizuna/user/application/StoreStaffService.java
+++ b/backend/src/main/java/com/kizuna/user/application/StoreStaffService.java
@@ -1,7 +1,6 @@
 package com.kizuna.user.application;
 
 import com.kizuna.shared.exception.DbConstraint;
-import com.kizuna.shared.exception.IntegrityViolations;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.shared.exception.ServiceException;
 import com.kizuna.shared.storescope.StoreContext;
@@ -36,7 +35,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -340,24 +338,18 @@ public class StoreStaffService {
   /**
    * 保存時の整合性違反を制約名で分類する。email 一意制約違反（同一メール二重送信レース）は重複エラー、店舗 FK 違反（存在しない店舗 id）は店舗エラー、ロール FK
    * 違反（requireRoles 通過後の並行ロール削除）はロール不存在エラーへ変換する（いずれも 400）。
-   *
-   * <p>店舗集合等の @ElementCollection 行はトランザクション commit 時に flush されるため、{@code save} だけでは FK 違反がこの try
-   * を突き抜けて 500 になる。{@code saveAndFlush} で違反をここで顕在化させ 400 へ変換する。
    */
   private PlatformUser save(PlatformUser user) {
-    try {
-      return repository.saveAndFlush(user);
-    } catch (DataIntegrityViolationException ex) {
-      throw IntegrityViolations.translate(
-          ex,
-          Map.of(
-              DbConstraint.UQ_T_USERS_EMAIL,
-              () -> new DuplicateStaffEmailException("このメールアドレスは既に登録されています"),
-              DbConstraint.FK_T_USER_STORES_STORE,
-              () -> new InvalidStoreScopeException("指定された店舗が存在しません"),
-              DbConstraint.FK_T_USER_ROLES_ROLE,
-              () -> new ServiceException("指定されたロールが存在しません")));
-    }
+    return IntegrityMappedSaves.save(
+        repository,
+        user,
+        Map.of(
+            DbConstraint.UQ_T_USERS_EMAIL,
+            () -> new DuplicateStaffEmailException("このメールアドレスは既に登録されています"),
+            DbConstraint.FK_T_USER_STORES_STORE,
+            () -> new InvalidStoreScopeException("指定された店舗が存在しません"),
+            DbConstraint.FK_T_USER_ROLES_ROLE,
+            () -> new ServiceException("指定されたロールが存在しません")));
   }
 
   private static StoreStaffResponse toResponse(


### PR DESCRIPTION
## 概要

`user/application` の 4 サービスに複製されていた「保存 → 整合性違反を業務例外へ写像」の機構を、package-private の `IntegrityMappedSaves` へ 1 本化する。とりわけ flush の根拠が一字一句同じ形で 4 箇所に写されており、CLAUDE.md の「説明は一箇所に置く」に反していた。

あわせて、この整理の過程で見つかった無守衛の経路（`/store/staff-members` の店舗 FK 写像）に統合テストを 1 本足す。

<!-- 対応 issue は無し（#778 の実装中に見つかった重複の解消） -->

## 変更内容

- `IntegrityMappedSaves` を新設。`saveAndFlush` と `IntegrityViolations.translate` の組を受け持ち、flush が要る根拠の記述をここだけに残す
- `PlatformStaffService` / `StoreStaffService` / `StoreManagerService` / `RoleService` の `private save` を、写像表を渡すだけの薄い委譲へ。各 Javadoc には「この面はどう分類するか」だけが残る
- 上記に伴い孤児になった `IntegrityViolations` / `DataIntegrityViolationException` の import を 3 サービスから除去
- `StoreStaffManagementIT` に「存在しない storeId での作成は 400」を追加

## 検証

- [x] `task -d backend lint` exit 0
- [x] `./gradlew test` exit 0（1233 件）＋ `jacocoTestCoverageVerification` exit 0
- [x] `task test-integration` exit 0（全量 3m38s）
- [x] `task build service=backend` exit 0
- [ ] `task e2e`（未実行）
- [ ] ローカルで code-review 実施済み（未実施）

差分はバックエンドの Java のみで、フロントエンド・e2e・マイグレーションには触れていないため、フロント側のゲートは回していない。

## 決定ログ

**共通口の形＝静的ユーティリティ（Spring bean ではない）**。既存の単体テストが `repository.saveAndFlush(...)` を 30 箇所以上でモックしており、bean 化すると呼出側のテストが軒並み書き換えになる。リポジトリを引数で受ける形なら既存テストは無改変で通る。`IntegrityViolations` 自体が同じ流儀の静的ユーティリティであることとも揃う。単一実装のインタフェースは backend/CLAUDE.md が禁じているので初めから候補外。

**型引数を取る**。対象の集約が `PlatformUser` と `Role` の 2 種あるため。「用途が 1 つの総称型は作らない」規約は満たしている。

**写像表は呼出側に残す**。同じ制約でも面によって適切な分類が異なる（`StoreManagerService` は既定ロールが削除不能なのでロール FK の写像を持たない）。この理由は `IntegrityViolations` の Javadoc が既に述べているので、共通口では `{@link}` で指すだけにして復唱しない。

**`RoleService#delete` の translate は対象外**。あちらは削除後 flush であって保存ではなく、機構が違う。

**見送った案**: 共通口を `shared/exception` へ置くこと。用途が user モジュール内の 4 箇所しかない現状で OPEN な共有カーネルへ出す理由が無く、package-private のまま射程を絞った。

## 備考 / レビュー観点

**PR #787 の差し替えである**（#787 はクローズ済み）。#787 は #786 の上に積んでいたが、#786 が SHA を書き換えて master へ入ったため衝突し、解消のマージコミットが master の `required_linear_history` に引っかかった。force push は使えないので、現在の master から 2 コミットを線形に置き直した本ブランチで出し直している。**成果物の内容は #787 と 1 バイトも変わらない**（`git diff` で確認済み）。

**新設 IT の位置づけ**: `withinScope` は行使者が ALL_STORES のとき早退して店舗 id の在否を見ない。したがって HQ からの作成では店舗 FK 違反が決定的に踏める — 競合限定ではなく日常操作で届く経路である。同形の断言は `PlatformStaffManagementIT#unknownStoreIdRejected` が持っていたが店舗側の面には無く、写像表を落としても全テストが緑のままだった。赤の実証として `StoreStaffService` から `FK_T_USER_STORES_STORE` の写像を外して確認済み（本テストのみ 500 で落ち、他は緑）。

**残る無守衛の写像 5 件**（`PlatformStaffService`・`StoreStaffService` の email 一意 / ロール FK、`StoreManagerService` の 2 件）は、いずれも事前検証を通過した後の競合でしか踏めない。HTTP からは決定的に到達できないため、固定するならモックで例外を投げる単体テストの形になる。本 PR では入れていない。
