### PR TITLE
fix: パスワード検証をバイト長で行い、店舗コンソールへ着地できないロール構成の授権を拒む

### DIFF
--- a/backend/src/integrationTest/java/com/kizuna/shared/CrossStoreTestSupport.java
+++ b/backend/src/integrationTest/java/com/kizuna/shared/CrossStoreTestSupport.java
@@ -73,6 +73,9 @@ public abstract class CrossStoreTestSupport {
         .asLong();
   }
 
+  /** 新規作成の要求が通る合言葉。要求側の最小 8 文字を満たす必要があり、種子の合言葉は使えない。 */
+  protected static final String NEW_ACCOUNT_PASSWORD = "pass1234";
+
   /** 種子ユーザーとして平台ログインする。実行者の身分そのものが主題のテストが使う（HQ 管理者など）。 */
   protected String login(String email) {
     return loginWithPassword(email, "pass");

--- a/backend/src/integrationTest/java/com/kizuna/shared/CrossStoreTestSupport.java
+++ b/backend/src/integrationTest/java/com/kizuna/shared/CrossStoreTestSupport.java
@@ -75,12 +75,18 @@ public abstract class CrossStoreTestSupport {
 
   /** 種子ユーザーとして平台ログインする。実行者の身分そのものが主題のテストが使う（HQ 管理者など）。 */
   protected String login(String email) {
+    return loginWithPassword(email, "pass");
+  }
+
+  /** テスト内で作成したアカウントとして平台ログインする。種子の合言葉を使えない場合に使う。 */
+  protected String loginWithPassword(String email, String password) {
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
     ResponseEntity<JsonNode> res =
         rest.postForEntity(
             "/platform/login",
-            new HttpEntity<>("{\"email\": \"" + email + "\", \"password\": \"pass\"}", headers),
+            new HttpEntity<>(
+                "{\"email\": \"" + email + "\", \"password\": \"" + password + "\"}", headers),
             JsonNode.class);
     assertThat(res.getStatusCode()).as("前提: %s でのログインが成功すること", email).isEqualTo(HttpStatus.OK);
     String issued = res.getBody().path("token").asString();

--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -60,6 +60,9 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
 
   private static final String PASSWORD = "pass";
 
+  /** 新規作成の要求が通る合言葉。要求側の最小 8 文字を満たす必要があり、種子の合言葉は使えない。 */
+  private static final String NEW_ACCOUNT_PASSWORD = "pass1234";
+
   /** ALL_STORES の HQ 管理者シード（seed/04-platform-admin.yaml）。 */
   private static final String SEED_EMAIL = "admin@kizuna.test";
 
@@ -220,7 +223,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
     return String.format(
         "{\"email\":\"%s\",\"password\":\"%s\",\"display_name\":\"IT表示名\",\"role_ids\":%s,"
             + "\"store_scope_type\":\"%s\",\"store_ids\":%s}",
-        email, PASSWORD, roleIdsJson, scopeType, storeIds);
+        email, NEW_ACCOUNT_PASSWORD, roleIdsJson, scopeType, storeIds);
   }
 
   private static String updateBody(
@@ -281,7 +284,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
         rest.exchange(
             "/platform/stores/me",
             HttpMethod.GET,
-            new HttpEntity<>(bearer(platformToken(CASE1_EMAIL, PASSWORD))),
+            new HttpEntity<>(bearer(platformToken(CASE1_EMAIL, NEW_ACCOUNT_PASSWORD))),
             String.class);
     assertThat(stores.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(stores.getBody())
@@ -332,7 +335,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
         rest.exchange(
             "/platform/stores/me",
             HttpMethod.GET,
-            new HttpEntity<>(bearer(platformToken(CASE3_EMAIL, PASSWORD))),
+            new HttpEntity<>(bearer(platformToken(CASE3_EMAIL, NEW_ACCOUNT_PASSWORD))),
             String.class);
     assertThat(before.getBody())
         .as("変更前は A のみ")
@@ -354,7 +357,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
         rest.exchange(
             "/platform/stores/me",
             HttpMethod.GET,
-            new HttpEntity<>(bearer(platformToken(CASE3_EMAIL, PASSWORD))),
+            new HttpEntity<>(bearer(platformToken(CASE3_EMAIL, NEW_ACCOUNT_PASSWORD))),
             String.class);
     assertThat(after.getBody())
         .as("再ログイン後は B のみ、A の実データは生ボディに一切現れないこと")
@@ -435,7 +438,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
         String.format(
             "{\"email\":\"%s\",\"password\":\"%s\",\"display_name\":\"%s\",\"role_ids\":%s,"
                 + "\"store_scope_type\":\"ALL_STORES\",\"store_ids\":[]}",
-            email, PASSWORD, "あ".repeat(151), rolesJson(HQ_SIDE_ROLE));
+            email, NEW_ACCOUNT_PASSWORD, "あ".repeat(151), rolesJson(HQ_SIDE_ROLE));
 
     ResponseEntity<JsonNode> res =
         rest.postForEntity(
@@ -458,7 +461,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
             "{\"email\":\"staff-it-wire-name@kizuna.test\",\"password\":\"%s\","
                 + "\"display_name\":\"\",\"role_ids\":%s,"
                 + "\"store_scope_type\":\"ALL_STORES\",\"store_ids\":[]}",
-            PASSWORD, rolesJson(HQ_SIDE_ROLE));
+            NEW_ACCOUNT_PASSWORD, rolesJson(HQ_SIDE_ROLE));
 
     ResponseEntity<JsonNode> res =
         rest.postForEntity(
@@ -785,7 +788,7 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
             JsonNode.class);
     assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 
-    String token = platformToken(email, PASSWORD);
+    String token = platformToken(email, NEW_ACCOUNT_PASSWORD);
 
     ResponseEntity<String> platform =
         rest.exchange(
@@ -839,7 +842,8 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
         rest.postForEntity(
             "/platform/login",
             new HttpEntity<>(
-                String.format("{\"email\": \"%s\", \"password\": \"%s\"}", email, PASSWORD),
+                String.format(
+                    "{\"email\": \"%s\", \"password\": \"%s\"}", email, NEW_ACCOUNT_PASSWORD),
                 jsonHeaders()),
             JsonNode.class);
     assertThat(login.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
@@ -993,7 +997,8 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
         rest.postForEntity(
             "/platform/login",
             new HttpEntity<>(
-                String.format("{\"email\": \"%s\", \"password\": \"%s\"}", email, PASSWORD),
+                String.format(
+                    "{\"email\": \"%s\", \"password\": \"%s\"}", email, NEW_ACCOUNT_PASSWORD),
                 jsonHeaders()),
             JsonNode.class);
     assertThat(login.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);

--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffManagementIT.java
@@ -60,9 +60,6 @@ class PlatformStaffManagementIT extends CrossStoreTestSupport {
 
   private static final String PASSWORD = "pass";
 
-  /** 新規作成の要求が通る合言葉。要求側の最小 8 文字を満たす必要があり、種子の合言葉は使えない。 */
-  private static final String NEW_ACCOUNT_PASSWORD = "pass1234";
-
   /** ALL_STORES の HQ 管理者シード（seed/04-platform-admin.yaml）。 */
   private static final String SEED_EMAIL = "admin@kizuna.test";
 

--- a/backend/src/integrationTest/java/com/kizuna/user/StoreManagerAppointmentIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/StoreManagerAppointmentIT.java
@@ -47,9 +47,6 @@ class StoreManagerAppointmentIT extends CrossStoreTestSupport {
 
   private static final String PASSWORD = "pass";
 
-  /** 新規作成の要求が通る合言葉。要求側の最小 8 文字を満たす必要があり、種子の合言葉は使えない。 */
-  private static final String NEW_ACCOUNT_PASSWORD = "pass1234";
-
   /** ROLE_MANAGE を持つ種子の HQ 管理者。この面の唯一の行使者。 */
   private static final String HQ_EMAIL = "admin@kizuna.test";
 

--- a/backend/src/integrationTest/java/com/kizuna/user/StoreManagerAppointmentIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/StoreManagerAppointmentIT.java
@@ -47,6 +47,9 @@ class StoreManagerAppointmentIT extends CrossStoreTestSupport {
 
   private static final String PASSWORD = "pass";
 
+  /** 新規作成の要求が通る合言葉。要求側の最小 8 文字を満たす必要があり、種子の合言葉は使えない。 */
+  private static final String NEW_ACCOUNT_PASSWORD = "pass1234";
+
   /** ROLE_MANAGE を持つ種子の HQ 管理者。この面の唯一の行使者。 */
   private static final String HQ_EMAIL = "admin@kizuna.test";
 
@@ -221,7 +224,7 @@ class StoreManagerAppointmentIT extends CrossStoreTestSupport {
             new HttpEntity<>(
                 String.format(
                     "{\"email\":\"%s\",\"password\":\"%s\",\"display_name\":\"初代店長\"}",
-                    email, PASSWORD),
+                    email, NEW_ACCOUNT_PASSWORD),
                 hqHeaders()),
             JsonNode.class);
 
@@ -232,7 +235,7 @@ class StoreManagerAppointmentIT extends CrossStoreTestSupport {
         rest.exchange(
             "/platform/me",
             HttpMethod.GET,
-            new HttpEntity<>(bearerJson(login(email))),
+            new HttpEntity<>(bearerJson(loginWithPassword(email, NEW_ACCOUNT_PASSWORD))),
             JsonNode.class);
 
     assertThat(me.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/backend/src/integrationTest/java/com/kizuna/user/StoreStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/StoreStaffManagementIT.java
@@ -38,9 +38,6 @@ class StoreStaffManagementIT extends CrossStoreTestSupport {
 
   private static final String PASSWORD = "pass";
 
-  /** 新規作成の要求が通る合言葉。要求側の最小 8 文字を満たす必要があり、種子の合言葉は使えない。 */
-  private static final String NEW_ACCOUNT_PASSWORD = "pass1234";
-
   /** 店長役（委譲層のみ・店舗A担当）。この面の主たる行使者。 */
   private static final String MANAGER_EMAIL = "store-staff-it-manager@kizuna.test";
 

--- a/backend/src/integrationTest/java/com/kizuna/user/StoreStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/StoreStaffManagementIT.java
@@ -52,6 +52,12 @@ class StoreStaffManagementIT extends CrossStoreTestSupport {
   /** HQ 側ロール（Console.PLATFORM の権限を含む）。この面には在否すら出てはならない。 */
   private static final String HQ_SIDE_ROLE = "店舗スタッフ管理IT_HQ側";
 
+  /** メニューの標識権限しか持たない自作ロール。単独では店舗コンソールへ着地できない。 */
+  private static final String MENU_ONLY_ROLE = "店舗スタッフ管理IT_標識のみ";
+
+  /** SHARED の跨店参照権限しか持たない自作ロール。これも単独では店舗コンソールへ着地できない。 */
+  private static final String SHARED_ONLY_ROLE = "店舗スタッフ管理IT_跨店参照のみ";
+
   /** 店舗A のみ担当の平スタッフ。店長から編集できる側の代表。 */
   private static final String CLERK_EMAIL = "store-staff-it-clerk@kizuna.test";
 
@@ -81,6 +87,8 @@ class StoreStaffManagementIT extends CrossStoreTestSupport {
     ensureRole(MANAGER_ROLE, PermissionCode.STAFF_MANAGE, PermissionCode.STORE_MENU_VIEW);
     ensureRole(CLERK_ROLE, PermissionCode.ORDER_MANAGE, PermissionCode.STORE_MENU_VIEW);
     ensureRole(HQ_SIDE_ROLE, PermissionCode.STORE_MANAGE, PermissionCode.STORE_VIEW);
+    ensureRole(MENU_ONLY_ROLE, PermissionCode.STORE_MENU_VIEW);
+    ensureRole(SHARED_ONLY_ROLE, PermissionCode.STORE_VIEW);
 
     ensureUser(MANAGER_EMAIL, "店舗スタッフ管理IT店長", roleIdsOf(MANAGER_ROLE), Set.of(STORE_A));
     ensureUser(CLERK_EMAIL, "店舗スタッフ管理IT平スタッフ", roleIdsOf(CLERK_ROLE), Set.of(STORE_A));
@@ -297,6 +305,85 @@ class StoreStaffManagementIT extends CrossStoreTestSupport {
   }
 
   @Test
+  @DisplayName("店舗コンソールへ入れないロール構成での作成は行使者を問わず 400 になること")
+  void roleSetWithoutStoreConsoleReachIsRefused() {
+    // 着地先の判定（hasStoreConsole）と同じ述語で撥ねる。素通しすると、作成は 201 で成功するのに本人が
+    // ログイン後どこへも着地できないアカウントができる。標識権限だけの形と SHARED だけの形の 2 通りがある。
+    ResponseEntity<String> markerOnly =
+        rest.postForEntity(
+            "/store/staff-members",
+            new HttpEntity<>(
+                createBody(
+                    "store-staff-it-menu-only@kizuna.test",
+                    rolesJson(MENU_ONLY_ROLE),
+                    "SPECIFIC_STORES",
+                    "[" + STORE_A + "]"),
+                headersFor(MANAGER_EMAIL, STORE_A)),
+            String.class);
+    assertThat(markerOnly.getStatusCode()).as("標識権限だけのロール").isEqualTo(HttpStatus.BAD_REQUEST);
+
+    ResponseEntity<String> sharedOnly =
+        rest.postForEntity(
+            "/store/staff-members",
+            new HttpEntity<>(
+                createBody(
+                    "store-staff-it-shared-only@kizuna.test",
+                    rolesJson(SHARED_ONLY_ROLE),
+                    "SPECIFIC_STORES",
+                    "[" + STORE_A + "]"),
+                headersFor("admin@kizuna.test", STORE_A)),
+            String.class);
+    assertThat(sharedOnly.getStatusCode())
+        .as("SHARED だけのロールは ROLE_MANAGE 保持者にも撥ねること")
+        .isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("着地できないロールも実動権限を含むロールと併せれば作成でき、本人がログインできること（判定は権限の並集）")
+  void roleSetReachingStoreConsoleThroughAnotherRoleIsAccepted() {
+    String email = "store-staff-it-menu-plus-clerk@kizuna.test";
+
+    ResponseEntity<JsonNode> created =
+        rest.postForEntity(
+            "/store/staff-members",
+            new HttpEntity<>(
+                createBody(
+                    email,
+                    rolesJson(MENU_ONLY_ROLE, CLERK_ROLE),
+                    "SPECIFIC_STORES",
+                    "[" + STORE_A + "]"),
+                headersFor(MANAGER_EMAIL, STORE_A)),
+            JsonNode.class);
+
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(loginWithPassword(email, NEW_ACCOUNT_PASSWORD)).isNotBlank();
+  }
+
+  @Test
+  @DisplayName("既存スタッフを着地できないロール構成へ変更する編集は 400 になること")
+  void updateIntoRoleSetWithoutStoreConsoleReachIsRefused() {
+    PlatformUser target = platformUserRepository.findByEmail(CLERK_EMAIL).orElseThrow();
+
+    ResponseEntity<String> res =
+        rest.exchange(
+            "/store/staff-members/" + target.getId(),
+            HttpMethod.PUT,
+            new HttpEntity<>(
+                updateBody(
+                    rolesJson(MENU_ONLY_ROLE),
+                    "SPECIFIC_STORES",
+                    "[" + STORE_A + "]",
+                    target.getVersion()),
+                headersFor(MANAGER_EMAIL, STORE_A)),
+            String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(platformUserRepository.findByEmail(CLERK_EMAIL).orElseThrow().getRoleIds())
+        .as("拒否された編集が部分適用されていないこと")
+        .isEqualTo(target.getRoleIds());
+  }
+
+  @Test
   @DisplayName("委譲権限を実効保持する同僚の編集は店長には 400 になること（G3）")
   void managerCannotEditDelegationHoldingPeer() {
     PlatformUser peer = platformUserRepository.findByEmail(PEER_EMAIL).orElseThrow();
@@ -415,8 +502,10 @@ class StoreStaffManagementIT extends CrossStoreTestSupport {
         roleIdsJson, scopeType, storeIds, version);
   }
 
-  private String rolesJson(String roleName) {
-    return "[" + roleRepository.findByName(roleName).orElseThrow().getId() + "]";
+  private String rolesJson(String... roleNames) {
+    return Arrays.stream(roleNames)
+        .map(name -> String.valueOf(roleRepository.findByName(name).orElseThrow().getId()))
+        .collect(Collectors.joining(",", "[", "]"));
   }
 
   private Set<Long> roleIdsOf(String roleName) {

--- a/backend/src/integrationTest/java/com/kizuna/user/StoreStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/StoreStaffManagementIT.java
@@ -447,6 +447,25 @@ class StoreStaffManagementIT extends CrossStoreTestSupport {
   }
 
   @Test
+  @DisplayName("可授ロールは着地資格の軸では濾さず、単独では付与できないロールも返ること")
+  void grantableRolesAreNotFilteredByStoreConsoleReach() {
+    // 付与の可否は権限の並集に対する条件なので、単独では着地できないロールも実動権限を持つロールと
+    // 併せれば正当な構成になる。ロール単位で濾すとその組合せごと選べなくなり、見出し節の通行に要る
+    // 標識権限を配れない。読み口が絞るのは行使者の権限による軸（委譲権限・HQ 側ロール）だけである。
+    ResponseEntity<String> res =
+        rest.exchange(
+            "/store/staff-members/grantable-roles",
+            HttpMethod.GET,
+            new HttpEntity<>(headersFor(MANAGER_EMAIL, STORE_A)),
+            String.class);
+
+    assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(res.getBody())
+        .as("標識権限だけのロールも SHARED だけのロールも目録には現れること")
+        .contains(MENU_ONLY_ROLE, SHARED_ONLY_ROLE);
+  }
+
+  @Test
   @DisplayName("STAFF_MANAGE を持たない店舗スタッフには全経路が 403 になること")
   void storeStaffWithoutDelegationIsForbidden() {
     ResponseEntity<String> list =

--- a/backend/src/integrationTest/java/com/kizuna/user/StoreStaffManagementIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/StoreStaffManagementIT.java
@@ -38,6 +38,9 @@ class StoreStaffManagementIT extends CrossStoreTestSupport {
 
   private static final String PASSWORD = "pass";
 
+  /** 新規作成の要求が通る合言葉。要求側の最小 8 文字を満たす必要があり、種子の合言葉は使えない。 */
+  private static final String NEW_ACCOUNT_PASSWORD = "pass1234";
+
   /** 店長役（委譲層のみ・店舗A担当）。この面の主たる行使者。 */
   private static final String MANAGER_EMAIL = "store-staff-it-manager@kizuna.test";
 
@@ -168,7 +171,7 @@ class StoreStaffManagementIT extends CrossStoreTestSupport {
             "{\"email\":\"%s\",\"password\":\"%s\",\"display_name\":\"%s\",\"role_ids\":%s,"
                 + "\"store_scope_type\":\"SPECIFIC_STORES\",\"store_ids\":[%d]}",
             "store-staff-it-longname@kizuna.test",
-            PASSWORD,
+            NEW_ACCOUNT_PASSWORD,
             "あ".repeat(151),
             rolesJson(CLERK_ROLE),
             STORE_A);
@@ -198,7 +201,9 @@ class StoreStaffManagementIT extends CrossStoreTestSupport {
     assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     assertThat(created.getBody().path("id").asLong()).isPositive();
     assertThat(created.getBody().path("editable").asBoolean()).isTrue();
-    assertThat(login(email)).as("作成された本人が平台ログインできること").isNotBlank();
+    assertThat(loginWithPassword(email, NEW_ACCOUNT_PASSWORD))
+        .as("作成された本人が平台ログインできること")
+        .isNotBlank();
   }
 
   @Test
@@ -400,7 +405,7 @@ class StoreStaffManagementIT extends CrossStoreTestSupport {
     return String.format(
         "{\"email\":\"%s\",\"password\":\"%s\",\"display_name\":\"IT表示名\",\"role_ids\":%s,"
             + "\"store_scope_type\":\"%s\",\"store_ids\":%s}",
-        email, PASSWORD, roleIdsJson, scopeType, storeIds);
+        email, NEW_ACCOUNT_PASSWORD, roleIdsJson, scopeType, storeIds);
   }
 
   private static String updateBody(

--- a/backend/src/main/java/com/kizuna/auth/api/dto/PasswordChangeRequest.java
+++ b/backend/src/main/java/com/kizuna/auth/api/dto/PasswordChangeRequest.java
@@ -1,7 +1,7 @@
 package com.kizuna.auth.api.dto;
 
+import com.kizuna.shared.validation.Password;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
@@ -9,7 +9,5 @@ public class PasswordChangeRequest {
 
   @NotBlank private String currentPassword;
 
-  @NotBlank
-  @Size(min = 8, max = 100)
-  private String newPassword;
+  @NotBlank @Password private String newPassword;
 }

--- a/backend/src/main/java/com/kizuna/auth/application/PlatformAuthService.java
+++ b/backend/src/main/java/com/kizuna/auth/application/PlatformAuthService.java
@@ -158,14 +158,9 @@ public class PlatformAuthService {
     };
   }
 
+  /** 入場資格の述語は {@link PermissionCode#grantsStoreConsole()} が単源（付与時の検証と共有する）。 */
   private static boolean hasStoreConsole(Set<PermissionCode> permissions) {
-    // 標識権限はコンソール入場・店舗文脈確立の資格にしない。STORE_MENU_VIEW 単独では
-    // storeBridge も店舗コンソール着地も許さず、実運用の STORE 権限（STORE_MENU_VIEW 以外）を要求する。
-    return permissions.stream()
-        .anyMatch(
-            permission ->
-                permission.getConsole() == PermissionCode.Console.STORE
-                    && permission != PermissionCode.STORE_MENU_VIEW);
+    return permissions.stream().anyMatch(PermissionCode::grantsStoreConsole);
   }
 
   /** ログイン後の着地先。PLATFORM 権限保持者は platform 優先（兼務者のコンソール切替導線は別票）。 */

--- a/backend/src/main/java/com/kizuna/cast/api/dto/CastInvitationAcceptRequest.java
+++ b/backend/src/main/java/com/kizuna/cast/api/dto/CastInvitationAcceptRequest.java
@@ -1,5 +1,6 @@
 package com.kizuna.cast.api.dto;
 
+import com.kizuna.shared.validation.Password;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -22,7 +23,7 @@ public class CastInvitationAcceptRequest {
   private String email;
 
   @NotBlank(message = "password is required")
-  @Size(min = 8, max = 100)
+  @Password
   private String password;
 
   @NotBlank(message = "display_name is required")

--- a/backend/src/main/java/com/kizuna/member/api/dto/MemberRegistrationRequest.java
+++ b/backend/src/main/java/com/kizuna/member/api/dto/MemberRegistrationRequest.java
@@ -1,5 +1,6 @@
 package com.kizuna.member.api.dto;
 
+import com.kizuna.shared.validation.Password;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -16,7 +17,7 @@ public class MemberRegistrationRequest {
   private String email;
 
   @NotBlank(message = "password is required")
-  @Size(min = 8, max = 100)
+  @Password
   private String password;
 
   @NotBlank(message = "display_name is required")

--- a/backend/src/main/java/com/kizuna/shared/validation/Password.java
+++ b/backend/src/main/java/com/kizuna/shared/validation/Password.java
@@ -1,0 +1,30 @@
+package com.kizuna.shared.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 平文パスワードの長さ制約。最小 8 文字、最大 72 <b>バイト</b>（UTF-8）。
+ *
+ * <p>上限が文字数でなくバイト数なのは BCrypt の受け入れ上限がバイト長だから — 72 バイト超を渡すと {@code BCrypt.hashpw} が
+ * IllegalArgumentException を投げ、制約違反に写像されないまま 500 に落ちる。日本語なら 25 文字で超える。
+ *
+ * <p>null は許す。必須判定は各要求の {@code @NotBlank} または application 層が担う。
+ */
+@Documented
+@Constraint(validatedBy = PasswordValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Password {
+
+  String message() default "password must be at least 8 characters and at most 72 bytes";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/kizuna/shared/validation/Password.java
+++ b/backend/src/main/java/com/kizuna/shared/validation/Password.java
@@ -18,7 +18,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Constraint(validatedBy = PasswordValidator.class)
-@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Password {
 

--- a/backend/src/main/java/com/kizuna/shared/validation/PasswordValidator.java
+++ b/backend/src/main/java/com/kizuna/shared/validation/PasswordValidator.java
@@ -1,0 +1,21 @@
+package com.kizuna.shared.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.nio.charset.StandardCharsets;
+
+/** {@link Password} の検証。境界は BCrypt に合わせ 72 バイトちょうどは通し、73 バイトから撥ねる。 */
+public class PasswordValidator implements ConstraintValidator<Password, String> {
+
+  private static final int MIN_LENGTH = 8;
+  private static final int MAX_BYTES = 72;
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return true;
+    }
+    return value.length() >= MIN_LENGTH
+        && value.getBytes(StandardCharsets.UTF_8).length <= MAX_BYTES;
+  }
+}

--- a/backend/src/main/java/com/kizuna/user/api/dto/PlatformStaffCreateRequest.java
+++ b/backend/src/main/java/com/kizuna/user/api/dto/PlatformStaffCreateRequest.java
@@ -1,5 +1,6 @@
 package com.kizuna.user.api.dto;
 
+import com.kizuna.shared.validation.Password;
 import com.kizuna.user.domain.StoreScopeType;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -27,6 +28,7 @@ public class PlatformStaffCreateRequest {
   private String email;
 
   @NotBlank(message = "password is required")
+  @Password
   private String password;
 
   @NotBlank(message = "display_name is required")

--- a/backend/src/main/java/com/kizuna/user/api/dto/StoreManagerAppointRequest.java
+++ b/backend/src/main/java/com/kizuna/user/api/dto/StoreManagerAppointRequest.java
@@ -1,5 +1,6 @@
 package com.kizuna.user.api.dto;
 
+import com.kizuna.shared.validation.Password;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -24,7 +25,7 @@ public class StoreManagerAppointRequest {
   @Size(max = 127)
   private String email;
 
-  private String password;
+  @Password private String password;
 
   // t_users.display_name VARCHAR(150)。列長超過は制約名を持たない整合性違反として写像に載らず 500 に落ちるため、
   // 上限は要求の側で止める。

--- a/backend/src/main/java/com/kizuna/user/api/dto/StoreStaffCreateRequest.java
+++ b/backend/src/main/java/com/kizuna/user/api/dto/StoreStaffCreateRequest.java
@@ -1,5 +1,6 @@
 package com.kizuna.user.api.dto;
 
+import com.kizuna.shared.validation.Password;
 import com.kizuna.user.domain.StoreScopeType;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -24,6 +25,7 @@ public class StoreStaffCreateRequest {
   private String email;
 
   @NotBlank(message = "password is required")
+  @Password
   private String password;
 
   @NotBlank(message = "display_name is required")

--- a/backend/src/main/java/com/kizuna/user/application/StoreStaffService.java
+++ b/backend/src/main/java/com/kizuna/user/application/StoreStaffService.java
@@ -56,6 +56,9 @@ import org.springframework.transaction.annotation.Transactional;
  * <p>防提権守衛（ADR 0020）: G1 付与できるのは店舗側ロールかつ委譲権限（STAFF_MANAGE）を含まないもの、G2 対象の店舗集合 ⊆ 行使者の担当店舗集合、G3
  * 編集・停止できるのは委譲権限の非実効保持者かつ現在の店舗集合が行使者の集合に収まる者。いずれも ROLE_MANAGE 保持者には課さない。
  *
+ * <p>付与には否定形の守衛に加えて肯定側の条件も課す（{@link #requireStoreConsoleReach}）— 権限並集が店舗コンソールの入場資格を
+ * 含むこと。着地の判定と述語を共有させ、作成できるのに何処へも着地できないアカウントを作らせない。こちらは行使者を問わず課す。
+ *
  * <p>不減零（G5）はここでは検査しない。ROLE_MANAGE は Console.PLATFORM の権限なので、それを含むロールは定義上 HQ 側ロールであり、
  * 母集団からも付与可能集合からも外れている — この面を通って ROLE_MANAGE 実効保持者が減ることは構造的に起こらない。
  */
@@ -137,6 +140,7 @@ public class StoreStaffService {
     Set<Long> delegationRoleIds = delegationRoleIds();
     StoreScope scope = actorScope();
     requireGrantableRoles(req.getRoleIds(), roleRepository.findHqRoleIds(), delegationRoleIds);
+    requireStoreConsoleReach(req.getRoleIds(), roleRepository.findStoreConsoleRoleIds());
     requireStoresWithinActorScope(req.getStoreScopeType(), req.getStoreIds(), scope);
     Map<Long, String> roleNames = requireRoles(req.getRoleIds());
     if (repository.findByEmail(req.getEmail().toLowerCase(Locale.ROOT)).isPresent()) {
@@ -171,6 +175,9 @@ public class StoreStaffService {
       throw new StaleStaffUpdateException("他の担当者が更新しました。最新の内容を確認してください");
     }
     requireGrantableRoles(req.getRoleIds(), hqRoleIds, delegationRoleIds);
+    // 判定は更新後の最終集合に対して行う（着地できない構成のまま更新を続けることは許さないが、
+    // 既に着地できない構成のアカウントを正しいロールへ付け替えて直すことはできる）。
+    requireStoreConsoleReach(req.getRoleIds(), roleRepository.findStoreConsoleRoleIds());
     requireStoresWithinActorScope(req.getStoreScopeType(), req.getStoreIds(), scope);
     Map<Long, String> roleNames = requireRoles(req.getRoleIds());
     user.reassignGrants(req.getRoleIds(), req.getStoreScopeType(), req.getStoreIds());
@@ -235,6 +242,18 @@ public class StoreStaffService {
     return actorHasRoleManage()
         ? Set.of()
         : roleRepository.findIdsByPermissionCode(PermissionCode.STAFF_MANAGE.name());
+  }
+
+  /**
+   * 付与するロールの権限並集が、店舗コンソールの入場資格（{@link PermissionCode#grantsStoreConsole()}）を 1 つ以上含むこと。
+   * 着地の判定と述語を共有するのが要点で、緩めると作成は成功するのに本人はログイン後どこへも着地できない。行使者を問わず課す。
+   *
+   * <p>条件は並集に対するもので、ロール単位ではない — 標識権限だけのロールも実動権限を持つロールと併せれば正当な構成になる。 付与可能ロールの読み口をこの軸で濾さないのはそのためである。
+   */
+  private static void requireStoreConsoleReach(Set<Long> roleIds, Set<Long> storeConsoleRoleIds) {
+    if (!holdsAny(roleIds, storeConsoleRoleIds)) {
+      throw new InvalidRoleGrantException("店舗コンソールを利用できる権限を含むロールを 1 つ以上選んでください");
+    }
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/user/domain/PermissionCode.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PermissionCode.java
@@ -139,14 +139,36 @@ public enum PermissionCode {
     return Authorities.permission(name());
   }
 
+  /**
+   * 店舗コンソールの入場資格になる権限か。標識権限 {@link #STORE_MENU_VIEW} は除く — 見出し節を通すためだけの権限で、これしか持たない者に
+   * 着地先も店舗文脈の確立資格も無い。着地の判定（{@code PlatformAuthService}）と付与時の検証は必ずこの述語を共有すること。
+   * 食い違うと、作成はできるのに何処へも着地しないアカウントが生まれる。
+   */
+  public boolean grantsStoreConsole() {
+    return console == Console.STORE && this != STORE_MENU_VIEW;
+  }
+
   private static final Set<String> PLATFORM_CODES =
       Arrays.stream(values())
           .filter(code -> code.console == Console.PLATFORM)
           .map(Enum::name)
           .collect(Collectors.toUnmodifiableSet());
 
+  private static final Set<String> STORE_CONSOLE_CODES =
+      Arrays.stream(values())
+          .filter(PermissionCode::grantsStoreConsole)
+          .map(Enum::name)
+          .collect(Collectors.toUnmodifiableSet());
+
   /** Console.PLATFORM に属する権限コード名の集合。HQ 側ロール判定の目録（{@link RoleRepository#findHqRoleIds}）。 */
   public static Set<String> platformCodes() {
     return PLATFORM_CODES;
+  }
+
+  /**
+   * {@link #grantsStoreConsole()} を満たす権限コード名の集合（{@link RoleRepository#findStoreConsoleRoleIds}）。
+   */
+  public static Set<String> storeConsoleCodes() {
+    return STORE_CONSOLE_CODES;
   }
 }

--- a/backend/src/main/java/com/kizuna/user/domain/RoleRepository.java
+++ b/backend/src/main/java/com/kizuna/user/domain/RoleRepository.java
@@ -47,4 +47,12 @@ public interface RoleRepository extends JpaRepository<Role, Long> {
   default Set<Long> findHqRoleIds() {
     return findIdsByPermissionCodeIn(PermissionCode.platformCodes());
   }
+
+  /**
+   * 店舗コンソールの入場資格になる権限（{@link PermissionCode#grantsStoreConsole()}）を 1 つ以上含むロールの id 集合。
+   * ロール集合の権限並集が資格を含むことと、集合中のどれかがこの集合に属することは同値なので、授権側はこの共通部分の有無で判定できる。
+   */
+  default Set<Long> findStoreConsoleRoleIds() {
+    return findIdsByPermissionCodeIn(PermissionCode.storeConsoleCodes());
+  }
 }

--- a/backend/src/test/java/com/kizuna/auth/api/dto/PasswordChangeRequestTest.java
+++ b/backend/src/test/java/com/kizuna/auth/api/dto/PasswordChangeRequestTest.java
@@ -1,0 +1,56 @@
+package com.kizuna.auth.api.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** 新パスワードの長さ制約（最小 8 文字・最大 72 バイト）を検証する。 */
+class PasswordChangeRequestTest {
+
+  private static ValidatorFactory factory;
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUp() {
+    factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    factory.close();
+  }
+
+  private PasswordChangeRequest request(String newPassword) {
+    PasswordChangeRequest req = new PasswordChangeRequest();
+    req.setCurrentPassword("current-password");
+    req.setNewPassword(newPassword);
+    return req;
+  }
+
+  @Test
+  void password72Bytes_passes() {
+    assertThat(validator.validateProperty(request("あ".repeat(24)), "newPassword")).isEmpty();
+  }
+
+  @Test
+  void password73Bytes_violates() {
+    assertThat(validator.validateProperty(request("あ".repeat(24) + "a"), "newPassword"))
+        .isNotEmpty();
+  }
+
+  @Test
+  void password7Chars_violates() {
+    assertThat(validator.validateProperty(request("abcdefg"), "newPassword")).isNotEmpty();
+  }
+
+  @Test
+  void password8Chars_passes() {
+    assertThat(validator.validateProperty(request("abcdefgh"), "newPassword")).isEmpty();
+  }
+}

--- a/backend/src/test/java/com/kizuna/cast/api/dto/CastInvitationAcceptRequestTest.java
+++ b/backend/src/test/java/com/kizuna/cast/api/dto/CastInvitationAcceptRequestTest.java
@@ -1,0 +1,54 @@
+package com.kizuna.cast.api.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** パスワードの長さ制約（最小 8 文字・最大 72 バイト）を検証する。 */
+class CastInvitationAcceptRequestTest {
+
+  private static ValidatorFactory factory;
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUp() {
+    factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    factory.close();
+  }
+
+  private CastInvitationAcceptRequest request(String password) {
+    CastInvitationAcceptRequest req = new CastInvitationAcceptRequest();
+    req.setPassword(password);
+    return req;
+  }
+
+  @Test
+  void password72Bytes_passes() {
+    assertThat(validator.validateProperty(request("あ".repeat(24)), "password")).isEmpty();
+  }
+
+  @Test
+  void password73Bytes_violates() {
+    assertThat(validator.validateProperty(request("あ".repeat(24) + "a"), "password")).isNotEmpty();
+  }
+
+  @Test
+  void password7Chars_violates() {
+    assertThat(validator.validateProperty(request("abcdefg"), "password")).isNotEmpty();
+  }
+
+  @Test
+  void password8Chars_passes() {
+    assertThat(validator.validateProperty(request("abcdefgh"), "password")).isEmpty();
+  }
+}

--- a/backend/src/test/java/com/kizuna/member/api/dto/MemberRegistrationRequestTest.java
+++ b/backend/src/test/java/com/kizuna/member/api/dto/MemberRegistrationRequestTest.java
@@ -1,0 +1,54 @@
+package com.kizuna.member.api.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** パスワードの長さ制約（最小 8 文字・最大 72 バイト）を検証する。 */
+class MemberRegistrationRequestTest {
+
+  private static ValidatorFactory factory;
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUp() {
+    factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    factory.close();
+  }
+
+  private MemberRegistrationRequest request(String password) {
+    MemberRegistrationRequest req = new MemberRegistrationRequest();
+    req.setPassword(password);
+    return req;
+  }
+
+  @Test
+  void password72Bytes_passes() {
+    assertThat(validator.validateProperty(request("あ".repeat(24)), "password")).isEmpty();
+  }
+
+  @Test
+  void password73Bytes_violates() {
+    assertThat(validator.validateProperty(request("あ".repeat(24) + "a"), "password")).isNotEmpty();
+  }
+
+  @Test
+  void password7Chars_violates() {
+    assertThat(validator.validateProperty(request("abcdefg"), "password")).isNotEmpty();
+  }
+
+  @Test
+  void password8Chars_passes() {
+    assertThat(validator.validateProperty(request("abcdefgh"), "password")).isEmpty();
+  }
+}

--- a/backend/src/test/java/com/kizuna/shared/validation/PasswordValidatorTest.java
+++ b/backend/src/test/java/com/kizuna/shared/validation/PasswordValidatorTest.java
@@ -41,8 +41,8 @@ class PasswordValidatorTest {
   }
 
   @Test
-  void hundredCharsWithinByteLimit_isValid() {
-    // 上限は文字数ではなくバイト数。ASCII なら 72 文字までは通る。
+  void asciiBoundaryIsCountedInBytes() {
+    // 上限は文字数ではなくバイト数。ASCII は 1 文字 1 バイトなので 72 文字までが通る。
     assertThat(validator.isValid("a".repeat(72), null)).isTrue();
     assertThat(validator.isValid("a".repeat(73), null)).isFalse();
   }

--- a/backend/src/test/java/com/kizuna/shared/validation/PasswordValidatorTest.java
+++ b/backend/src/test/java/com/kizuna/shared/validation/PasswordValidatorTest.java
@@ -1,0 +1,57 @@
+package com.kizuna.shared.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+/** 長さ判定そのものと、上限 72 バイトが BCrypt の受け入れ上限と一致することを固定する。 */
+class PasswordValidatorTest {
+
+  /** 日本語 24 文字 = UTF-8 で 72 バイトちょうど。 */
+  private static final String LIMIT = "あ".repeat(24);
+
+  private final PasswordValidator validator = new PasswordValidator();
+
+  @Test
+  void nullIsTolerated() {
+    assertThat(validator.isValid(null, null)).isTrue();
+  }
+
+  @Test
+  void exactly72Bytes_isValid() {
+    assertThat(validator.isValid(LIMIT, null)).isTrue();
+  }
+
+  @Test
+  void over72Bytes_isInvalid() {
+    assertThat(validator.isValid(LIMIT + "a", null)).isFalse();
+  }
+
+  @Test
+  void under8Chars_isInvalid() {
+    assertThat(validator.isValid("abcdefg", null)).isFalse();
+  }
+
+  @Test
+  void exactly8Chars_isValid() {
+    assertThat(validator.isValid("abcdefgh", null)).isTrue();
+  }
+
+  @Test
+  void hundredCharsWithinByteLimit_isValid() {
+    // 上限は文字数ではなくバイト数。ASCII なら 72 文字までは通る。
+    assertThat(validator.isValid("a".repeat(72), null)).isTrue();
+    assertThat(validator.isValid("a".repeat(73), null)).isFalse();
+  }
+
+  @Test
+  void boundaryMatchesBCrypt() {
+    BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+    assertThatCode(() -> encoder.encode(LIMIT)).doesNotThrowAnyException();
+    assertThatThrownBy(() -> encoder.encode(LIMIT + "a"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/backend/src/test/java/com/kizuna/user/api/dto/PlatformStaffCreateRequestTest.java
+++ b/backend/src/test/java/com/kizuna/user/api/dto/PlatformStaffCreateRequestTest.java
@@ -1,0 +1,54 @@
+package com.kizuna.user.api.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** パスワードの長さ制約（最小 8 文字・最大 72 バイト）を検証する。 */
+class PlatformStaffCreateRequestTest {
+
+  private static ValidatorFactory factory;
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUp() {
+    factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    factory.close();
+  }
+
+  private PlatformStaffCreateRequest request(String password) {
+    PlatformStaffCreateRequest req = new PlatformStaffCreateRequest();
+    req.setPassword(password);
+    return req;
+  }
+
+  @Test
+  void password72Bytes_passes() {
+    assertThat(validator.validateProperty(request("あ".repeat(24)), "password")).isEmpty();
+  }
+
+  @Test
+  void password73Bytes_violates() {
+    assertThat(validator.validateProperty(request("あ".repeat(24) + "a"), "password")).isNotEmpty();
+  }
+
+  @Test
+  void password7Chars_violates() {
+    assertThat(validator.validateProperty(request("abcdefg"), "password")).isNotEmpty();
+  }
+
+  @Test
+  void password8Chars_passes() {
+    assertThat(validator.validateProperty(request("abcdefgh"), "password")).isEmpty();
+  }
+}

--- a/backend/src/test/java/com/kizuna/user/api/dto/StoreManagerAppointRequestTest.java
+++ b/backend/src/test/java/com/kizuna/user/api/dto/StoreManagerAppointRequestTest.java
@@ -1,0 +1,60 @@
+package com.kizuna.user.api.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** パスワードの長さ制約（最小 8 文字・最大 72 バイト）を検証する。二択の要求のため未指定は制約に触れない。 */
+class StoreManagerAppointRequestTest {
+
+  private static ValidatorFactory factory;
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUp() {
+    factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    factory.close();
+  }
+
+  private StoreManagerAppointRequest request(String password) {
+    StoreManagerAppointRequest req = new StoreManagerAppointRequest();
+    req.setPassword(password);
+    return req;
+  }
+
+  @Test
+  void password72Bytes_passes() {
+    assertThat(validator.validateProperty(request("あ".repeat(24)), "password")).isEmpty();
+  }
+
+  @Test
+  void password73Bytes_violates() {
+    assertThat(validator.validateProperty(request("あ".repeat(24) + "a"), "password")).isNotEmpty();
+  }
+
+  @Test
+  void password7Chars_violates() {
+    assertThat(validator.validateProperty(request("abcdefg"), "password")).isNotEmpty();
+  }
+
+  @Test
+  void password8Chars_passes() {
+    assertThat(validator.validateProperty(request("abcdefgh"), "password")).isEmpty();
+  }
+
+  @Test
+  void nullPassword_passes() {
+    // user_id を送る既存アカウント任命の形。必須判定は application 層が担う。
+    assertThat(validator.validateProperty(request(null), "password")).isEmpty();
+  }
+}

--- a/backend/src/test/java/com/kizuna/user/api/dto/StoreStaffCreateRequestTest.java
+++ b/backend/src/test/java/com/kizuna/user/api/dto/StoreStaffCreateRequestTest.java
@@ -1,0 +1,54 @@
+package com.kizuna.user.api.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** パスワードの長さ制約（最小 8 文字・最大 72 バイト）を検証する。 */
+class StoreStaffCreateRequestTest {
+
+  private static ValidatorFactory factory;
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUp() {
+    factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    factory.close();
+  }
+
+  private StoreStaffCreateRequest request(String password) {
+    StoreStaffCreateRequest req = new StoreStaffCreateRequest();
+    req.setPassword(password);
+    return req;
+  }
+
+  @Test
+  void password72Bytes_passes() {
+    assertThat(validator.validateProperty(request("あ".repeat(24)), "password")).isEmpty();
+  }
+
+  @Test
+  void password73Bytes_violates() {
+    assertThat(validator.validateProperty(request("あ".repeat(24) + "a"), "password")).isNotEmpty();
+  }
+
+  @Test
+  void password7Chars_violates() {
+    assertThat(validator.validateProperty(request("abcdefg"), "password")).isNotEmpty();
+  }
+
+  @Test
+  void password8Chars_passes() {
+    assertThat(validator.validateProperty(request("abcdefgh"), "password")).isEmpty();
+  }
+}

--- a/backend/src/test/java/com/kizuna/user/application/StoreStaffServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/StoreStaffServiceTest.java
@@ -67,6 +67,12 @@ class StoreStaffServiceTest {
   /** 委譲権限を含まない店舗側ロール。店長が付与できる唯一の種類。 */
   private static final long CLERK_ROLE = 12L;
 
+  /**
+   * 店舗コンソールの実動権限を 1 つも含まない自作ロール。標識権限だけの形と SHARED だけの形の双方を代表する — その 2 形の区別は権限目録側の述語（{@code
+   * PermissionCodeTest}）と統合テストが持ち、ここが固定するのは守衛の配線である。
+   */
+  private static final long NO_CONSOLE_ROLE = 13L;
+
   private static final long CONTEXT_STORE = 1L;
   private static final long OTHER_STORE = 2L;
 
@@ -128,6 +134,11 @@ class StoreStaffServiceTest {
   private void givenStaffManageRoles() {
     when(roleRepository.findIdsByPermissionCode(PermissionCode.STAFF_MANAGE.name()))
         .thenReturn(Set.of(MANAGER_ROLE));
+  }
+
+  /** 店舗コンソールへ入れるロールの解決を差し込む。NO_CONSOLE_ROLE だけがこの集合の外にある。 */
+  private void givenStoreConsoleRoles() {
+    when(roleRepository.findStoreConsoleRoleIds()).thenReturn(Set.of(MANAGER_ROLE, CLERK_ROLE));
   }
 
   private Role role(long id, String name) {
@@ -303,6 +314,7 @@ class StoreStaffServiceTest {
     givenHqSideRoles();
     givenRoleNames();
     givenHqActor();
+    givenStoreConsoleRoles();
     when(encoder.encode(RAW_CREDENTIAL)).thenReturn("hashed");
     when(repository.findByEmail("new@kizuna.test")).thenReturn(Optional.empty());
     when(repository.saveAndFlush(userCaptor.capture()))
@@ -318,11 +330,83 @@ class StoreStaffServiceTest {
   }
 
   @Test
+  @DisplayName("作成: 店舗コンソールへ入れないロール構成は拒否されること")
+  void createRejectsRoleSetThatCannotReachStoreConsole() {
+    givenHqSideRoles();
+    givenStaffManageRoles();
+    givenStoreConsoleRoles();
+    givenManagerActor(CONTEXT_STORE);
+
+    assertThatThrownBy(
+            () ->
+                service.create(
+                    createRequest(
+                        Set.of(NO_CONSOLE_ROLE),
+                        StoreScopeType.SPECIFIC_STORES,
+                        Set.of(CONTEXT_STORE))))
+        .isInstanceOf(InvalidRoleGrantException.class);
+    verify(repository, never()).saveAndFlush(ArgumentMatchers.any());
+  }
+
+  @Test
+  @DisplayName("作成: 標識権限だけのロールも実動権限を含むロールと併せれば付与できること（判定は権限の並集）")
+  void createAcceptsRoleWithoutConsoleWhenCombinedWithOneThatHasIt() {
+    givenHqSideRoles();
+    givenStaffManageRoles();
+    givenStoreConsoleRoles();
+    givenRoleNames();
+    givenManagerActor(CONTEXT_STORE);
+    when(encoder.encode(RAW_CREDENTIAL)).thenReturn("hashed");
+    when(repository.findByEmail("new@kizuna.test")).thenReturn(Optional.empty());
+    when(repository.saveAndFlush(userCaptor.capture()))
+        .thenAnswer(StoreStaffServiceTest::persisted);
+
+    service.create(
+        createRequest(
+            Set.of(NO_CONSOLE_ROLE, CLERK_ROLE),
+            StoreScopeType.SPECIFIC_STORES,
+            Set.of(CONTEXT_STORE)));
+
+    assertThat(userCaptor.getValue().getRoleIds())
+        .containsExactlyInAnyOrder(NO_CONSOLE_ROLE, CLERK_ROLE);
+  }
+
+  @Test
+  @DisplayName("編集: 店舗コンソールへ入れないロール構成への変更は拒否されること（判定は更新後の集合）")
+  void updateRejectsRoleSetThatCannotReachStoreConsole() {
+    PlatformUser target =
+        staff(
+            1L,
+            "clerk@kizuna.test",
+            Set.of(CLERK_ROLE),
+            StoreScopeType.SPECIFIC_STORES,
+            Set.of(CONTEXT_STORE));
+    when(repository.findById(1L)).thenReturn(Optional.of(target));
+    givenHqSideRoles();
+    givenStaffManageRoles();
+    givenStoreConsoleRoles();
+    givenContextStore();
+    givenManagerActor(CONTEXT_STORE);
+
+    assertThatThrownBy(
+            () ->
+                service.update(
+                    1L,
+                    updateRequest(
+                        Set.of(NO_CONSOLE_ROLE),
+                        StoreScopeType.SPECIFIC_STORES,
+                        Set.of(CONTEXT_STORE))))
+        .isInstanceOf(InvalidRoleGrantException.class);
+    assertThat(target.getRoleIds()).as("拒否された編集が部分適用されていないこと").containsExactly(CLERK_ROLE);
+  }
+
+  @Test
   @DisplayName("作成: 担当外店舗を含む店舗集合の指定が拒否されること（G2）")
   void createRejectsStoresOutsideActorScope() {
     givenHqSideRoles();
     givenStaffManageRoles();
     givenManagerActor(CONTEXT_STORE);
+    givenStoreConsoleRoles();
 
     assertThatThrownBy(
             () ->
@@ -340,6 +424,7 @@ class StoreStaffServiceTest {
     givenHqSideRoles();
     givenStaffManageRoles();
     givenManagerActor(CONTEXT_STORE);
+    givenStoreConsoleRoles();
 
     assertThatThrownBy(
             () ->
@@ -476,6 +561,7 @@ class StoreStaffServiceTest {
     givenRoleNames();
     givenContextStore();
     givenManagerActor(CONTEXT_STORE);
+    givenStoreConsoleRoles();
 
     StoreStaffUpdateRequest req =
         updateRequest(Set.of(CLERK_ROLE), StoreScopeType.SPECIFIC_STORES, Set.of(CONTEXT_STORE));

--- a/backend/src/test/java/com/kizuna/user/domain/PermissionCodeTest.java
+++ b/backend/src/test/java/com/kizuna/user/domain/PermissionCodeTest.java
@@ -58,6 +58,23 @@ class PermissionCodeTest {
   }
 
   @Test
+  @DisplayName("店舗コンソールの入場資格は STORE の権限から標識権限を除いたもの")
+  void storeConsoleCodesExcludeTheMenuMarkerAndSharedPermissions() {
+    // 着地の判定と付与時の検証が共有する述語の定義そのもの。標識権限だけ、あるいは SHARED だけのロールを
+    // 資格ありに数えると、作成はできるのにログイン後どこへも着地できないアカウントが通ってしまう。
+    assertThat(PermissionCode.STORE_MENU_VIEW.grantsStoreConsole()).isFalse();
+    assertThat(PermissionCode.STORE_VIEW.grantsStoreConsole()).isFalse();
+    assertThat(PermissionCode.ORDER_MANAGE.grantsStoreConsole()).isTrue();
+    assertThat(PermissionCode.storeConsoleCodes())
+        .contains(PermissionCode.ORDER_MANAGE.name(), PermissionCode.STAFF_MANAGE.name())
+        .doesNotContain(
+            PermissionCode.STORE_MENU_VIEW.name(),
+            PermissionCode.STORE_VIEW.name(),
+            PermissionCode.ORDER_SET_MANAGE.name(),
+            PermissionCode.ROLE_MANAGE.name());
+  }
+
+  @Test
   @DisplayName("権限目録は 20 個で全てコンソール分類を持つ")
   void catalogIsComplete() {
     assertThat(PermissionCode.values()).hasSize(20);

--- a/backend/src/test/java/com/kizuna/user/domain/RoleRepositoryTest.java
+++ b/backend/src/test/java/com/kizuna/user/domain/RoleRepositoryTest.java
@@ -34,4 +34,25 @@ class RoleRepositoryTest {
             PermissionCode.STORE_VIEW.name(),
             PermissionCode.ORDER_MANAGE.name());
   }
+
+  @Test
+  @DisplayName("店舗コンソールへ入れるロールは標識権限だけ・SHARED だけの権限からは解決されない")
+  void storeConsoleRoleIsResolvedFromOperationalStorePermissionsOnly() {
+    // 授与の検証はこの目録で行い、着地の判定（PlatformAuthService）と述語を共有する。
+    // 目録が緩むと、付与はできるのにログイン後どこへも着地できないアカウントが作れてしまう。
+    RoleRepository repository = mock(RoleRepository.class);
+    when(repository.findStoreConsoleRoleIds()).thenCallRealMethod();
+    when(repository.findIdsByPermissionCodeIn(anyCollection())).thenReturn(Set.of(8L));
+
+    assertThat(repository.findStoreConsoleRoleIds()).containsExactly(8L);
+
+    ArgumentCaptor<Collection<String>> codes = ArgumentCaptor.captor();
+    verify(repository).findIdsByPermissionCodeIn(codes.capture());
+    assertThat(codes.getValue())
+        .contains(PermissionCode.ORDER_MANAGE.name(), PermissionCode.STAFF_MANAGE.name())
+        .doesNotContain(
+            PermissionCode.STORE_MENU_VIEW.name(),
+            PermissionCode.STORE_VIEW.name(),
+            PermissionCode.ROLE_MANAGE.name());
+  }
 }


### PR DESCRIPTION
## 概要

パスワードを受け取る全経路の検証を BCrypt の実制限（72 **バイト**）に合わせ、500 で落ちる穴を塞いだ。あわせて、店舗コンソールへ着地できないロール構成でのスタッフ授権を作成・更新時に 400 で拒むようにした。

Closes #783
Closes #784

## 変更内容

- 共通制約 `@Password`（`shared/validation`）を新設: 最小 8 文字 + 最大 72 UTF-8 バイト、null 宽容（必須性は既存の `@NotBlank` / サービス側検査が持つ）
- 明文パスワードを受け取る 6 経路（`PasswordChangeRequest` / `PlatformStaffCreateRequest` / `StoreStaffCreateRequest` / `StoreManagerAppointRequest` / `CastInvitationAcceptRequest` / `MemberRegistrationRequest`）へ `@Password` を適用。`@Size(min=8,max=100)` は置換（叠加ではない）
- `PermissionCode#grantsStoreConsole()` を新設し、「店舗コンソールに数える権限」の述語を単源化。ログイン着地側 `PlatformAuthService.hasStoreConsole` と授権検証の双方が消費
- `POST /store/staff-members` / `PUT /store/staff-members/{id}` に肯定側守衛を追加: 選択ロールの権限**並集**に標識権限 `STORE_MENU_VIEW` 以外の `Console.STORE` 権限が 1 つ以上含まれなければ 400。PUT は更新後の最終集合で判定
- `GET /store/staff-members/grantable-roles` は意図的に濾さない（条件が並集性のため、標識権限のみのロールも実権ロールとの組合せでは合法）。この不変量を統合テストで固定
- 統合テストの新規作成用合言葉を `CrossStoreTestSupport.NEW_ACCOUNT_PASSWORD` へ単源化（最小 8 文字の影響で種子合言葉 `pass` が使えなくなったため）

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全 34 シナリオ、店舗スタッフ管理 4 件を含む）
- [x] ローカルで code-review 実施済み（Standards / Spec 二軸、指摘 4 件消化・1 件見送り→備考）

TDD の赤証: #783 は 73 バイト（かな 24 + ASCII 1）と 7 文字の要求で 9 件赤 → 修正後緑。#784 は守衛未接続の状態で「作成/編集: 店舗コンソールへ入れないロール構成」2 件赤 → 接続後緑。さらに述語の変異（`!= STORE_MENU_VIEW` を削除）で着地判定・授権検証の既存/新規テスト 4 件が同時に赤になることを実測し、単源化の成立を確認した。

## 決定ログ

- **#783 の形態**: 文字数の `@Size` では多バイト文字の穴が残るため、バイト長を検証する共通注釈を 1 か所に置いた。境界は spring-security-crypto 7.1.1 `BCrypt.java:615`（`> 72` で throw）に一致させ、72 バイトは通し 73 バイトで拒む。issue 記載の 4 経路に加え、`.encode(` 呼び出し元の全量走査でキャスト招待受諾・会員登録の 2 経路を発見し同時に塞いだ（`randomPassword()` は 43 ASCII バイトで限内、`matches()` は `for_check=true` のため截断挙動で影響なし）
- **#784 の規則**: issue が素描した「選択ロールの並集に標識以外の `Console.STORE` 権限 ≥1」を採用した。#762 の裁定に無い規則のため、本 PR のレビューが否決点になる
- **読み口を濾さない選択**: ロール単位の濾過は並集性の条件を表現できず、標識権限のみのロール（メニュー節の通行証）と実権ロールの合法な組合せを丸ごと選べなくする誤殺のため見送り。写入側の守衛のみが正
- **並發姿態**: 既存の否定形 2 検査（HQ 側ロール排除・委譲権限排除）と同じく無ロックの通常読取に揃えた。G5 の直列化点は跨行の母集団不変量を守るもので、本守衛は要求単位の述語のため別類。授権済みロールの権限を後から空にする競合は #762 系の別案として射程外

## 備考 / レビュー観点

- 統合テストの合言葉を `NEW_ACCOUNT_PASSWORD`（新規作成用）と `PASSWORD`（種子ログイン用）に分けたのは、単一常量に寄せるとどちらかが即 401 になるため。また最小長導入で「別の理由で 400 が続いて緑」に化ける既存テストが数件あり、fixture 側で塞いだ
- DTO ごとの接線テスト 6 本は様板が重複するが、4 モジュール（auth/user/cast/member）を跨ぐ共有基底はモジュール間結合を生むため抽象化を見送った（評審指摘に対する判断）
- ADR 0020 の守衛表は G1〜G5 で埋まっているため、本守衛は無番号で `StoreStaffService` の類 Javadoc にのみ記載。表へ載せる場合は別途 1 行の追加が要る
