### PR TITLE
feat: パスワード再設定 — アカウント管理からの発行と再設定境界（G6）

### DIFF
--- a/backend/docs/modulith/module-auth.adoc
+++ b/backend/docs/modulith/module-auth.adoc
@@ -10,6 +10,7 @@
 * `c.k.s.config.AppProperties` (in Shared)
 * `c.k.s.application.SystemConfigService` (in Settings)
 |Events listened to
-|* `c.k.u.domain.PlatformUserResumed` 
+|* `c.k.u.domain.PlatformUserPasswordReset` 
+* `c.k.u.domain.PlatformUserResumed` 
 * `c.k.u.domain.PlatformUserStopped` 
 |===

--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffPasswordResetIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffPasswordResetIT.java
@@ -2,12 +2,15 @@ package com.kizuna.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.kizuna.auth.infrastructure.TokenBlacklistService;
 import com.kizuna.shared.config.AppProperties;
 import com.kizuna.user.domain.PlatformUser;
 import com.kizuna.user.domain.PlatformUserRepository;
 import com.kizuna.user.domain.RoleRepository;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -52,6 +55,7 @@ class PlatformStaffPasswordResetIT {
   private static final String RESUME_EMAIL = "pwreset-resume@kizuna.test";
   private static final String SECRET_EMAIL = "pwreset-secret@kizuna.test";
   private static final String TTL_EMAIL = "pwreset-ttl@kizuna.test";
+  private static final String MONOTONIC_EMAIL = "pwreset-monotonic@kizuna.test";
 
   /** 再設定の対象に使う店舗側ロール。HQ 側の権限を含まないので守衛 G6 に掛からない。 */
   private static final String TARGET_ROLE = "店長";
@@ -68,12 +72,20 @@ class PlatformStaffPasswordResetIT {
   @Autowired private PasswordEncoder passwordEncoder;
   @Autowired private RedisTemplate<String, Object> redisTemplate;
   @Autowired private AppProperties appProperties;
+  @Autowired private TokenBlacklistService tokenBlacklistService;
 
   /** 各テストで書かれ得る 2 系統の key を後始末する（テスト間の Redis 状態汚染を防ぐ）。 */
   @AfterEach
   void cleanupRedis() {
     for (String email :
-        List.of(ADMIN_EMAIL, RESET_EMAIL, REVOKE_EMAIL, RESUME_EMAIL, SECRET_EMAIL, TTL_EMAIL)) {
+        List.of(
+            ADMIN_EMAIL,
+            RESET_EMAIL,
+            REVOKE_EMAIL,
+            RESUME_EMAIL,
+            SECRET_EMAIL,
+            TTL_EMAIL,
+            MONOTONIC_EMAIL)) {
       redisTemplate.delete(USER_BLACKLIST_KEY_PREFIX + email);
       redisTemplate.delete(PASSWORD_RESET_KEY_PREFIX + email);
     }
@@ -254,7 +266,7 @@ class PlatformStaffPasswordResetIT {
     String adminToken = platformToken(ADMIN_EMAIL, TEST_PASSWORD);
     PlatformUser admin = platformUserRepository.findByEmail(ADMIN_EMAIL).orElseThrow();
 
-    // 実行主体は必ず HQ 側ロールを持つため、自己再設定は G6 に吸収されて拒否される。
+    // 自己再設定は G6 に委ねず名指しで拒む（JWT の権限は写しで、降格後の残存セッションが G6 を素通りするため）。
     assertThat(resetPassword(adminToken, admin.getId()).getStatusCode())
         .isEqualTo(HttpStatus.BAD_REQUEST);
 
@@ -303,5 +315,18 @@ class PlatformStaffPasswordResetIT {
     assertThat(ttlMillis).isNotNull();
     assertThat(ttlMillis).isLessThanOrEqualTo(expiration);
     assertThat(ttlMillis).isGreaterThan(expiration - 60_000);
+  }
+
+  @Test
+  @DisplayName("再設定の記録は単調で、遅れて届いた古い時刻が新しい境界を巻き戻さないこと")
+  void passwordResetMarkerIsMonotonic() {
+    // 再設定が重なると commit 順と書込み順は一致しない。素の SET なら本テストは現在時刻へ巻き戻って赤になる。
+    String key = PASSWORD_RESET_KEY_PREFIX + MONOTONIC_EMAIL;
+    String newerBoundary = String.valueOf(Instant.now().getEpochSecond() + 600);
+    redisTemplate.opsForValue().set(key, newerBoundary, Duration.ofMinutes(5));
+
+    tokenBlacklistService.markPasswordReset(MONOTONIC_EMAIL);
+
+    assertThat(redisTemplate.opsForValue().get(key)).as("より新しい境界が残ること").isEqualTo(newerBoundary);
   }
 }

--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffPasswordResetIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffPasswordResetIT.java
@@ -320,12 +320,13 @@ class PlatformStaffPasswordResetIT {
   @Test
   @DisplayName("再設定の記録は単調で、遅れて届いた古い時刻が新しい境界を巻き戻さないこと")
   void passwordResetMarkerIsMonotonic() {
-    // 再設定が重なると commit 順と書込み順は一致しない。素の SET なら本テストは現在時刻へ巻き戻って赤になる。
+    // 再設定が重なると commit 順と callback 実行順は一致しない。素の SET なら本テストは古い境界へ巻き戻って赤になる。
     String key = PASSWORD_RESET_KEY_PREFIX + MONOTONIC_EMAIL;
-    String newerBoundary = String.valueOf(Instant.now().getEpochSecond() + 600);
+    long newerSeconds = Instant.now().getEpochSecond();
+    String newerBoundary = String.valueOf(newerSeconds);
     redisTemplate.opsForValue().set(key, newerBoundary, Duration.ofMinutes(5));
 
-    tokenBlacklistService.markPasswordReset(MONOTONIC_EMAIL);
+    tokenBlacklistService.markPasswordReset(MONOTONIC_EMAIL, newerSeconds - 30);
 
     assertThat(redisTemplate.opsForValue().get(key)).as("より新しい境界が残ること").isEqualTo(newerBoundary);
   }

--- a/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffPasswordResetIT.java
+++ b/backend/src/integrationTest/java/com/kizuna/user/PlatformStaffPasswordResetIT.java
@@ -1,0 +1,307 @@
+package com.kizuna.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.kizuna.shared.config.AppProperties;
+import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserRepository;
+import com.kizuna.user.domain.RoleRepository;
+import com.kizuna.user.domain.StoreScopeType;
+import com.kizuna.user.domain.UserType;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * HQ 管理者によるパスワード再設定（{@code POST /platform/staff-accounts/{id}/password-reset}）を本物の PostgreSQL +
+ * Redis で固定する統合テスト。実行主体は種子の HQ 管理者 admin@kizuna.test。
+ *
+ * <p>専用鍵（{@code blacklist:password-reset:}）を停止用の鍵と分けてある理由そのものを {@link
+ * #resumingAfterResetDoesNotReviveThePreResetToken} が固定する — 鍵を共用すると無関係な再開 1 回で再設定前のセッションが蘇る。
+ *
+ * <p>対象は repository 直挿の専用テストユーザーのみを使う（種子ユーザーの資格情報を書き換えると後続 IT が連鎖破綻するため）。{@link
+ * PlatformStaffRevocationIT} と同じ理由で {@code CrossStoreTestSupport} は継承しない。
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestRestTemplate
+class PlatformStaffPasswordResetIT {
+
+  private static final String TEST_PASSWORD = "pass";
+
+  /** 種子の HQ 管理者（PERM_STAFF_ACCOUNT_MANAGE 保持、再設定操作の実行主体）。 */
+  private static final String ADMIN_EMAIL = "admin@kizuna.test";
+
+  private static final String RESET_EMAIL = "pwreset-target@kizuna.test";
+  private static final String REVOKE_EMAIL = "pwreset-revoke@kizuna.test";
+  private static final String RESUME_EMAIL = "pwreset-resume@kizuna.test";
+  private static final String SECRET_EMAIL = "pwreset-secret@kizuna.test";
+  private static final String TTL_EMAIL = "pwreset-ttl@kizuna.test";
+
+  /** 再設定の対象に使う店舗側ロール。HQ 側の権限を含まないので守衛 G6 に掛からない。 */
+  private static final String TARGET_ROLE = "店長";
+
+  private static final String USER_BLACKLIST_KEY_PREFIX = "blacklist:users:";
+  private static final String PASSWORD_RESET_KEY_PREFIX = "blacklist:password-reset:";
+
+  /** 同一秒に発行された旧トークンは意図的に生き残るため、旧トークンと再設定の間に 1 秒以上空ける。 */
+  private static final long SECOND_BOUNDARY_MILLIS = 1_100L;
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private PlatformUserRepository platformUserRepository;
+  @Autowired private RoleRepository roleRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+  @Autowired private RedisTemplate<String, Object> redisTemplate;
+  @Autowired private AppProperties appProperties;
+
+  /** 各テストで書かれ得る 2 系統の key を後始末する（テスト間の Redis 状態汚染を防ぐ）。 */
+  @AfterEach
+  void cleanupRedis() {
+    for (String email :
+        List.of(ADMIN_EMAIL, RESET_EMAIL, REVOKE_EMAIL, RESUME_EMAIL, SECRET_EMAIL, TTL_EMAIL)) {
+      redisTemplate.delete(USER_BLACKLIST_KEY_PREFIX + email);
+      redisTemplate.delete(PASSWORD_RESET_KEY_PREFIX + email);
+    }
+  }
+
+  /**
+   * 専用テストユーザーを取得または作成する。前回実行が残した停止状態とパスワードを毎回初期値へ戻す — 本 IT は対象のパスワードを書き換えるため、戻さないと 2
+   * 回目以降の実行が前提のログインで落ちる。
+   */
+  private PlatformUser ensureResettableTestUser(String email) {
+    PlatformUser user =
+        platformUserRepository
+            .findByEmail(email)
+            .orElseGet(
+                () ->
+                    platformUserRepository.save(
+                        PlatformUser.builder()
+                            .email(email)
+                            .password(passwordEncoder.encode(TEST_PASSWORD))
+                            .displayName("再設定IT " + email)
+                            .enabled(true)
+                            .userType(UserType.STAFF)
+                            .roleIds(roleIdsOf(TARGET_ROLE))
+                            .storeScopeType(StoreScopeType.ALL_STORES)
+                            .storeIds(Set.of())
+                            .build()));
+    if (!user.getEnabled()) {
+      user.resume();
+    }
+    user.changePassword(passwordEncoder.encode(TEST_PASSWORD));
+    return platformUserRepository.saveAndFlush(user);
+  }
+
+  /** 種子の既定束を名称で解決する（束はデータ — id を決め打ちしない）。 */
+  private Set<Long> roleIdsOf(String roleName) {
+    return Set.of(roleRepository.findByName(roleName).orElseThrow().getId());
+  }
+
+  private String platformToken(String email, String password) {
+    ResponseEntity<JsonNode> res =
+        rest.postForEntity(
+            "/platform/login",
+            new HttpEntity<>(
+                String.format("{\"email\": \"%s\", \"password\": \"%s\"}", email, password),
+                jsonHeaders()),
+            JsonNode.class);
+    assertThat(res.getStatusCode()).as("前提: 平台ログインが成功すること").isEqualTo(HttpStatus.OK);
+    String token = res.getBody().path("token").asString();
+    assertThat(token).isNotBlank();
+    return token;
+  }
+
+  private static HttpHeaders jsonHeaders() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return headers;
+  }
+
+  private static HttpHeaders bearer(String token) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(token);
+    return headers;
+  }
+
+  private ResponseEntity<String> meWith(String token) {
+    return rest.exchange(
+        "/platform/me", HttpMethod.GET, new HttpEntity<>(bearer(token)), String.class);
+  }
+
+  private ResponseEntity<JsonNode> resetPassword(String actorToken, long targetId) {
+    return rest.exchange(
+        "/platform/staff-accounts/" + targetId + "/password-reset",
+        HttpMethod.POST,
+        new HttpEntity<>(bearer(actorToken)),
+        JsonNode.class);
+  }
+
+  private ResponseEntity<String> suspend(String actorToken, long targetId) {
+    return rest.exchange(
+        "/platform/staff-accounts/" + targetId + "/suspension",
+        HttpMethod.POST,
+        new HttpEntity<>(bearer(actorToken)),
+        String.class);
+  }
+
+  private ResponseEntity<String> resume(String actorToken, long targetId) {
+    return rest.exchange(
+        "/platform/staff-accounts/" + targetId + "/resumption",
+        HttpMethod.POST,
+        new HttpEntity<>(bearer(actorToken)),
+        String.class);
+  }
+
+  private static String temporaryPasswordOf(ResponseEntity<JsonNode> response) {
+    String temporary = response.getBody().path("temporary_password").asString();
+    assertThat(temporary).as("仮パスワードの生値が snake_case のキーで返ること").isNotBlank();
+    return temporary;
+  }
+
+  @Test
+  @DisplayName("店舗側ロールだけの対象は再設定に成功し、返された仮パスワードでログインして /platform/me が読めること")
+  void resetIssuesATemporaryPasswordThatCanLogIn() {
+    PlatformUser target = ensureResettableTestUser(RESET_EMAIL);
+    String admin = platformToken(ADMIN_EMAIL, TEST_PASSWORD);
+
+    ResponseEntity<JsonNode> response = resetPassword(admin, target.getId());
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    String temporary = temporaryPasswordOf(response);
+
+    // 再設定と同じ秒に発行される token も受理される（比較が厳密な iat < resetAt であることの実証）。
+    String newToken = platformToken(RESET_EMAIL, temporary);
+    assertThat(meWith(newToken).getStatusCode())
+        .as("仮パスワードで得た新しいトークンは通ること")
+        .isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  @DisplayName("再設定前に発行された JWT は再設定直後に 401 になること")
+  void resetRevokesPreviouslyIssuedTokens() throws InterruptedException {
+    PlatformUser target = ensureResettableTestUser(REVOKE_EMAIL);
+    String oldToken = platformToken(REVOKE_EMAIL, TEST_PASSWORD);
+    assertThat(meWith(oldToken).getStatusCode()).as("前提: 再設定前は me が読めること").isEqualTo(HttpStatus.OK);
+
+    // 旧トークンの iat が再設定時刻と同じ秒に落ちると意図どおり生き残るため、秒境界を跨がせる。
+    Thread.sleep(SECOND_BOUNDARY_MILLIS);
+    String admin = platformToken(ADMIN_EMAIL, TEST_PASSWORD);
+    assertThat(resetPassword(admin, target.getId()).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    assertThat(meWith(oldToken).getStatusCode())
+        .as("再設定前に発行された JWT は即時に拒否されること")
+        .isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  /** 専用鍵の独立性を固定する。停止用の鍵を共用する実装だと、再開が {@code clearUser} で鍵を消してしまい 再設定前のトークンが蘇るため、この命題が赤になる。 */
+  @Test
+  @DisplayName("再設定後に停止・再開しても、再設定前のトークンは 401 のままであること（専用鍵が再開で消えない）")
+  void resumingAfterResetDoesNotReviveThePreResetToken() throws InterruptedException {
+    PlatformUser target = ensureResettableTestUser(RESUME_EMAIL);
+    String oldToken = platformToken(RESUME_EMAIL, TEST_PASSWORD);
+    assertThat(meWith(oldToken).getStatusCode()).as("前提: 再設定前は me が読めること").isEqualTo(HttpStatus.OK);
+
+    Thread.sleep(SECOND_BOUNDARY_MILLIS);
+    String admin = platformToken(ADMIN_EMAIL, TEST_PASSWORD);
+    String temporary = temporaryPasswordOf(resetPassword(admin, target.getId()));
+
+    assertThat(suspend(admin, target.getId()).getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    assertThat(resume(admin, target.getId()).getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+    assertThat(meWith(oldToken).getStatusCode())
+        .as("再開は停止の鍵しか解かない — 再設定前のトークンは失効したままであること")
+        .isEqualTo(HttpStatus.UNAUTHORIZED);
+    // 対照: 再開後の対象自身は仮パスワードで正常にログインできる（失効が過剰に効いていない）。
+    assertThat(meWith(platformToken(RESUME_EMAIL, temporary)).getStatusCode())
+        .as("再開後は仮パスワードでの新規ログインが通ること")
+        .isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  @DisplayName("HQ 側ロール保持者への再設定は 400 になり、店舗側ロールの対象は 200 になること（境界 G6 の両側）")
+  void hqRoleHolderIsRejectedWhileStoreSideTargetSucceeds() {
+    String admin = platformToken(ADMIN_EMAIL, TEST_PASSWORD);
+    PlatformUser hqAdmin = platformUserRepository.findByEmail(ADMIN_EMAIL).orElseThrow();
+
+    assertThat(resetPassword(admin, hqAdmin.getId()).getStatusCode())
+        .as("HQ 側ロール保持者は再設定できないこと")
+        .isEqualTo(HttpStatus.BAD_REQUEST);
+
+    PlatformUser storeSide = ensureResettableTestUser(RESET_EMAIL);
+    assertThat(resetPassword(admin, storeSide.getId()).getStatusCode())
+        .as("同じ操作が店舗側ロールの対象には通ること（守衛が再設定そのものを塞いでいない対照）")
+        .isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  @DisplayName("実行主体が自分自身へ再設定すると 400 になり、自分のトークンも有効なままであること")
+  void selfResetIsRejected() {
+    String adminToken = platformToken(ADMIN_EMAIL, TEST_PASSWORD);
+    PlatformUser admin = platformUserRepository.findByEmail(ADMIN_EMAIL).orElseThrow();
+
+    // 実行主体は必ず HQ 側ロールを持つため、自己再設定は G6 に吸収されて拒否される。
+    assertThat(resetPassword(adminToken, admin.getId()).getStatusCode())
+        .isEqualTo(HttpStatus.BAD_REQUEST);
+
+    assertThat(redisTemplate.hasKey(PASSWORD_RESET_KEY_PREFIX + ADMIN_EMAIL))
+        .as("拒否されたため再設定の記録は書かれないこと")
+        .isNotEqualTo(true);
+    assertThat(meWith(adminToken).getStatusCode())
+        .as("自己再設定が拒否されたため管理者自身のトークンは引き続き有効なこと")
+        .isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  @DisplayName("仮パスワードの生値は応答一度きりで、詳細にも DB にも平文で残らないこと")
+  void temporaryPasswordIsNotRetrievableAfterTheResponse() {
+    PlatformUser target = ensureResettableTestUser(SECRET_EMAIL);
+    String admin = platformToken(ADMIN_EMAIL, TEST_PASSWORD);
+
+    String temporary = temporaryPasswordOf(resetPassword(admin, target.getId()));
+
+    ResponseEntity<String> detail =
+        rest.exchange(
+            "/platform/staff-accounts/" + target.getId(),
+            HttpMethod.GET,
+            new HttpEntity<>(bearer(admin)),
+            String.class);
+    assertThat(detail.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(detail.getBody()).as("詳細の応答本文に生値が現れないこと").doesNotContain(temporary);
+
+    String stored = platformUserRepository.findByEmail(SECRET_EMAIL).orElseThrow().getPassword();
+    assertThat(stored).as("保存値は bcrypt ハッシュであること").startsWith("$2");
+    assertThat(stored).as("保存値が平文でないこと").isNotEqualTo(temporary);
+  }
+
+  @Test
+  @DisplayName("再設定で書き込まれる専用キーの TTL が JWT 有効期間(app.jwt.expiration)と一致すること")
+  void passwordResetKeyTtlMatchesJwtExpiration() {
+    PlatformUser target = ensureResettableTestUser(TTL_EMAIL);
+    String admin = platformToken(ADMIN_EMAIL, TEST_PASSWORD);
+
+    assertThat(resetPassword(admin, target.getId()).getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    Long ttlMillis =
+        redisTemplate.getExpire(PASSWORD_RESET_KEY_PREFIX + TTL_EMAIL, TimeUnit.MILLISECONDS);
+    // 下界も固定する: 上界だけだと TTL を 1 秒に誤設定しても緑のままで、AC「JWT 有効期間と一致」を守れない。
+    long expiration = appProperties.getJwtExpiration();
+    assertThat(ttlMillis).isNotNull();
+    assertThat(ttlMillis).isLessThanOrEqualTo(expiration);
+    assertThat(ttlMillis).isGreaterThan(expiration - 60_000);
+  }
+}

--- a/backend/src/main/java/com/kizuna/auth/application/AuthSessionService.java
+++ b/backend/src/main/java/com/kizuna/auth/application/AuthSessionService.java
@@ -2,6 +2,7 @@ package com.kizuna.auth.application;
 
 import com.kizuna.auth.infrastructure.TokenBlacklistService;
 import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserPasswordReset;
 import com.kizuna.user.domain.PlatformUserRepository;
 import com.kizuna.user.domain.PlatformUserResumed;
 import com.kizuna.user.domain.PlatformUserStopped;
@@ -102,6 +103,16 @@ public class AuthSessionService {
                     .findByEmail(email)
                     .map(PlatformUser::getEnabled)
                     .orElse(false)));
+  }
+
+  /**
+   * パスワード再設定イベントを受けて再設定時刻を記録する（commit 後）。commit 後に書く理由は {@link #onPlatformUserStopped} と同じ。
+   *
+   * <p>停止・再開と違い確定状態の読み直しは要らない。再設定には逆操作が無く、コールバックの実行順が入れ替わっても 記録された時刻が前後するだけで収束先は変わらない。
+   */
+  @EventListener
+  public void onPlatformUserPasswordReset(PlatformUserPasswordReset event) {
+    afterCommit(() -> tokenBlacklistService.markPasswordReset(event.email()));
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/auth/application/AuthSessionService.java
+++ b/backend/src/main/java/com/kizuna/auth/application/AuthSessionService.java
@@ -112,7 +112,8 @@ public class AuthSessionService {
    */
   @EventListener
   public void onPlatformUserPasswordReset(PlatformUserPasswordReset event) {
-    afterCommit(() -> tokenBlacklistService.markPasswordReset(event.email()));
+    afterCommit(
+        () -> tokenBlacklistService.markPasswordReset(event.email(), event.resetAtSeconds()));
   }
 
   /**

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/TokenBlacklistService.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/TokenBlacklistService.java
@@ -2,6 +2,8 @@ package com.kizuna.auth.infrastructure;
 
 import com.kizuna.shared.config.AppProperties;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -11,7 +13,8 @@ import org.springframework.stereotype.Component;
 
 /**
  * JWT ブラックリストの読み書き（Redis）。TTL は token 単位（{@link #blacklist(String)}）は実際の exp まで、ユーザー単位（{@link
- * #blacklistUser(String)}）は JWT 有効期間ぶん。書き込みはセッション失効、判定は認証フィルタから使う。
+ * #blacklistUser(String)}）とパスワード再設定（{@link #markPasswordReset(String)}）は JWT
+ * 有効期間ぶん。書き込みはセッション失効、判定は認証フィルタから使う。
  */
 @Component
 public class TokenBlacklistService {
@@ -20,6 +23,9 @@ public class TokenBlacklistService {
 
   /** ユーザー単位ブラックリストの key 接頭辞。停止済みユーザーの全セッションを email 単位で一括失効させる。 */
   private static final String USER_KEY_PREFIX = "blacklist:users:";
+
+  /** パスワード再設定の key 接頭辞。停止用の鍵と分けてあり、再開（{@link #clearUser}）では決して消さない。 */
+  private static final String PASSWORD_RESET_KEY_PREFIX = "blacklist:password-reset:";
 
   private final RedisTemplate<String, Object> redisTemplate;
   private final AppProperties appProperties;
@@ -95,5 +101,28 @@ public class TokenBlacklistService {
   /** 指定 email がユーザー単位ブラックリストに登録済みかを返す。 */
   public boolean isUserBlacklisted(String email) {
     return Boolean.TRUE.equals(redisTemplate.hasKey(USER_KEY_PREFIX + email));
+  }
+
+  /**
+   * パスワード再設定の時刻を記録し、それ以前に発行された JWT を失効させる（再設定時に使う）。
+   *
+   * <p>停止用の鍵とは独立の鍵を使う。共用すると、無関係な再開操作 1 回（{@link #clearUser}）が再設定前のセッションまで蘇らせてしまう。
+   *
+   * <p>値は書込み時点（＝ commit 後）のエポック秒。TTL は {@link #blacklistUser} と同じ理由で JWT 有効期間ぶん取る —
+   * その時間が経てば再設定前のトークンはどれも自身の期限切れで無効になっている。
+   */
+  public void markPasswordReset(String email) {
+    redisTemplate
+        .opsForValue()
+        .set(
+            PASSWORD_RESET_KEY_PREFIX + email,
+            String.valueOf(Instant.now().getEpochSecond()),
+            Duration.ofMillis(appProperties.getJwtExpiration()));
+  }
+
+  /** 記録済みのパスワード再設定時刻（エポック秒）を返す。記録が無ければ空。 */
+  public Optional<Long> getPasswordResetAtSeconds(String email) {
+    Object value = redisTemplate.opsForValue().get(PASSWORD_RESET_KEY_PREFIX + email);
+    return value == null ? Optional.empty() : Optional.of(Long.parseLong(value.toString()));
   }
 }

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/TokenBlacklistService.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/TokenBlacklistService.java
@@ -2,7 +2,6 @@ package com.kizuna.auth.infrastructure;
 
 import com.kizuna.shared.config.AppProperties;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -119,17 +118,17 @@ public class TokenBlacklistService {
    *
    * <p>停止用の鍵とは独立の鍵を使う。共用すると、無関係な再開操作 1 回（{@link #clearUser}）が再設定前のセッションまで蘇らせてしまう。
    *
-   * <p>値は書込み時点（＝ commit 後）のエポック秒。TTL は {@link #blacklistUser} と同じ理由で JWT 有効期間ぶん取る —
-   * その時間が経てば再設定前のトークンはどれも自身の期限切れで無効になっている。
+   * <p>値は再設定イベント自身が運ぶエポック秒（commit 前に捕獲）。callback の実行時刻で刻むと、遅延した古い callback
+   * が新しい再設定より後の時刻を書き、最新パスワードで得た正当トークンを誤失効させる。捕獲〜commit 間に旧パスワードで ログインされる窓は、既記載の同一秒生存窓に包含される。TTL は
+   * {@link #blacklistUser} と同じ理由で JWT 有効期間ぶん。
    *
-   * <p>書込みは Lua で単調化する。再設定が重なると commit 順と callback 実行順は一致せず、素の SET
-   * では遅れた古い時刻が新しい境界を巻き戻し、両境界の間に発行されたトークンが復活し得る。
+   * <p>書込みは Lua で単調化する。素の SET では遅れた古い callback が新しい境界を巻き戻し、両境界の間に発行されたトークンが復活し得る。
    */
-  public void markPasswordReset(String email) {
+  public void markPasswordReset(String email, long resetAtSeconds) {
     redisTemplate.execute(
         MONOTONIC_MARK,
         List.of(PASSWORD_RESET_KEY_PREFIX + email),
-        String.valueOf(Instant.now().getEpochSecond()),
+        String.valueOf(resetAtSeconds),
         String.valueOf(appProperties.getJwtExpiration()));
   }
 

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/TokenBlacklistService.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/TokenBlacklistService.java
@@ -3,8 +3,10 @@ package com.kizuna.auth.infrastructure;
 import com.kizuna.shared.config.AppProperties;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtException;
@@ -26,6 +28,15 @@ public class TokenBlacklistService {
 
   /** パスワード再設定の key 接頭辞。停止用の鍵と分けてあり、再開（{@link #clearUser}）では決して消さない。 */
   private static final String PASSWORD_RESET_KEY_PREFIX = "blacklist:password-reset:";
+
+  /** 既存値以上のときだけ書く（単調書込み）。巻き戻さないことは Redis 側の原子性で保証する。 */
+  private static final RedisScript<Long> MONOTONIC_MARK =
+      RedisScript.of(
+          "local cur = redis.call('GET', KEYS[1]) "
+              + "if cur and tonumber(cur) >= tonumber(ARGV[1]) then return 0 end "
+              + "redis.call('SET', KEYS[1], ARGV[1], 'PX', ARGV[2]) "
+              + "return 1",
+          Long.class);
 
   private final RedisTemplate<String, Object> redisTemplate;
   private final AppProperties appProperties;
@@ -110,14 +121,16 @@ public class TokenBlacklistService {
    *
    * <p>値は書込み時点（＝ commit 後）のエポック秒。TTL は {@link #blacklistUser} と同じ理由で JWT 有効期間ぶん取る —
    * その時間が経てば再設定前のトークンはどれも自身の期限切れで無効になっている。
+   *
+   * <p>書込みは Lua で単調化する。再設定が重なると commit 順と callback 実行順は一致せず、素の SET
+   * では遅れた古い時刻が新しい境界を巻き戻し、両境界の間に発行されたトークンが復活し得る。
    */
   public void markPasswordReset(String email) {
-    redisTemplate
-        .opsForValue()
-        .set(
-            PASSWORD_RESET_KEY_PREFIX + email,
-            String.valueOf(Instant.now().getEpochSecond()),
-            Duration.ofMillis(appProperties.getJwtExpiration()));
+    redisTemplate.execute(
+        MONOTONIC_MARK,
+        List.of(PASSWORD_RESET_KEY_PREFIX + email),
+        String.valueOf(Instant.now().getEpochSecond()),
+        String.valueOf(appProperties.getJwtExpiration()));
   }
 
   /** 記録済みのパスワード再設定時刻（エポック秒）を返す。記録が無ければ空。 */

--- a/backend/src/main/java/com/kizuna/auth/infrastructure/TokenBlacklistValidator.java
+++ b/backend/src/main/java/com/kizuna/auth/infrastructure/TokenBlacklistValidator.java
@@ -8,7 +8,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
 
 /**
- * トークン単位・ユーザー単位の Redis ブラックリスト（{@link TokenBlacklistService}）を検証する {@code
+ * トークン単位・ユーザー単位・パスワード再設定の Redis ブラックリスト（{@link TokenBlacklistService}）を検証する {@code
  * OAuth2TokenValidator}。判定は毎回 Redis へ問い合わせる必要があるため、{@link JwtDecoderConfig} が組み立てる decoder
  * にはキャッシュを付けないこと（付けるとブラックリストの即時性が壊れる）。
  *
@@ -26,9 +26,25 @@ public class TokenBlacklistValidator implements OAuth2TokenValidator<Jwt> {
   @Override
   public OAuth2TokenValidatorResult validate(Jwt jwt) {
     if (tokenBlacklistService.isBlacklisted(jwt.getTokenValue())
-        || tokenBlacklistService.isUserBlacklisted(jwt.getSubject())) {
+        || tokenBlacklistService.isUserBlacklisted(jwt.getSubject())
+        || issuedBeforePasswordReset(jwt)) {
       return OAuth2TokenValidatorResult.failure(INVALID_TOKEN);
     }
     return OAuth2TokenValidatorResult.success();
+  }
+
+  /**
+   * パスワード再設定より前に発行された token かを判定する。iat が無い token は再設定の記録がある間だけ拒否する（発行時刻の分からない token を再設定前とみなす
+   * fail-closed）。
+   *
+   * <p>比較はエポック秒の厳密な {@code iat < resetAt} で、同一秒に発行された旧 token は生き残る（最長 1 秒の窓、許容）。
+   * 緩めると再設定直後に仮パスワードで得た token が同じ秒に落ちて即座に締め出されるため、こちら側へ倒している。
+   */
+  private boolean issuedBeforePasswordReset(Jwt jwt) {
+    return tokenBlacklistService
+        .getPasswordResetAtSeconds(jwt.getSubject())
+        .filter(
+            resetAt -> jwt.getIssuedAt() == null || jwt.getIssuedAt().getEpochSecond() < resetAt)
+        .isPresent();
   }
 }

--- a/backend/src/main/java/com/kizuna/user/api/dto/StaffAccountPasswordResetResponse.java
+++ b/backend/src/main/java/com/kizuna/user/api/dto/StaffAccountPasswordResetResponse.java
@@ -1,0 +1,8 @@
+package com.kizuna.user.api.dto;
+
+/**
+ * パスワード再設定の応答。仮パスワードの生値をこの一度だけ返す。JSON キーは Jackson 設定により snake_case（temporary_password）。
+ *
+ * <p>専用の型にしてあるのは、生値が一覧・詳細 DTO の型に存在してはならないためである（api-guidelines §6 — 実行時の抑制では漏出を防げない）。
+ */
+public record StaffAccountPasswordResetResponse(String temporaryPassword) {}

--- a/backend/src/main/java/com/kizuna/user/api/platform/PlatformStaffAccountController.java
+++ b/backend/src/main/java/com/kizuna/user/api/platform/PlatformStaffAccountController.java
@@ -63,8 +63,10 @@ public class PlatformStaffAccountController {
   /** 仮パスワードを発行して再設定する。生値を返すのはこの応答だけで、資源を作らないので 200 を返す。 */
   @PostMapping("/{id}/password-reset")
   @PreAuthorize("hasAuthority('PERM_STAFF_ACCOUNT_MANAGE')")
-  public ResponseEntity<StaffAccountPasswordResetResponse> resetPassword(@PathVariable Long id) {
+  public ResponseEntity<StaffAccountPasswordResetResponse> resetPassword(
+      @PathVariable Long id, Principal principal) {
     return ResponseEntity.ok(
-        new StaffAccountPasswordResetResponse(platformStaffAccountService.resetPassword(id)));
+        new StaffAccountPasswordResetResponse(
+            platformStaffAccountService.resetPassword(id, principal.getName())));
   }
 }

--- a/backend/src/main/java/com/kizuna/user/api/platform/PlatformStaffAccountController.java
+++ b/backend/src/main/java/com/kizuna/user/api/platform/PlatformStaffAccountController.java
@@ -1,5 +1,6 @@
 package com.kizuna.user.api.platform;
 
+import com.kizuna.user.api.dto.StaffAccountPasswordResetResponse;
 import com.kizuna.user.api.dto.StaffAccountResponse;
 import com.kizuna.user.api.dto.StaffAccountSummaryResponse;
 import com.kizuna.user.application.PlatformStaffAccountService;
@@ -18,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * アカウント管理 API（本人種別 STAFF の全アカウントの閲覧と停止・再開）。全操作 STAFF_ACCOUNT_MANAGE 権限限定。
+ * アカウント管理 API（本人種別 STAFF の全アカウントの閲覧・停止・再開・パスワード再設定）。全操作 STAFF_ACCOUNT_MANAGE 権限限定。
  *
  * <p>授権を書く口はこの面に存在しない。ロールと店舗集合の変更は管理者管理（/platform/staff）と店舗スタッフ管理が引き続き担う。
  */
@@ -57,5 +58,13 @@ public class PlatformStaffAccountController {
   public ResponseEntity<Void> resume(@PathVariable Long id) {
     platformStaffAccountService.resume(id);
     return ResponseEntity.noContent().build();
+  }
+
+  /** 仮パスワードを発行して再設定する。生値を返すのはこの応答だけで、資源を作らないので 200 を返す。 */
+  @PostMapping("/{id}/password-reset")
+  @PreAuthorize("hasAuthority('PERM_STAFF_ACCOUNT_MANAGE')")
+  public ResponseEntity<StaffAccountPasswordResetResponse> resetPassword(@PathVariable Long id) {
+    return ResponseEntity.ok(
+        new StaffAccountPasswordResetResponse(platformStaffAccountService.resetPassword(id)));
   }
 }

--- a/backend/src/main/java/com/kizuna/user/application/PlatformStaffAccountService.java
+++ b/backend/src/main/java/com/kizuna/user/application/PlatformStaffAccountService.java
@@ -21,6 +21,7 @@ import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
 import jakarta.persistence.criteria.Predicate;
 import java.security.SecureRandom;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Comparator;
@@ -172,7 +173,8 @@ public class PlatformStaffAccountService {
     String temporaryPassword = temporaryPassword();
     target.changePassword(passwordEncoder.encode(temporaryPassword));
     repository.saveAndFlush(target);
-    eventPublisher.publishEvent(new PlatformUserPasswordReset(target.getEmail()));
+    eventPublisher.publishEvent(
+        new PlatformUserPasswordReset(target.getEmail(), Instant.now().getEpochSecond()));
     return temporaryPassword;
   }
 

--- a/backend/src/main/java/com/kizuna/user/application/PlatformStaffAccountService.java
+++ b/backend/src/main/java/com/kizuna/user/application/PlatformStaffAccountService.java
@@ -15,6 +15,7 @@ import com.kizuna.user.domain.PlatformUserResumed;
 import com.kizuna.user.domain.PlatformUserStopped;
 import com.kizuna.user.domain.Role;
 import com.kizuna.user.domain.RoleRepository;
+import com.kizuna.user.domain.SelfPasswordResetNotAllowedException;
 import com.kizuna.user.domain.SelfStopNotAllowedException;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
@@ -157,9 +158,14 @@ public class PlatformStaffAccountService {
    * 状態機械の遷移が無く、並行書込みは楽観ロック（@Version）が担う。
    */
   @Transactional
-  public String resetPassword(Long id) {
+  public String resetPassword(Long id, String actorEmail) {
     PlatformUser target = requireStaffAccount(id);
-    // HQ 側ロール保持者は対象外（ADR 0021 の守衛 G6）。実行主体も必ず HQ 側ロールを持つため、自己再設定はこの判定に含まれる。
+    // 自己再設定は G6 に委ねず名指しで拒む。JWT の権限は発行時の写しでロール降格後も失効まで残るため、
+    // 降格済みの残存セッションからは自分が店舗側に見え、G6 を素通りして口座を恒久奪取できてしまう。
+    if (target.getEmail().equals(actorEmail)) {
+      throw new SelfPasswordResetNotAllowedException("自分自身のパスワードは再設定できません");
+    }
+    // HQ 側ロール保持者は対象外（ADR 0021 の守衛 G6）。
     if (holdsAny(target.getRoleIds(), roleRepository.findHqRoleIds())) {
       throw new HqPasswordResetNotAllowedException("HQ 側ロール保持者のパスワードは再設定できません");
     }

--- a/backend/src/main/java/com/kizuna/user/application/PlatformStaffAccountService.java
+++ b/backend/src/main/java/com/kizuna/user/application/PlatformStaffAccountService.java
@@ -4,10 +4,12 @@ import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.user.api.dto.StaffAccountResponse;
 import com.kizuna.user.api.dto.StaffAccountRoleRef;
 import com.kizuna.user.api.dto.StaffAccountSummaryResponse;
+import com.kizuna.user.domain.HqPasswordResetNotAllowedException;
 import com.kizuna.user.domain.LastRoleManageHolderException;
 import com.kizuna.user.domain.PermissionCode;
 import com.kizuna.user.domain.PermissionRepository;
 import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserPasswordReset;
 import com.kizuna.user.domain.PlatformUserRepository;
 import com.kizuna.user.domain.PlatformUserResumed;
 import com.kizuna.user.domain.PlatformUserStopped;
@@ -17,7 +19,9 @@ import com.kizuna.user.domain.SelfStopNotAllowedException;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
 import jakarta.persistence.criteria.Predicate;
+import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -31,13 +35,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.query.EscapeCharacter;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
  * アカウント管理ユースケース。対象は本人種別 STAFF の全アカウントで、ロール構成（HQ 側／店舗側）を問わない — CAST/MEMBER は権限モデルの外なので在否も出さない。
  *
- * <p>授権は一切書かない。停止・再開だけを扱い、ロールと店舗集合は表示にしか現れない。
+ * <p>授権は一切書かない。停止・再開とパスワード再設定だけを扱い、ロールと店舗集合は表示にしか現れない。
  *
  * <p><b>ロックの獲得順は 権限目録行（{@link PermissionRepository#lockIdByCode}）→ 利用者行</b>で、授権管理の PUT
  * 経路と同一。逆順の行使点が 1 つでも生まれると、二経路が互いの保持する行を待って環になる。
@@ -49,9 +54,13 @@ public class PlatformStaffAccountService {
   /** LIKE パターンのエスケープ規則。派生クエリが内部で使うものと同一で、手書きの cb.like にも同じ規則を適用する。 */
   private static final EscapeCharacter LIKE_ESCAPE = EscapeCharacter.DEFAULT;
 
+  /** 仮パスワードの生成源。予測可能な乱数だと発行直後の乗っ取りを許すため暗号論的乱数に限る。 */
+  private final SecureRandom random = new SecureRandom();
+
   private final PlatformUserRepository repository;
   private final RoleRepository roleRepository;
   private final PermissionRepository permissionRepository;
+  private final PasswordEncoder passwordEncoder;
   private final ApplicationEventPublisher eventPublisher;
 
   @Transactional(readOnly = true)
@@ -138,6 +147,34 @@ public class PlatformStaffAccountService {
       repository.saveAndFlush(target);
     }
     eventPublisher.publishEvent(new PlatformUserStopped(target.getEmail()));
+  }
+
+  /**
+   * 仮パスワードを発行して再設定し、対象の既存セッションを失効させる。生値の戻り値はこの一度だけで、以後どこからも取り出せない。
+   *
+   * <p>直列化点（{@link PermissionRepository#lockIdByCode}）は押さえない。再設定は enabled もロール構成も動かさないので
+   * ROLE_MANAGE 保持者の母集団を減らしようがなく、「増やすだけの操作は押さえない」に当たる。行ロックも取らない —
+   * 状態機械の遷移が無く、並行書込みは楽観ロック（@Version）が担う。
+   */
+  @Transactional
+  public String resetPassword(Long id) {
+    PlatformUser target = requireStaffAccount(id);
+    // HQ 側ロール保持者は対象外（ADR 0021 の守衛 G6）。実行主体も必ず HQ 側ロールを持つため、自己再設定はこの判定に含まれる。
+    if (holdsAny(target.getRoleIds(), roleRepository.findHqRoleIds())) {
+      throw new HqPasswordResetNotAllowedException("HQ 側ロール保持者のパスワードは再設定できません");
+    }
+    String temporaryPassword = temporaryPassword();
+    target.changePassword(passwordEncoder.encode(temporaryPassword));
+    repository.saveAndFlush(target);
+    eventPublisher.publishEvent(new PlatformUserPasswordReset(target.getEmail()));
+    return temporaryPassword;
+  }
+
+  /** 仮パスワード（URL 安全 Base64 の 16 文字）。生値は符号化して保存した後、応答以外のどこにも残さない。 */
+  private String temporaryPassword() {
+    byte[] bytes = new byte[12];
+    random.nextBytes(bytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
   }
 
   /** 再開する。既に有効でも 204 で受理し、解除イベントを発行する（停止と同じ理由の冪等化）。 */

--- a/backend/src/main/java/com/kizuna/user/domain/HqPasswordResetNotAllowedException.java
+++ b/backend/src/main/java/com/kizuna/user/domain/HqPasswordResetNotAllowedException.java
@@ -1,0 +1,15 @@
+package com.kizuna.user.domain;
+
+import com.kizuna.shared.exception.ServiceException;
+
+/**
+ * HQ 側ロール保持者へパスワード再設定を試みたことを表すドメイン例外。ServiceException 継承により HTTP 400 で応答される。
+ *
+ * <p>実行主体は必ず HQ 側ロールを持つため、自分自身への再設定もこの境界に含まれて拒否される。
+ */
+public class HqPasswordResetNotAllowedException extends ServiceException {
+
+  public HqPasswordResetNotAllowedException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/com/kizuna/user/domain/PlatformUserPasswordReset.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PlatformUserPasswordReset.java
@@ -5,5 +5,8 @@ package com.kizuna.user.domain;
  *
  * <p>auth モジュールが再設定前に発行済みの JWT を即時失効させるために購読する。イベント経由にしている理由（モジュール環の回避）は {@link
  * PlatformUserStopped} を参照。
+ *
+ * <p>失効境界（resetAtSeconds）は再設定自身が運ぶ — callback の実行時刻で刻むと、遅延した古い callback が
+ * 新しい再設定より後の時刻を書き、最新パスワードで得た正当トークンを誤失効させる。
  */
-public record PlatformUserPasswordReset(String email) {}
+public record PlatformUserPasswordReset(String email, long resetAtSeconds) {}

--- a/backend/src/main/java/com/kizuna/user/domain/PlatformUserPasswordReset.java
+++ b/backend/src/main/java/com/kizuna/user/domain/PlatformUserPasswordReset.java
@@ -1,0 +1,9 @@
+package com.kizuna.user.domain;
+
+/**
+ * プラットフォームユーザーのパスワードが再設定されたことを表すドメインイベント。
+ *
+ * <p>auth モジュールが再設定前に発行済みの JWT を即時失効させるために購読する。イベント経由にしている理由（モジュール環の回避）は {@link
+ * PlatformUserStopped} を参照。
+ */
+public record PlatformUserPasswordReset(String email) {}

--- a/backend/src/main/java/com/kizuna/user/domain/SelfPasswordResetNotAllowedException.java
+++ b/backend/src/main/java/com/kizuna/user/domain/SelfPasswordResetNotAllowedException.java
@@ -1,0 +1,16 @@
+package com.kizuna.user.domain;
+
+import com.kizuna.shared.exception.ServiceException;
+
+/**
+ * 実行主体が自分自身へパスワード再設定を試みたことを表すドメイン例外。ServiceException 継承により HTTP 400 で応答される。
+ *
+ * <p>G6（HQ 側ロール判定）には委ねない — JWT の権限は発行時の写しで、ロール降格後も失効まで生き残るため、
+ * 降格済みの残存セッションが「店舗側の自分」を再設定して口座を恒久奪取できてしまう。自己は名指しで拒む。
+ */
+public class SelfPasswordResetNotAllowedException extends ServiceException {
+
+  public SelfPasswordResetNotAllowedException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/test/java/com/kizuna/user/application/PlatformStaffAccountServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/PlatformStaffAccountServiceTest.java
@@ -28,12 +28,14 @@ import com.kizuna.user.domain.SelfPasswordResetNotAllowedException;
 import com.kizuna.user.domain.SelfStopNotAllowedException;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
@@ -297,14 +299,21 @@ class PlatformStaffAccountServiceTest {
     when(roleRepository.findHqRoleIds()).thenReturn(Set.of(HQ_ROLE));
     when(passwordEncoder.encode(ArgumentMatchers.anyString())).thenReturn("encoded");
 
+    long beforeSeconds = Instant.now().getEpochSecond();
     String temporaryPassword = service.resetPassword(4L, "admin@kizuna.test");
+    long afterSeconds = Instant.now().getEpochSecond();
 
     // 返した生値そのものが符号化されて保存される（別の値を返す取り違えを排除する）。
     assertThat(temporaryPassword).hasSize(16);
     verify(passwordEncoder).encode(temporaryPassword);
     assertThat(existing.getPassword()).isEqualTo("encoded");
     verify(repository).saveAndFlush(existing);
-    verify(eventPublisher).publishEvent(new PlatformUserPasswordReset("store-only@kizuna.test"));
+    ArgumentCaptor<PlatformUserPasswordReset> published =
+        ArgumentCaptor.forClass(PlatformUserPasswordReset.class);
+    verify(eventPublisher).publishEvent(published.capture());
+    assertThat(published.getValue().email()).isEqualTo("store-only@kizuna.test");
+    // 失効境界はイベント自身が運ぶ（callback 実行時刻だと遅延で境界が前へ這う）。
+    assertThat(published.getValue().resetAtSeconds()).isBetween(beforeSeconds, afterSeconds);
     // 再設定は enabled もロールも動かさないので、不減零の直列化点は押さえない。
     verifyNoInteractions(permissionRepository);
   }

--- a/backend/src/test/java/com/kizuna/user/application/PlatformStaffAccountServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/PlatformStaffAccountServiceTest.java
@@ -13,10 +13,12 @@ import static org.mockito.Mockito.when;
 import com.kizuna.shared.exception.NotFoundException;
 import com.kizuna.user.api.dto.StaffAccountRoleRef;
 import com.kizuna.user.api.dto.StaffAccountSummaryResponse;
+import com.kizuna.user.domain.HqPasswordResetNotAllowedException;
 import com.kizuna.user.domain.LastRoleManageHolderException;
 import com.kizuna.user.domain.PermissionCode;
 import com.kizuna.user.domain.PermissionRepository;
 import com.kizuna.user.domain.PlatformUser;
+import com.kizuna.user.domain.PlatformUserPasswordReset;
 import com.kizuna.user.domain.PlatformUserRepository;
 import com.kizuna.user.domain.PlatformUserResumed;
 import com.kizuna.user.domain.PlatformUserStopped;
@@ -42,6 +44,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
 class PlatformStaffAccountServiceTest {
@@ -52,6 +55,9 @@ class PlatformStaffAccountServiceTest {
   /** 店舗側ロール。この面では HQ 側と同じく対象になる。 */
   private static final long STORE_SIDE_ROLE = 11L;
 
+  /** HQ 側ロール。パスワード再設定の境界（G6）の母集団を作るのに使う。 */
+  private static final long HQ_ROLE = 13L;
+
   private static final Pageable PAGEABLE = PageRequest.of(0, 20);
 
   private static final String ACTOR = "actor@kizuna.test";
@@ -61,6 +67,8 @@ class PlatformStaffAccountServiceTest {
   @Mock private RoleRepository roleRepository;
 
   @Mock private PermissionRepository permissionRepository;
+
+  @Mock private PasswordEncoder passwordEncoder;
 
   @Mock private ApplicationEventPublisher eventPublisher;
 
@@ -241,6 +249,57 @@ class PlatformStaffAccountServiceTest {
 
     assertThatThrownBy(() -> service.resume(8L)).isInstanceOf(NotFoundException.class);
 
+    verify(repository, never()).saveAndFlush(any());
+    verifyNoInteractions(eventPublisher);
+  }
+
+  @Test
+  @DisplayName("HQ 側ロール保持者へのパスワード再設定は 400 で拒否され、何も書かれないこと（守衛 G6）")
+  void resetPassword_hqRoleHolder_isRejectedAndWritesNothing() {
+    // 実行主体も必ず HQ 側ロールを持つため、自己再設定もこの判定に吸収される。
+    PlatformUser existing = staff(3L, "hq@kizuna.test", Set.of(HQ_ROLE));
+    when(repository.findById(3L)).thenReturn(Optional.of(existing));
+    when(roleRepository.findHqRoleIds()).thenReturn(Set.of(HQ_ROLE));
+
+    assertThatThrownBy(() -> service.resetPassword(3L))
+        .isInstanceOf(HqPasswordResetNotAllowedException.class)
+        .hasMessage("HQ 側ロール保持者のパスワードは再設定できません");
+
+    assertThat(existing.getPassword()).as("パスワードは書き換わらないこと").isEqualTo("hash");
+    verify(repository, never()).saveAndFlush(any());
+    verifyNoInteractions(passwordEncoder);
+    verifyNoInteractions(eventPublisher);
+  }
+
+  @Test
+  @DisplayName("店舗側ロールだけの対象は仮パスワードを符号化して保存し、失効イベントを発行すること")
+  void resetPassword_storeSideTarget_encodesAndPublishes() {
+    PlatformUser existing = staff(4L, "store-only@kizuna.test", Set.of(STORE_SIDE_ROLE));
+    when(repository.findById(4L)).thenReturn(Optional.of(existing));
+    when(roleRepository.findHqRoleIds()).thenReturn(Set.of(HQ_ROLE));
+    when(passwordEncoder.encode(ArgumentMatchers.anyString())).thenReturn("encoded");
+
+    String temporaryPassword = service.resetPassword(4L);
+
+    // 返した生値そのものが符号化されて保存される（別の値を返す取り違えを排除する）。
+    assertThat(temporaryPassword).hasSize(16);
+    verify(passwordEncoder).encode(temporaryPassword);
+    assertThat(existing.getPassword()).isEqualTo("encoded");
+    verify(repository).saveAndFlush(existing);
+    verify(eventPublisher).publishEvent(new PlatformUserPasswordReset("store-only@kizuna.test"));
+    // 再設定は enabled もロールも動かさないので、不減零の直列化点は押さえない。
+    verifyNoInteractions(permissionRepository);
+  }
+
+  @Test
+  @DisplayName("CAST の id を直接指定した再設定は、ロールを引く前に 404 になること")
+  void resetPassword_targetIsNotStaff_throwsNotFoundBeforeRoleLookup() {
+    when(repository.findById(8L)).thenReturn(Optional.of(castUser(8L, "cast@kizuna.test")));
+
+    assertThatThrownBy(() -> service.resetPassword(8L)).isInstanceOf(NotFoundException.class);
+
+    verifyNoInteractions(roleRepository);
+    verifyNoInteractions(passwordEncoder);
     verify(repository, never()).saveAndFlush(any());
     verifyNoInteractions(eventPublisher);
   }

--- a/backend/src/test/java/com/kizuna/user/application/PlatformStaffAccountServiceTest.java
+++ b/backend/src/test/java/com/kizuna/user/application/PlatformStaffAccountServiceTest.java
@@ -24,6 +24,7 @@ import com.kizuna.user.domain.PlatformUserResumed;
 import com.kizuna.user.domain.PlatformUserStopped;
 import com.kizuna.user.domain.Role;
 import com.kizuna.user.domain.RoleRepository;
+import com.kizuna.user.domain.SelfPasswordResetNotAllowedException;
 import com.kizuna.user.domain.SelfStopNotAllowedException;
 import com.kizuna.user.domain.StoreScopeType;
 import com.kizuna.user.domain.UserType;
@@ -256,18 +257,35 @@ class PlatformStaffAccountServiceTest {
   @Test
   @DisplayName("HQ 側ロール保持者へのパスワード再設定は 400 で拒否され、何も書かれないこと（守衛 G6）")
   void resetPassword_hqRoleHolder_isRejectedAndWritesNothing() {
-    // 実行主体も必ず HQ 側ロールを持つため、自己再設定もこの判定に吸収される。
     PlatformUser existing = staff(3L, "hq@kizuna.test", Set.of(HQ_ROLE));
     when(repository.findById(3L)).thenReturn(Optional.of(existing));
     when(roleRepository.findHqRoleIds()).thenReturn(Set.of(HQ_ROLE));
 
-    assertThatThrownBy(() -> service.resetPassword(3L))
+    assertThatThrownBy(() -> service.resetPassword(3L, "admin@kizuna.test"))
         .isInstanceOf(HqPasswordResetNotAllowedException.class)
         .hasMessage("HQ 側ロール保持者のパスワードは再設定できません");
 
     assertThat(existing.getPassword()).as("パスワードは書き換わらないこと").isEqualTo("hash");
     verify(repository, never()).saveAndFlush(any());
     verifyNoInteractions(passwordEncoder);
+    verifyNoInteractions(eventPublisher);
+  }
+
+  @Test
+  @DisplayName("店舗側の実行主体でも自分自身への再設定は G6 に依らず 400 で拒否されること")
+  void resetPassword_selfTarget_isRejectedWithoutRoleLookup() {
+    // JWT の権限は発行時の写しなので、降格済みの残存セッションでは実行主体が店舗側になり G6 を通る。
+    // 自己拒否がロール判定に依存しない（roleRepository を引く前に落ちる）ことまで固定する。
+    PlatformUser existing = staff(5L, "self@kizuna.test", Set.of(STORE_SIDE_ROLE));
+    when(repository.findById(5L)).thenReturn(Optional.of(existing));
+
+    assertThatThrownBy(() -> service.resetPassword(5L, "self@kizuna.test"))
+        .isInstanceOf(SelfPasswordResetNotAllowedException.class)
+        .hasMessage("自分自身のパスワードは再設定できません");
+
+    verifyNoInteractions(roleRepository);
+    verifyNoInteractions(passwordEncoder);
+    verify(repository, never()).saveAndFlush(any());
     verifyNoInteractions(eventPublisher);
   }
 
@@ -279,7 +297,7 @@ class PlatformStaffAccountServiceTest {
     when(roleRepository.findHqRoleIds()).thenReturn(Set.of(HQ_ROLE));
     when(passwordEncoder.encode(ArgumentMatchers.anyString())).thenReturn("encoded");
 
-    String temporaryPassword = service.resetPassword(4L);
+    String temporaryPassword = service.resetPassword(4L, "admin@kizuna.test");
 
     // 返した生値そのものが符号化されて保存される（別の値を返す取り違えを排除する）。
     assertThat(temporaryPassword).hasSize(16);
@@ -296,7 +314,8 @@ class PlatformStaffAccountServiceTest {
   void resetPassword_targetIsNotStaff_throwsNotFoundBeforeRoleLookup() {
     when(repository.findById(8L)).thenReturn(Optional.of(castUser(8L, "cast@kizuna.test")));
 
-    assertThatThrownBy(() -> service.resetPassword(8L)).isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(() -> service.resetPassword(8L, "admin@kizuna.test"))
+        .isInstanceOf(NotFoundException.class);
 
     verifyNoInteractions(roleRepository);
     verifyNoInteractions(passwordEncoder);

--- a/frontend/src/_pages/platform-staff-accounts/__tests__/StaffAccountsPage.test.tsx
+++ b/frontend/src/_pages/platform-staff-accounts/__tests__/StaffAccountsPage.test.tsx
@@ -220,7 +220,7 @@ describe('アカウント管理ページ', () => {
 describe('パスワード再設定', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedApi.resetPassword.mockResolvedValue({ temporary_password: 'Ab3xYz9QmT2wKp7L' });
+    mockedApi.resetPassword.mockResolvedValue({ temporary_password: 'test-temporary-password' });
     mockedApi.list.mockResolvedValue(
       paginated([account({ id: 1, display_name: '山田太郎', enabled: true })])
     );
@@ -230,7 +230,7 @@ describe('パスワード再設定', () => {
     render(<StaffAccountsPage />);
     fireEvent.click(await screen.findByRole('button', { name: 'パスワード再設定' }));
     fireEvent.click(await screen.findByRole('button', { name: '再設定する' }));
-    return screen.findByDisplayValue('Ab3xYz9QmT2wKp7L');
+    return screen.findByDisplayValue('test-temporary-password');
   };
 
   // 対象のセッションを即時に失効させるうえ、生値は一度しか出ないので確認を挟む
@@ -244,7 +244,7 @@ describe('パスワード再設定', () => {
     fireEvent.click(screen.getByRole('button', { name: '再設定する' }));
 
     await waitFor(() => expect(mockedApi.resetPassword).toHaveBeenCalledWith(1));
-    expect(await screen.findByDisplayValue('Ab3xYz9QmT2wKp7L')).toBeInTheDocument();
+    expect(await screen.findByDisplayValue('test-temporary-password')).toBeInTheDocument();
     expect(screen.getByText('山田太郎 の仮パスワード')).toBeInTheDocument();
   });
 
@@ -274,7 +274,7 @@ describe('パスワード再設定', () => {
     await waitFor(() =>
       expect(notify.error).toHaveBeenCalledWith('HQ 側ロール保持者のパスワードは再設定できません')
     );
-    expect(screen.queryByDisplayValue('Ab3xYz9QmT2wKp7L')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('test-temporary-password')).not.toBeInTheDocument();
   });
 
   // 生値はこの表示にしか無く、誤って閉じると再発行しかやり直す手段が無い
@@ -283,7 +283,7 @@ describe('パスワード再設定', () => {
 
     fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
 
-    await waitFor(() => expect(screen.getByDisplayValue('Ab3xYz9QmT2wKp7L')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByDisplayValue('test-temporary-password')).toBeInTheDocument());
   });
 
   it('背景クリックでは仮パスワードの表示を閉じないこと', async () => {
@@ -293,7 +293,7 @@ describe('パスワード再設定', () => {
     expect(backdrop).not.toBeNull();
     fireEvent.click(backdrop as Element);
 
-    await waitFor(() => expect(screen.getByDisplayValue('Ab3xYz9QmT2wKp7L')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByDisplayValue('test-temporary-password')).toBeInTheDocument());
   });
 
   it('「閉じる」ボタンでだけ仮パスワードの表示を閉じること', async () => {
@@ -302,7 +302,7 @@ describe('パスワード再設定', () => {
     fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
 
     await waitFor(() =>
-      expect(screen.queryByDisplayValue('Ab3xYz9QmT2wKp7L')).not.toBeInTheDocument()
+      expect(screen.queryByDisplayValue('test-temporary-password')).not.toBeInTheDocument()
     );
   });
 });

--- a/frontend/src/_pages/platform-staff-accounts/__tests__/StaffAccountsPage.test.tsx
+++ b/frontend/src/_pages/platform-staff-accounts/__tests__/StaffAccountsPage.test.tsx
@@ -283,7 +283,9 @@ describe('パスワード再設定', () => {
 
     fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
 
-    await waitFor(() => expect(screen.getByDisplayValue('test-temporary-password')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByDisplayValue('test-temporary-password')).toBeInTheDocument()
+    );
   });
 
   it('背景クリックでは仮パスワードの表示を閉じないこと', async () => {
@@ -293,7 +295,9 @@ describe('パスワード再設定', () => {
     expect(backdrop).not.toBeNull();
     fireEvent.click(backdrop as Element);
 
-    await waitFor(() => expect(screen.getByDisplayValue('test-temporary-password')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByDisplayValue('test-temporary-password')).toBeInTheDocument()
+    );
   });
 
   it('「閉じる」ボタンでだけ仮パスワードの表示を閉じること', async () => {

--- a/frontend/src/_pages/platform-staff-accounts/__tests__/StaffAccountsPage.test.tsx
+++ b/frontend/src/_pages/platform-staff-accounts/__tests__/StaffAccountsPage.test.tsx
@@ -245,7 +245,8 @@ describe('パスワード再設定', () => {
 
     await waitFor(() => expect(mockedApi.resetPassword).toHaveBeenCalledWith(1));
     expect(await screen.findByDisplayValue('test-temporary-password')).toBeInTheDocument();
-    expect(screen.getByText('山田太郎 の仮パスワード')).toBeInTheDocument();
+    // 表示名は一意でないため、取り違え防止の同定は一意な email が担う。
+    expect(screen.getByText('山田太郎（staff@example.com）の仮パスワード')).toBeInTheDocument();
   });
 
   it('確認をキャンセルすると再設定しないこと', async () => {

--- a/frontend/src/_pages/platform-staff-accounts/__tests__/StaffAccountsPage.test.tsx
+++ b/frontend/src/_pages/platform-staff-accounts/__tests__/StaffAccountsPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { PageResult } from '@/shared/api';
 import { StaffAccountSummaryResponse, platformStaffAccountApi } from '@/entities/user';
 import { notify } from '@/shared/notify';
@@ -259,6 +259,41 @@ describe('パスワード再設定', () => {
       expect(screen.queryByText('パスワードを再設定しますか？')).not.toBeInTheDocument()
     );
     expect(mockedApi.resetPassword).not.toHaveBeenCalled();
+  });
+
+  // 応答は一度きり表示の値を運ぶ。遅れて届いた古い応答が唯一有効な最新値を上書きすると、
+  // 有効な仮パスワードが誰にも見えないまま失われる。
+  it('遅れて届いた古い応答は最新の仮パスワードを上書きしないこと', async () => {
+    mockedApi.list.mockResolvedValue(
+      paginated([
+        account({ id: 1, display_name: '山田太郎', enabled: true }),
+        account({ id: 2, display_name: '佐藤次郎', enabled: true }),
+      ])
+    );
+    let resolveFirst: (value: { temporary_password: string }) => void = () => {};
+    mockedApi.resetPassword
+      .mockImplementationOnce(
+        () => new Promise(resolve => (resolveFirst = resolve)) // 1 件目は遅延させる
+      )
+      .mockResolvedValueOnce({ temporary_password: 'newer-temporary-password' });
+
+    render(<StaffAccountsPage />);
+    const buttons = await screen.findAllByRole('button', { name: 'パスワード再設定' });
+    fireEvent.click(buttons[0]);
+    fireEvent.click(await screen.findByRole('button', { name: '再設定する' }));
+    fireEvent.click(buttons[1]);
+    fireEvent.click(await screen.findByRole('button', { name: '再設定する' }));
+
+    expect(await screen.findByDisplayValue('newer-temporary-password')).toBeInTheDocument();
+
+    // act で古い応答の状態更新を確実に流し切ってから断言する（流す前の断言は世代守衛が無くても緑になる）。
+    await act(async () => {
+      resolveFirst({ temporary_password: 'stale-temporary-password' });
+    });
+
+    expect(screen.getByDisplayValue('newer-temporary-password')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('stale-temporary-password')).not.toBeInTheDocument();
+    expect(screen.getByText('佐藤次郎 の仮パスワード')).toBeInTheDocument();
   });
 
   // 対象外（HQ 側ロール保持者・自分自身）の判定はサーバだけが持つので、そのまま出す

--- a/frontend/src/_pages/platform-staff-accounts/__tests__/StaffAccountsPage.test.tsx
+++ b/frontend/src/_pages/platform-staff-accounts/__tests__/StaffAccountsPage.test.tsx
@@ -261,9 +261,9 @@ describe('パスワード再設定', () => {
     expect(mockedApi.resetPassword).not.toHaveBeenCalled();
   });
 
-  // 応答は一度きり表示の値を運ぶ。遅れて届いた古い応答が唯一有効な最新値を上書きすると、
-  // 有効な仮パスワードが誰にも見えないまま失われる。
-  it('遅れて届いた古い応答は最新の仮パスワードを上書きしないこと', async () => {
+  // 応答は一度きり表示の値を運び、表示枠は 1 つしかない。重ねて実行できると
+  // どちらか一方の有効な仮パスワードが誰にも見えないまま失われるため、進行中は入口を塞ぐ。
+  it('再設定の進行中は全行の再設定ボタンが無効になり、応答後に戻ること', async () => {
     mockedApi.list.mockResolvedValue(
       paginated([
         account({ id: 1, display_name: '山田太郎', enabled: true }),
@@ -271,29 +271,24 @@ describe('パスワード再設定', () => {
       ])
     );
     let resolveFirst: (value: { temporary_password: string }) => void = () => {};
-    mockedApi.resetPassword
-      .mockImplementationOnce(
-        () => new Promise(resolve => (resolveFirst = resolve)) // 1 件目は遅延させる
-      )
-      .mockResolvedValueOnce({ temporary_password: 'newer-temporary-password' });
+    mockedApi.resetPassword.mockImplementationOnce(
+      () => new Promise(resolve => (resolveFirst = resolve))
+    );
 
     render(<StaffAccountsPage />);
     const buttons = await screen.findAllByRole('button', { name: 'パスワード再設定' });
     fireEvent.click(buttons[0]);
     fireEvent.click(await screen.findByRole('button', { name: '再設定する' }));
-    fireEvent.click(buttons[1]);
-    fireEvent.click(await screen.findByRole('button', { name: '再設定する' }));
 
-    expect(await screen.findByDisplayValue('newer-temporary-password')).toBeInTheDocument();
+    await waitFor(() => expect(mockedApi.resetPassword).toHaveBeenCalledTimes(1));
+    buttons.forEach(button => expect(button).toBeDisabled());
 
-    // act で古い応答の状態更新を確実に流し切ってから断言する（流す前の断言は世代守衛が無くても緑になる）。
     await act(async () => {
-      resolveFirst({ temporary_password: 'stale-temporary-password' });
+      resolveFirst({ temporary_password: 'test-temporary-password' });
     });
 
-    expect(screen.getByDisplayValue('newer-temporary-password')).toBeInTheDocument();
-    expect(screen.queryByDisplayValue('stale-temporary-password')).not.toBeInTheDocument();
-    expect(screen.getByText('佐藤次郎 の仮パスワード')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('test-temporary-password')).toBeInTheDocument();
+    buttons.forEach(button => expect(button).toBeEnabled());
   });
 
   // 対象外（HQ 側ロール保持者・自分自身）の判定はサーバだけが持つので、そのまま出す

--- a/frontend/src/_pages/platform-staff-accounts/__tests__/StaffAccountsPage.test.tsx
+++ b/frontend/src/_pages/platform-staff-accounts/__tests__/StaffAccountsPage.test.tsx
@@ -5,7 +5,12 @@ import { notify } from '@/shared/notify';
 import StaffAccountsPage from '../ui/StaffAccountsPage';
 
 jest.mock('@/entities/user', () => ({
-  platformStaffAccountApi: { list: jest.fn(), suspend: jest.fn(), resume: jest.fn() },
+  platformStaffAccountApi: {
+    list: jest.fn(),
+    suspend: jest.fn(),
+    resume: jest.fn(),
+    resetPassword: jest.fn(),
+  },
 }));
 
 jest.mock('@/features/staff-management', () => ({
@@ -209,6 +214,96 @@ describe('アカウント管理ページ', () => {
     fireEvent.click(screen.getByRole('button', { name: '再試行' }));
 
     expect(await screen.findByText('山田太郎')).toBeInTheDocument();
+  });
+});
+
+describe('パスワード再設定', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApi.resetPassword.mockResolvedValue({ temporary_password: 'Ab3xYz9QmT2wKp7L' });
+    mockedApi.list.mockResolvedValue(
+      paginated([account({ id: 1, display_name: '山田太郎', enabled: true })])
+    );
+  });
+
+  const openIssuedModal = async () => {
+    render(<StaffAccountsPage />);
+    fireEvent.click(await screen.findByRole('button', { name: 'パスワード再設定' }));
+    fireEvent.click(await screen.findByRole('button', { name: '再設定する' }));
+    return screen.findByDisplayValue('Ab3xYz9QmT2wKp7L');
+  };
+
+  // 対象のセッションを即時に失効させるうえ、生値は一度しか出ないので確認を挟む
+  it('確認してから再設定し、発行された仮パスワードを表示すること', async () => {
+    render(<StaffAccountsPage />);
+    fireEvent.click(await screen.findByRole('button', { name: 'パスワード再設定' }));
+
+    expect(await screen.findByText('パスワードを再設定しますか？')).toBeInTheDocument();
+    expect(mockedApi.resetPassword).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: '再設定する' }));
+
+    await waitFor(() => expect(mockedApi.resetPassword).toHaveBeenCalledWith(1));
+    expect(await screen.findByDisplayValue('Ab3xYz9QmT2wKp7L')).toBeInTheDocument();
+    expect(screen.getByText('山田太郎 の仮パスワード')).toBeInTheDocument();
+  });
+
+  it('確認をキャンセルすると再設定しないこと', async () => {
+    render(<StaffAccountsPage />);
+    fireEvent.click(await screen.findByRole('button', { name: 'パスワード再設定' }));
+    await screen.findByText('パスワードを再設定しますか？');
+
+    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+    await waitFor(() =>
+      expect(screen.queryByText('パスワードを再設定しますか？')).not.toBeInTheDocument()
+    );
+    expect(mockedApi.resetPassword).not.toHaveBeenCalled();
+  });
+
+  // 対象外（HQ 側ロール保持者・自分自身）の判定はサーバだけが持つので、そのまま出す
+  it('再設定の拒否はサーバの文言をそのまま通知すること', async () => {
+    mockedApi.resetPassword.mockRejectedValue({
+      response: { data: { error: 'HQ 側ロール保持者のパスワードは再設定できません' } },
+    });
+
+    render(<StaffAccountsPage />);
+    fireEvent.click(await screen.findByRole('button', { name: 'パスワード再設定' }));
+    fireEvent.click(await screen.findByRole('button', { name: '再設定する' }));
+
+    await waitFor(() =>
+      expect(notify.error).toHaveBeenCalledWith('HQ 側ロール保持者のパスワードは再設定できません')
+    );
+    expect(screen.queryByDisplayValue('Ab3xYz9QmT2wKp7L')).not.toBeInTheDocument();
+  });
+
+  // 生値はこの表示にしか無く、誤って閉じると再発行しかやり直す手段が無い
+  it('ESC では仮パスワードの表示を閉じないこと', async () => {
+    await openIssuedModal();
+
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+
+    await waitFor(() => expect(screen.getByDisplayValue('Ab3xYz9QmT2wKp7L')).toBeInTheDocument());
+  });
+
+  it('背景クリックでは仮パスワードの表示を閉じないこと', async () => {
+    await openIssuedModal();
+
+    const backdrop = document.querySelector('[data-slot="dialog-overlay"]');
+    expect(backdrop).not.toBeNull();
+    fireEvent.click(backdrop as Element);
+
+    await waitFor(() => expect(screen.getByDisplayValue('Ab3xYz9QmT2wKp7L')).toBeInTheDocument());
+  });
+
+  it('「閉じる」ボタンでだけ仮パスワードの表示を閉じること', async () => {
+    await openIssuedModal();
+
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
+
+    await waitFor(() =>
+      expect(screen.queryByDisplayValue('Ab3xYz9QmT2wKp7L')).not.toBeInTheDocument()
+    );
   });
 });
 

--- a/frontend/src/_pages/platform-staff-accounts/ui/StaffAccountsPage.tsx
+++ b/frontend/src/_pages/platform-staff-accounts/ui/StaffAccountsPage.tsx
@@ -51,14 +51,19 @@ export default function StaffAccountsPage() {
   const [resetTarget, setResetTarget] = useState<StaffAccountSummaryResponse | null>(null);
   const [issued, setIssued] = useState<{ displayName: string; password: string } | null>(null);
 
-  // 応答順は要求順と一致しない。応答は一度きり表示の仮パスワードを運ぶため、遅れて届いた
-  // 古い応答が最新の（唯一有効な）値を上書きしないよう世代で守り、最新要求以外は棄てる。
+  // 応答は一度きり表示の仮パスワードを運ぶため、重ねて実行できてしまうとどちらか一方の
+  // 有効な値が必ず失われる（表示枠は 1 つしかない）。進行中は全行の入口を塞いで直列化する。
+  const [resetting, setResetting] = useState(false);
+
+  // 直列化が入口で重なりを塞ぐため通常は届かないが、応答の取り違えは有効な値の恒久喪失に
+  // 直結するので、最新要求以外の応答を棄てる世代守衛も残す。
   const resetRequestIdRef = useRef(0);
 
   // 一覧の型では HQ 側ロールを判別できないので行は出し分けない。対象外（HQ 側ロール保持者・
   // 自分自身）の拒否はサーバだけが判定でき、文言は応答からそのまま出す。
   const resetPassword = async (account: StaffAccountSummaryResponse) => {
     setResetTarget(null);
+    setResetting(true);
     const requestId = ++resetRequestIdRef.current;
     try {
       const result = await platformStaffAccountApi.resetPassword(account.id ?? 0);
@@ -70,6 +75,8 @@ export default function StaffAccountsPage() {
     } catch (error) {
       if (requestId !== resetRequestIdRef.current) return;
       notify.error(getApiErrorMessage(error, 'パスワードの再設定に失敗しました'));
+    } finally {
+      setResetting(false);
     }
   };
 
@@ -167,7 +174,12 @@ export default function StaffAccountsPage() {
                   )}
                 </TableCell>
                 <TableCell className="text-right">
-                  <Button variant="ghost" size="sm" onClick={() => setResetTarget(account)}>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={resetting}
+                    onClick={() => setResetTarget(account)}
+                  >
                     パスワード再設定
                   </Button>
                   {account.enabled ? (

--- a/frontend/src/_pages/platform-staff-accounts/ui/StaffAccountsPage.tsx
+++ b/frontend/src/_pages/platform-staff-accounts/ui/StaffAccountsPage.tsx
@@ -18,12 +18,13 @@ import {
   TableHeader,
   TableRow,
 } from '@/shared/ui';
+import { TemporaryPasswordModal } from './TemporaryPasswordModal';
 
 /** 一覧 1 ページあたりの件数 */
 const PAGE_SIZE = 10;
 
 /**
- * アカウント管理ページ。全スタッフアカウントの状態を並べ、停止・再開だけを行う。
+ * アカウント管理ページ。全スタッフアカウントの状態を並べ、停止・再開とパスワード再設定だけを行う。
  * この面は授権を一切動かさない（ロールは表示専用で、編集への導線も持たない）。
  */
 export default function StaffAccountsPage() {
@@ -44,6 +45,26 @@ export default function StaffAccountsPage() {
     errorMessage: 'アカウントの停止に失敗しました',
     onDeleted: list.reload,
   });
+
+  // 再設定の確認対象と、発行された仮パスワードの表示。どちらもページに置く —
+  // 行に持たせると成功後の一覧取り直しで行ごと unmount され、表示が消える。
+  const [resetTarget, setResetTarget] = useState<StaffAccountSummaryResponse | null>(null);
+  const [issued, setIssued] = useState<{ displayName: string; password: string } | null>(null);
+
+  // 一覧の型では HQ 側ロールを判別できないので行は出し分けない。対象外（HQ 側ロール保持者・
+  // 自分自身）の拒否はサーバだけが判定でき、文言は応答からそのまま出す。
+  const resetPassword = async (account: StaffAccountSummaryResponse) => {
+    setResetTarget(null);
+    try {
+      const result = await platformStaffAccountApi.resetPassword(account.id ?? 0);
+      setIssued({
+        displayName: account.display_name ?? '',
+        password: result.temporary_password,
+      });
+    } catch (error) {
+      notify.error(getApiErrorMessage(error, 'パスワードの再設定に失敗しました'));
+    }
+  };
 
   // 再開は元に戻す操作なので確認を挟まない
   const resume = async (account: StaffAccountSummaryResponse) => {
@@ -139,6 +160,9 @@ export default function StaffAccountsPage() {
                   )}
                 </TableCell>
                 <TableCell className="text-right">
+                  <Button variant="ghost" size="sm" onClick={() => setResetTarget(account)}>
+                    パスワード再設定
+                  </Button>
                   {account.enabled ? (
                     <Button
                       variant="ghost"
@@ -172,6 +196,22 @@ export default function StaffAccountsPage() {
         confirmLabel="停止する"
         onConfirm={() => void suspension.confirm()}
         onClose={suspension.cancel}
+      />
+
+      <ConfirmDialog
+        open={resetTarget !== null}
+        title="パスワードを再設定しますか？"
+        description={`${resetTarget?.display_name ?? ''} のセッションは即時に失効します。仮パスワードは発行直後に一度だけ表示され、閉じると二度と確認できません。`}
+        confirmLabel="再設定する"
+        onConfirm={() => void (resetTarget && resetPassword(resetTarget))}
+        onClose={() => setResetTarget(null)}
+      />
+
+      <TemporaryPasswordModal
+        open={issued !== null}
+        temporaryPassword={issued?.password ?? ''}
+        displayName={issued?.displayName ?? ''}
+        onClose={() => setIssued(null)}
       />
     </>
   );

--- a/frontend/src/_pages/platform-staff-accounts/ui/StaffAccountsPage.tsx
+++ b/frontend/src/_pages/platform-staff-accounts/ui/StaffAccountsPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { StaffAccountSummaryResponse, platformStaffAccountApi } from '@/entities/user';
 import { roleSetLabel } from '@/features/staff-management';
 import { getApiErrorMessage, useDeleteAction, useListPage } from '@/shared/lib';
@@ -51,17 +51,24 @@ export default function StaffAccountsPage() {
   const [resetTarget, setResetTarget] = useState<StaffAccountSummaryResponse | null>(null);
   const [issued, setIssued] = useState<{ displayName: string; password: string } | null>(null);
 
+  // 応答順は要求順と一致しない。応答は一度きり表示の仮パスワードを運ぶため、遅れて届いた
+  // 古い応答が最新の（唯一有効な）値を上書きしないよう世代で守り、最新要求以外は棄てる。
+  const resetRequestIdRef = useRef(0);
+
   // 一覧の型では HQ 側ロールを判別できないので行は出し分けない。対象外（HQ 側ロール保持者・
   // 自分自身）の拒否はサーバだけが判定でき、文言は応答からそのまま出す。
   const resetPassword = async (account: StaffAccountSummaryResponse) => {
     setResetTarget(null);
+    const requestId = ++resetRequestIdRef.current;
     try {
       const result = await platformStaffAccountApi.resetPassword(account.id ?? 0);
+      if (requestId !== resetRequestIdRef.current) return;
       setIssued({
         displayName: account.display_name ?? '',
         password: result.temporary_password,
       });
     } catch (error) {
+      if (requestId !== resetRequestIdRef.current) return;
       notify.error(getApiErrorMessage(error, 'パスワードの再設定に失敗しました'));
     }
   };

--- a/frontend/src/_pages/platform-staff-accounts/ui/StaffAccountsPage.tsx
+++ b/frontend/src/_pages/platform-staff-accounts/ui/StaffAccountsPage.tsx
@@ -49,7 +49,11 @@ export default function StaffAccountsPage() {
   // 再設定の確認対象と、発行された仮パスワードの表示。どちらもページに置く —
   // 行に持たせると成功後の一覧取り直しで行ごと unmount され、表示が消える。
   const [resetTarget, setResetTarget] = useState<StaffAccountSummaryResponse | null>(null);
-  const [issued, setIssued] = useState<{ displayName: string; password: string } | null>(null);
+  const [issued, setIssued] = useState<{
+    displayName: string;
+    email: string;
+    password: string;
+  } | null>(null);
 
   // 応答は一度きり表示の仮パスワードを運ぶため、重ねて実行できてしまうとどちらか一方の
   // 有効な値が必ず失われる（表示枠は 1 つしかない）。進行中は全行の入口を塞いで直列化する。
@@ -70,6 +74,7 @@ export default function StaffAccountsPage() {
       if (requestId !== resetRequestIdRef.current) return;
       setIssued({
         displayName: account.display_name ?? '',
+        email: account.email ?? '',
         password: result.temporary_password,
       });
     } catch (error) {
@@ -230,6 +235,7 @@ export default function StaffAccountsPage() {
         open={issued !== null}
         temporaryPassword={issued?.password ?? ''}
         displayName={issued?.displayName ?? ''}
+        email={issued?.email ?? ''}
         onClose={() => setIssued(null)}
       />
     </>

--- a/frontend/src/_pages/platform-staff-accounts/ui/TemporaryPasswordModal.tsx
+++ b/frontend/src/_pages/platform-staff-accounts/ui/TemporaryPasswordModal.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { notify } from '@/shared/notify';
+import { Button, Dialog, DialogContent, DialogTitle, Input, Label } from '@/shared/ui';
+
+interface TemporaryPasswordModalProps {
+  open: boolean;
+  /** 発行された仮パスワードの生値。閉じると二度と取り出せない。 */
+  temporaryPassword: string;
+  /** 対象アカウントの表示名（誰の仮パスワードかの取り違えを防ぐ）。 */
+  displayName: string;
+  onClose: () => void;
+}
+
+/**
+ * 仮パスワードの一度きりの表示。ESC と背景クリックでは閉じない — 生値はこの表示にしか無く、
+ * 誤って閉じると再発行しかやり直す手段が無いため、閉じる意思は明示のボタンでしか受け取らない。
+ */
+export function TemporaryPasswordModal({
+  open,
+  temporaryPassword,
+  displayName,
+  onClose,
+}: TemporaryPasswordModalProps) {
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(temporaryPassword);
+      notify.success('仮パスワードをコピーしました');
+    } catch {
+      notify.error('仮パスワードのコピーに失敗しました');
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={next => {
+        // 閉じる要求（next === false）は握り潰す。閉じるのは下の「閉じる」ボタンだけ。
+        if (next) return;
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        aria-describedby={undefined}
+        className="gap-0 rounded-[10px] p-0 sm:max-w-md"
+      >
+        <DialogTitle className="border-b px-6 py-4 text-lg font-semibold text-foreground">
+          仮パスワードを発行しました
+        </DialogTitle>
+        <div className="space-y-4 px-6 py-5">
+          <div className="grid gap-1">
+            <Label htmlFor="temporary-password">{displayName} の仮パスワード</Label>
+            <Input
+              id="temporary-password"
+              type="text"
+              readOnly
+              value={temporaryPassword}
+              className="bg-muted font-mono"
+            />
+          </div>
+          <p className="text-sm text-muted-foreground">
+            この画面を閉じると二度と表示できません。本人へ安全な手段で伝え、初回ログイン後に変更してもらってください。
+          </p>
+          <p className="text-xs text-muted-foreground">
+            対象の既存セッションは失効済みです。再設定前のログイン状態では操作を続けられません。
+          </p>
+          <div className="flex justify-end gap-3 border-t pt-4">
+            <Button type="button" variant="outline" onClick={onClose}>
+              閉じる
+            </Button>
+            <Button type="button" onClick={handleCopy}>
+              コピー
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/_pages/platform-staff-accounts/ui/TemporaryPasswordModal.tsx
+++ b/frontend/src/_pages/platform-staff-accounts/ui/TemporaryPasswordModal.tsx
@@ -7,8 +7,10 @@ interface TemporaryPasswordModalProps {
   open: boolean;
   /** 発行された仮パスワードの生値。閉じると二度と取り出せない。 */
   temporaryPassword: string;
-  /** 対象アカウントの表示名（誰の仮パスワードかの取り違えを防ぐ）。 */
+  /** 対象アカウントの表示名。 */
   displayName: string;
+  /** 対象アカウントのメールアドレス。表示名は一意でないため、取り違え防止の同定は一意なこちらが担う。 */
+  email: string;
   onClose: () => void;
 }
 
@@ -20,6 +22,7 @@ export function TemporaryPasswordModal({
   open,
   temporaryPassword,
   displayName,
+  email,
   onClose,
 }: TemporaryPasswordModalProps) {
   const handleCopy = async () => {
@@ -49,7 +52,9 @@ export function TemporaryPasswordModal({
         </DialogTitle>
         <div className="space-y-4 px-6 py-5">
           <div className="grid gap-1">
-            <Label htmlFor="temporary-password">{displayName} の仮パスワード</Label>
+            <Label htmlFor="temporary-password">
+              {displayName}（{email}）の仮パスワード
+            </Label>
             <Input
               id="temporary-password"
               type="text"

--- a/frontend/src/entities/user/__tests__/platform-staff-account-api.test.ts
+++ b/frontend/src/entities/user/__tests__/platform-staff-account-api.test.ts
@@ -40,12 +40,12 @@ describe('platformStaffAccountApi', () => {
   // 仮パスワードの生値はこの応答にしか現れないので、本体をそのまま返す
   it('resetPassword は /platform/staff-accounts/{id}/password-reset を POST し応答本体を返す', async () => {
     (apiClient.post as jest.Mock).mockResolvedValueOnce({
-      data: { temporary_password: 'Ab3xYz9QmT2wKp7L' },
+      data: { temporary_password: 'test-temporary-password' },
     });
 
     const res = await platformStaffAccountApi.resetPassword(7);
 
-    expect(res).toEqual({ temporary_password: 'Ab3xYz9QmT2wKp7L' });
+    expect(res).toEqual({ temporary_password: 'test-temporary-password' });
     expect(apiClient.post).toHaveBeenCalledWith('/platform/staff-accounts/7/password-reset');
   });
 });

--- a/frontend/src/entities/user/__tests__/platform-staff-account-api.test.ts
+++ b/frontend/src/entities/user/__tests__/platform-staff-account-api.test.ts
@@ -36,4 +36,16 @@ describe('platformStaffAccountApi', () => {
 
     expect(apiClient.post).toHaveBeenCalledWith('/platform/staff-accounts/7/resumption');
   });
+
+  // 仮パスワードの生値はこの応答にしか現れないので、本体をそのまま返す
+  it('resetPassword は /platform/staff-accounts/{id}/password-reset を POST し応答本体を返す', async () => {
+    (apiClient.post as jest.Mock).mockResolvedValueOnce({
+      data: { temporary_password: 'Ab3xYz9QmT2wKp7L' },
+    });
+
+    const res = await platformStaffAccountApi.resetPassword(7);
+
+    expect(res).toEqual({ temporary_password: 'Ab3xYz9QmT2wKp7L' });
+    expect(apiClient.post).toHaveBeenCalledWith('/platform/staff-accounts/7/password-reset');
+  });
 });

--- a/frontend/src/entities/user/api/platform-staff-account.ts
+++ b/frontend/src/entities/user/api/platform-staff-account.ts
@@ -1,5 +1,5 @@
 import { apiClient, PageResult, fromSpringPage, toSpringPageParams } from '@/shared/api';
-import { StaffAccountSummaryResponse } from '../model/types';
+import { StaffAccountPasswordResetResponse, StaffAccountSummaryResponse } from '../model/types';
 
 /**
  * アカウント管理 API（本人種別 STAFF の全アカウントの閲覧と停止・再開）。
@@ -26,5 +26,10 @@ export const platformStaffAccountApi = {
   },
   resume: async (id: number): Promise<void> => {
     await apiClient.post(`/platform/staff-accounts/${id}/resumption`);
+  },
+  /** 仮パスワードを発行して再設定する。生値は戻り値にしか現れず、対象のセッションは即時に失効する。 */
+  resetPassword: async (id: number): Promise<StaffAccountPasswordResetResponse> => {
+    const response = await apiClient.post(`/platform/staff-accounts/${id}/password-reset`);
+    return response.data;
   },
 };

--- a/frontend/src/entities/user/model/types.ts
+++ b/frontend/src/entities/user/model/types.ts
@@ -171,6 +171,11 @@ export interface PlatformStaffUpdateRequest {
 
 // アカウント面の一覧 1 件。停止・再開はどちらも冪等で版を往復しないため version を持たず、
 // ロールは表示専用（この面からは授権を動かせない）。
+// パスワード再設定の応答。仮パスワードの生値はこの応答にしか現れず、以後どこからも取り出せない。
+export interface StaffAccountPasswordResetResponse {
+  temporary_password: string;
+}
+
 export interface StaffAccountSummaryResponse {
   id?: number;
   email?: string;

--- a/frontend/src/entities/user/model/types.ts
+++ b/frontend/src/entities/user/model/types.ts
@@ -169,13 +169,13 @@ export interface PlatformStaffUpdateRequest {
   version: number;
 }
 
-// アカウント面の一覧 1 件。停止・再開はどちらも冪等で版を往復しないため version を持たず、
-// ロールは表示専用（この面からは授権を動かせない）。
 // パスワード再設定の応答。仮パスワードの生値はこの応答にしか現れず、以後どこからも取り出せない。
 export interface StaffAccountPasswordResetResponse {
   temporary_password: string;
 }
 
+// アカウント面の一覧 1 件。停止・再開はどちらも冪等で版を往復しないため version を持たず、
+// ロールは表示専用（この面からは授権を動かせない）。
 export interface StaffAccountSummaryResponse {
   id?: number;
   email?: string;


### PR DESCRIPTION
## 概要

アカウント管理面に「パスワード再設定」を追加する。サーバが仮パスワード（ASCII 16 文字）を生成して応答に 1 回だけ返し、対象の既存セッションは停止用の失効キーとは独立した専用エントリで即時失効する。対象が HQ 側ロール保持者の場合は新設の再設定境界（G6）が 400 で拒否する。

Closes #789

## API 契約（票面の指定どおり）

| 項目 | 内容 |
| --- | --- |
| 端点 | `POST /platform/staff-accounts/{id}/password-reset`（要求本体なし） |
| 認可 | `@PreAuthorize("hasAuthority('PERM_STAFF_ACCOUNT_MANAGE')")` |
| 200 | `{ "temporary_password": "..." }` — この応答にしか現れない。専用 DTO `StaffAccountPasswordResetResponse`（一覧・詳細 DTO には載せない、api-guidelines §6） |
| 400 | G6 抵触（`HqPasswordResetNotAllowedException` → `ServiceException` 系） |
| 404 | 不在 / CAST / MEMBER（既存 `requireStaffAccount` と同じ漏斗） |

api-guidelines §4 は「トークン発行等は 201」に寄るが、本票は票面が 200 を明示しているためそれに従った（`reissueReceiptToken` の 201 とは意図的に不一致）。

## 変更内容

- backend: `PlatformStaffAccountService#resetPassword`（G6 判定は既存 `RoleRepository#findHqRoleIds` の単源を再利用）、`PlatformUserPasswordReset` イベント → `AuthSessionService` が afterCommit で `TokenBlacklistService#markPasswordReset` を呼ぶ
- backend: 専用失効エントリ `blacklist:password-reset:{email}`（値 = 再設定時刻 epoch 秒、TTL = JWT 有効期限で自然満了）。`TokenBlacklistValidator` に第 3 の検査を追加し、**発行時刻（iat）が再設定時刻より前のトークンだけ**を拒否する
- frontend: アカウント管理の各行に「パスワード再設定」操作を追加。確認ダイアログ → 仮パスワードの一度きり表示モーダル（ESC・背景押下では閉じず、「閉じる」ボタンのみで閉じる）
- docs: modulith 文書（auth の購読イベント）に構造変化 1 行を反映

## 検証

- [x] `task lint` exit 0
- [x] `task test` exit 0
- [x] `task build` exit 0
- [x] `task e2e` exit 0（実行シナリオ: 全シナリオ）
- [x] ローカルで code-review 実施済み（Standards / Spec 二軸。Spec 軸指摘ゼロ、Standards 軸の型定義コメント錯位は修正済み）

受け入れ基準はすべて `PlatformStaffPasswordResetIT` に固定した（仮パスワードでの実ログイン / HQ 対象 400 と店舗側 200 の対照を同一クラスに配置 / 自分自身 400 / 既存セッション即時失効 / **再設定→停止→再開でも失効維持** / 平文の再取得不能 / TTL）。

赤証: 失効エントリを停止用キー（`blacklist:users:`）に差し替える変異で「再開は停止の鍵しか解かない」テストが `expected: 401 but was: 200` で赤になることを実測（連動して仮パスワードログインの AC も赤化）。逆変換で復元後に全緑。フロントの ESC・背景ゲートも `onOpenChange` を素通しに戻す変異で 2 件赤を実測。

### 視覚確認（UI 変更時）

実ブラウザ（build + up）で実施: ライト/ダーク両テーマで確認ダイアログ → 仮パスワードモーダルの表示、ESC・背景押下で閉じないこと、「閉じる」で閉じること、HQ 管理者対象時の 400 トースト（サーバ文言「HQ 側ロール保持者のパスワードは再設定できません」）を確認。コピー失敗時のトースト（clipboard 権限なし環境）も try/catch 経路として確認。

## 決定ログ

1. **失効エントリは時刻比較型**。停止用キーと同じ「存在すれば全拒否」だと、仮パスワードでログインした新セッションまで最長 1 時間拒否され、受け入れ基準 1 が成立しない。エントリに再設定時刻（epoch 秒）を持たせ、iat がそれより前のトークンだけ拒否する。代価として**再設定と同一秒に発行済みだった旧トークンが最長 1 秒弱生き残る**（iat の分解能が秒のため）。この取捨は `TokenBlacklistValidator` に注釈済み。iat 欠落トークンはエントリ存在時に拒否（fail-closed）。
2. **G5 直列化点（`lockIdByCode`）は押さえない**。再設定は enabled もロール集合も変えず ROLE_MANAGE 実効保持者の母集団を減らし得ないため、`PermissionRepository#lockIdByCode` Javadoc の「増やすだけの操作は押さえない」の側に該当する（#788 の押さえ順先例コメントは踏襲対象を「母集団を減らしうる経路」と限定している）。
3. **停止中アカウントへの再設定は許可**（票面は無言）。再開までログイン不能なので害はなく、拒否する根拠もない。
4. **G6 の残余競合は受容**。判定後〜保存前に並行して対象が HQ 側化する窓（新規ロールの授与でも、保持済みロールへの PLATFORM 権限追加＝ロール定義編集でも）は、付与・編集経路と共有するロックが存在しないため閉じられない。窓は極小で、閉じるには付与経路側の改造が要るため本票の範囲外とした。
5. **一覧の全行に操作を表示**。一覧 DTO からは HQ 側ロールかを判別できない（ロール名は表示専用でロール→権限構成を持たない）ため、HQ 対象はサーバの 400 文言をトーストで表示する形にした。

6. **自己再設定は G6 に委ねず名指しで拒否**（codex 指摘 P1 の採用、票面の「行使者は必ず HQ 側ロール保持者のため自動的に除外」からの意図的逸脱）。JWT の権限は発行時の写しで、ロール降格後も失効まで残る — 降格済みの残存セッションからは自分が店舗側に見え、G6 を素通りして現パスワード確認なしに口座を恒久奪取できてしまう。suspend と同型で Principal を受け取り対象 email＝行使者 email を 400 で拒否。守衛撤去の変異で単体テストが赤になることを実測。
7. **失効エントリの書込みは Lua で単調化し、境界の時刻はイベント自身に運ばせる**（codex 指摘 P2 二件の採用）。再設定が重なると commit 順と afterCommit の実行順は一致しない — 素の SET だと遅れた古い時刻が新しい境界を巻き戻し（素の SET へ戻す変異で新設 IT が赤になることを実測）、逆に callback 実行時刻で刻むと遅延した古い callback が後の時刻を書いて最新パスワードの正当トークンを誤失効させる。時刻は publish 時（commit 前）に捕獲して `PlatformUserPasswordReset` に載せ、捕獲〜commit 間の旧パスワードログイン窓は裁定④の同一秒生存窓に包含される。

8. **前端は再設定要求を直列化する**（codex 指摘 P2 二件・4 巡目はユーザー裁定で案A採用）。応答は一度きり表示の仮パスワードを運び表示枠は 1 つしかないため、重ねて実行できる限りどちらか一方の有効な値が必ず失われる（応答順で守っても先行成功側が落ちるだけ — 4 巡目の指摘どおり）。進行中は全行のボタンを無効化して重なりを構造的に排除し、requestIdRef の世代守衛は兜底として残す。無効化を外す変異でテストが赤になることを実測。

見送った代替: 管理者が新パスワードを指定する形・メールリンク・初回強制変更（いずれも票面の対象外指定どおり）。

## 備考 / レビュー観点

- 重点: `TokenBlacklistValidator` の第 3 検査（時刻比較の向きと fail-closed）、`AuthSessionService` の afterCommit 経路（`@TransactionalEventListener` を使わない既存理由の踏襲）。
- `TemporaryPasswordModal` は `InvitationModal` と骨格が重複するが、閉じる挙動が意図的に異なる（あちらは ESC で閉じる）。共通化は 3 例目が出た時点で判断したい。
- ページ副題（停止・再開の文言）は再設定に触れていないが、既存テストが文字列を固定しているため本 PR では触らず、必要なら別対応とする。
- `module-user.adoc` に既存の漂移（`StoreExistenceCheck`）を発見したが本票と無関係のため触っていない。
- **一度きり応答の受容境界（裁定済み）**: 仮パスワードの応答は、到達前にページを離れる（在途中の画面遷移等）と失われ得る。「平文はどこにも残らない・再取得不能」は本票の AC そのものなので、値をページ外へ保活する修法は採らない。回復は再発行 1 回で完了し、追加の露出は生まない。以後この同族（一度きりの値が見えないまま失われ得る系）の指摘はこの境界を引用して見送る。
- codex 指摘のうち 2 件を見送り（いずれも根治＝資格情報の版列（credential version）で同族）: ①「稼働中の APP_JWT_EXPIRATION_MS 短縮で再設定エントリが既発行トークンより先に満了し得る」— 停止用 `blacklist:users:` が持つ既知・既記載（`blacklistUser` Javadoc）の前提と同一で、本 PR はそれを新鍵へ踏襲しただけ。②「旧パスワードの照合〜発行の間に再設定 commit が挟まると発行後 iat の token が生き残る」— 前提が旧パスワード保持者（＝再設定前ならいつでもログインできた者）で、増える能力は境界と同瞬間の発行のみ。裁定④の同族の秒未満エッジとして受容。版列の導入は別票 #798 へ切り出した。③「降格済み行使者の残存トークンで他アカウントを再設定できる」— 請求快照方式の全書込み端点に等しく存在する陳腐化窓で、単発の DB 再照合は採らず #798 の版 claim が根治。
