### PR TITLE
refactor: HQ 側ロール述語を RoleRepository へ単源化する

### DIFF
--- a/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
+++ b/backend/src/main/java/com/kizuna/user/application/PlatformStaffService.java
@@ -23,7 +23,6 @@ import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
 import jakarta.persistence.criteria.Predicate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -43,10 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 管理者（HQ 側ロール保持者）の授権管理ユースケース。対象は本人種別 STAFF のうち HQ 側ロールを 1 つ以上持つ者に限る — CAST/MEMBER
- * は専用フローが、店舗側ロールのみの利用者は店舗スタッフ管理が扱う（ADR 0020）。
- *
- * <p>HQ 側ロールとは構成権限に Console.PLATFORM の権限を 1 つ以上含むロールを言う。判定を役職名（HQ_ADMIN）でなく権限構成で行うのは、
- * 管理が自作ロールへ移った配備でも同じ境界が成り立つようにするためである。
+ * は専用フローが、店舗側ロールのみの利用者は店舗スタッフ管理が扱う（ADR 0020）。HQ 側ロールの定義は {@link RoleRepository#findHqRoleIds} が単源。
  */
 @Service
 @RequiredArgsConstructor
@@ -54,13 +50,6 @@ public class PlatformStaffService {
 
   /** LIKE パターンのエスケープ規則。派生クエリが内部で使うものと同一で、手書きの cb.like にも同じ規則を適用する。 */
   private static final EscapeCharacter LIKE_ESCAPE = EscapeCharacter.DEFAULT;
-
-  /** HQ 側ロールの判定に使う権限コード（Console.PLATFORM の全権限）。目録は静的なので毎回引き直さない。 */
-  private static final Set<String> PLATFORM_PERMISSION_CODES =
-      Arrays.stream(PermissionCode.values())
-          .filter(code -> code.getConsole() == PermissionCode.Console.PLATFORM)
-          .map(PermissionCode::name)
-          .collect(Collectors.toUnmodifiableSet());
 
   private final PlatformUserRepository repository;
   private final RoleRepository roleRepository;
@@ -70,7 +59,7 @@ public class PlatformStaffService {
   @Transactional(readOnly = true)
   public Page<PlatformStaffResponse> list(String search, Long storeId, Pageable pageable) {
     Page<PlatformUser> staff =
-        repository.findAll(staffSpec(search, storeId, hqRoleIds()), pageable);
+        repository.findAll(staffSpec(search, storeId, roleRepository.findHqRoleIds()), pageable);
     Set<Long> allRoleIds =
         staff.getContent().stream()
             .flatMap(user -> user.getRoleIds().stream())
@@ -121,7 +110,7 @@ public class PlatformStaffService {
   @Transactional
   public PlatformStaffResponse create(PlatformStaffCreateRequest req) {
     Map<Long, String> roleNames = requireRoles(req.getRoleIds());
-    requireHqRole(req.getRoleIds(), hqRoleIds());
+    requireHqRole(req.getRoleIds(), roleRepository.findHqRoleIds());
     if (repository.findByEmail(req.getEmail().toLowerCase(Locale.ROOT)).isPresent()) {
       throw new DuplicateStaffEmailException("このメールアドレスは既に登録されています");
     }
@@ -142,14 +131,14 @@ public class PlatformStaffService {
   /** 1 件取得。編集中に競合（409）が起きたとき、一覧の現在ページに対象が居なくても最新の版を取り直せるようにするための経路。 */
   @Transactional(readOnly = true)
   public PlatformStaffResponse get(Long id) {
-    PlatformUser user = requireManagedStaff(id, hqRoleIds());
+    PlatformUser user = requireManagedStaff(id, roleRepository.findHqRoleIds());
     return toResponse(user, roleNamesOf(user.getRoleIds()));
   }
 
   @Transactional
   public PlatformStaffResponse update(Long id, PlatformStaffUpdateRequest req, String actorEmail) {
     Map<Long, String> roleNames = requireRoles(req.getRoleIds());
-    Set<Long> hqRoleIds = hqRoleIds();
+    Set<Long> hqRoleIds = roleRepository.findHqRoleIds();
     requireHqRole(req.getRoleIds(), hqRoleIds);
     PlatformUser user = requireManagedStaff(id, hqRoleIds);
     // 陳腐化した編集フォームの提出は JPA の @Version では捕まらない（再読込後の正当な更新に見える）
@@ -196,11 +185,6 @@ public class PlatformStaffService {
         .filter(user -> user.getUserType() == UserType.STAFF)
         .filter(user -> holdsAny(user.getRoleIds(), hqRoleIds))
         .orElseThrow(() -> new NotFoundException("管理者が見つかりません: " + id));
-  }
-
-  /** HQ 側ロール（Console.PLATFORM の権限を 1 つ以上含むロール）の id 集合。 */
-  private Set<Long> hqRoleIds() {
-    return roleRepository.findIdsByPermissionCodeIn(PLATFORM_PERMISSION_CODES);
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/user/application/StoreManagerService.java
+++ b/backend/src/main/java/com/kizuna/user/application/StoreManagerService.java
@@ -9,7 +9,6 @@ import com.kizuna.user.api.dto.StoreManagerCandidateResponse;
 import com.kizuna.user.api.dto.StoreManagerResponse;
 import com.kizuna.user.domain.DuplicateStaffEmailException;
 import com.kizuna.user.domain.InvalidStoreScopeException;
-import com.kizuna.user.domain.PermissionCode;
 import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
 import com.kizuna.user.domain.Role;
@@ -19,13 +18,11 @@ import com.kizuna.user.domain.SystemRole;
 import com.kizuna.user.domain.UserType;
 import jakarta.persistence.criteria.Predicate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -55,13 +52,6 @@ public class StoreManagerService {
 
   /** LIKE パターンのエスケープ規則。派生クエリが内部で使うものと同一で、手書きの cb.like にも同じ規則を適用する。 */
   private static final EscapeCharacter LIKE_ESCAPE = EscapeCharacter.DEFAULT;
-
-  /** HQ 側ロールの判定に使う権限コード（Console.PLATFORM の全権限）。目録は静的なので毎回引き直さない。 */
-  private static final Set<String> PLATFORM_PERMISSION_CODES =
-      Arrays.stream(PermissionCode.values())
-          .filter(code -> code.getConsole() == PermissionCode.Console.PLATFORM)
-          .map(PermissionCode::name)
-          .collect(Collectors.toUnmodifiableSet());
 
   /** 一覧・候補の並び。offset ページングの境界を確定させるため、表示名には一意な副キーを添える。 */
   private static final Sort BY_DISPLAY_NAME = Sort.by("displayName", "id");
@@ -99,7 +89,8 @@ public class StoreManagerService {
     requireStore(storeId);
     return repository
         .findAll(
-            candidateSpec(storeId, requireStoreManagerRole().getId(), hqRoleIds(), search),
+            candidateSpec(
+                storeId, requireStoreManagerRole().getId(), roleRepository.findHqRoleIds(), search),
             pageable)
         .map(
             user ->
@@ -139,7 +130,7 @@ public class StoreManagerService {
     if (user.getRoleIds().contains(managerRoleId) && user.authorizes(storeId)) {
       throw new ServiceException("このアカウントは既にこの店舗の店長です");
     }
-    if (!isCandidate(user, hqRoleIds())) {
+    if (!isCandidate(user, roleRepository.findHqRoleIds())) {
       throw new ServiceException("このアカウントは店長に任命できません");
     }
     Set<Long> roleIds = new HashSet<>(user.getRoleIds());
@@ -257,11 +248,6 @@ public class StoreManagerService {
         && Boolean.TRUE.equals(user.getEnabled())
         && user.getStoreScopeType() == StoreScopeType.SPECIFIC_STORES
         && user.getRoleIds().stream().noneMatch(hqRoleIds::contains);
-  }
-
-  /** HQ 側ロール（Console.PLATFORM の権限を 1 つ以上含むロール）の id 集合。 */
-  private Set<Long> hqRoleIds() {
-    return roleRepository.findIdsByPermissionCodeIn(PLATFORM_PERMISSION_CODES);
   }
 
   /** 店長ロール。既定ロールは名称が自然キーで、播種の正本は {@link SystemRole} 側にある。 */

--- a/backend/src/main/java/com/kizuna/user/application/StoreStaffService.java
+++ b/backend/src/main/java/com/kizuna/user/application/StoreStaffService.java
@@ -25,7 +25,6 @@ import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
 import jakarta.persistence.criteria.Predicate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -67,13 +66,6 @@ public class StoreStaffService {
   /** LIKE パターンのエスケープ規則。派生クエリが内部で使うものと同一で、手書きの cb.like にも同じ規則を適用する。 */
   private static final EscapeCharacter LIKE_ESCAPE = EscapeCharacter.DEFAULT;
 
-  /** HQ 側ロールの判定に使う権限コード（Console.PLATFORM の全権限）。目録は静的なので毎回引き直さない。 */
-  private static final Set<String> PLATFORM_PERMISSION_CODES =
-      Arrays.stream(PermissionCode.values())
-          .filter(code -> code.getConsole() == PermissionCode.Console.PLATFORM)
-          .map(PermissionCode::name)
-          .collect(Collectors.toUnmodifiableSet());
-
   private final PlatformUserRepository repository;
   private final RoleRepository roleRepository;
   private final PasswordEncoder passwordEncoder;
@@ -82,7 +74,7 @@ public class StoreStaffService {
 
   @Transactional(readOnly = true)
   public Page<StoreStaffResponse> list(String search, Pageable pageable) {
-    Set<Long> hqRoleIds = hqRoleIds();
+    Set<Long> hqRoleIds = roleRepository.findHqRoleIds();
     Page<PlatformUser> staff =
         repository.findAll(staffSpec(search, storeContext.getStoreId(), hqRoleIds), pageable);
     Map<Long, String> roleNames =
@@ -136,7 +128,7 @@ public class StoreStaffService {
   /** 1 件取得。編集中に競合（409）が起きたとき、一覧の現在ページに対象が居なくても最新の版を取り直せるようにするための経路。 */
   @Transactional(readOnly = true)
   public StoreStaffResponse get(Long id) {
-    PlatformUser user = requireManagedStaff(id, hqRoleIds());
+    PlatformUser user = requireManagedStaff(id, roleRepository.findHqRoleIds());
     return toResponse(user, roleNamesOf(user.getRoleIds()), delegationRoleIds(), actorScope());
   }
 
@@ -144,7 +136,7 @@ public class StoreStaffService {
   public StoreStaffResponse create(StoreStaffCreateRequest req) {
     Set<Long> delegationRoleIds = delegationRoleIds();
     StoreScope scope = actorScope();
-    requireGrantableRoles(req.getRoleIds(), hqRoleIds(), delegationRoleIds);
+    requireGrantableRoles(req.getRoleIds(), roleRepository.findHqRoleIds(), delegationRoleIds);
     requireStoresWithinActorScope(req.getStoreScopeType(), req.getStoreIds(), scope);
     Map<Long, String> roleNames = requireRoles(req.getRoleIds());
     if (repository.findByEmail(req.getEmail().toLowerCase(Locale.ROOT)).isPresent()) {
@@ -166,7 +158,7 @@ public class StoreStaffService {
 
   @Transactional
   public StoreStaffResponse update(Long id, StoreStaffUpdateRequest req) {
-    Set<Long> hqRoleIds = hqRoleIds();
+    Set<Long> hqRoleIds = roleRepository.findHqRoleIds();
     PlatformUser user = requireManagedStaff(id, hqRoleIds);
     Set<Long> delegationRoleIds = delegationRoleIds();
     StoreScope scope = actorScope();
@@ -204,7 +196,7 @@ public class StoreStaffService {
   /** 行使者が付与できるロールの目録。防提権述語（店舗側ロールであること・委譲権限を含まないこと）をサーバ側の単源に置き、 前端に判定を複製させないための読み口である。 */
   @Transactional(readOnly = true)
   public List<RoleSummaryResponse> grantableRoles() {
-    Set<Long> excluded = new HashSet<>(hqRoleIds());
+    Set<Long> excluded = new HashSet<>(roleRepository.findHqRoleIds());
     excluded.addAll(delegationRoleIds());
     return roleRepository.findAllSummaries().stream()
         .filter(summary -> !excluded.contains(summary.getId()))
@@ -233,11 +225,6 @@ public class StoreStaffService {
         .filter(user -> !holdsAny(user.getRoleIds(), hqRoleIds))
         .filter(user -> user.authorizes(contextStoreId))
         .orElseThrow(() -> new NotFoundException("スタッフが見つかりません: " + id));
-  }
-
-  /** HQ 側ロール（Console.PLATFORM の権限を 1 つ以上含むロール）の id 集合。 */
-  private Set<Long> hqRoleIds() {
-    return roleRepository.findIdsByPermissionCodeIn(PLATFORM_PERMISSION_CODES);
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/user/domain/PermissionCode.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PermissionCode.java
@@ -1,6 +1,8 @@
 package com.kizuna.user.domain;
 
+import java.util.Arrays;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Getter;
 
 /**
@@ -135,5 +137,16 @@ public enum PermissionCode {
   /** SecurityContext 上の authority 表現（例: PERM_ORDER_MANAGE）を返す。 */
   public String authority() {
     return Authorities.permission(name());
+  }
+
+  private static final Set<String> PLATFORM_CODES =
+      Arrays.stream(values())
+          .filter(code -> code.console == Console.PLATFORM)
+          .map(Enum::name)
+          .collect(Collectors.toUnmodifiableSet());
+
+  /** Console.PLATFORM に属する権限コード名の集合。HQ 側ロール判定の目録（{@link RoleRepository#findHqRoleIds}）。 */
+  public static Set<String> platformCodes() {
+    return PLATFORM_CODES;
   }
 }

--- a/backend/src/main/java/com/kizuna/user/domain/RoleRepository.java
+++ b/backend/src/main/java/com/kizuna/user/domain/RoleRepository.java
@@ -25,8 +25,7 @@ public interface RoleRepository extends JpaRepository<Role, Long> {
   List<RoleSummary> findAllSummaries();
 
   /**
-   * 指定した権限コードのいずれかを含むロールの id 集合。呼び出し側はユーザーのロール集合とこの集合の共通部分の有無で権限保持を判定する。 複数コードを渡す形は「HQ
-   * 側ロール」（Console.PLATFORM の権限を 1 つ以上含むロール）の解決に使う。
+   * 指定した権限コードのいずれかを含むロールの id 集合。呼び出し側はユーザーのロール集合とこの集合の共通部分の有無で権限保持を判定する。
    *
    * <p>ロールは権限を ID 集合（{@code @ElementCollection}）で持つため、コードから id への解決を副問い合わせで挟む。
    */
@@ -39,5 +38,13 @@ public interface RoleRepository extends JpaRepository<Role, Long> {
   /** 単一コード版。 */
   default Set<Long> findIdsByPermissionCode(String code) {
     return findIdsByPermissionCodeIn(Set.of(code));
+  }
+
+  /**
+   * HQ 側ロール（構成権限に Console.PLATFORM の権限を 1 つ以上含むロール）の id 集合。管理面が共有する境界述語の単源で、判定を
+   * 役職名（HQ_ADMIN）でなく権限構成で行うのは、管理が自作ロールへ移った配備でも同じ境界が成り立つようにするためである（ADR 0020）。
+   */
+  default Set<Long> findHqRoleIds() {
+    return findIdsByPermissionCodeIn(PermissionCode.platformCodes());
   }
 }

--- a/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/PlatformStaffServiceTest.java
@@ -31,7 +31,6 @@ import com.kizuna.user.domain.StaleStaffUpdateException;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
 import java.sql.SQLException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -84,8 +83,7 @@ class PlatformStaffServiceTest {
 
   /** HQ 側ロールの解決を差し込む。既定では HQ_ROLE と ROLE_MANAGE_ROLE だけが HQ 側。 */
   private void givenHqSideRoles() {
-    when(roleRepository.findIdsByPermissionCodeIn(ArgumentMatchers.anyCollection()))
-        .thenReturn(Set.of(HQ_ROLE, ROLE_MANAGE_ROLE));
+    when(roleRepository.findHqRoleIds()).thenReturn(Set.of(HQ_ROLE, ROLE_MANAGE_ROLE));
   }
 
   /** ROLE_MANAGE を含むロールの解決を差し込む（不減零の母集団判定）。 */
@@ -630,28 +628,6 @@ class PlatformStaffServiceTest {
     assertThat(existing.getEnabled()).as("ガードは reassignGrants 前で発火し授権も変更されないこと").isTrue();
     verify(repository, never()).saveAndFlush(any());
     verifyNoInteractions(eventPublisher);
-  }
-
-  @Test
-  void hqSideRoleIsResolvedFromPlatformConsolePermissionsOnly() {
-    // 「HQ 側ロール」の定義そのものを固定する。STAFF_MANAGE は店舗側へ移った権限（ADR 0020）、STORE_VIEW は SHARED で、
-    // どちらもロールを HQ 側にはしない。判定が旧目録のまま取り残されると、店長のロールが管理者管理へ現れる。
-    ArgumentCaptor<Collection<String>> codes = ArgumentCaptor.captor();
-    PlatformUser existing =
-        staff(3L, "target@kizuna.test", Set.of(HQ_ROLE), StoreScopeType.ALL_STORES, Set.of());
-    givenHqSideRoles();
-    when(repository.findById(3L)).thenReturn(Optional.of(existing));
-    when(roleRepository.findAllById(Set.of(HQ_ROLE))).thenReturn(List.of(role(HQ_ROLE, "HQ管理者")));
-
-    service.get(3L);
-
-    verify(roleRepository).findIdsByPermissionCodeIn(codes.capture());
-    assertThat(codes.getValue())
-        .contains(PermissionCode.ROLE_MANAGE.name(), PermissionCode.STORE_MANAGE.name())
-        .doesNotContain(
-            PermissionCode.STAFF_MANAGE.name(),
-            PermissionCode.STORE_VIEW.name(),
-            PermissionCode.ORDER_MANAGE.name());
   }
 
   @Test

--- a/backend/src/test/java/com/kizuna/user/application/StoreManagerServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/StoreManagerServiceTest.java
@@ -86,8 +86,7 @@ class StoreManagerServiceTest {
 
   /** HQ 側ロールの解決を差し込む。既定では HQ_ROLE だけが HQ 側。 */
   private void givenHqSideRoles() {
-    when(roleRepository.findIdsByPermissionCodeIn(ArgumentMatchers.anyCollection()))
-        .thenReturn(Set.of(HQ_ROLE));
+    when(roleRepository.findHqRoleIds()).thenReturn(Set.of(HQ_ROLE));
   }
 
   private PlatformUser staff(

--- a/backend/src/test/java/com/kizuna/user/application/StoreStaffServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/StoreStaffServiceTest.java
@@ -121,8 +121,7 @@ class StoreStaffServiceTest {
 
   /** HQ 側ロールの解決を差し込む。既定では HQ_ROLE だけが HQ 側。 */
   private void givenHqSideRoles() {
-    when(roleRepository.findIdsByPermissionCodeIn(ArgumentMatchers.anyCollection()))
-        .thenReturn(Set.of(HQ_ROLE));
+    when(roleRepository.findHqRoleIds()).thenReturn(Set.of(HQ_ROLE));
   }
 
   /** 委譲権限を含むロールの解決を差し込む。 */

--- a/backend/src/test/java/com/kizuna/user/domain/RoleRepositoryTest.java
+++ b/backend/src/test/java/com/kizuna/user/domain/RoleRepositoryTest.java
@@ -1,0 +1,37 @@
+package com.kizuna.user.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class RoleRepositoryTest {
+
+  @Test
+  @DisplayName("HQ 側ロールは Console.PLATFORM の権限だけから解決される")
+  void hqSideRoleIsResolvedFromPlatformConsolePermissionsOnly() {
+    // 「HQ 側ロール」の定義そのものを固定する。STAFF_MANAGE は店舗側へ移った権限（ADR 0020）、STORE_VIEW は SHARED で、
+    // どちらもロールを HQ 側にはしない。目録が緩むと、店長のロールが管理者管理へ現れる。
+    RoleRepository repository = mock(RoleRepository.class);
+    when(repository.findHqRoleIds()).thenCallRealMethod();
+    when(repository.findIdsByPermissionCodeIn(anyCollection())).thenReturn(Set.of(7L));
+
+    assertThat(repository.findHqRoleIds()).containsExactly(7L);
+
+    ArgumentCaptor<Collection<String>> codes = ArgumentCaptor.captor();
+    verify(repository).findIdsByPermissionCodeIn(codes.capture());
+    assertThat(codes.getValue())
+        .contains(PermissionCode.ROLE_MANAGE.name(), PermissionCode.STORE_MANAGE.name())
+        .doesNotContain(
+            PermissionCode.STAFF_MANAGE.name(),
+            PermissionCode.STORE_VIEW.name(),
+            PermissionCode.ORDER_MANAGE.name());
+  }
+}


### PR DESCRIPTION
## 概要

3 サービス（管理者管理・店舗スタッフ管理・店長設定）に一字一句同じ形で複製されていた「HQ 側ロール」判定（`PLATFORM_PERMISSION_CODES` ＋ 私有 `hqRoleIds()`）を、`PermissionCode#platformCodes` ＋ `RoleRepository#findHqRoleIds`（default メソッド）へ 1 本化する。

「HQ 側ロール」は ADR 0020 の境界述語であり、拷貝のどれか 1 つだけが編集されると面ごとに境界の解釈が割れる。#762 の追加裁定（2026-08-26）も守衛 G6 を「既存の `hqRoleIds()` 述語の**単源**を再利用する」前提で書いており、票F（#789）が 4 つ目の拷貝を作る前に前提を事実へ揃える。

<!-- 対応 issue 無し（#762 実装中に見つかった重複の解消。PR #792 と同族） -->

## 変更内容

- `PermissionCode#platformCodes` を新設（Console.PLATFORM の権限コード名の集合）
- `RoleRepository#findHqRoleIds` を新設。境界の定義と「役職名でなく権限構成で判定する理由」の説明をここへ単源化
- `PlatformStaffService`・`StoreStaffService`・`StoreManagerService` の複製（静的目録＋私有 `hqRoleIds()`）を撤去し呼び替え。挙動・呼び出し回数は不変
- 定義の固定テスト（Console.PLATFORM だけから解決されること）を `PlatformStaffServiceTest` から domain の `RoleRepositoryTest` へ同じ断言で移設

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0（`task test-unit`・`task test-integration` を個別に実行、いずれも exit 0。統合テストが 3 面すべてを HTTP 経由で移設後の述語に対して検証済み）
- [x] `task build` exit 0（`service=backend`。frontend は無変更）
- [ ] `task e2e` — 未実行。バックエンド内部の等価リファクタで API 契約・応答形状に変更が無いため
- [x] ローカルで code-review 実施済み（Standards / Spec 二軸・双方指摘なし）

### 視覚確認（UI 変更時）

対象外（UI 変更なし）。

## 決定ログ

- **置き場所は repository の default メソッド**。`findIdsByPermissionCode`（単一コード版）の既存先例に揃えた。per-service 静的フィールドの温存（説明だけ単源化）も検討したが、述語そのものが割れる危険は残るため不採用
- **固定テストは層移動で再固定**。サービス層の旧テストは「サービスが目録をどう渡すか」を捕まえていたが、移設後その事実は default メソッドの中にある。同じ contains / doesNotContain 断言を `RoleRepositoryTest` に置き直し、目録の過剰（SHARED 混入）を意図的に注入して赤になることを実測済み。サービス→述語の結線は各テストの `findHqRoleIds` スタブ経由の挙動テストが引き続き固定する

## 備考 / レビュー観点

- `PlatformAuthService`（着地先導出）と `StoreActivationInterceptor` にも `Console.PLATFORM` 判定があるが、これらは行使者自身の権限 enum を見る別関心（ロール行の解決ではない）ため意図的に触っていない
- `RoleRepositoryTest` の手書き `mock` ＋ `thenCallRealMethod()` は本仓初出の形。interface default メソッドの検証に `@InjectMocks` の SUT が存在しないための選択

🤖 Generated with [Claude Code](https://claude.com/claude-code)